### PR TITLE
Consistency middleware for V1 API

### DIFF
--- a/internal/middleware/consistency/consistency.go
+++ b/internal/middleware/consistency/consistency.go
@@ -1,0 +1,186 @@
+package consistency
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"github.com/shopspring/decimal"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/authzed/spicedb/internal/datastore"
+	v1 "github.com/authzed/spicedb/internal/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/internal/services/serviceerrors"
+	"github.com/authzed/spicedb/pkg/zedtoken"
+)
+
+type hasConsistency interface {
+	GetConsistency() *v1.Consistency
+}
+
+type ctxKeyType string
+
+var revisionKey ctxKeyType = "revision"
+
+var errInvalidZedToken = errors.New("invalid revision requested")
+
+// RevisionFromContext reads the selected revision out of a context.Context and returns nil if it
+// does not exist.
+func RevisionFromContext(ctx context.Context) *decimal.Decimal {
+	if c := ctx.Value(revisionKey); c != nil {
+		revision := c.(decimal.Decimal)
+		return &revision
+	}
+	return nil
+}
+
+// AddRevisionToContext adds a revision to the given context, based on the consistency block found
+// in the given request (if applicable).
+func AddRevisionToContext(ctx context.Context, req interface{}, ds datastore.Datastore) (context.Context, error) {
+	reqWithConsistency, ok := req.(hasConsistency)
+	if !ok {
+		return ctx, nil
+	}
+
+	revision := decimal.Zero
+	consistency := reqWithConsistency.GetConsistency()
+
+	switch {
+	case consistency == nil || consistency.GetMinimizeLatency():
+		// Minimize Latency: Use the datastore's current revision, whatever it may be.
+		databaseRev, err := ds.Revision(ctx)
+		if err != nil {
+			return nil, rewriteDatastoreError(err)
+		}
+		revision = databaseRev
+		break
+
+	case consistency.GetFullyConsistent():
+		// Fully Consistent: Use the datastore's synchronized revision.
+		databaseRev, err := ds.SyncRevision(ctx)
+		if err != nil {
+			return nil, rewriteDatastoreError(err)
+		}
+		revision = databaseRev
+		break
+
+	case consistency.GetAtLeastAsFresh() != nil:
+		// At least as fresh as: Pick one of the datastore's revision and that specified, which
+		// ever is later.
+		picked, err := pickBestRevision(ctx, consistency.GetAtLeastAsFresh(), ds)
+		if err != nil {
+			return nil, rewriteDatastoreError(err)
+		}
+		revision = picked
+		break
+
+	case consistency.GetAtExactSnapshot() != nil:
+		// Exact snapshot: Use the revision as encoded in the zed token.
+		requestedRev, err := zedtoken.DecodeRevision(consistency.GetAtExactSnapshot())
+		if err != nil {
+			return nil, errInvalidZedToken
+		}
+
+		err = ds.CheckRevision(ctx, requestedRev)
+		if err != nil {
+			return nil, rewriteDatastoreError(err)
+		}
+
+		revision = requestedRev
+		break
+
+	default:
+		return nil, fmt.Errorf("missing handling of consistency case in %v", consistency)
+	}
+
+	return context.WithValue(ctx, revisionKey, revision), nil
+}
+
+// UnaryServerInterceptor returns a new unary server interceptor that performs per-request exchange of
+// the specified consistency configuration for the revision at which to perform the request.
+func UnaryServerInterceptor(ds datastore.Datastore) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		newCtx, err := AddRevisionToContext(ctx, req, ds)
+		if err != nil {
+			return nil, err
+		}
+
+		return handler(newCtx, req)
+	}
+}
+
+// StreamServerInterceptor returns a new stream server interceptor that performs per-request exchange of
+// the specified consistency configuration for the revision at which to perform the request.
+func StreamServerInterceptor(ds datastore.Datastore) grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		wrapper := &recvWrapper{stream, ds, stream.Context(), stream.Context()}
+		return handler(srv, wrapper)
+	}
+}
+
+type recvWrapper struct {
+	grpc.ServerStream
+	ds         datastore.Datastore
+	initialCtx context.Context
+	ctx        context.Context
+}
+
+func (s *recvWrapper) Context() context.Context {
+	return s.ctx
+}
+
+func (s *recvWrapper) RecvMsg(m interface{}) error {
+	if err := s.ServerStream.RecvMsg(m); err != nil {
+		return err
+	}
+
+	ctx, err := AddRevisionToContext(s.initialCtx, m, s.ds)
+	if err != nil {
+		return err
+	}
+
+	s.ctx = ctx
+	return nil
+}
+
+func pickBestRevision(ctx context.Context, requested *v1.ZedToken, ds datastore.Datastore) (decimal.Decimal, error) {
+	// Calculate a revision as we see fit
+	databaseRev, err := ds.Revision(ctx)
+	if err != nil {
+		return decimal.Zero, err
+	}
+
+	if requested != nil {
+		requestedRev, err := zedtoken.DecodeRevision(requested)
+		if err != nil {
+			return decimal.Zero, errInvalidZedToken
+		}
+
+		if requestedRev.GreaterThan(databaseRev) {
+			return requestedRev, nil
+		}
+		return databaseRev, nil
+	}
+
+	return databaseRev, nil
+}
+
+func rewriteDatastoreError(err error) error {
+	switch {
+	case errors.As(err, &datastore.ErrPreconditionFailed{}):
+		return status.Errorf(codes.FailedPrecondition, "failed precondition: %s", err)
+
+	case errors.As(err, &datastore.ErrInvalidRevision{}):
+		return status.Errorf(codes.OutOfRange, "invalid zookie: %s", err)
+
+	case errors.As(err, &datastore.ErrReadOnly{}):
+		return serviceerrors.ErrServiceReadOnly
+
+	default:
+		log.Err(err)
+		return err
+	}
+}

