### PR TITLE
proxy: use buffered channels and only let one subrequest write a result

### DIFF
--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -213,7 +213,7 @@ func (cds *crdbDatastore) Revision(ctx context.Context) (datastore.Revision, err
 }
 
 func (cds *crdbDatastore) SyncRevision(ctx context.Context) (datastore.Revision, error) {
-	ctx, span := tracer.Start(ctx, "SyncRevision")
+	ctx, span := tracer.Start(datastore.SeparateContextWithTracing(ctx), "SyncRevision")
 	defer span.End()
 
 	tx, err := cds.conn.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})

--- a/internal/datastore/proxy/hedging_test.go
+++ b/internal/datastore/proxy/hedging_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/authzed/spicedb/internal/datastore"
 	"github.com/authzed/spicedb/internal/datastore/test"
@@ -91,6 +92,7 @@ func TestDatastoreRequestHedging(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.methodName, func(t *testing.T) {
+			defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/authzed/spicedb/internal/datastore/proxy.autoAdvance.func1"), goleak.IgnoreCurrent())
 			mockTime := clock.NewMock()
 			delegate := &test.MockedDatastore{}
 			proxy := newHedgingProxyWithTimeSource(
@@ -148,6 +150,7 @@ type isMock interface {
 }
 
 func runQueryTest(t *testing.T, delegate isMock, mockTime *clock.Mock, exec tupleExecutor) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/authzed/spicedb/internal/datastore/proxy.autoAdvance.func1"), goleak.IgnoreCurrent())
 	require := require.New(t)
 
 	delegate.


### PR DESCRIPTION
Fixes #235 

Once we’re in a “hedged” case, we have two goroutines running, and this select reading from both response channels for answers:
```go
select {
case <-responseReady:
  duration = timeSource.Since(originalStart)
case <-hedgedResponseReady:
  duration = timeSource.Since(hedgedStart)
}
```

Once we get an answer from one of the two, the hedger unblocks and cancels the context that is shared by both subrequest goroutines.

This is what a subrequest looks like for reference:

```go
func(ctx context.Context, responseReady chan<- struct{}) {
  rev, err = hp.delegate.Revision(ctx)
  responseReady <- struct{}{}
}
```
So if there are two of these running, the context is cancelled once the fastest one returns and the hedger func exits, and there’s nothing to read from the “slow” channel, so the subrequest goroutine hangs on send.

There are two parts to the fix:

- using buffered "ready" channels for hedger will keep the subrequest goroutines from blocking on send
- since both subrequests capture the parent return values and attempt to write to them, there's a potential data race. they're protected with `sync.Once` to avoid this problem

The tests were updated to detect the leak (and confirm it no longer happens)