### PR TITLE
Enable better reporting of schema errors

### DIFF
--- a/internal/services/v0/developer_test.go
+++ b/internal/services/v0/developer_test.go
@@ -99,8 +99,22 @@ func TestEditCheck(t *testing.T) {
 			[]*v0.EditCheckResult{},
 		},
 		{
-			"valid namespace",
+			"invalid namespace name",
 			`definition foo {}`,
+			[]*v0.RelationTuple{},
+			[]*v0.RelationTuple{},
+			&v0.DeveloperError{
+				Message: "parse error in `schema`, line 1, column 1: error in object definition foo: invalid NamespaceDefinition.Name: value does not match regex pattern \"^([a-z][a-z0-9_]{2,62}[a-z0-9]/)?[a-z][a-z0-9_]{2,62}[a-z0-9]$\"",
+				Kind:    v0.DeveloperError_SCHEMA_ISSUE,
+				Source:  v0.DeveloperError_SCHEMA,
+				Line:    1,
+				Column:  1,
+			},
+			[]*v0.EditCheckResult{},
+		},
+		{
+			"valid namespace",
+			`definition foos {}`,
 			[]*v0.RelationTuple{},
 			[]*v0.RelationTuple{},
 			nil,
@@ -617,11 +631,11 @@ func TestFormatSchema(t *testing.T) {
 	srv := NewDeveloperServer(store)
 
 	lresp, err := srv.FormatSchema(context.Background(), &v0.FormatSchemaRequest{
-		Schema: "definition foo {} definition bar{}",
+		Schema: "definition foos {} definition bars{}",
 	})
 
 	require.NoError(err)
-	require.Equal("definition foo {}\n\ndefinition bar {}", lresp.FormattedSchema)
+	require.Equal("definition foos {}\n\ndefinition bars {}", lresp.FormattedSchema)
 }
 
 func TestValidateONR(t *testing.T) {

--- a/pkg/schemadsl/compiler/compiler_test.go
+++ b/pkg/schemadsl/compiler/compiler_test.go
@@ -40,9 +40,9 @@ func TestCompile(t *testing.T) {
 			"nested parse error",
 			&someTenant,
 			`definition foo {
-				relation something: a | b + c	
+				relation something: rela | relb + relc	
 			}`,
-			"parse error in `nested parse error`, line 2, column 31: Expected end of statement or definition, found: TokenTypePlus",
+			"parse error in `nested parse error`, line 2, column 37: Expected end of statement or definition, found: TokenTypePlus",
 			[]*v0.NamespaceDefinition{},
 		},
 		{
@@ -58,13 +58,13 @@ func TestCompile(t *testing.T) {
 			"simple def",
 			&someTenant,
 			`definition simple {
-				relation foo: bar;
+				relation foos: bars;
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/simple",
-					namespace.Relation("foo", nil,
-						namespace.RelationReference("sometenant/bar", "..."),
+					namespace.Relation("foos", nil,
+						namespace.RelationReference("sometenant/bars", "..."),
 					),
 				),
 			},
@@ -73,13 +73,13 @@ func TestCompile(t *testing.T) {
 			"explicit relation",
 			&someTenant,
 			`definition simple {
-				relation foo: bar#meh;
+				relation foos: bars#mehs;
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/simple",
-					namespace.Relation("foo", nil,
-						namespace.RelationReference("sometenant/bar", "meh"),
+					namespace.Relation("foos", nil,
+						namespace.RelationReference("sometenant/bars", "mehs"),
 					),
 				),
 			},
@@ -88,13 +88,13 @@ func TestCompile(t *testing.T) {
 			"cross tenant relation",
 			&someTenant,
 			`definition simple {
-				relation foo: anothertenant/bar#meh;
+				relation foos: anothertenant/bars#mehs;
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/simple",
-					namespace.Relation("foo", nil,
-						namespace.RelationReference("anothertenant/bar", "meh"),
+					namespace.Relation("foos", nil,
+						namespace.RelationReference("anothertenant/bars", "mehs"),
 					),
 				),
 			},
@@ -103,16 +103,16 @@ func TestCompile(t *testing.T) {
 			"multiple relations",
 			&someTenant,
 			`definition simple {
-				relation foo: bar#meh;
-				relation hi: there | world;
+				relation foos: bars#mehs;
+				relation hello: there | world;
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/simple",
-					namespace.Relation("foo", nil,
-						namespace.RelationReference("sometenant/bar", "meh"),
+					namespace.Relation("foos", nil,
+						namespace.RelationReference("sometenant/bars", "mehs"),
 					),
-					namespace.Relation("hi", nil,
+					namespace.Relation("hello", nil,
 						namespace.RelationReference("sometenant/there", "..."),
 						namespace.RelationReference("sometenant/world", "..."),
 					),
@@ -123,14 +123,14 @@ func TestCompile(t *testing.T) {
 			"simple permission",
 			&someTenant,
 			`definition simple {
-				permission foo = bar;
+				permission foos = bars;
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/simple",
-					namespace.Relation("foo",
+					namespace.Relation("foos",
 						namespace.Union(
-							namespace.ComputedUserset("bar"),
+							namespace.ComputedUserset("bars"),
 						),
 					),
 				),
@@ -140,15 +140,15 @@ func TestCompile(t *testing.T) {
 			"union permission",
 			&someTenant,
 			`definition simple {
-				permission foo = bar + baz;
+				permission foos = bars + bazs;
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/simple",
-					namespace.Relation("foo",
+					namespace.Relation("foos",
 						namespace.Union(
-							namespace.ComputedUserset("bar"),
-							namespace.ComputedUserset("baz"),
+							namespace.ComputedUserset("bars"),
+							namespace.ComputedUserset("bazs"),
 						),
 					),
 				),
@@ -158,15 +158,15 @@ func TestCompile(t *testing.T) {
 			"intersection permission",
 			&someTenant,
 			`definition simple {
-				permission foo = bar & baz;
+				permission foos = bars & bazs;
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/simple",
-					namespace.Relation("foo",
+					namespace.Relation("foos",
 						namespace.Intersection(
-							namespace.ComputedUserset("bar"),
-							namespace.ComputedUserset("baz"),
+							namespace.ComputedUserset("bars"),
+							namespace.ComputedUserset("bazs"),
 						),
 					),
 				),
@@ -176,15 +176,15 @@ func TestCompile(t *testing.T) {
 			"exclusion permission",
 			&someTenant,
 			`definition simple {
-				permission foo = bar - baz;
+				permission foos = bars - bazs;
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/simple",
-					namespace.Relation("foo",
+					namespace.Relation("foos",
 						namespace.Exclusion(
-							namespace.ComputedUserset("bar"),
-							namespace.ComputedUserset("baz"),
+							namespace.ComputedUserset("bars"),
+							namespace.ComputedUserset("bazs"),
 						),
 					),
 				),
@@ -194,20 +194,20 @@ func TestCompile(t *testing.T) {
 			"multi-union permission",
 			&someTenant,
 			`definition simple {
-				permission foo = bar + baz + meh;
+				permission foos = bars + bazs + mehs;
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/simple",
-					namespace.Relation("foo",
+					namespace.Relation("foos",
 						namespace.Union(
 							namespace.Rewrite(
 								namespace.Union(
-									namespace.ComputedUserset("bar"),
-									namespace.ComputedUserset("baz"),
+									namespace.ComputedUserset("bars"),
+									namespace.ComputedUserset("bazs"),
 								),
 							),
-							namespace.ComputedUserset("meh"),
+							namespace.ComputedUserset("mehs"),
 						),
 					),
 				),
@@ -217,20 +217,20 @@ func TestCompile(t *testing.T) {
 			"complex permission",
 			&someTenant,
 			`definition complex {
-				permission foo = bar + baz - meh;
+				permission foos = bars + bazs - mehs;
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/complex",
-					namespace.Relation("foo",
+					namespace.Relation("foos",
 						namespace.Exclusion(
 							namespace.Rewrite(
 								namespace.Union(
-									namespace.ComputedUserset("bar"),
-									namespace.ComputedUserset("baz"),
+									namespace.ComputedUserset("bars"),
+									namespace.ComputedUserset("bazs"),
 								),
 							),
-							namespace.ComputedUserset("meh"),
+							namespace.ComputedUserset("mehs"),
 						),
 					),
 				),
@@ -240,18 +240,18 @@ func TestCompile(t *testing.T) {
 			"complex parens permission",
 			&someTenant,
 			`definition complex {
-				permission foo = bar + (baz - meh);
+				permission foos = bars + (bazs - mehs);
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/complex",
-					namespace.Relation("foo",
+					namespace.Relation("foos",
 						namespace.Union(
-							namespace.ComputedUserset("bar"),
+							namespace.ComputedUserset("bars"),
 							namespace.Rewrite(
 								namespace.Exclusion(
-									namespace.ComputedUserset("baz"),
-									namespace.ComputedUserset("meh"),
+									namespace.ComputedUserset("bazs"),
+									namespace.ComputedUserset("mehs"),
 								),
 							),
 						),
@@ -263,14 +263,14 @@ func TestCompile(t *testing.T) {
 			"arrow permission",
 			&someTenant,
 			`definition arrowed {
-				permission foo = bar->baz
+				permission foos = bars->bazs
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/arrowed",
-					namespace.Relation("foo",
+					namespace.Relation("foos",
 						namespace.Union(
-							namespace.TupleToUserset("bar", "baz"),
+							namespace.TupleToUserset("bars", "bazs"),
 						),
 					),
 				),
@@ -281,10 +281,10 @@ func TestCompile(t *testing.T) {
 			"multiarrow permission",
 			&someTenant,
 			`definition arrowed {
-				relation a: something;
-				permission foo = a->b->c
+				relation somerel: something;
+				permission foos = somerel->brel->crel
 			}`,
-			"Nested arrows not yet supported",
+			"parse error in `multiarrow permission`, line 3, column 23: Nested arrows not yet supported",
 			[]*v0.NamespaceDefinition{},
 		},
 
@@ -293,8 +293,8 @@ func TestCompile(t *testing.T) {
 			{
 				"multiarrow permission",
 				`definition arrowed {
-					relation a: something;
-					permission foo = a->b->c
+					relation somerel: something;
+					permission foo = somerel->brel->crel
 				}`,
 				"",
 				[]*v0.NamespaceDefinition{
@@ -313,20 +313,20 @@ func TestCompile(t *testing.T) {
 			"expression permission",
 			&someTenant,
 			`definition expressioned {
-				permission foo = ((a->b) + c) - d
+				permission foos = ((arel->brel) + crel) - drel
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/expressioned",
-					namespace.Relation("foo",
+					namespace.Relation("foos",
 						namespace.Exclusion(
 							namespace.Rewrite(
 								namespace.Union(
-									namespace.TupleToUserset("a", "b"),
-									namespace.ComputedUserset("c"),
+									namespace.TupleToUserset("arel", "brel"),
+									namespace.ComputedUserset("crel"),
 								),
 							),
-							namespace.ComputedUserset("d"),
+							namespace.ComputedUserset("drel"),
 						),
 					),
 				),
@@ -336,35 +336,35 @@ func TestCompile(t *testing.T) {
 			"multiple permission",
 			&someTenant,
 			`definition multiple {
-				permission first = bar + baz
-				permission second = bar - baz
-				permission third = bar & baz
-				permission fourth = bar->baz
+				permission first = bars + bazs
+				permission second = bars - bazs
+				permission third = bars & bazs
+				permission fourth = bars->bazs
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
 				namespace.Namespace("sometenant/multiple",
 					namespace.Relation("first",
 						namespace.Union(
-							namespace.ComputedUserset("bar"),
-							namespace.ComputedUserset("baz"),
+							namespace.ComputedUserset("bars"),
+							namespace.ComputedUserset("bazs"),
 						),
 					),
 					namespace.Relation("second",
 						namespace.Exclusion(
-							namespace.ComputedUserset("bar"),
-							namespace.ComputedUserset("baz"),
+							namespace.ComputedUserset("bars"),
+							namespace.ComputedUserset("bazs"),
 						),
 					),
 					namespace.Relation("third",
 						namespace.Intersection(
-							namespace.ComputedUserset("bar"),
-							namespace.ComputedUserset("baz"),
+							namespace.ComputedUserset("bars"),
+							namespace.ComputedUserset("bazs"),
 						),
 					),
 					namespace.Relation("fourth",
 						namespace.Union(
-							namespace.TupleToUserset("bar", "baz"),
+							namespace.TupleToUserset("bars", "bazs"),
 						),
 					),
 				),
@@ -373,41 +373,57 @@ func TestCompile(t *testing.T) {
 		{
 			"no implicit tenant with unspecified tenant",
 			nil,
-			`definition foo {}`,
-			"found reference `foo` without prefix",
+			`definition foos {}`,
+			"parse error in `no implicit tenant with unspecified tenant`, line 1, column 1: found reference `foos` without prefix",
 			[]*v0.NamespaceDefinition{},
 		},
 		{
 			"no implicit tenant with specified tenant",
 			nil,
-			`definition someTenant/foo {}`,
+			`definition some_tenant/foos {}`,
 			"",
 			[]*v0.NamespaceDefinition{
-				namespace.Namespace("someTenant/foo"),
+				namespace.Namespace("some_tenant/foos"),
 			},
 		},
 		{
 			"no implicit tenant with unspecified tenant on type ref",
 			nil,
-			`definition someTenant/foo {
-				relation somerel: bar
+			`definition some_tenant/foo {
+				relation somerel: bars
 			}`,
-			"found reference `bar` without prefix",
+			"parse error in `no implicit tenant with unspecified tenant on type ref`, line 2, column 23: found reference `bars` without prefix",
+			[]*v0.NamespaceDefinition{},
+		},
+		{
+			"invalid definition name",
+			nil,
+			`definition someTenant/foo {}`,
+			"parse error in `invalid definition name`, line 1, column 1: error in object definition someTenant/foo: invalid NamespaceDefinition.Name: value does not match regex pattern \"^([a-z][a-z0-9_]{2,62}[a-z0-9]/)?[a-z][a-z0-9_]{2,62}[a-z0-9]$\"",
+			[]*v0.NamespaceDefinition{},
+		},
+		{
+			"invalid relation name",
+			nil,
+			`definition some_tenant/foos {
+				relation bar: some_tenant/foos
+			}`,
+			"parse error in `invalid relation name`, line 2, column 5: error in relation bar: invalid Relation.Name: value does not match regex pattern \"^[a-z][a-z0-9_]{2,62}[a-z0-9]$\"",
 			[]*v0.NamespaceDefinition{},
 		},
 		{
 			"no implicit tenant with specified tenant on type ref",
 			nil,
-			`definition someTenant/foo {
-				relation somerel: someTenant/bar
+			`definition some_tenant/foos {
+				relation somerel: some_tenant/bars
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
-				namespace.Namespace("someTenant/foo",
+				namespace.Namespace("some_tenant/foos",
 					namespace.Relation(
 						"somerel",
 						nil,
-						namespace.RelationReference("someTenant/bar", "..."),
+						namespace.RelationReference("some_tenant/bars", "..."),
 					),
 				),
 			},
@@ -427,7 +443,7 @@ func TestCompile(t *testing.T) {
 				/**
 				 * some permission
 				 */
-				permission first = bar + baz
+				permission first = bars + bazs
 			}`,
 			"",
 			[]*v0.NamespaceDefinition{
@@ -441,8 +457,8 @@ func TestCompile(t *testing.T) {
 * some permission
 */`,
 						namespace.Union(
-							namespace.ComputedUserset("bar"),
-							namespace.ComputedUserset("baz"),
+							namespace.ComputedUserset("bars"),
+							namespace.ComputedUserset("bazs"),
 						),
 					),
 				),

--- a/pkg/schemadsl/compiler/node.go
+++ b/pkg/schemadsl/compiler/node.go
@@ -155,5 +155,8 @@ func (tn *dslNode) Lookup(predicateName string) (*dslNode, error) {
 }
 
 func (tn *dslNode) Errorf(message string, args ...interface{}) error {
-	return fmt.Errorf(message, args...)
+	return errorWithNode{
+		error: fmt.Errorf(message, args...),
+		node:  tn,
+	}
 }

--- a/pkg/schemadsl/generator/generator_test.go
+++ b/pkg/schemadsl/generator/generator_test.go
@@ -22,76 +22,76 @@ func TestGenerator(t *testing.T) {
 	tests := []generatorTest{
 		{
 			"empty",
-			namespace.Namespace("foo/test"),
-			"definition foo/test {}",
+			namespace.Namespace("foos/test"),
+			"definition foos/test {}",
 			true,
 		},
 		{
 			"simple relation",
-			namespace.Namespace("foo/test",
+			namespace.Namespace("foos/test",
 				namespace.Relation("somerel", nil, &v0.RelationReference{
-					Namespace: "foo/bar",
+					Namespace: "foos/bars",
 					Relation:  "hiya",
 				}),
 			),
-			`definition foo/test {
-	relation somerel: foo/bar#hiya
+			`definition foos/test {
+	relation somerel: foos/bars#hiya
 }`,
 			true,
 		},
 		{
 			"simple permission",
-			namespace.Namespace("foo/test",
+			namespace.Namespace("foos/test",
 				namespace.Relation("someperm", namespace.Union(
 					namespace.ComputedUserset("anotherrel"),
 				)),
 			),
-			`definition foo/test {
+			`definition foos/test {
 	permission someperm = anotherrel
 }`,
 			true,
 		},
 		{
 			"complex permission",
-			namespace.Namespace("foo/test",
+			namespace.Namespace("foos/test",
 				namespace.Relation("someperm", namespace.Union(
 					namespace.Rewrite(
 						namespace.Exclusion(
-							namespace.ComputedUserset("a"),
-							namespace.ComputedUserset("b"),
-							namespace.TupleToUserset("y", "z"),
+							namespace.ComputedUserset("rela"),
+							namespace.ComputedUserset("relb"),
+							namespace.TupleToUserset("rely", "relz"),
 						),
 					),
-					namespace.ComputedUserset("c"),
+					namespace.ComputedUserset("relc"),
 				)),
 			),
-			`definition foo/test {
-	permission someperm = (a - b - y->z) + c
+			`definition foos/test {
+	permission someperm = (rela - relb - rely->relz) + relc
 }`,
 			true,
 		},
 		{
 			"legacy relation",
-			namespace.Namespace("foo/test",
+			namespace.Namespace("foos/test",
 				namespace.Relation("somerel", namespace.Union(
 					namespace.This(),
 					namespace.ComputedUserset("anotherrel"),
 				), &v0.RelationReference{
-					Namespace: "foo/bar",
+					Namespace: "foos/bars",
 					Relation:  "hiya",
 				}),
 			),
-			`definition foo/test {
-	relation somerel: foo/bar#hiya = /* _this unsupported here. Please rewrite into a relation and permission */ + anotherrel
+			`definition foos/test {
+	relation somerel: foos/bars#hiya = /* _this unsupported here. Please rewrite into a relation and permission */ + anotherrel
 }`,
 			false,
 		},
 		{
 			"missing type information",
-			namespace.Namespace("foo/test",
+			namespace.Namespace("foos/test",
 				namespace.Relation("somerel", nil),
 			),
-			`definition foo/test {
+			`definition foos/test {
 	relation somerel: /* missing allowed types */
 }`,
 			false,
@@ -99,22 +99,22 @@ func TestGenerator(t *testing.T) {
 
 		{
 			"full example",
-			namespace.NamespaceWithComment("foo/document", `/**
+			namespace.NamespaceWithComment("foos/document", `/**
 * Some comment goes here
 */`,
 				namespace.Relation("owner", nil,
 					&v0.RelationReference{
-						Namespace: "foo/user",
+						Namespace: "foos/user",
 						Relation:  "...",
 					},
 				),
 				namespace.RelationWithComment("reader", "//foobar", nil,
 					&v0.RelationReference{
-						Namespace: "foo/user",
+						Namespace: "foos/user",
 						Relation:  "...",
 					},
 					&v0.RelationReference{
-						Namespace: "foo/group",
+						Namespace: "foos/group",
 						Relation:  "member",
 					},
 				),
@@ -124,11 +124,11 @@ func TestGenerator(t *testing.T) {
 				)),
 			),
 			`/** Some comment goes here */
-definition foo/document {
-	relation owner: foo/user
+definition foos/document {
+	relation owner: foos/user
 
 	// foobar
-	relation reader: foo/user | foo/group#member
+	relation reader: foos/user | foos/group#member
 	permission read = reader + owner
 }`,
 			true,
@@ -155,56 +155,56 @@ func TestFormatting(t *testing.T) {
 	tests := []formattingTest{
 		{
 			"empty",
-			"definition foo/test {}",
-			"definition foo/test {}",
+			"definition foos/test {}",
+			"definition foos/test {}",
 		},
 		{
 			"with comment",
-			`/** some def */definition foo/test {}`,
+			`/** some def */definition foos/test {}`,
 			`/** some def */
-definition foo/test {}`,
+definition foos/test {}`,
 		},
 		{
 			"with rel comment",
-			`/** some def */definition foo/test {
+			`/** some def */definition foos/test {
 
 				// some rel
-				relation somerel: foo/bar;
+				relation somerel: foos/bars;
 			}`,
 			`/** some def */
-definition foo/test {
+definition foos/test {
 	// some rel
-	relation somerel: foo/bar
+	relation somerel: foos/bars
 }`,
 		},
 		{
 			"with multiple rel comment",
-			`/** some def */definition foo/test {
+			`/** some def */definition foos/test {
 
 				// some rel
 				/* another comment */
-				relation somerel: foo/bar;
+				relation somerel: foos/bars;
 			}`,
 			`/** some def */
-definition foo/test {
+definition foos/test {
 	// some rel
 	/* another comment */
-	relation somerel: foo/bar
+	relation somerel: foos/bars
 }`,
 		},
 		{
 			"with multiple rels with comment",
-			`/** some def */definition foo/test {
+			`/** some def */definition foos/test {
 
 				// some rel
-				relation somerel: foo/bar;
+				relation somerel: foos/bars;
 				// another perm
 				permission someperm = somerel
 			}`,
 			`/** some def */
-definition foo/test {
+definition foos/test {
 	// some rel
-	relation somerel: foo/bar
+	relation somerel: foos/bars
 
 	// another perm
 	permission someperm = somerel
@@ -213,15 +213,15 @@ definition foo/test {
 
 		{
 			"becomes single line comment",
-			`definition foo/test {
+			`definition foos/test {
 				/**
 				 * hi there
 				 */
-				relation somerel: foo/bar;
+				relation somerel: foos/bars;
 			}`,
-			`definition foo/test {
+			`definition foos/test {
 	/** hi there */
-	relation somerel: foo/bar
+	relation somerel: foos/bars
 }`,
 		},
 
@@ -229,37 +229,37 @@ definition foo/test {
 			"full example",
 			`
 /** the document */
-definition foo/document {
+definition foos/document {
 	/** some super long comment goes here and therefore should be made into a multiline comment */
-	relation reader: foo/user
+	relation reader: foos/user
 
 	/** multiline
 comment */
-	relation  writer: foo/user
+	relation  writer: foos/user
 
 	// writers are also readers
 	permission read = reader + writer + another
 	permission write = writer
-	permission minus = a - b - c
+	permission minus = rela - relb - relc
 }
 `,
 			`/** the document */
-definition foo/document {
+definition foos/document {
 	/**
 	 * some super long comment goes here and therefore should be made into a multiline comment
 	 */
-	relation reader: foo/user
+	relation reader: foos/user
 
 	/**
 	 * multiline
 	 * comment
 	 */
-	relation writer: foo/user
+	relation writer: foos/user
 
 	// writers are also readers
 	permission read = reader + writer + another
 	permission write = writer
-	permission minus = (a - b) - c
+	permission minus = (rela - relb) - relc
 }`,
 		},
 	}


### PR DESCRIPTION
We now call Validate on the relations/permissions, type refs and namespaces produced, assigning the error to the proper context. This PR also changes the errors created via dslNode.Errorf to be decorated with node-specific information as originally intended