### PR TITLE
Increase gc window for revision expiration test

### DIFF
--- a/internal/datastore/test/tuples.go
+++ b/internal/datastore/test/tuples.go
@@ -433,7 +433,7 @@ func DeleteRelationshipsTest(t *testing.T, tester DatastoreTester) {
 // invalid revisions hold for a particular datastore.
 func InvalidReadsTest(t *testing.T, tester DatastoreTester) {
 	t.Run("revision expiration", func(t *testing.T) {
-		testGCDuration := 40 * time.Millisecond
+		testGCDuration := 600 * time.Millisecond
 
 		require := require.New(t)
 


### PR DESCRIPTION
On the github runners, presumably due to noisy neighbors, sometimes the initial check in `InvalidReadsTest` would find that the zookie that it had just written had already fallen outside the gcwindow.

The value I picked worked locally for me (I was able to reproduce easily, presumably due to Cockroach running in qemu in docker on m1)