### PR TITLE
add support for decorators to schema langauge

### DIFF
--- a/pkg/schemadsl/dslshape/dslshape.go
+++ b/pkg/schemadsl/dslshape/dslshape.go
@@ -17,6 +17,9 @@ const (
 	NodeTypeRelation   // A relation
 	NodeTypePermission // A permission
 
+	NodeTypeDecorator        // A decorator
+	NodeTypeDecoratorOptions // Options for a decorator
+
 	NodeTypeTypeReference         // A type reference
 	NodeTypeSpecificTypeReference // A reference to a specific type.
 
@@ -46,6 +49,9 @@ const (
 	// automatically for this predicate.
 	NodePredicateChild = "child-node"
 
+	// A decorator for this node
+	NodePredicateDecorator = "decorator-node"
+
 	//
 	// NodeTypeError
 	//
@@ -73,6 +79,27 @@ const (
 
 	// The name of the relation/permission
 	NodePredicateName = "relation-name"
+
+	//
+	// NodeTypeDecorator
+	//
+
+	// The name of the decorator
+	NodeDecoratorName = "decorator-name"
+
+	//
+	// NodeTypeDecoratorOptions
+	//
+
+	// The options or sub-options for a decorator
+	NodeDecoratorOptions = "decorator-options"
+
+	//
+	// NodeTypeDecoratorOptions
+	//
+
+	// The value of an option for a decortor
+	NodeDecoratorOptionValue = "decorator-option-value"
 
 	//
 	// NodeTypeRelation

--- a/pkg/schemadsl/dslshape/zz_generated.nodetype_string.go
+++ b/pkg/schemadsl/dslshape/zz_generated.nodetype_string.go
@@ -14,18 +14,20 @@ func _() {
 	_ = x[NodeTypeDefinition-3]
 	_ = x[NodeTypeRelation-4]
 	_ = x[NodeTypePermission-5]
-	_ = x[NodeTypeTypeReference-6]
-	_ = x[NodeTypeSpecificTypeReference-7]
-	_ = x[NodeTypeUnionExpression-8]
-	_ = x[NodeTypeIntersectExpression-9]
-	_ = x[NodeTypeExclusionExpression-10]
-	_ = x[NodeTypeArrowExpression-11]
-	_ = x[NodeTypeIdentifier-12]
+	_ = x[NodeTypeDecorator-6]
+	_ = x[NodeTypeDecoratorOptions-7]
+	_ = x[NodeTypeTypeReference-8]
+	_ = x[NodeTypeSpecificTypeReference-9]
+	_ = x[NodeTypeUnionExpression-10]
+	_ = x[NodeTypeIntersectExpression-11]
+	_ = x[NodeTypeExclusionExpression-12]
+	_ = x[NodeTypeArrowExpression-13]
+	_ = x[NodeTypeIdentifier-14]
 }
 
-const _NodeType_name = "NodeTypeErrorNodeTypeFileNodeTypeCommentNodeTypeDefinitionNodeTypeRelationNodeTypePermissionNodeTypeTypeReferenceNodeTypeSpecificTypeReferenceNodeTypeUnionExpressionNodeTypeIntersectExpressionNodeTypeExclusionExpressionNodeTypeArrowExpressionNodeTypeIdentifier"
+const _NodeType_name = "NodeTypeErrorNodeTypeFileNodeTypeCommentNodeTypeDefinitionNodeTypeRelationNodeTypePermissionNodeTypeDecoratorNodeTypeDecoratorOptionsNodeTypeTypeReferenceNodeTypeSpecificTypeReferenceNodeTypeUnionExpressionNodeTypeIntersectExpressionNodeTypeExclusionExpressionNodeTypeArrowExpressionNodeTypeIdentifier"
 
-var _NodeType_index = [...]uint16{0, 13, 25, 40, 58, 74, 92, 113, 142, 165, 192, 219, 242, 260}
+var _NodeType_index = [...]uint16{0, 13, 25, 40, 58, 74, 92, 109, 133, 154, 183, 206, 233, 260, 283, 301}
 
 func (i NodeType) String() string {
 	if i < 0 || i >= NodeType(len(_NodeType_index)-1) {

--- a/pkg/schemadsl/lexer/lex_def.go
+++ b/pkg/schemadsl/lexer/lex_def.go
@@ -49,6 +49,8 @@ const (
 	TokenTypeRightArrow // ->
 	TokenTypeHash       // #
 	TokenTypeEllipsis   // ...
+	TokenTypeAt         // @
+	TokenTypeComma      // ,
 )
 
 // keywords contains the full set of keywords supported.
@@ -108,6 +110,12 @@ Loop:
 
 		case r == '#':
 			l.emit(TokenTypeHash)
+
+		case r == '@':
+			l.emit(TokenTypeAt)
+
+		case r == ',':
+			l.emit(TokenTypeComma)
 
 		case r == '.':
 			if l.acceptString("..") {

--- a/pkg/schemadsl/lexer/lex_test.go
+++ b/pkg/schemadsl/lexer/lex_test.go
@@ -44,6 +44,7 @@ var lexerTests = []lexerTest{
 
 	{"hash", "#", []Lexeme{{TokenTypeHash, 0, "#"}, tEOF}},
 	{"ellipsis", "...", []Lexeme{{TokenTypeEllipsis, 0, "..."}, tEOF}},
+	{"at", "@", []Lexeme{{TokenTypeAt, 0, "@"}, tEOF}},
 
 	{"relation reference", "foo#...", []Lexeme{
 		{TokenTypeIdentifier, 0, "foo"},
@@ -108,6 +109,44 @@ var lexerTests = []lexerTest{
 		{TokenTypeIdentifier, 0, "foo"},
 		{TokenTypeRightArrow, 0, "->"},
 		{TokenTypeIdentifier, 0, "bar"},
+		{TokenTypeRightParen, 0, ")"},
+		{TokenTypeSyntheticSemicolon, 0, "\n"},
+		tEOF,
+	}},
+
+	{"decorator", "@decname\n", []Lexeme{
+		{TokenTypeAt, 0, "@"},
+		{TokenTypeIdentifier, 0, "decname"},
+		{TokenTypeSyntheticSemicolon, 0, "\n"},
+		tEOF,
+	}},
+
+	{"decorator with options", "@decname(opt1, opt2)\n", []Lexeme{
+		{TokenTypeAt, 0, "@"},
+		{TokenTypeIdentifier, 0, "decname"},
+		{TokenTypeLeftParen, 0, "("},
+		{TokenTypeIdentifier, 0, "opt1"},
+		{TokenTypeComma, 0, ","},
+		tWhitespace,
+		{TokenTypeIdentifier, 0, "opt2"},
+		{TokenTypeRightParen, 0, ")"},
+		{TokenTypeSyntheticSemicolon, 0, "\n"},
+		tEOF,
+	}},
+
+	{"decorator with nested options", "@decname(opt1, (opt2a, opt2b))\n", []Lexeme{
+		{TokenTypeAt, 0, "@"},
+		{TokenTypeIdentifier, 0, "decname"},
+		{TokenTypeLeftParen, 0, "("},
+		{TokenTypeIdentifier, 0, "opt1"},
+		{TokenTypeComma, 0, ","},
+		tWhitespace,
+		{TokenTypeLeftParen, 0, "("},
+		{TokenTypeIdentifier, 0, "opt2a"},
+		{TokenTypeComma, 0, ","},
+		tWhitespace,
+		{TokenTypeIdentifier, 0, "opt2b"},
+		{TokenTypeRightParen, 0, ")"},
 		{TokenTypeRightParen, 0, ")"},
 		{TokenTypeSyntheticSemicolon, 0, "\n"},
 		tEOF,

--- a/pkg/schemadsl/lexer/tokentype_string.go
+++ b/pkg/schemadsl/lexer/tokentype_string.go
@@ -33,11 +33,13 @@ func _() {
 	_ = x[TokenTypeRightArrow-22]
 	_ = x[TokenTypeHash-23]
 	_ = x[TokenTypeEllipsis-24]
+	_ = x[TokenTypeAt-25]
+	_ = x[TokenTypeComma-26]
 }
 
-const _TokenType_name = "TokenTypeErrorTokenTypeSyntheticSemicolonTokenTypeEOFTokenTypeWhitespaceTokenTypeSinglelineCommentTokenTypeMultilineCommentTokenTypeNewlineTokenTypeKeywordTokenTypeIdentifierTokenTypeNumberTokenTypeLeftBraceTokenTypeRightBraceTokenTypeLeftParenTokenTypeRightParenTokenTypePipeTokenTypePlusTokenTypeMinusTokenTypeAndTokenTypeDivTokenTypeEqualsTokenTypeColonTokenTypeSemicolonTokenTypeRightArrowTokenTypeHashTokenTypeEllipsis"
+const _TokenType_name = "TokenTypeErrorTokenTypeSyntheticSemicolonTokenTypeEOFTokenTypeWhitespaceTokenTypeSinglelineCommentTokenTypeMultilineCommentTokenTypeNewlineTokenTypeKeywordTokenTypeIdentifierTokenTypeNumberTokenTypeLeftBraceTokenTypeRightBraceTokenTypeLeftParenTokenTypeRightParenTokenTypePipeTokenTypePlusTokenTypeMinusTokenTypeAndTokenTypeDivTokenTypeEqualsTokenTypeColonTokenTypeSemicolonTokenTypeRightArrowTokenTypeHashTokenTypeEllipsisTokenTypeAtTokenTypeComma"
 
-var _TokenType_index = [...]uint16{0, 14, 41, 53, 72, 98, 123, 139, 155, 174, 189, 207, 226, 244, 263, 276, 289, 303, 315, 327, 342, 356, 374, 393, 406, 423}
+var _TokenType_index = [...]uint16{0, 14, 41, 53, 72, 98, 123, 139, 155, 174, 189, 207, 226, 244, 263, 276, 289, 303, 315, 327, 342, 356, 374, 393, 406, 423, 434, 448}
 
 func (i TokenType) String() string {
 	if i < 0 || i >= TokenType(len(_TokenType_index)-1) {

--- a/pkg/schemadsl/parser/parser_test.go
+++ b/pkg/schemadsl/parser/parser_test.go
@@ -106,6 +106,9 @@ func TestParser(t *testing.T) {
 		{"indented comments test", "indentedcomments"},
 		{"parens test", "parens"},
 		{"multiple parens test", "multiparen"},
+		{"decorator test", "decorator"},
+		{"decorator options test", "decorator_options"},
+		{"decorator nested options test", "decorator_nested_options"},
 	}
 
 	for _, test := range parserTests {

--- a/pkg/schemadsl/parser/tests/decorator.zed
+++ b/pkg/schemadsl/parser/tests/decorator.zed
@@ -1,0 +1,4 @@
+definition mydefinition {
+    @example
+    relation foo: sometype
+}

--- a/pkg/schemadsl/parser/tests/decorator.zed.expected
+++ b/pkg/schemadsl/parser/tests/decorator.zed.expected
@@ -1,0 +1,33 @@
+NodeTypeFile
+  end-rune = 66
+  input-source = decorator test
+  start-rune = 0
+  child-node =>
+    NodeTypeDefinition
+      definition-name = mydefinition
+      end-rune = 66
+      input-source = decorator test
+      start-rune = 0
+      child-node =>
+        NodeTypeRelation
+          end-rune = 64
+          input-source = decorator test
+          relation-name = foo
+          start-rune = 43
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 64
+              input-source = decorator test
+              start-rune = 57
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 64
+                  input-source = decorator test
+                  start-rune = 57
+                  type-name = sometype
+          decorator-node =>
+            NodeTypeDecorator
+              decorator-name = example
+              end-rune = 37
+              input-source = decorator test
+              start-rune = 30

--- a/pkg/schemadsl/parser/tests/decorator_nested_options.zed
+++ b/pkg/schemadsl/parser/tests/decorator_nested_options.zed
@@ -1,0 +1,4 @@
+definition mydefinition {
+    @example(opt1, (opt2a,opt2b))
+    relation foo: sometype
+}

--- a/pkg/schemadsl/parser/tests/decorator_nested_options.zed.expected
+++ b/pkg/schemadsl/parser/tests/decorator_nested_options.zed.expected
@@ -1,0 +1,59 @@
+NodeTypeFile
+  end-rune = 87
+  input-source = decorator nested options test
+  start-rune = 0
+  child-node =>
+    NodeTypeDefinition
+      definition-name = mydefinition
+      end-rune = 87
+      input-source = decorator nested options test
+      start-rune = 0
+      child-node =>
+        NodeTypeRelation
+          end-rune = 85
+          input-source = decorator nested options test
+          relation-name = foo
+          start-rune = 64
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 85
+              input-source = decorator nested options test
+              start-rune = 78
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 85
+                  input-source = decorator nested options test
+                  start-rune = 78
+                  type-name = sometype
+          decorator-node =>
+            NodeTypeDecorator
+              decorator-name = example
+              end-rune = 58
+              input-source = decorator nested options test
+              start-rune = 30
+              decorator-options =>
+                NodeTypeDecoratorOptions
+                  end-rune = 58
+                  input-source = decorator nested options test
+                  start-rune = 38
+                  decorator-options =>
+                    NodeTypeDecoratorOptions
+                      decorator-option-value = opt1
+                      end-rune = 42
+                      input-source = decorator nested options test
+                      start-rune = 43
+                    NodeTypeDecoratorOptions
+                      end-rune = 57
+                      input-source = decorator nested options test
+                      start-rune = 45
+                      decorator-options =>
+                        NodeTypeDecoratorOptions
+                          decorator-option-value = opt2a
+                          end-rune = 50
+                          input-source = decorator nested options test
+                          start-rune = 51
+                        NodeTypeDecoratorOptions
+                          decorator-option-value = opt2b
+                          end-rune = 56
+                          input-source = decorator nested options test
+                          start-rune = 57

--- a/pkg/schemadsl/parser/tests/decorator_options.zed
+++ b/pkg/schemadsl/parser/tests/decorator_options.zed
@@ -1,0 +1,4 @@
+definition mydefinition {
+    @example(opt1, opt2)
+    relation foo: sometype
+}

--- a/pkg/schemadsl/parser/tests/decorator_options.zed.expected
+++ b/pkg/schemadsl/parser/tests/decorator_options.zed.expected
@@ -1,0 +1,49 @@
+NodeTypeFile
+  end-rune = 78
+  input-source = decorator options test
+  start-rune = 0
+  child-node =>
+    NodeTypeDefinition
+      definition-name = mydefinition
+      end-rune = 78
+      input-source = decorator options test
+      start-rune = 0
+      child-node =>
+        NodeTypeRelation
+          end-rune = 76
+          input-source = decorator options test
+          relation-name = foo
+          start-rune = 55
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 76
+              input-source = decorator options test
+              start-rune = 69
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 76
+                  input-source = decorator options test
+                  start-rune = 69
+                  type-name = sometype
+          decorator-node =>
+            NodeTypeDecorator
+              decorator-name = example
+              end-rune = 49
+              input-source = decorator options test
+              start-rune = 30
+              decorator-options =>
+                NodeTypeDecoratorOptions
+                  end-rune = 49
+                  input-source = decorator options test
+                  start-rune = 38
+                  decorator-options =>
+                    NodeTypeDecoratorOptions
+                      decorator-option-value = opt1
+                      end-rune = 42
+                      input-source = decorator options test
+                      start-rune = 43
+                    NodeTypeDecoratorOptions
+                      decorator-option-value = opt2
+                      end-rune = 48
+                      input-source = decorator options test
+                      start-rune = 49


### PR DESCRIPTION
Supports decorators of the forms:

```
@decoratorName
@decoratorName(opt1,opt2)
@decoratorName(opt1,(opt2a,opt2b))
```

This parses the decorators into the AST as a new edge type from the items they decorate (currently only supported within `definition` blocks, pending more discussion of how they will be used)

- [x] basic decorators
- [x] options
- [x] nested options
- [x] multiple decorators for the same statement
- [ ] strings or identifiers as option values