### PR TITLE
buf: remove non-existent authzed-api path

### DIFF
--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,5 +1,4 @@
 ---
 version: "v1"
 directories:
-  - "proto/authzed-api"
   - "proto/internal"


### PR DESCRIPTION
I just noticed that we forgot to delete this in #84