### PR TITLE
remove nsswitch file from release image

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -5,10 +5,8 @@ ARG GRPC_HEALTH_PROBE_VERSION=0.3.6
 RUN apk add curl
 RUN curl -v -Lo /etc/grpc_health_probe  "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-$(echo $TARGETPLATFORM | tr / -)"
 RUN chmod +x /etc/grpc_health_probe
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 FROM gcr.io/distroless/base
-COPY --from=grpc /etc/nsswitch.conf /etc/nsswitch.conf
 COPY --from=grpc /etc/grpc_health_probe /usr/local/bin/grpc_health_probe
 COPY spicedb /usr/local/bin/spicedb
 ENTRYPOINT ["spicedb"]


### PR DESCRIPTION
distroless already has a good nsswitch file: https://github.com/GoogleContainerTools/distroless/blob/a33309963242c19cc25df7334e4226fe8eb2bdeb/base/nsswitch.tar#L12