### PR TITLE
Ensure e2e doesn't time out when it would have succeeded

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,9 +104,11 @@ jobs:
       - name: "Run e2e"
         working-directory: "e2e/newenemy"
         run: |
-          go test -v -timeout 20m ./...
+          go test -v -timeout 30m ./...
       - uses: "actions/upload-artifact@v2"
         if: "always()"
+        # this upload step is really flaky, don't fail the job if it fails
+        continue-on-error: true
         with:
           name: "node-logs"
           path: "e2e/newenemy/*.log"


### PR DESCRIPTION
Because of the network delay added for the newenemy test, sometimes the number of required successful iterations exceeded the timeout. This change makes the timeout depend on the number of iterations picked.

I also adjusted the constants to try to improve the worst-case runtime, and marked the artifact upload step to not fail the job if it fails (since it has a surprisingly high failure rate).