### PR TITLE
Fix docker release images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,8 +58,7 @@ brews:
 dockers:
   - image_templates:
       - &amd_image "quay.io/authzed/spicedb:{{ .Version }}-amd64"
-    ids: ["linux-amd64"]
-    dockerfile: &dockerfile "Dockerfile"
+    dockerfile: &dockerfile "Dockerfile.release"
     goos: "linux"
     goarch: "amd64"
     use: "buildx"
@@ -67,7 +66,6 @@ dockers:
       - "--platform=linux/amd64"
   - image_templates:
       - &arm_image "quay.io/authzed/spicedb:{{ .Version }}-arm64"
-    ids: ["linux-arm64"]
     dockerfile: *dockerfile
     goos: "linux"
     goarch: "arm64"
@@ -92,3 +90,6 @@ changelog:
 release:
   draft: true
   prerelease: "auto"
+  footer: |
+    ## Docker Images
+    This release is available at `quay.io/authzed/spicedb:{{ .Version }}`

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,14 @@
+# vim: syntax=dockerfile
+FROM alpine:3.13 AS grpc
+ARG TARGETPLATFORM
+ARG GRPC_HEALTH_PROBE_VERSION=0.3.6
+RUN apk add curl
+RUN curl -v -Lo /etc/grpc_health_probe  "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-$(echo $TARGETPLATFORM | tr / -)"
+RUN chmod +x /etc/grpc_health_probe
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+FROM gcr.io/distroless/base
+COPY --from=grpc /etc/nsswitch.conf /etc/nsswitch.conf
+COPY --from=grpc /etc/grpc_health_probe /usr/local/bin/grpc_health_probe
+COPY spicedb /usr/local/bin/spicedb
+ENTRYPOINT ["spicedb"]


### PR DESCRIPTION
Tested locally with:

```sh
$ goreleaser release --snapshot --skip-publish --rm-dist
$ docker run quay.io/authzed/spicedb:1.0.1-next-arm64
$ docker run --entrypoint=grpc_health_probe quay.io/authzed/spicedb:1.0.1-next-arm64
```

And they worked as expected. 

