### PR TITLE
add version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,9 @@ builds:
       - "amd64"
       - "arm64"
     mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - "-s -w"
+      - "-X {{ .Env.PKG }}internal/version.Version={{ .Version }}"
 nfpms:
   - vendor: "authzed inc."
     homepage: "https://spicedb.io"

--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -12,6 +12,7 @@ var persistentPreRunE = cobrautil.CommandStack(
 
 func main() {
 	rootCmd := newRootCmd()
+	registerVersionCmd(rootCmd)
 	registerServeCmd(rootCmd)
 	registerMigrateCmd(rootCmd)
 	registerHeadCmd(rootCmd)

--- a/cmd/spicedb/version.go
+++ b/cmd/spicedb/version.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/jzelinskie/cobrautil"
+	"github.com/spf13/cobra"
+
+	"github.com/authzed/spicedb/internal/version"
+)
+
+func registerVersionCmd(rootCmd *cobra.Command) {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "displays the version of spicedb",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version.UsageVersion(cobrautil.MustGetBool(cmd, "include-deps")))
+		},
+	}
+	versionCmd.Flags().Bool("include-deps", false, "include versions of dependencies")
+	rootCmd.AddCommand(versionCmd)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,76 @@
+package version
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"strings"
+)
+
+// Version is this program's version string
+var Version string
+
+// UsageVersion introspects the process debug data for Go modules to return a
+// version string.
+func UsageVersion(includeDeps bool) string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		panic("failed to read BuildInfo because the program was compiled with Go " + runtime.Version())
+	}
+
+	if Version == "" {
+		// The version wasn't set by ldflags, so fallback to the git sha
+		Version = sha()
+	}
+
+	if Version == "" {
+		// Couldn't determine git sha, fall back to build info
+		// Although, this value is pretty much guaranteed to just be "(devel)".
+		Version = bi.Main.Version
+	}
+
+	if !includeDeps {
+		if Version == "(devel)" {
+			return "spicedb development build (unknown exact version)"
+		}
+		return "spicedb " + Version
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %s", bi.Path, Version)
+	for _, dep := range bi.Deps {
+		fmt.Fprintf(&b, "\n\t%s %s", dep.Path, dep.Version)
+	}
+	return b.String()
+}
+
+func sha() string {
+	info, err := os.Stat(".git")
+	if os.IsNotExist(err) {
+		return ""
+	}
+	dotGit := info.Name()
+
+	// handle submodule case, .git points to the real directory
+	if !info.IsDir() {
+		file, err := os.ReadFile(info.Name())
+		if err != nil {
+			return ""
+		}
+		dotGit = strings.TrimSpace(strings.TrimPrefix(string(file), "gitdir: "))
+	}
+
+	// head ref location
+	headFile, err := os.ReadFile(filepath.Join(dotGit, "HEAD"))
+	if err != nil {
+		return ""
+	}
+	headRef := strings.TrimSpace(strings.TrimPrefix(string(headFile), "ref: "))
+	sha, err := os.ReadFile(filepath.Join(dotGit, headRef))
+	if err != nil {
+		return ""
+	}
+	return string(sha)
+}


### PR DESCRIPTION
This is mostly the same thing we do for `zed`, but it will also attempt to pick up the git sha if it can.

Run with git info available (works with submodules too)

```
$ go run ./cmd/spicedb/... version
10:12AM INF set log level new level=info
10:12AM INF set tracing provider new provider=none
spicedb 0f786b753045a96ac447225cf23fb47bf49d6928
```

Set a git sha as version:
```
$ go run -ldflags="-X github.com/authzed/spicedb/internal/version.Version=0f786b75" ./cmd/spicedb/... version
10:16AM INF set log level new level=info
10:16AM INF set tracing provider new provider=none
spicedb 0f786b75
```

Set a tagged version:
```
$ go run -ldflags="-X github.com/authzed/spicedb/internal/version.Version=v1.2.3" ./cmd/spicedb/... version
10:14AM INF set log level new level=info
10:14AM INF set tracing provider new provider=none
spicedb v1.2.3
```

The git sha parsing is simple / manual to avoid pulling in a dependency. I was on the fence on whether it was worth it, since 98% of the time we should be injecting the git sha into the build in CI.