--- a/internal/middleware/consistency/consistency_test.go
+++ b/internal/middleware/consistency/consistency_test.go
@@ -1,0 +1,171 @@
+package consistency
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	grpc_testing "github.com/grpc-ecosystem/go-grpc-middleware/testing"
+	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+
+	"github.com/authzed/spicedb/internal/datastore/memdb"
+	v1 "github.com/authzed/spicedb/internal/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/zedtoken"
+)
+
+func TestAddRevisionToContextNoneSupplied(t *testing.T) {
+	require := require.New(t)
+
+	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC, 0)
+	require.NoError(err)
+
+	databaseRev, err := ds.Revision(context.Background())
+	require.NoError(err)
+
+	updated, err := AddRevisionToContext(context.Background(), &v1.ReadRelationshipsRequest{}, ds)
+	require.NoError(err)
+	require.Equal(databaseRev.BigInt(), RevisionFromContext(updated).BigInt())
+}
+
+func TestAddRevisionToContextMinimizeLatency(t *testing.T) {
+	require := require.New(t)
+
+	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC, 0)
+	require.NoError(err)
+
+	databaseRev, err := ds.Revision(context.Background())
+	require.NoError(err)
+
+	updated, err := AddRevisionToContext(context.Background(), &v1.ReadRelationshipsRequest{
+		Consistency: &v1.Consistency{
+			Requirement: &v1.Consistency_MinimizeLatency{
+				MinimizeLatency: true,
+			},
+		},
+	}, ds)
+	require.NoError(err)
+	require.Equal(databaseRev.BigInt(), RevisionFromContext(updated).BigInt())
+}
+
+func TestAddRevisionToContextFullyConsistent(t *testing.T) {
+	require := require.New(t)
+
+	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC, 0)
+	require.NoError(err)
+
+	databaseRev, err := ds.SyncRevision(context.Background())
+	require.NoError(err)
+
+	updated, err := AddRevisionToContext(context.Background(), &v1.ReadRelationshipsRequest{
+		Consistency: &v1.Consistency{
+			Requirement: &v1.Consistency_FullyConsistent{
+				FullyConsistent: true,
+			},
+		},
+	}, ds)
+	require.NoError(err)
+	require.Equal(databaseRev.BigInt(), RevisionFromContext(updated).BigInt())
+}
+
+func TestAddRevisionToContextAtLeastAsFresh(t *testing.T) {
+	require := require.New(t)
+
+	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC, 0)
+	require.NoError(err)
+
+	databaseRev, err := ds.SyncRevision(context.Background())
+	require.NoError(err)
+
+	updated, err := AddRevisionToContext(context.Background(), &v1.ReadRelationshipsRequest{
+		Consistency: &v1.Consistency{
+			Requirement: &v1.Consistency_AtLeastAsFresh{
+				AtLeastAsFresh: zedtoken.NewFromRevision(decimal.Zero),
+			},
+		},
+	}, ds)
+	require.NoError(err)
+	require.Equal(databaseRev.BigInt(), RevisionFromContext(updated).BigInt())
+}
+
+func TestAddRevisionToContextAtValidExactSnapshot(t *testing.T) {
+	require := require.New(t)
+
+	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC, 0)
+	require.NoError(err)
+
+	databaseRev, err := ds.SyncRevision(context.Background())
+	require.NoError(err)
+
+	updated, err := AddRevisionToContext(context.Background(), &v1.ReadRelationshipsRequest{
+		Consistency: &v1.Consistency{
+			Requirement: &v1.Consistency_AtExactSnapshot{
+				AtExactSnapshot: zedtoken.NewFromRevision(databaseRev),
+			},
+		},
+	}, ds)
+	require.NoError(err)
+	require.Equal(databaseRev.BigInt(), RevisionFromContext(updated).BigInt())
+}
+
+func TestAddRevisionToContextAtInvalidExactSnapshot(t *testing.T) {
+	require := require.New(t)
+
+	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC, 0)
+	require.NoError(err)
+
+	_, err = AddRevisionToContext(context.Background(), &v1.ReadRelationshipsRequest{
+		Consistency: &v1.Consistency{
+			Requirement: &v1.Consistency_AtExactSnapshot{
+				AtExactSnapshot: zedtoken.NewFromRevision(decimal.Zero),
+			},
+		},
+	}, ds)
+	require.Error(err)
+}
+
+func TestConsistencyTestSuite(t *testing.T) {
+	require := require.New(t)
+
+	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC, 0)
+	require.NoError(err)
+
+	s := &ConsistencyTestSuite{
+		InterceptorTestSuite: &grpc_testing.InterceptorTestSuite{
+			ServerOpts: []grpc.ServerOption{
+				grpc.StreamInterceptor(StreamServerInterceptor(ds)),
+				grpc.UnaryInterceptor(UnaryServerInterceptor(ds)),
+			},
+		},
+	}
+	suite.Run(t, s)
+}
+
+var goodPing = &pb_testproto.PingRequest{Value: "something"}
+
+type ConsistencyTestSuite struct {
+	*grpc_testing.InterceptorTestSuite
+}
+
+func (s *ConsistencyTestSuite) TestValidPasses_Unary() {
+	require := require.New(s.T())
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	require.NoError(err)
+}
+
+func (s *ConsistencyTestSuite) TestValidPasses_ServerStream() {
+	require := require.New(s.T())
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing)
+	require.NoError(err)
+	for true {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		assert.NoError(s.T(), err, "no error on messages sent occured")
+	}
+}


### PR DESCRIPTION
Adds a middleware interceptor that reads the consistency block on an incoming request and injects the computed revision into the context, if applicable