### PR TITLE
add a default nsswitch.conf file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN go build ./cmd/zed-testserver/
 
 FROM alpine:3.14.2
 
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 COPY --from=build /go/bin/grpc_health_probe /usr/local/bin/
 COPY --from=build /go/src/app/spicedb /usr/local/bin/spicedb
 COPY --from=build /go/src/app/zed-testserver /usr/local/bin/zed-testserver


### PR DESCRIPTION
The go networking stack will hit dns first unless you configure it
otherwise

Without this, `grpc_health_probe` can fail to hit localhost due to slow
external dns

Docs:
- glibc behavior: https://man7.org/linux/man-pages/man5/nsswitch.conf.5.html
- discussion of golang matching glibc behavior: https://github.com/golang/go/issues/35305
- some thoughts from alpine: https://github.com/gliderlabs/docker-alpine/issues/367
- some thoughts from docker: https://github.com/docker-library/docker/issues/82
