### PR TITLE
Adds index on transations table timestamp

### DIFF
--- a/internal/datastore/postgres/migrations/add_transaction_timestamp_index.go
+++ b/internal/datastore/postgres/migrations/add_transaction_timestamp_index.go
@@ -1,7 +1,7 @@
 package migrations
 
 const createIndexOnTupleTransactionTimestamp = `
-	CREATE INDEX id_relation_tuple_transaction_by_timestamp on relation_tuple_transaction(timestamp);
+	CREATE INDEX ix_relation_tuple_transaction_by_timestamp on relation_tuple_transaction(timestamp);
 `
 
 func init() {


### PR DESCRIPTION
Hi folks during a poc with spicedb with a considerable amount to data, noticed a query on the transactions table was very slow.

Adding the index in this PR seems to have sorted the issue.

```
spicedb=> SELECT MIN(id), MAX(id) FROM relation_tuple_transaction WHERE timestamp >= '2021-10-24T09:38:54.987366Z';
 min | max 
-----+-----
     |    
(1 row)

Time: 8303.089 ms (00:08.303)
spicedb=> CREATE INDEX idx_relation_tuple_transaction_timestamp on relation_tuple_transaction(timestamp);
CREATE INDEX
Time: 5283.843 ms (00:05.284)
spicedb=> SELECT MIN(id), MAX(id) FROM relation_tuple_transaction WHERE timestamp >= '2021-10-24T09:38:54.987366Z';
 min | max 
-----+-----
     |    
(1 row)

Time: 1.142 ms
```