### PR TITLE
allow head install from brew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,9 @@ brews:
     test: |
       system "#{bin}/spicedb version"
     install: |
+      if !File.exists? "spicedb"
+        system "go build --ldflags \"-s -w -X github.com/authzed/spicedb/internal/version.Version=$(git describe --always --abbrev=7 --dirty)\" ./cmd/spicedb"
+      end
       bin.install "spicedb"
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
If a prebuilt `spicedb` can't be found, this will build from source