### PR TITLE
Change all legacy tuple string formats to elide ellipsis

### DIFF
--- a/internal/datastore/test/namespace.go
+++ b/internal/datastore/test/namespace.go
@@ -77,11 +77,11 @@ func TestNamespaceDelete(t *testing.T, tester DatastoreTester) {
 	ctx := context.Background()
 
 	tRequire := testfixtures.TupleChecker{Require: require, DS: ds}
-	docTpl := tuple.Scan(testfixtures.StandardTuples[0])
+	docTpl := tuple.Parse(testfixtures.StandardTuples[0])
 	require.NotNil(docTpl)
 	tRequire.TupleExists(ctx, docTpl, revision)
 
-	folderTpl := tuple.Scan(testfixtures.StandardTuples[2])
+	folderTpl := tuple.Parse(testfixtures.StandardTuples[2])
 	require.NotNil(folderTpl)
 	tRequire.TupleExists(ctx, folderTpl, revision)
 

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -84,8 +84,8 @@ func TestMaxDepthCaching(t *testing.T) {
 			for _, step := range tc.script {
 				if step.expectPassthrough {
 					delegate.On("DispatchCheck", &v1.DispatchCheckRequest{
-						ObjectAndRelation: tuple.ScanONR(step.start),
-						Subject:           tuple.ScanONR(step.goal),
+						ObjectAndRelation: tuple.ParseONR(step.start),
+						Subject:           tuple.ParseSubjectONR(step.goal),
 						Metadata: &v1.ResolverMeta{
 							AtRevision:     step.atRevision.String(),
 							DepthRemaining: uint32(step.depthRemaining),
@@ -104,8 +104,8 @@ func TestMaxDepthCaching(t *testing.T) {
 
 			for _, step := range tc.script {
 				resp, err := dispatch.DispatchCheck(context.Background(), &v1.DispatchCheckRequest{
-					ObjectAndRelation: tuple.ScanONR(step.start),
-					Subject:           tuple.ScanONR(step.goal),
+					ObjectAndRelation: tuple.ParseONR(step.start),
+					Subject:           tuple.ParseSubjectONR(step.goal),
 					Metadata: &v1.ResolverMeta{
 						AtRevision:     step.atRevision.String(),
 						DepthRemaining: uint32(step.depthRemaining),

--- a/internal/services/v0/acl_test.go
+++ b/internal/services/v0/acl_test.go
@@ -61,15 +61,15 @@ func TestRead(t *testing.T) {
 			&v0.RelationTupleFilter{Namespace: tf.DocumentNS.Name},
 			codes.OK,
 			[]string{
-				"document:companyplan#parent@folder:company#...",
-				"document:masterplan#parent@folder:strategy#...",
-				"document:masterplan#owner@user:product_manager#...",
-				"document:masterplan#viewer@user:eng_lead#...",
-				"document:masterplan#parent@folder:plans#...",
-				"document:healthplan#parent@folder:plans#...",
-				"document:specialplan#editor@user:multiroleguy#...",
-				"document:specialplan#viewer_and_editor@user:multiroleguy#...",
-				"document:specialplan#viewer_and_editor@user:missingrolegal#...",
+				"document:companyplan#parent@folder:company",
+				"document:masterplan#parent@folder:strategy",
+				"document:masterplan#owner@user:product_manager",
+				"document:masterplan#viewer@user:eng_lead",
+				"document:masterplan#parent@folder:plans",
+				"document:healthplan#parent@folder:plans",
+				"document:specialplan#editor@user:multiroleguy",
+				"document:specialplan#viewer_and_editor@user:multiroleguy",
+				"document:specialplan#viewer_and_editor@user:missingrolegal",
 			},
 		},
 		{
@@ -83,7 +83,7 @@ func TestRead(t *testing.T) {
 			},
 			codes.OK,
 			[]string{
-				"document:healthplan#parent@folder:plans#...",
+				"document:healthplan#parent@folder:plans",
 			},
 		},
 		{
@@ -97,10 +97,10 @@ func TestRead(t *testing.T) {
 			},
 			codes.OK,
 			[]string{
-				"document:companyplan#parent@folder:company#...",
-				"document:masterplan#parent@folder:strategy#...",
-				"document:masterplan#parent@folder:plans#...",
-				"document:healthplan#parent@folder:plans#...",
+				"document:companyplan#parent@folder:company",
+				"document:masterplan#parent@folder:strategy",
+				"document:masterplan#parent@folder:plans",
+				"document:healthplan#parent@folder:plans",
 			},
 		},
 		{
@@ -114,8 +114,8 @@ func TestRead(t *testing.T) {
 			},
 			codes.OK,
 			[]string{
-				"document:masterplan#parent@folder:plans#...",
-				"document:healthplan#parent@folder:plans#...",
+				"document:masterplan#parent@folder:plans",
+				"document:healthplan#parent@folder:plans",
 			},
 		},
 		{
@@ -131,7 +131,7 @@ func TestRead(t *testing.T) {
 			},
 			codes.OK,
 			[]string{
-				"document:masterplan#parent@folder:plans#...",
+				"document:masterplan#parent@folder:plans",
 			},
 		},
 		{
@@ -299,8 +299,8 @@ func TestWrite(t *testing.T) {
 	client, stop, _, _ := newACLServicer(require, 0, memdb.DisableGC, 0)
 	defer stop()
 
-	toWriteStr := "document:totallynew#parent@folder:plans#..."
-	toWrite := tuple.Scan(toWriteStr)
+	toWriteStr := "document:totallynew#parent@folder:plans"
+	toWrite := tuple.Parse(toWriteStr)
 	require.NotNil(toWrite)
 
 	resp, err := client.Write(context.Background(), &v0.WriteRequest{
@@ -310,7 +310,7 @@ func TestWrite(t *testing.T) {
 	require.Nil(resp)
 	grpcutil.RequireStatus(t, codes.FailedPrecondition, err)
 
-	existing := tuple.Scan(tf.StandardTuples[0])
+	existing := tuple.Parse(tf.StandardTuples[0])
 	require.NotNil(existing)
 
 	resp, err = client.Write(context.Background(), &v0.WriteRequest{
@@ -375,32 +375,32 @@ func TestInvalidWriteArguments(t *testing.T) {
 		},
 		{
 			"good precondition, short object ID",
-			[]string{"document:newdoc#parent@folder:afolder#..."},
-			[]string{"document:#parent@folder:afolder#..."},
+			[]string{"document:newdoc#parent@folder:afolder"},
+			[]string{"document:#parent@folder:afolder"},
 			codes.InvalidArgument,
 		},
 		{
 			"bad precondition, good write",
-			[]string{"document:newdoc#parent@folder:#..."},
-			[]string{"document:newdoc#parent@folder:afolder#..."},
+			[]string{"document:newdoc#parent@folder:"},
+			[]string{"document:newdoc#parent@folder:afolder"},
 			codes.InvalidArgument,
 		},
 		{
 			"bad write namespace",
 			nil,
-			[]string{"docu:newdoc#parent@folder:afolder#..."},
+			[]string{"docu:newdoc#parent@folder:afolder"},
 			codes.FailedPrecondition,
 		},
 		{
 			"bad write relation",
 			nil,
-			[]string{"document:newdoc#pare@folder:afolder#..."},
+			[]string{"document:newdoc#pare@folder:afolder"},
 			codes.FailedPrecondition,
 		},
 		{
 			"bad write userset namespace",
 			nil,
-			[]string{"document:newdoc#parent@fold:afolder#..."},
+			[]string{"document:newdoc#parent@fold:afolder"},
 			codes.FailedPrecondition,
 		},
 		{
@@ -412,7 +412,7 @@ func TestInvalidWriteArguments(t *testing.T) {
 		{
 			"bad write wrong relation type",
 			nil,
-			[]string{"document:newdoc#parent@user:someuser#..."},
+			[]string{"document:newdoc#parent@user:someuser"},
 			codes.InvalidArgument,
 		},
 	}
@@ -425,12 +425,12 @@ func TestInvalidWriteArguments(t *testing.T) {
 
 			var preconditions []*v0.RelationTuple
 			for _, p := range tc.preconditions {
-				preconditions = append(preconditions, tuple.Scan(p))
+				preconditions = append(preconditions, tuple.Parse(p))
 			}
 
 			var mutations []*v0.RelationTupleUpdate
 			for _, tpl := range tc.tuples {
-				mutations = append(mutations, tuple.Touch(tuple.Scan(tpl)))
+				mutations = append(mutations, tuple.Touch(tuple.Parse(tpl)))
 			}
 
 			_, err := client.Write(context.Background(), &v0.WriteRequest{

--- a/internal/services/v0/developer_test.go
+++ b/internal/services/v0/developer_test.go
@@ -129,10 +129,10 @@ func TestEditCheck(t *testing.T) {
 				}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("somenamespace:someobj#somerel@user:foo#..."),
+				tuple.Parse("somenamespace:someobj#somerel@user:foo"),
 			},
 			[]*v0.RelationTuple{
-				tuple.Scan("somenamespace:someobj#anotherrel@user:foo#..."),
+				tuple.Parse("somenamespace:someobj#anotherrel@user:foo"),
 			},
 			nil,
 			[]*v0.EditCheckResult{
@@ -141,7 +141,7 @@ func TestEditCheck(t *testing.T) {
 						Message: "relation/permission `anotherrel` not found under definition `somenamespace`",
 						Kind:    v0.DeveloperError_UNKNOWN_RELATION,
 						Source:  v0.DeveloperError_CHECK_WATCH,
-						Context: "somenamespace:someobj#anotherrel@user:foo#...",
+						Context: "somenamespace:someobj#anotherrel@user:foo",
 					},
 				},
 			},
@@ -155,20 +155,20 @@ func TestEditCheck(t *testing.T) {
 				}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("somenamespace:someobj#somerel@user:foo#..."),
+				tuple.Parse("somenamespace:someobj#somerel@user:foo"),
 			},
 			[]*v0.RelationTuple{
-				tuple.Scan("somenamespace:someobj#somerel@user:foo#..."),
-				tuple.Scan("somenamespace:someobj#somerel@user:anotheruser#..."),
+				tuple.Parse("somenamespace:someobj#somerel@user:foo"),
+				tuple.Parse("somenamespace:someobj#somerel@user:anotheruser"),
 			},
 			nil,
 			[]*v0.EditCheckResult{
 				{
-					Relationship: tuple.Scan("somenamespace:someobj#somerel@user:foo#..."),
+					Relationship: tuple.Parse("somenamespace:someobj#somerel@user:foo"),
 					IsMember:     true,
 				},
 				{
-					Relationship: tuple.Scan("somenamespace:someobj#somerel@user:anotheruser#..."),
+					Relationship: tuple.Parse("somenamespace:someobj#somerel@user:anotheruser"),
 					IsMember:     false,
 				},
 			},
@@ -274,16 +274,16 @@ func TestValidate(t *testing.T) {
 				}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#viewer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#viewer@user:jimmy"),
 			},
 			"",
 			`assertTrue:
-- document:somedoc#viewer@user:jake#...`,
+- document:somedoc#viewer@user:jake`,
 			&v0.DeveloperError{
-				Message: "Expected relation or permission document:somedoc#viewer@user:jake#... to exist",
+				Message: "Expected relation or permission document:somedoc#viewer@user:jake to exist",
 				Kind:    v0.DeveloperError_ASSERTION_FAILED,
 				Source:  v0.DeveloperError_ASSERTION,
-				Context: "document:somedoc#viewer@user:jake#...",
+				Context: "document:somedoc#viewer@user:jake",
 				Line:    2,
 				Column:  3,
 			},
@@ -298,16 +298,16 @@ func TestValidate(t *testing.T) {
 				}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#viewer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#viewer@user:jimmy"),
 			},
 			"",
 			`assertFalse:
-- document:somedoc#viewer@user:jimmy#...`,
+- document:somedoc#viewer@user:jimmy`,
 			&v0.DeveloperError{
-				Message: "Expected relation or permission document:somedoc#viewer@user:jimmy#... to not exist",
+				Message: "Expected relation or permission document:somedoc#viewer@user:jimmy to not exist",
 				Kind:    v0.DeveloperError_ASSERTION_FAILED,
 				Source:  v0.DeveloperError_ASSERTION,
-				Context: "document:somedoc#viewer@user:jimmy#...",
+				Context: "document:somedoc#viewer@user:jimmy",
 				Line:    2,
 				Column:  3,
 			},
@@ -322,12 +322,12 @@ func TestValidate(t *testing.T) {
 			[]*v0.RelationTuple{},
 			"",
 			`assertFalse:
-- document:somedoc#viewer@user:jimmy#...`,
+- document:somedoc#viewer@user:jimmy`,
 			&v0.DeveloperError{
 				Message: "relation/permission `viewer` not found under definition `document`",
 				Kind:    v0.DeveloperError_UNKNOWN_RELATION,
 				Source:  v0.DeveloperError_ASSERTION,
-				Context: "document:somedoc#viewer@user:jimmy#...",
+				Context: "document:somedoc#viewer@user:jimmy",
 				Line:    2,
 				Column:  3,
 			},
@@ -344,19 +344,19 @@ func TestValidate(t *testing.T) {
 			}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#writer@user:jimmy"),
 			},
 			`"document:somedoc#view":`,
 			`assertTrue:
-- document:somedoc#view@user:jimmy#...`,
+- document:somedoc#view@user:jimmy`,
 			&v0.DeveloperError{
-				Message: "For object and permission/relation `document:somedoc#view`, subject `user:jimmy#...` found but missing from specified",
+				Message: "For object and permission/relation `document:somedoc#view`, subject `user:jimmy` found but missing from specified",
 				Kind:    v0.DeveloperError_EXTRA_RELATIONSHIP_FOUND,
 				Source:  v0.DeveloperError_VALIDATION_YAML,
 				Context: "document:somedoc#view",
 			},
 			`document:somedoc#view:
-- '[user:jimmy#...] is <document:somedoc#writer>'
+- '[user:jimmy] is <document:somedoc#writer>'
 `,
 		},
 		{
@@ -370,21 +370,21 @@ func TestValidate(t *testing.T) {
 			}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#writer@user:jimmy"),
 			},
 			`"document:somedoc#view":
-- "[user:jimmy#...] is <document:somedoc#writer>"
-- "[user:jake#...] is <document:somedoc#viewer>"`,
+- "[user:jimmy] is <document:somedoc#writer>"
+- "[user:jake] is <document:somedoc#viewer>"`,
 			`assertTrue:
-- document:somedoc#view@user:jimmy#...`,
+- document:somedoc#view@user:jimmy`,
 			&v0.DeveloperError{
-				Message: "For object and permission/relation `document:somedoc#view`, missing expected subject `user:jake#...`",
+				Message: "For object and permission/relation `document:somedoc#view`, missing expected subject `user:jake`",
 				Kind:    v0.DeveloperError_MISSING_EXPECTED_RELATIONSHIP,
 				Source:  v0.DeveloperError_VALIDATION_YAML,
-				Context: "user:jake#...",
+				Context: "user:jake",
 			},
 			`document:somedoc#view:
-- '[user:jimmy#...] is <document:somedoc#writer>'
+- '[user:jimmy] is <document:somedoc#writer>'
 `,
 		},
 		{
@@ -398,12 +398,12 @@ func TestValidate(t *testing.T) {
 			}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#writer@user:jimmy"),
 			},
 			`"document:somedoc#view":
 - "[user] is <document:somedoc#writer>"`,
 			`assertTrue:
-- document:somedoc#view@user:jimmy#...`,
+- document:somedoc#view@user:jimmy`,
 			&v0.DeveloperError{
 				Message: "For object and permission/relation `document:somedoc#view`, invalid subject: user",
 				Kind:    v0.DeveloperError_PARSE_ERROR,
@@ -411,7 +411,7 @@ func TestValidate(t *testing.T) {
 				Context: "[user]",
 			},
 			`document:somedoc#view:
-- '[user:jimmy#...] is <document:somedoc#writer>'
+- '[user:jimmy] is <document:somedoc#writer>'
 `,
 		},
 		{
@@ -425,12 +425,12 @@ func TestValidate(t *testing.T) {
 			}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#writer@user:jimmy"),
 			},
 			`"document:somedoc#view":
-- "[user:jimmy#...] is <document:som>"`,
+- "[user:jimmy] is <document:som>"`,
 			`assertTrue:
-- document:somedoc#view@user:jimmy#...`,
+- document:somedoc#view@user:jimmy`,
 			&v0.DeveloperError{
 				Message: "For object and permission/relation `document:somedoc#view`, invalid object and relation: document:som",
 				Kind:    v0.DeveloperError_PARSE_ERROR,
@@ -438,7 +438,7 @@ func TestValidate(t *testing.T) {
 				Context: "<document:som>",
 			},
 			`document:somedoc#view:
-- '[user:jimmy#...] is <document:somedoc#writer>'
+- '[user:jimmy] is <document:somedoc#writer>'
 `,
 		},
 		{
@@ -452,20 +452,20 @@ func TestValidate(t *testing.T) {
 			}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#writer@user:jimmy"),
 			},
 			`"document:somedoc#view":
-- "[user:jimmy#...] is <document:somedoc#viewer>"`,
+- "[user:jimmy] is <document:somedoc#viewer>"`,
 			`assertTrue:
-- document:somedoc#view@user:jimmy#...`,
+- document:somedoc#view@user:jimmy`,
 			&v0.DeveloperError{
-				Message: "For object and permission/relation `document:somedoc#view`, found different relationships for subject `user:jimmy#...`: Specified: `<document:somedoc#viewer>`, Computed: `<document:somedoc#writer>`",
+				Message: "For object and permission/relation `document:somedoc#view`, found different relationships for subject `user:jimmy`: Specified: `<document:somedoc#viewer>`, Computed: `<document:somedoc#writer>`",
 				Kind:    v0.DeveloperError_MISSING_EXPECTED_RELATIONSHIP,
 				Source:  v0.DeveloperError_VALIDATION_YAML,
-				Context: `[user:jimmy#...] is <document:somedoc#viewer>`,
+				Context: `[user:jimmy] is <document:somedoc#viewer>`,
 			},
 			`document:somedoc#view:
-- '[user:jimmy#...] is <document:somedoc#writer>'
+- '[user:jimmy] is <document:somedoc#writer>'
 `,
 		},
 		{
@@ -479,23 +479,23 @@ func TestValidate(t *testing.T) {
 			}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writer@user:jimmy#..."),
-				tuple.Scan("document:somedoc#viewer@user:jake#..."),
+				tuple.Parse("document:somedoc#writer@user:jimmy"),
+				tuple.Parse("document:somedoc#viewer@user:jake"),
 			},
 			`"document:somedoc#view":
-- "[user:jimmy#...] is <document:somedoc#writer>"
-- "[user:jake#...] is <document:somedoc#viewer>"`,
+- "[user:jimmy] is <document:somedoc#writer>"
+- "[user:jake] is <document:somedoc#viewer>"`,
 			`assertTrue:
-- document:somedoc#writer@user:jimmy#...
-- document:somedoc#viewer@user:jimmy#...
-- document:somedoc#viewer@user:jake#...
+- document:somedoc#writer@user:jimmy
+- document:somedoc#viewer@user:jimmy
+- document:somedoc#viewer@user:jake
 assertFalse:
-- document:somedoc#writer@user:jake#...
+- document:somedoc#writer@user:jake
 `,
 			nil,
 			`document:somedoc#view:
-- '[user:jake#...] is <document:somedoc#viewer>'
-- '[user:jimmy#...] is <document:somedoc#writer>'
+- '[user:jake] is <document:somedoc#viewer>'
+- '[user:jimmy] is <document:somedoc#writer>'
 `,
 		},
 		{
@@ -509,17 +509,17 @@ assertFalse:
 			}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writer@user:jimmy#..."),
-				tuple.Scan("document:somedoc#viewer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#writer@user:jimmy"),
+				tuple.Parse("document:somedoc#viewer@user:jimmy"),
 			},
 			`"document:somedoc#view":
-- "[user:jimmy#...] is <document:somedoc#writer>/<document:somedoc#viewer>"`,
+- "[user:jimmy] is <document:somedoc#writer>/<document:somedoc#viewer>"`,
 			`assertTrue:
-- document:somedoc#writer@user:jimmy#...
+- document:somedoc#writer@user:jimmy
 `,
 			nil,
 			`document:somedoc#view:
-- '[user:jimmy#...] is <document:somedoc#viewer>/<document:somedoc#writer>'
+- '[user:jimmy] is <document:somedoc#viewer>/<document:somedoc#writer>'
 `,
 		},
 		{
@@ -533,22 +533,22 @@ assertFalse:
 			}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writer@user:jimmy#..."),
-				tuple.Scan("document:somedoc#viewer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#writer@user:jimmy"),
+				tuple.Parse("document:somedoc#viewer@user:jimmy"),
 			},
 			`"document:somedoc#view":
-- "[user:jimmy#...] is <document:somedoc#writer>"`,
+- "[user:jimmy] is <document:somedoc#writer>"`,
 			`assertTrue:
-- document:somedoc#writer@user:jimmy#...
+- document:somedoc#writer@user:jimmy
 `,
 			&v0.DeveloperError{
-				Message: "For object and permission/relation `document:somedoc#view`, found different relationships for subject `user:jimmy#...`: Specified: `<document:somedoc#writer>`, Computed: `<document:somedoc#viewer>/<document:somedoc#writer>`",
+				Message: "For object and permission/relation `document:somedoc#view`, found different relationships for subject `user:jimmy`: Specified: `<document:somedoc#writer>`, Computed: `<document:somedoc#viewer>/<document:somedoc#writer>`",
 				Kind:    v0.DeveloperError_MISSING_EXPECTED_RELATIONSHIP,
 				Source:  v0.DeveloperError_VALIDATION_YAML,
-				Context: `[user:jimmy#...] is <document:somedoc#writer>`,
+				Context: `[user:jimmy] is <document:somedoc#writer>`,
 			},
 			`document:somedoc#view:
-- '[user:jimmy#...] is <document:somedoc#viewer>/<document:somedoc#writer>'
+- '[user:jimmy] is <document:somedoc#viewer>/<document:somedoc#writer>'
 `,
 		},
 		{
@@ -557,7 +557,7 @@ assertFalse:
 			definition user {}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#writer@user:jimmy"),
 			},
 			``,
 			``,
@@ -565,7 +565,7 @@ assertFalse:
 				Message: "object definition `document` not found",
 				Kind:    v0.DeveloperError_UNKNOWN_OBJECT_TYPE,
 				Source:  v0.DeveloperError_RELATIONSHIP,
-				Context: `document:somedoc#writer@user:jimmy#...`,
+				Context: `document:somedoc#writer@user:jimmy`,
 			},
 			``,
 		},
@@ -576,7 +576,7 @@ assertFalse:
 			definition document {}
 			`,
 			[]*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writer@user:jimmy#..."),
+				tuple.Parse("document:somedoc#writer@user:jimmy"),
 			},
 			``,
 			``,
@@ -584,7 +584,7 @@ assertFalse:
 				Message: "relation/permission `writer` not found under definition `document`",
 				Kind:    v0.DeveloperError_UNKNOWN_RELATION,
 				Source:  v0.DeveloperError_RELATIONSHIP,
-				Context: `document:somedoc#writer@user:jimmy#...`,
+				Context: `document:somedoc#writer@user:jimmy`,
 			},
 			``,
 		},
@@ -655,7 +655,22 @@ func TestValidateONR(t *testing.T) {
 			}
 			`,
 			Relationships: []*v0.RelationTuple{
-				tuple.Scan("document:somedoc#writerIsNotValid@user:jimmy#..."),
+				{
+					ObjectAndRelation: &v0.ObjectAndRelation{
+						Namespace: "document",
+						ObjectId:  "somedoc",
+						Relation:  "writerIsNotValid",
+					},
+					User: &v0.User{
+						UserOneof: &v0.User_Userset{
+							Userset: &v0.ObjectAndRelation{
+								Namespace: "user",
+								ObjectId:  "jimmy",
+								Relation:  "...",
+							},
+						},
+					},
+				},
 			},
 		},
 		ValidationYaml:       "",
@@ -668,6 +683,6 @@ func TestValidateONR(t *testing.T) {
 		Message: "invalid RelationTuple.ObjectAndRelation: embedded message failed validation | caused by: invalid ObjectAndRelation.Relation: value does not match regex pattern \"^(\\\\.\\\\.\\\\.|[a-z][a-z0-9_]{2,62}[a-z0-9])$\"",
 		Kind:    v0.DeveloperError_PARSE_ERROR,
 		Source:  v0.DeveloperError_RELATIONSHIP,
-		Context: `document:somedoc#writerIsNotValid@user:jimmy#...`,
+		Context: `document:somedoc#writerIsNotValid@user:jimmy`,
 	}, resp.RequestErrors[0])
 }

--- a/internal/services/v0/namespace_test.go
+++ b/internal/services/v0/namespace_test.go
@@ -84,7 +84,7 @@ func TestNamespaceChanged(t *testing.T) {
 					ns.RelationReference("user", "..."),
 				),
 			),
-			[]*v0.RelationTuple{tuple.Scan("folder:somefolder#viewer@user:someuser#...")},
+			[]*v0.RelationTuple{tuple.Parse("folder:somefolder#viewer@user:someuser#...")},
 			ns.Namespace(
 				"folder",
 			),
@@ -103,7 +103,7 @@ func TestNamespaceChanged(t *testing.T) {
 					ns.RelationReference("user", "..."),
 				),
 			),
-			[]*v0.RelationTuple{tuple.Scan("folder:somefolder#anotherrel@folder:somefolder#viewer")},
+			[]*v0.RelationTuple{tuple.Parse("folder:somefolder#anotherrel@folder:somefolder#viewer")},
 			ns.Namespace(
 				"folder",
 				ns.Relation("anotherrel",
@@ -122,7 +122,7 @@ func TestNamespaceChanged(t *testing.T) {
 					ns.RelationReference("user", "..."),
 				),
 			),
-			[]*v0.RelationTuple{tuple.Scan("folder:somefolder#viewer@user:someuser#...")},
+			[]*v0.RelationTuple{tuple.Parse("folder:somefolder#viewer@user:someuser#...")},
 			ns.Namespace(
 				"folder",
 				ns.Relation("viewer",
@@ -160,7 +160,7 @@ func TestNamespaceChanged(t *testing.T) {
 					ns.RelationReference("user", "..."),
 				),
 			),
-			[]*v0.RelationTuple{tuple.Scan("folder:somefolder#viewer@user:someuser#...")},
+			[]*v0.RelationTuple{tuple.Parse("folder:somefolder#viewer@user:someuser#...")},
 			ns.Namespace(
 				"folder",
 				ns.Relation("viewer",
@@ -252,7 +252,7 @@ func TestDeleteNamespace(t *testing.T) {
 			),
 			[]string{"folder"},
 			[]*v0.RelationTuple{
-				tuple.Scan("folder:somefolder#viewer@user:someuser#..."),
+				tuple.Parse("folder:somefolder#viewer@user:someuser#..."),
 			},
 			"cannot delete definition `folder`, as a relationship exists under it",
 		},
@@ -267,7 +267,7 @@ func TestDeleteNamespace(t *testing.T) {
 			),
 			[]string{"user"},
 			[]*v0.RelationTuple{
-				tuple.Scan("folder:somefolder#viewer@user:someuser#..."),
+				tuple.Parse("folder:somefolder#viewer@user:someuser#..."),
 			},
 			"cannot delete definition `user`, as a relationship references it",
 		},

--- a/internal/services/v1/schema_test.go
+++ b/internal/services/v1/schema_test.go
@@ -110,7 +110,7 @@ func TestSchemaDeleteRelation(t *testing.T) {
 
 	_, err = aclSrv.Write(context.Background(), &v0.WriteRequest{
 		Updates: []*v0.RelationTupleUpdate{tuple.Create(
-			tuple.Scan("example/document:somedoc#somerelation@example/user:someuser#..."),
+			tuple.Parse("example/document:somedoc#somerelation@example/user:someuser#..."),
 		)},
 	})
 	require.Nil(t, err)
@@ -138,7 +138,7 @@ func TestSchemaDeleteRelation(t *testing.T) {
 	// Delete the relationship.
 	_, err = aclSrv.Write(context.Background(), &v0.WriteRequest{
 		Updates: []*v0.RelationTupleUpdate{tuple.Delete(
-			tuple.Scan("example/document:somedoc#somerelation@example/user:someuser#..."),
+			tuple.Parse("example/document:somedoc#somerelation@example/user:someuser#..."),
 		)},
 	})
 	require.Nil(t, err)
@@ -178,7 +178,7 @@ func TestSchemaDeleteDefinition(t *testing.T) {
 
 	_, err = aclSrv.Write(context.Background(), &v0.WriteRequest{
 		Updates: []*v0.RelationTupleUpdate{tuple.Create(
-			tuple.Scan("example/document:somedoc#somerelation@example/user:someuser#..."),
+			tuple.Parse("example/document:somedoc#somerelation@example/user:someuser#..."),
 		)},
 	})
 	require.Nil(t, err)
@@ -192,7 +192,7 @@ func TestSchemaDeleteDefinition(t *testing.T) {
 	// Delete the relationship.
 	_, err = aclSrv.Write(context.Background(), &v0.WriteRequest{
 		Updates: []*v0.RelationTupleUpdate{tuple.Delete(
-			tuple.Scan("example/document:somedoc#somerelation@example/user:someuser#..."),
+			tuple.Parse("example/document:somedoc#somerelation@example/user:someuser#..."),
 		)},
 	})
 	require.Nil(t, err)

--- a/internal/services/v1alpha1/acl_test.go
+++ b/internal/services/v1alpha1/acl_test.go
@@ -44,7 +44,7 @@ func TestAttemptWriteRelationshipToPermission(t *testing.T) {
 
 	_, err = aclSrv.Write(context.Background(), &v0.WriteRequest{
 		Updates: []*v0.RelationTupleUpdate{tuple.Create(
-			tuple.Scan("example/document:somedoc#reader@example/user:someuser#..."),
+			tuple.Parse("example/document:somedoc#reader@example/user:someuser#..."),
 		)},
 	})
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestAttemptWriteRelationshipToPermission(t *testing.T) {
 	// Attempt to write a relation to the permission, which should fail.
 	_, err = aclSrv.Write(context.Background(), &v0.WriteRequest{
 		Updates: []*v0.RelationTupleUpdate{tuple.Create(
-			tuple.Scan("example/document:somedoc#read@example/user:someuser#..."),
+			tuple.Parse("example/document:somedoc#read@example/user:someuser#..."),
 		)},
 	})
 	grpcutil.RequireStatus(t, codes.InvalidArgument, err)

--- a/internal/services/v1alpha1/schema_test.go
+++ b/internal/services/v1alpha1/schema_test.go
@@ -198,7 +198,7 @@ func TestSchemaDeleteRelation(t *testing.T) {
 
 	_, err = aclSrv.Write(context.Background(), &v0.WriteRequest{
 		Updates: []*v0.RelationTupleUpdate{tuple.Create(
-			tuple.Scan("example/document:somedoc#somerelation@example/user:someuser#..."),
+			tuple.Parse("example/document:somedoc#somerelation@example/user:someuser#..."),
 		)},
 	})
 	require.Nil(t, err)
@@ -226,7 +226,7 @@ func TestSchemaDeleteRelation(t *testing.T) {
 	// Delete the relationship.
 	_, err = aclSrv.Write(context.Background(), &v0.WriteRequest{
 		Updates: []*v0.RelationTupleUpdate{tuple.Delete(
-			tuple.Scan("example/document:somedoc#somerelation@example/user:someuser#..."),
+			tuple.Parse("example/document:somedoc#somerelation@example/user:someuser#..."),
 		)},
 	})
 	require.Nil(t, err)

--- a/internal/testfixtures/datastore.go
+++ b/internal/testfixtures/datastore.go
@@ -118,7 +118,7 @@ func StandardDatastoreWithData(ds datastore.Datastore, require *require.Assertio
 
 	var revision datastore.Revision
 	for _, tupleStr := range StandardTuples {
-		tpl := tuple.Scan(tupleStr)
+		tpl := tuple.Parse(tupleStr)
 		require.NotNil(tpl)
 
 		var err error

--- a/pkg/membership/membership_test.go
+++ b/pkg/membership/membership_test.go
@@ -62,17 +62,17 @@ func TestMembershipSet(t *testing.T) {
 	fso, ok, err := ms.AddExpansion(ONR("folder", "company", "owner"), companyOwner)
 	require.True(ok)
 	require.NoError(err)
-	verifySubjects(require, fso, "user:owner#...")
+	verifySubjects(require, fso, "user:owner")
 
 	fse, ok, err := ms.AddExpansion(ONR("folder", "company", "editor"), companyEditor)
 	require.True(ok)
 	require.NoError(err)
-	verifySubjects(require, fse, "user:owner#...", "user:writer#...")
+	verifySubjects(require, fse, "user:owner", "user:writer")
 
 	fsv, ok, err := ms.AddExpansion(ONR("folder", "company", "viewer"), companyViewerRecursive)
 	require.True(ok)
 	require.NoError(err)
-	verifySubjects(require, fsv, "folder:auditors#viewer", "user:auditor#...", "user:legal#...", "user:owner#...", "user:writer#...")
+	verifySubjects(require, fsv, "folder:auditors#viewer", "user:auditor", "user:legal", "user:owner", "user:writer")
 }
 
 func TestMembershipSetIntersection(t *testing.T) {
@@ -93,7 +93,7 @@ func TestMembershipSetIntersection(t *testing.T) {
 	fso, ok, err := ms.AddExpansion(ONR("folder", "company", "viewer"), intersection)
 	require.True(ok)
 	require.NoError(err)
-	verifySubjects(require, fso, "user:legal#...")
+	verifySubjects(require, fso, "user:legal")
 }
 
 func TestMembershipSetExclusion(t *testing.T) {
@@ -114,7 +114,7 @@ func TestMembershipSetExclusion(t *testing.T) {
 	fso, ok, err := ms.AddExpansion(ONR("folder", "company", "viewer"), intersection)
 	require.True(ok)
 	require.NoError(err)
-	verifySubjects(require, fso, "user:owner#...")
+	verifySubjects(require, fso, "user:owner")
 }
 
 func verifySubjects(require *require.Assertions, fs FoundSubjects, expected ...string) {

--- a/pkg/tuple/onr.go
+++ b/pkg/tuple/onr.go
@@ -2,19 +2,19 @@ package tuple
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
 
 	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
+	"github.com/jzelinskie/stringz"
 )
 
 const (
 	// Format is the serialized form of the tuple
-	onrFormat = "%s:%s#%s"
+	formatWithRel            = "%s:%s#%s"
+	formatImplicitSubjectRel = "%s:%s"
 )
 
-var onrRegex = regexp.MustCompile(`([^:]*):([^#]*)#([^@]*)`)
-
+// ObjectAndRelation creates an ONR from string pieces.
 func ObjectAndRelation(ns, oid, rel string) *v0.ObjectAndRelation {
 	return &v0.ObjectAndRelation{
 		Namespace: ns,
@@ -23,22 +23,46 @@ func ObjectAndRelation(ns, oid, rel string) *v0.ObjectAndRelation {
 	}
 }
 
+// User creates a user wrapping a userset ONR.
 func User(userset *v0.ObjectAndRelation) *v0.User {
 	return &v0.User{UserOneof: &v0.User_Userset{Userset: userset}}
 }
 
-// ScanONR converts a string representation of an ONR to a proto object.
-func ScanONR(onr string) *v0.ObjectAndRelation {
+// ParseSubjectONR converts a string representation of a Subject ONR to a proto object. Unlike
+// ParseONR, this method allows for objects without relations. If an object without a relation
+// is given, the relation will be set to ellipsis.
+func ParseSubjectONR(subjectOnr string) *v0.ObjectAndRelation {
+	groups := subjectRegex.FindStringSubmatch(subjectOnr)
+
+	if len(groups) == 0 {
+		return nil
+	}
+
+	relation := "..."
+	subjectRelIndex := stringz.SliceIndex(subjectRegex.SubexpNames(), "subjectRel")
+	if len(groups[subjectRelIndex]) > 0 {
+		relation = groups[subjectRelIndex]
+	}
+
+	return &v0.ObjectAndRelation{
+		Namespace: groups[stringz.SliceIndex(subjectRegex.SubexpNames(), "subjectType")],
+		ObjectId:  groups[stringz.SliceIndex(subjectRegex.SubexpNames(), "subjectID")],
+		Relation:  relation,
+	}
+}
+
+// ParseONR converts a string representation of an ONR to a proto object.
+func ParseONR(onr string) *v0.ObjectAndRelation {
 	groups := onrRegex.FindStringSubmatch(onr)
 
-	if len(groups) != 4 {
+	if len(groups) == 0 {
 		return nil
 	}
 
 	return &v0.ObjectAndRelation{
-		Namespace: groups[1],
-		ObjectId:  groups[2],
-		Relation:  groups[3],
+		Namespace: groups[stringz.SliceIndex(onrRegex.SubexpNames(), "resourceType")],
+		ObjectId:  groups[stringz.SliceIndex(onrRegex.SubexpNames(), "resourceID")],
+		Relation:  groups[stringz.SliceIndex(onrRegex.SubexpNames(), "resourceRel")],
 	}
 }
 
@@ -48,7 +72,11 @@ func StringONR(onr *v0.ObjectAndRelation) string {
 		return ""
 	}
 
-	return fmt.Sprintf(onrFormat, onr.Namespace, onr.ObjectId, onr.Relation)
+	if onr.Relation == ellipsis {
+		return fmt.Sprintf(formatImplicitSubjectRel, onr.Namespace, onr.ObjectId)
+	}
+
+	return fmt.Sprintf(formatWithRel, onr.Namespace, onr.ObjectId, onr.Relation)
 }
 
 // StringsONRs converts ONR objects to a string slice, sorted.

--- a/pkg/tuple/onr_test.go
+++ b/pkg/tuple/onr_test.go
@@ -16,6 +16,14 @@ var onrTestCases = []struct {
 		objectFormat: ObjectAndRelation("tenant/testns", "testobj", "testrel"),
 	},
 	{
+		serialized:   "tenant/testns:testobj#...",
+		objectFormat: nil,
+	},
+	{
+		serialized:   "tenant/testns:testobj",
+		objectFormat: nil,
+	},
+	{
 		serialized:   "",
 		objectFormat: nil,
 	},
@@ -23,21 +31,65 @@ var onrTestCases = []struct {
 
 func TestSerializeONR(t *testing.T) {
 	for _, tc := range onrTestCases {
+		if tc.objectFormat == nil {
+			continue
+		}
+
 		t.Run(tc.serialized, func(t *testing.T) {
 			require := require.New(t)
-
 			serialized := StringONR(tc.objectFormat)
 			require.Equal(tc.serialized, serialized)
 		})
 	}
 }
 
-func TestScanONR(t *testing.T) {
+func TestParseONR(t *testing.T) {
 	for _, tc := range onrTestCases {
 		t.Run(tc.serialized, func(t *testing.T) {
 			require := require.New(t)
 
-			parsed := ScanONR(tc.serialized)
+			parsed := ParseONR(tc.serialized)
+			require.Equal(tc.objectFormat, parsed)
+		})
+	}
+}
+
+var subjectOnrTestCases = []struct {
+	serialized   string
+	objectFormat *v0.ObjectAndRelation
+}{
+	{
+		serialized:   "tenant/testns:testobj#testrel",
+		objectFormat: ObjectAndRelation("tenant/testns", "testobj", "testrel"),
+	},
+	{
+		serialized:   "tenant/testns:testobj#...",
+		objectFormat: ObjectAndRelation("tenant/testns", "testobj", "..."),
+	},
+	{
+		serialized:   "tenant/testns:testobj",
+		objectFormat: ObjectAndRelation("tenant/testns", "testobj", "..."),
+	},
+	{
+		serialized:   "tenant/testns:testobj#",
+		objectFormat: nil,
+	},
+	{
+		serialized:   "tenant/testns:testobj:",
+		objectFormat: nil,
+	},
+	{
+		serialized:   "",
+		objectFormat: nil,
+	},
+}
+
+func TestParseSubjectONR(t *testing.T) {
+	for _, tc := range subjectOnrTestCases {
+		t.Run(tc.serialized, func(t *testing.T) {
+			require := require.New(t)
+
+			parsed := ParseSubjectONR(tc.serialized)
 			require.Equal(tc.objectFormat, parsed)
 		})
 	}

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -15,40 +15,125 @@ func makeTuple(onr *v0.ObjectAndRelation, userset *v0.ObjectAndRelation) *v0.Rel
 }
 
 var testCases = []struct {
-	serialized   string
-	objectFormat *v0.RelationTuple
+	input          string
+	expectedOutput string
+	objectFormat   *v0.RelationTuple
 }{
 	{
-		serialized: "tenant/testns:testobj#testrel@tenant/user:testusr#...",
+		input:          "testns:testobj#testrel@user:testusr",
+		expectedOutput: "testns:testobj#testrel@user:testusr",
+		objectFormat: makeTuple(
+			ObjectAndRelation("testns", "testobj", "testrel"),
+			ObjectAndRelation("user", "testusr", "..."),
+		),
+	},
+	{
+		input:          "testns:testobj#testrel@user:testusr#...",
+		expectedOutput: "testns:testobj#testrel@user:testusr",
+		objectFormat: makeTuple(
+			ObjectAndRelation("testns", "testobj", "testrel"),
+			ObjectAndRelation("user", "testusr", "..."),
+		),
+	},
+	{
+		input:          "tenant/testns:testobj#testrel@tenant/user:testusr",
+		expectedOutput: "tenant/testns:testobj#testrel@tenant/user:testusr",
 		objectFormat: makeTuple(
 			ObjectAndRelation("tenant/testns", "testobj", "testrel"),
 			ObjectAndRelation("tenant/user", "testusr", "..."),
 		),
 	},
 	{
-		serialized:   "",
-		objectFormat: nil,
+		input:          "tenant/testns:testobj#testrel@tenant/user:testusr#...",
+		expectedOutput: "tenant/testns:testobj#testrel@tenant/user:testusr",
+		objectFormat: makeTuple(
+			ObjectAndRelation("tenant/testns", "testobj", "testrel"),
+			ObjectAndRelation("tenant/user", "testusr", "..."),
+		),
+	},
+	{
+		input:          "tenant/testns:testobj#testrel@tenant/user:testusr#somerel",
+		expectedOutput: "tenant/testns:testobj#testrel@tenant/user:testusr#somerel",
+		objectFormat: makeTuple(
+			ObjectAndRelation("tenant/testns", "testobj", "testrel"),
+			ObjectAndRelation("tenant/user", "testusr", "somerel"),
+		),
+	},
+	{
+		input:          "tenant/testns:testobj#testrel@tenant/user:testusr something",
+		expectedOutput: "tenant/testns:testobj#testrel@tenant/user:testusr",
+		objectFormat:   nil,
+	},
+	{
+		input:          "tenant/testns:testobj#testrel@tenant/user:testusr:",
+		expectedOutput: "tenant/testns:testobj#testrel@tenant/user:testusr",
+		objectFormat:   nil,
+	},
+	{
+		input:          "tenant/testns:testobj#testrel@tenant/user:testusr#",
+		expectedOutput: "tenant/testns:testobj#testrel@tenant/user:testusr",
+		objectFormat:   nil,
+	},
+	{
+		input:          "",
+		expectedOutput: "",
+		objectFormat:   nil,
+	},
+	{
+		input:          "foos:bar#bazzy@groo:grar#...",
+		expectedOutput: "foos:bar#bazzy@groo:grar",
+		objectFormat: makeTuple(
+			ObjectAndRelation("foos", "bar", "bazzy"),
+			ObjectAndRelation("groo", "grar", "..."),
+		),
 	},
 }
 
 func TestSerialize(t *testing.T) {
 	for _, tc := range testCases {
-		t.Run(tc.serialized, func(t *testing.T) {
+		t.Run(tc.input, func(t *testing.T) {
 			require := require.New(t)
+			if tc.objectFormat == nil {
+				return
+			}
 
 			serialized := String(tc.objectFormat)
-			require.Equal(tc.serialized, serialized)
+			require.Equal(tc.expectedOutput, serialized)
 		})
 	}
 }
 
-func TestScan(t *testing.T) {
+func TestParse(t *testing.T) {
 	for _, tc := range testCases {
-		t.Run(tc.serialized, func(t *testing.T) {
+		t.Run(tc.input, func(t *testing.T) {
 			require := require.New(t)
 
-			parsed := Scan(tc.serialized)
+			parsed := Parse(tc.input)
 			require.Equal(tc.objectFormat, parsed)
+		})
+	}
+}
+
+func TestConvert(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			require := require.New(t)
+
+			parsed := Parse(tc.input)
+			require.Equal(tc.objectFormat, parsed)
+			if parsed == nil {
+				return
+			}
+
+			relationship := ToRelationship(parsed)
+			relString := RelString(relationship)
+			require.Equal(tc.expectedOutput, relString)
+
+			backToTpl := FromRelationship(relationship)
+			require.Equal(tc.objectFormat, backToTpl)
+
+			serialized := String(backToTpl)
+			require.Equal(tc.expectedOutput, serialized)
 		})
 	}
 }

--- a/pkg/validationfile/fileformat.go
+++ b/pkg/validationfile/fileformat.go
@@ -3,6 +3,7 @@ package validationfile
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
 	yaml "gopkg.in/yaml.v2"
@@ -131,7 +132,7 @@ type ObjectRelationString string
 // ONR returns the ObjectAndRelation parsed from this string, if valid, or an error on failure
 // to parse.
 func (ors ObjectRelationString) ONR() (*v0.ObjectAndRelation, *ErrorWithSource) {
-	parsed := tuple.ScanONR(string(ors))
+	parsed := tuple.ParseONR(string(ors))
 	if parsed == nil {
 		return nil, &ErrorWithSource{fmt.Errorf("could not parse %s", ors), string(ors), 0, 0}
 	}
@@ -165,7 +166,7 @@ func (vs ValidationString) Subject() (*v0.ObjectAndRelation, *ErrorWithSource) {
 		return nil, nil
 	}
 
-	found := tuple.ScanONR(subjectStr)
+	found := tuple.ParseSubjectONR(subjectStr)
 	if found == nil {
 		return nil, &ErrorWithSource{fmt.Errorf("invalid subject: %s", subjectStr), subjectStr, 0, 0}
 	}
@@ -188,7 +189,7 @@ func (vs ValidationString) ONRS() ([]*v0.ObjectAndRelation, *ErrorWithSource) {
 
 	onrs := []*v0.ObjectAndRelation{}
 	for _, onrString := range onrStrings {
-		found := tuple.ScanONR(onrString)
+		found := tuple.ParseONR(onrString)
 		if found == nil {
 			return nil, &ErrorWithSource{fmt.Errorf("invalid object and relation: %s", onrString), onrString, 0, 0}
 		}
@@ -230,7 +231,8 @@ type ParsedAssertion struct {
 func (a Assertions) AssertTrueRelationships() ([]ParsedAssertion, *ErrorWithSource) {
 	var relationships []ParsedAssertion
 	for _, assertion := range a.AssertTrue {
-		parsed := tuple.Scan(assertion.relationshipString)
+		trimmed := strings.TrimSpace(assertion.relationshipString)
+		parsed := tuple.Parse(trimmed)
 		if parsed == nil {
 			return relationships, &ErrorWithSource{
 				fmt.Errorf("could not parse relationship `%s`", assertion.relationshipString),
@@ -252,7 +254,8 @@ func (a Assertions) AssertTrueRelationships() ([]ParsedAssertion, *ErrorWithSour
 func (a Assertions) AssertFalseRelationships() ([]ParsedAssertion, *ErrorWithSource) {
 	var relationships []ParsedAssertion
 	for _, assertion := range a.AssertFalse {
-		parsed := tuple.Scan(assertion.relationshipString)
+		trimmed := strings.TrimSpace(assertion.relationshipString)
+		parsed := tuple.Parse(trimmed)
 		if parsed == nil {
 			return relationships, &ErrorWithSource{
 				fmt.Errorf("could not parse relationship `%s`", assertion.relationshipString),

--- a/pkg/validationfile/fileformat_test.go
+++ b/pkg/validationfile/fileformat_test.go
@@ -25,13 +25,13 @@ func TestValidationString(t *testing.T) {
 		{
 			"basic",
 			"[tenant/user:someuser#...] is <tenant/document:example#viewer>",
-			"tenant/user:someuser#...",
+			"tenant/user:someuser",
 			[]string{"tenant/document:example#viewer"},
 		},
 		{
 			"missing onrs",
 			"[tenant/user:someuser#...]",
-			"tenant/user:someuser#...",
+			"tenant/user:someuser",
 			[]string{},
 		},
 		{
@@ -43,7 +43,13 @@ func TestValidationString(t *testing.T) {
 		{
 			"multiple onrs",
 			"[tenant/user:someuser#...] is <tenant/document:example#viewer>/<tenant/document:example#builder>",
-			"tenant/user:someuser#...",
+			"tenant/user:someuser",
+			[]string{"tenant/document:example#viewer", "tenant/document:example#builder"},
+		},
+		{
+			"ellided ellipsis",
+			"[tenant/user:someuser] is <tenant/document:example#viewer>/<tenant/document:example#builder>",
+			"tenant/user:someuser",
 			[]string{"tenant/document:example#viewer", "tenant/document:example#builder"},
 		},
 		{
@@ -54,7 +60,7 @@ func TestValidationString(t *testing.T) {
 		},
 		{
 			"bad parse",
-			"[tenant/user:someuser...] is <tenant/document:example#viewer>/<tenant/document:example#builder>",
+			"[tenant/user:someuser:asdsad] is <tenant/document:example#viewer>/<tenant/document:example#builder>",
 			"",
 			[]string{"tenant/document:example#viewer", "tenant/document:example#builder"},
 		},
@@ -85,21 +91,31 @@ func TestValidationString(t *testing.T) {
 
 func TestAssertions(t *testing.T) {
 	type testCase struct {
-		name     string
-		input    string
-		expected bool
+		name                 string
+		input                string
+		expectedRelationship string
 	}
 
 	tests := []testCase{
 		{
 			"empty",
 			"",
-			false,
+			"",
 		},
 		{
 			"empty",
-			"foo:bar#baz@groo:grar#graz",
-			true,
+			"foos:bar#bazzy@groo:grar#graz",
+			"foos:bar#bazzy@groo:grar#graz",
+		},
+		{
+			"empty",
+			"foos:bar#bazzy@groo:grar",
+			"foos:bar#bazzy@groo:grar",
+		},
+		{
+			"empty",
+			"foos:bar#bazzy@groo:grar#...",
+			"foos:bar#bazzy@groo:grar",
 		},
 	}
 
@@ -114,8 +130,8 @@ func TestAssertions(t *testing.T) {
 				foundRelationships = append(foundRelationships, tuple.String(assertion.Relationship))
 			}
 
-			if tc.expected {
-				require.Equal([]string{tc.input}, foundRelationships)
+			if tc.expectedRelationship != "" {
+				require.Equal([]string{tc.expectedRelationship}, foundRelationships)
 			} else {
 				require.Equal(0, len(foundRelationships))
 			}

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -98,7 +98,7 @@ func PopulateFromFiles(ds datastore.Datastore, filePaths []string) (*FullyParsed
 					continue
 				}
 
-				tpl := tuple.Scan(trimmed)
+				tpl := tuple.Parse(trimmed)
 				if tpl == nil {
 					return nil, decimal.Zero, fmt.Errorf("Error parsing relationship #%v: %s", index, trimmed)
 				}
@@ -119,7 +119,7 @@ func PopulateFromFiles(ds datastore.Datastore, filePaths []string) (*FullyParsed
 
 		log.Info().Str("filePath", filePath).Int("tupleCount", len(updates)+len(parsed.ValidationTuples)).Msg("Loading test data")
 		for index, validationTuple := range parsed.ValidationTuples {
-			tpl := tuple.Scan(validationTuple)
+			tpl := tuple.Parse(validationTuple)
 			if tpl == nil {
 				return nil, decimal.Zero, fmt.Errorf("Error parsing validation tuple #%v: %s", index, validationTuple)
 			}


### PR DESCRIPTION
Ellipsis is now *optional* as part of a subject ONR and all string conversions will elide adding it