### PR TITLE
Add an http download api to devtools

### DIFF
--- a/cmd/spicedb/developer.go
+++ b/cmd/spicedb/developer.go
@@ -47,6 +47,7 @@ func registerDeveloperServiceCmd(rootCmd *cobra.Command) {
 	developerServiceCmd.Flags().String("s3-bucket", "", "s3 bucket name for s3 share store")
 	developerServiceCmd.Flags().String("s3-endpoint", "", "s3 endpoint for s3 share store")
 	developerServiceCmd.Flags().String("s3-region", "auto", "s3 region for s3 share store")
+	developerServiceCmd.Flags().String("download-addr", ":8443", "address to listen for download requests")
 
 	rootCmd.AddCommand(developerServiceCmd)
 }
@@ -86,6 +87,14 @@ func developerServiceRun(cmd *cobra.Command, args []string) {
 		log.Info().Str("addr", metricsrv.Addr).Msg("metrics server started listening")
 		if err := metricsrv.ListenAndServe(); err != http.ErrServerClosed {
 			log.Fatal().Err(err).Msg("failed while serving metrics")
+		}
+	}()
+
+	downloadSrv := v0svc.NewHTTPDownloadServer(cobrautil.MustGetString(cmd, "download-addr"), shareStore)
+	go func() {
+		log.Info().Str("addr", downloadSrv.Addr).Msg("download server started listening")
+		if err := downloadSrv.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatal().Err(err).Msg("failed while serving http api")
 		}
 	}()
 

--- a/internal/services/v0/download.go
+++ b/internal/services/v0/download.go
@@ -1,0 +1,60 @@
+package v0
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
+)
+
+const downloadPath = "/download/"
+
+func NewHTTPDownloadServer(addr string, shareStore ShareStore) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc(downloadPath, downloadHandler(shareStore))
+	return &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+}
+
+func downloadHandler(shareStore ShareStore) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		ref := strings.TrimPrefix(r.URL.Path, downloadPath)
+		if ref == "" {
+			http.Error(w, "ref is missing", http.StatusBadRequest)
+			return
+		}
+		if strings.Contains(ref, "/") {
+			http.Error(w, "ref may not contain a '/'", http.StatusBadRequest)
+			return
+		}
+		shared, status, err := shareStore.LookupSharedByReference(ref)
+		if err != nil {
+			log.Debug().Str("id", ref).Err(err).Msg("Lookup Shared Error")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		if status == LookupNotFound {
+			log.Debug().Str("id", ref).Msg("Lookup Shared Not Found")
+			http.NotFound(w, r)
+			return
+		}
+		out, err := yaml.Marshal(&shared)
+		if err != nil {
+			log.Debug().Str("id", ref).Err(err).Msg("Couldn't marshall as yaml")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if _, err := w.Write(out); err != nil {
+			log.Debug().Str("id", ref).Err(err).Msg("Couldn't write as yaml")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/internal/services/v0/download_test.go
+++ b/internal/services/v0/download_test.go
@@ -1,0 +1,81 @@
+package v0
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeveloperDownload(t *testing.T) {
+	require := require.New(t)
+
+	store := NewInMemoryShareStore("flavored")
+	devsrv := NewDeveloperServer(store)
+	handler := downloadHandler(store)
+
+	sresp, err := devsrv.Share(context.Background(), &v0.ShareRequest{
+		Schema:            "s",
+		RelationshipsYaml: "ry",
+		ValidationYaml:    "vy",
+		AssertionsYaml:    "ay",
+	})
+	require.NoError(err)
+
+	tests := []struct {
+		name         string
+		method       string
+		ref          string
+		expectedCode int
+		expectedBody string
+	}{
+		{
+			name:         "valid",
+			method:       http.MethodGet,
+			ref:          sresp.ShareReference,
+			expectedCode: http.StatusOK,
+			expectedBody: `schema: s
+relationships: ry
+validation: vy
+assertions: ay
+`,
+		},
+		{
+			name:         "invalid ref",
+			method:       http.MethodGet,
+			ref:          "nope",
+			expectedCode: http.StatusNotFound,
+		},
+		{
+			name:         "ref with /",
+			method:       http.MethodGet,
+			ref:          "ref/hasslash",
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "ref may not contain a '/'",
+		},
+		{
+			name:         "invalid params",
+			method:       http.MethodGet,
+			ref:          "",
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "ref is missing",
+		},
+		{
+			name:         "invalid method",
+			method:       http.MethodPost,
+			ref:          "ref",
+			expectedCode: http.StatusMethodNotAllowed,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			url := downloadPath + test.ref
+			require.HTTPStatusCode(handler, test.method, url, nil, test.expectedCode)
+			if len(test.expectedBody) > 0 {
+				require.HTTPBodyContains(handler, test.method, url, nil, test.expectedBody)
+			}
+		})
+	}
+}

--- a/internal/services/v0/sharestore.go
+++ b/internal/services/v0/sharestore.go
@@ -37,11 +37,11 @@ type SharedDataV1 struct {
 
 // SharedDataV2 represents the data stored in a shared playground file.
 type SharedDataV2 struct {
-	Version           string `json:"version"`
-	Schema            string `json:"schema"`
-	RelationshipsYaml string `json:"relationships_yaml"`
-	ValidationYaml    string `json:"validation_yaml"`
-	AssertionsYaml    string `json:"assertions_yaml"`
+	Version           string `json:"version" yaml:"-"`
+	Schema            string `json:"schema" yaml:"schema"`
+	RelationshipsYaml string `json:"relationships_yaml" yaml:"relationships"`
+	ValidationYaml    string `json:"validation_yaml" yaml:"validation"`
+	AssertionsYaml    string `json:"assertions_yaml" yaml:"assertions"`
 }
 
 // LookupStatus is an enum for the possible ShareStore lookup outcomes.


### PR DESCRIPTION
This serves a non-grpc api to download a yaml representation of the sharestore:

```
/download/<ref>
```

This is to support importing a schema from the playground (which is backed by `spicedb serve-devtools`) with `zed` (something like `zed import <playground url>`)

The playground doesn't have a backend (it just talks to the devtools api), and the devtools API is grpc, so providing an http1 url that we can redirect to makes it easy to export data from a devtools instance (and redirect to it from the frontend).

Another option would be serving the devtools grpc api over http1, similar to #188, but it's not clear that there are many other use-cases for talking to the devtools API over http1.
