### PR TITLE
fix TestReadBadZookieFlake

### DIFF
--- a/internal/services/v0/acl_test.go
+++ b/internal/services/v0/acl_test.go
@@ -246,7 +246,7 @@ func TestRead(t *testing.T) {
 func TestReadBadZookie(t *testing.T) {
 	require := require.New(t)
 
-	client, stop, revision, _ := newACLServicer(require, 0, 10*time.Millisecond, 0)
+	client, stop, revision, _ := newACLServicer(require, 0, 20*time.Millisecond, 0)
 	defer stop()
 
 	_, err := client.Read(context.Background(), &v0.ReadRequest{
@@ -266,7 +266,7 @@ func TestReadBadZookie(t *testing.T) {
 	require.NoError(err)
 
 	// Wait until the gc window expires
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(40 * time.Millisecond)
 
 	_, err = client.Read(context.Background(), &v0.ReadRequest{
 		Tuplesets: []*v0.RelationTupleFilter{


### PR DESCRIPTION
The flake is caused by GC pauses. I can't produce a failure with `GOGC=off`.

When the test gets unlucky w.r.t GC, the timestamps in the changelog can be behind `now-gcwindow` by 5-7ms. Bumping the GC window up a bit stabilizes the test so that `now-gcwindow` is less than the changelog timestamps even if there are GC pauses.

Prior to this change, I could get 1-5 failures / 1k runs. After the change, I can't reproduce the flake.

Fixes #101 
