### PR TITLE
cmd: consistent flags for http/grpc servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ SpiceDB supports environment variables. You can replace any command's argument w
 For example `--log-level` becomes `SPICEDB_LOG_LEVEL`.
 
 ```sh
-docker run -e SPICEDB_GRPC_PRESHARED_KEY=somerandomkeyhere -e SPICEDB_GRPC_NO_TLS=1 -e SPICEDB_HTTP_NO_TLS=1 quay.io/authzed/spicedb serve
+docker run -e SPICEDB_GRPC_PRESHARED_KEY=somerandomkeyhere quay.io/authzed/spicedb serve
 ```
 
 For production usage, we **highly** recommend using a tag that corresponds to the [latest release], rather than `latest`.
@@ -98,7 +98,7 @@ For production usage, we **highly** recommend using a tag that corresponds to th
 ### Running SpiceDB locally
 
 ```sh
-spicedb serve --grpc-preshared-key "somerandomkeyhere" --grpc-no-tls --http-no-tls
+spicedb serve --grpc-preshared-key "somerandomkeyhere"
 ```
 
 Visit [http://localhost:8080](http://localhost:8080) to see next steps, including loading the schema

--- a/cmd/spicedb/developer.go
+++ b/cmd/spicedb/developer.go
@@ -38,8 +38,8 @@ func registerDeveloperServiceCmd(rootCmd *cobra.Command) {
 		Args:    cobra.ExactArgs(0),
 	}
 
-	cobrautil.RegisterGrpcServerFlags(developerServiceCmd.Flags(), "grpc", "gRPC", ":50051")
-	cobrautil.RegisterHttpServerFlags(developerServiceCmd.Flags(), "metrics", "metrics", ":9090")
+	cobrautil.RegisterGrpcServerFlags(developerServiceCmd.Flags(), "grpc", "gRPC", ":50051", true)
+	cobrautil.RegisterHttpServerFlags(developerServiceCmd.Flags(), "metrics", "metrics", ":9090", true)
 
 	developerServiceCmd.Flags().String("share-store", "inmemory", "kind of share store to use")
 	developerServiceCmd.Flags().String("share-store-salt", "", "salt for share store hashing")

--- a/cmd/spicedb/developer.go
+++ b/cmd/spicedb/developer.go
@@ -30,15 +30,16 @@ import (
 
 func registerDeveloperServiceCmd(rootCmd *cobra.Command) {
 	developerServiceCmd := &cobra.Command{
-		Use:   "serve-devtools",
-		Short: "runs the developer tools service",
-		Long:  "Serves the authzed.api.v0.DeveloperService which is used for development tooling such as the Authzed Playground",
-		Run:   developerServiceRun,
-		Args:  cobra.ExactArgs(0),
+		Use:     "serve-devtools",
+		Short:   "runs the developer tools service",
+		Long:    "Serves the authzed.api.v0.DeveloperService which is used for development tooling such as the Authzed Playground",
+		PreRunE: defaultPreRunE,
+		Run:     developerServiceRun,
+		Args:    cobra.ExactArgs(0),
 	}
 
-	cobrautil.RegisterGrpcServerFlags(developerServiceCmd.Flags())
-	cobrautil.RegisterMetricsServerFlags(developerServiceCmd.Flags())
+	cobrautil.RegisterGrpcServerFlags(developerServiceCmd.Flags(), "grpc", "gRPC", ":50051")
+	cobrautil.RegisterHttpServerFlags(developerServiceCmd.Flags(), "metrics", "metrics", ":9090")
 
 	developerServiceCmd.Flags().String("share-store", "inmemory", "kind of share store to use")
 	developerServiceCmd.Flags().String("share-store-salt", "", "salt for share store hashing")
@@ -48,12 +49,11 @@ func registerDeveloperServiceCmd(rootCmd *cobra.Command) {
 	developerServiceCmd.Flags().String("s3-endpoint", "", "s3 endpoint for s3 share store")
 	developerServiceCmd.Flags().String("s3-region", "auto", "s3 region for s3 share store")
 	developerServiceCmd.Flags().String("download-addr", ":8443", "address to listen for download requests")
-
 	rootCmd.AddCommand(developerServiceCmd)
 }
 
 func developerServiceRun(cmd *cobra.Command, args []string) {
-	grpcServer, err := cobrautil.GrpcServerFromFlags(cmd, grpc.ChainUnaryInterceptor(
+	grpcServer, err := cobrautil.GrpcServerFromFlags(cmd, "grpc", grpc.ChainUnaryInterceptor(
 		grpclog.UnaryServerInterceptor(grpczerolog.InterceptorLogger(log.Logger)),
 		otelgrpc.UnaryServerInterceptor(),
 		grpcprom.UnaryServerInterceptor,
@@ -73,7 +73,7 @@ func developerServiceRun(cmd *cobra.Command, args []string) {
 		addr := cobrautil.MustGetStringExpanded(cmd, "grpc-addr")
 		l, err := net.Listen("tcp", addr)
 		if err != nil {
-			log.Fatal().Str("addr", addr).Msg("failed to listen on addr for gRPC server")
+			log.Fatal().Err(err).Str("addr", addr).Msg("failed to listen on addr for gRPC server")
 		}
 
 		log.Info().Str("addr", addr).Msg("gRPC server started listening")
@@ -82,10 +82,12 @@ func developerServiceRun(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	metricsrv := cobrautil.MetricsServerFromFlags(cmd)
+	// Start the metrics endpoint.
+	metricsSrv := cobrautil.HttpServerFromFlags(cmd, "metrics")
+	metricsSrv.Handler = metricsHandler()
 	go func() {
-		log.Info().Str("addr", metricsrv.Addr).Msg("metrics server started listening")
-		if err := metricsrv.ListenAndServe(); err != http.ErrServerClosed {
+		log.Info().Str("addr", metricsSrv.Addr).Msg("metrics server started listening")
+		if err := cobrautil.HttpListenFromFlags(cmd, "metrics", metricsSrv); err != nil {
 			log.Fatal().Err(err).Msg("failed while serving metrics")
 		}
 	}()
@@ -102,7 +104,7 @@ func developerServiceRun(cmd *cobra.Command, args []string) {
 	<-signalctx.Done()
 	log.Info().Msg("received interrupt")
 	grpcServer.GracefulStop()
-	if err := metricsrv.Close(); err != nil {
+	if err := metricsSrv.Close(); err != nil {
 		log.Fatal().Err(err).Msg("failed while shutting down metrics server")
 	}
 }

--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -1,14 +1,30 @@
 package main
 
 import (
+	"net/http"
+	"net/http/pprof"
+
 	"github.com/jzelinskie/cobrautil"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog"
 )
 
-var persistentPreRunE = cobrautil.CommandStack(
+var defaultPreRunE = cobrautil.CommandStack(
 	cobrautil.SyncViperPreRunE("spicedb"),
-	cobrautil.ZeroLogPreRunE,
-	cobrautil.OpenTelemetryPreRunE,
+	cobrautil.ZeroLogPreRunE("log", zerolog.InfoLevel),
+	cobrautil.OpenTelemetryPreRunE("otel", zerolog.InfoLevel),
 )
+
+func metricsHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	return mux
+}
 
 func main() {
 	rootCmd := newRootCmd()

--- a/cmd/spicedb/migrate.go
+++ b/cmd/spicedb/migrate.go
@@ -15,12 +15,12 @@ import (
 
 func registerMigrateCmd(rootCmd *cobra.Command) {
 	migrateCmd := &cobra.Command{
-		Use:               "migrate [revision]",
-		Short:             "execute datastore schema migrations",
-		Long:              fmt.Sprintf("Executes datastore schema migrations for the datastore.\nThe special value \"%s\" can be used to migrate to the latest revision.", color.YellowString(migrate.Head)),
-		PersistentPreRunE: persistentPreRunE,
-		Run:               migrateRun,
-		Args:              cobra.ExactArgs(1),
+		Use:     "migrate [revision]",
+		Short:   "execute datastore schema migrations",
+		Long:    fmt.Sprintf("Executes datastore schema migrations for the datastore.\nThe special value \"%s\" can be used to migrate to the latest revision.", color.YellowString(migrate.Head)),
+		PreRunE: defaultPreRunE,
+		Run:     migrateRun,
+		Args:    cobra.ExactArgs(1),
 	}
 
 	migrateCmd.Flags().String("datastore-engine", "memory", `type of datastore to initialize ("memory", "postgres", "cockroachdb")`)

--- a/cmd/spicedb/root.go
+++ b/cmd/spicedb/root.go
@@ -14,11 +14,11 @@ func newRootCmd() *cobra.Command {
 		Short: "A modern permissions database",
 		Long:  "A database that stores, computes, and validates application permissions",
 		Example: fmt.Sprintf(`	%s:
-		spicedb serve --grpc-preshared-key "somerandomkeyhere" --grpc-no-tls --http-no-tls
+		spicedb serve --grpc-preshared-key "somerandomkeyhere"
 
 	%s:
-		spicedb serve --grpc-preshared-key "realkeyhere" --grpc-cert-path path/to/tls/cert --grpc-key-path path/to/tls/key \
-			--http-cert-path path/to/tls/cert --http-key-path path/to/tls/key \
+		spicedb serve --grpc-preshared-key "realkeyhere" --grpc-tls-cert-path path/to/tls/cert --grpc-tls-key-path path/to/tls/key \
+			--http-tls-cert-path path/to/tls/cert --http-tls-key-path path/to/tls/key \
 			--datastore-engine postgres --datastore-conn-uri "postgres-connection-string-here"
 	%s:
 		spicedb serve-testing

--- a/cmd/spicedb/root.go
+++ b/cmd/spicedb/root.go
@@ -10,11 +10,9 @@ import (
 
 func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:               "spicedb",
-		Short:             "A modern permissions database",
-		Long:              "A database that stores, computes, and validates application permissions",
-		PersistentPreRunE: persistentPreRunE,
-		TraverseChildren:  true,
+		Use:   "spicedb",
+		Short: "A modern permissions database",
+		Long:  "A database that stores, computes, and validates application permissions",
 		Example: fmt.Sprintf(`	%s:
 		spicedb serve --grpc-preshared-key "somerandomkeyhere" --grpc-no-tls --http-no-tls
 
@@ -31,8 +29,8 @@ func newRootCmd() *cobra.Command {
 		),
 	}
 
-	cobrautil.RegisterZeroLogFlags(rootCmd.PersistentFlags())
-	cobrautil.RegisterOpenTelemetryFlags(rootCmd.PersistentFlags(), rootCmd.Use)
+	cobrautil.RegisterZeroLogFlags(rootCmd.PersistentFlags(), "log")
+	cobrautil.RegisterOpenTelemetryFlags(rootCmd.PersistentFlags(), "otel", rootCmd.Use)
 
 	return rootCmd
 }

--- a/cmd/spicedb/testserver.go
+++ b/cmd/spicedb/testserver.go
@@ -44,11 +44,11 @@ const (
 
 func registerTestserverCmd(rootCmd *cobra.Command) {
 	testserveCmd := &cobra.Command{
-		Use:               "serve-testing",
-		Short:             "test server with an in-memory datastore",
-		Long:              "An in-memory spicedb server which serves completely isolated datastores per client-supplied auth token used.",
-		PersistentPreRunE: persistentPreRunE,
-		Run:               runTestServer,
+		Use:     "serve-testing",
+		Short:   "test server with an in-memory datastore",
+		Long:    "An in-memory spicedb server which serves completely isolated datastores per client-supplied auth token used.",
+		PreRunE: defaultPreRunE,
+		Run:     runTestServer,
 	}
 
 	testserveCmd.Flags().String("grpc-addr", ":50051", "address to listen on for serving gRPC services")

--- a/e2e/newenemy/newenemy_test.go
+++ b/e2e/newenemy/newenemy_test.go
@@ -84,7 +84,7 @@ func TestNoNewEnemy(t *testing.T) {
 	t.Log("start protected spicedb cluster")
 	protectedSpiceDb := spice.NewClusterFromCockroachCluster(crdb,
 		spice.WithGrpcPort(50061),
-		spice.WithInternalPort(50062),
+		spice.WithDispatchPort(50062),
 		spice.WithHttpPort(8444),
 		spice.WithMetricsPort(9100),
 		spice.WithDashboardPort(8100),

--- a/e2e/spice/spicedb.go
+++ b/e2e/spice/spicedb.go
@@ -27,7 +27,7 @@ type Node struct {
 	URI           string
 	GrpcPort      int
 	HttpPort      int
-	InternalPort  int
+	DispatchPort  int
 	MetricsPort   int
 	DashboardPort int
 	Pid           int
@@ -44,8 +44,8 @@ func WithTestDefaults(opts ...SpiceDbOption) SpiceDbOption {
 		if s.GrpcPort == 0 {
 			s.GrpcPort = 50051
 		}
-		if s.InternalPort == 0 {
-			s.InternalPort = 50052
+		if s.DispatchPort == 0 {
+			s.DispatchPort = 50052
 		}
 		if s.HttpPort == 0 {
 			s.HttpPort = 8443
@@ -83,7 +83,7 @@ func (s *Node) Start(ctx context.Context, logprefix string, args ...string) erro
 		"--datastore-conn-uri=" + s.URI,
 		fmt.Sprintf("--grpc-addr=:%d", s.GrpcPort),
 		fmt.Sprintf("--http-addr=:%d", s.HttpPort),
-		fmt.Sprintf("--internal-grpc-addr=:%d", s.InternalPort),
+		fmt.Sprintf("--dispatch-cluster-addr=:%d", s.DispatchPort),
 		fmt.Sprintf("--metrics-addr=:%d", s.MetricsPort),
 		fmt.Sprintf("--dashboard-addr=:%d", s.DashboardPort),
 	}
@@ -147,7 +147,7 @@ func NewClusterFromCockroachCluster(c cockroach.Cluster, opts ...SpiceDbOption) 
 			Datastore:     "cockroachdb",
 			URI:           c[i].ConnectionString(proto.DbName),
 			GrpcPort:      proto.GrpcPort + 2*i,
-			InternalPort:  proto.InternalPort + 2*i,
+			DispatchPort:  proto.DispatchPort + 2*i,
 			HttpPort:      proto.HttpPort + 2*i,
 			MetricsPort:   proto.MetricsPort + i,
 			DashboardPort: proto.DashboardPort + i,

--- a/e2e/spice/spicedb.go
+++ b/e2e/spice/spicedb.go
@@ -77,8 +77,6 @@ func (s *Node) Start(ctx context.Context, logprefix string, args ...string) erro
 		"serve",
 		"--log-level=debug",
 		"--grpc-preshared-key=" + s.PresharedKey,
-		"--grpc-no-tls",
-		"--http-no-tls",
 		"--datastore-engine=" + s.Datastore,
 		"--datastore-conn-uri=" + s.URI,
 		fmt.Sprintf("--grpc-addr=:%d", s.GrpcPort),

--- a/e2e/spice/spicedb_options.go
+++ b/e2e/spice/spicedb_options.go
@@ -64,10 +64,10 @@ func WithGrpcPort(grpcPort int) SpiceDbOption {
 	}
 }
 
-// WithInternalPort returns an option that can set InternalPort on a Node
-func WithInternalPort(internalPort int) SpiceDbOption {
+// WithDispatchPort returns an option that can set DispatchPort on a Node
+func WithDispatchPort(dispatchPort int) SpiceDbOption {
 	return func(s *Node) {
-		s.InternalPort = internalPort
+		s.DispatchPort = dispatchPort
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/johannesboyne/gofakes3 v0.0.0-20210608054100-92d5d4af5fde
 	github.com/jpillora/backoff v1.0.0
 	github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6
-	github.com/jzelinskie/cobrautil v0.0.5
+	github.com/jzelinskie/cobrautil v0.0.6-0.20211103005615-2d3ced57292a
 	github.com/jzelinskie/stringz v0.0.1
 	github.com/lib/pq v1.10.3
 	github.com/mattn/go-colorable v0.1.11 // indirect
@@ -64,9 +64,9 @@ require (
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20211101193420-4a448f8816b3 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20211102061401-a2f17f7b995c // indirect
-	google.golang.org/genproto v0.0.0-20211101144312-62acf1d99145
-	google.golang.org/grpc v1.41.0
+	golang.org/x/sys v0.0.0-20211102192858-4dd72447c267 // indirect
+	google.golang.org/genproto v0.0.0-20211102202547-e9cf271f7f2c
+	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/johannesboyne/gofakes3 v0.0.0-20210608054100-92d5d4af5fde
 	github.com/jpillora/backoff v1.0.0
 	github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6
-	github.com/jzelinskie/cobrautil v0.0.6-0.20211103220709-94a276f2510d
+	github.com/jzelinskie/cobrautil v0.0.6
 	github.com/jzelinskie/stringz v0.0.1
 	github.com/lib/pq v1.10.3
 	github.com/mattn/go-colorable v0.1.11 // indirect
@@ -62,9 +62,9 @@ require (
 	go.opentelemetry.io/otel/trace v1.1.0
 	go.uber.org/goleak v1.1.12
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
-	golang.org/x/net v0.0.0-20211101193420-4a448f8816b3 // indirect
+	golang.org/x/net v0.0.0-20211104170005-ce137452f963 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20211103184734-ae416a5f93c7 // indirect
+	golang.org/x/sys v0.0.0-20211103235746-7861aae1554b // indirect
 	google.golang.org/genproto v0.0.0-20211102202547-e9cf271f7f2c
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/johannesboyne/gofakes3 v0.0.0-20210608054100-92d5d4af5fde
 	github.com/jpillora/backoff v1.0.0
 	github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6
-	github.com/jzelinskie/cobrautil v0.0.6-0.20211103005615-2d3ced57292a
+	github.com/jzelinskie/cobrautil v0.0.6-0.20211103220709-94a276f2510d
 	github.com/jzelinskie/stringz v0.0.1
 	github.com/lib/pq v1.10.3
 	github.com/mattn/go-colorable v0.1.11 // indirect
@@ -64,7 +64,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20211101193420-4a448f8816b3 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20211102192858-4dd72447c267 // indirect
+	golang.org/x/sys v0.0.0-20211103184734-ae416a5f93c7 // indirect
 	google.golang.org/genproto v0.0.0-20211102202547-e9cf271f7f2c
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6 h1:OzCtZaD1uI5Fc1C+4oNAp7kZ4ibh5OIgxI29moH/IbE=
 github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6/go.mod h1:CEusGbCRDFcHX9EgEhPsgJX33kpp9CfSFRBAoSGOems=
-github.com/jzelinskie/cobrautil v0.0.6-0.20211103220709-94a276f2510d h1:HqUHAdguU5PMm2UAuugGvvxLg2yj+EiN1miBOxY9EFg=
-github.com/jzelinskie/cobrautil v0.0.6-0.20211103220709-94a276f2510d/go.mod h1:kmMHKeMougZuCBGdrTL1/G1Ub1sS4AnclyfcbHKIrV4=
+github.com/jzelinskie/cobrautil v0.0.6 h1:lLkvU5aqGFZbsnkrRk6rgDThhmBFYGjLV0RiVFQKUOM=
+github.com/jzelinskie/cobrautil v0.0.6/go.mod h1:kmMHKeMougZuCBGdrTL1/G1Ub1sS4AnclyfcbHKIrV4=
 github.com/jzelinskie/stringz v0.0.0-20210414224931-d6a8ce844a70/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
 github.com/jzelinskie/stringz v0.0.1 h1:IahR+y8ct2nyj7B6i8UtFsGFj4ex1SX27iKFYsAheLk=
 github.com/jzelinskie/stringz v0.0.1/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
@@ -815,8 +815,8 @@ golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211101193420-4a448f8816b3 h1:VrJZAjbekhoRn7n5FBujY31gboH+iB3pdLxn3gE9FjU=
-golang.org/x/net v0.0.0-20211101193420-4a448f8816b3/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211104170005-ce137452f963 h1:8gJUadZl+kWvZBqG/LautX0X6qe5qTC2VI/3V3NBRAY=
+golang.org/x/net v0.0.0-20211104170005-ce137452f963/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -924,8 +924,8 @@ golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211103184734-ae416a5f93c7 h1:wQUOddybiV2Rfc8FX691KCOx5yEoZlfwpBjtKV6huYo=
-golang.org/x/sys v0.0.0-20211103184734-ae416a5f93c7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211103235746-7861aae1554b h1:1VkfZQv42XQlA/jchYumAnv1UPo6RgF9rJFkTgZIxO4=
+golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,11 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
@@ -415,8 +418,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6 h1:OzCtZaD1uI5Fc1C+4oNAp7kZ4ibh5OIgxI29moH/IbE=
 github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6/go.mod h1:CEusGbCRDFcHX9EgEhPsgJX33kpp9CfSFRBAoSGOems=
-github.com/jzelinskie/cobrautil v0.0.5 h1:R78XJnCrlpcTRixsvkk2sZnvpUl2DU3pv3eAkf+ZNsU=
-github.com/jzelinskie/cobrautil v0.0.5/go.mod h1:svcV0pfy8vH8O+IpYaJgWw70PJuAtvoKXsIELG8Krzs=
+github.com/jzelinskie/cobrautil v0.0.6-0.20211103005615-2d3ced57292a h1:V9k14YDc1hRR1dWqSr8e38bRYpRGJ9pR+Qusbro93t0=
+github.com/jzelinskie/cobrautil v0.0.6-0.20211103005615-2d3ced57292a/go.mod h1:kmMHKeMougZuCBGdrTL1/G1Ub1sS4AnclyfcbHKIrV4=
 github.com/jzelinskie/stringz v0.0.0-20210414224931-d6a8ce844a70/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
 github.com/jzelinskie/stringz v0.0.1 h1:IahR+y8ct2nyj7B6i8UtFsGFj4ex1SX27iKFYsAheLk=
 github.com/jzelinskie/stringz v0.0.1/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
@@ -921,8 +924,8 @@ golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211102061401-a2f17f7b995c h1:QOfDMdrf/UwlVR0UBq2Mpr58UzNtvgJRXA4BgPfFACs=
-golang.org/x/sys v0.0.0-20211102061401-a2f17f7b995c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211102192858-4dd72447c267 h1:7zYaz3tjChtpayGDzu6H0hDAUM5zIGA2XW7kRNgQ0jc=
+golang.org/x/sys v0.0.0-20211102192858-4dd72447c267/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1108,8 +1111,8 @@ google.golang.org/genproto v0.0.0-20210821163610-241b8fcbd6c8/go.mod h1:eFjDcFEc
 google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210903162649-d08c68adba83/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210909211513-a8c4777a87af/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
-google.golang.org/genproto v0.0.0-20211101144312-62acf1d99145 h1:vum3nDKdleYb+aePXKFEDT2+ghuH00EgYp9B7Q7EZZE=
-google.golang.org/genproto v0.0.0-20211101144312-62acf1d99145/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211102202547-e9cf271f7f2c h1:UQDUEuW1R2dcciOjiFmuzE4skW4n/zGGNMU0RhU3hQI=
+google.golang.org/genproto v0.0.0-20211102202547-e9cf271f7f2c/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -1136,8 +1139,9 @@ google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQ
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.41.0 h1:f+PlOh7QV4iIJkPrx5NQ7qaNGFQ3OTse67yaDHfju4E=
 google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
+google.golang.org/grpc v1.42.0 h1:XT2/MFpuPFsEX2fWh3YQtHkZ+WYZFQRfaUgLZYj/p6A=
+google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6 h1:OzCtZaD1uI5Fc1C+4oNAp7kZ4ibh5OIgxI29moH/IbE=
 github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6/go.mod h1:CEusGbCRDFcHX9EgEhPsgJX33kpp9CfSFRBAoSGOems=
-github.com/jzelinskie/cobrautil v0.0.6-0.20211103005615-2d3ced57292a h1:V9k14YDc1hRR1dWqSr8e38bRYpRGJ9pR+Qusbro93t0=
-github.com/jzelinskie/cobrautil v0.0.6-0.20211103005615-2d3ced57292a/go.mod h1:kmMHKeMougZuCBGdrTL1/G1Ub1sS4AnclyfcbHKIrV4=
+github.com/jzelinskie/cobrautil v0.0.6-0.20211103220709-94a276f2510d h1:HqUHAdguU5PMm2UAuugGvvxLg2yj+EiN1miBOxY9EFg=
+github.com/jzelinskie/cobrautil v0.0.6-0.20211103220709-94a276f2510d/go.mod h1:kmMHKeMougZuCBGdrTL1/G1Ub1sS4AnclyfcbHKIrV4=
 github.com/jzelinskie/stringz v0.0.0-20210414224931-d6a8ce844a70/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
 github.com/jzelinskie/stringz v0.0.1 h1:IahR+y8ct2nyj7B6i8UtFsGFj4ex1SX27iKFYsAheLk=
 github.com/jzelinskie/stringz v0.0.1/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
@@ -924,8 +924,8 @@ golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211102192858-4dd72447c267 h1:7zYaz3tjChtpayGDzu6H0hDAUM5zIGA2XW7kRNgQ0jc=
-golang.org/x/sys v0.0.0-20211102192858-4dd72447c267/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211103184734-ae416a5f93c7 h1:wQUOddybiV2Rfc8FX691KCOx5yEoZlfwpBjtKV6huYo=
+golang.org/x/sys v0.0.0-20211103184734-ae416a5f93c7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -54,7 +54,7 @@ const rootTemplate = `
 brew install authzed/tap/zed
 
 # Login to SpiceDB
-zed context set first-dev-context {{ .GrpcAddr }} "the preshared key here" {{if .GrpcNoTLS }}--insecure {{end}}
+zed context set first-dev-context {{ .GrpcAddr }} "the preshared key here" {{if not .GrpcTLSEnabled }}--insecure {{end}}
 
 # Save the sample schema
 cat > sample.zed << 'SCHEMA'
@@ -70,7 +70,7 @@ definition resource {
 SCHEMA
 
 # Write a sample schema
-zed schema write sample.zed {{if .GrpcNoTLS }}--insecure {{end}}
+zed schema write sample.zed {{if not .GrpcTLSEnabled }}--insecure {{end}}
 </pre>
 			</p>
 		{{ else }}
@@ -83,13 +83,13 @@ zed schema write sample.zed {{if .GrpcNoTLS }}--insecure {{end}}
 			<h3>How to write a relationship</h3>
 <pre>
 # Write a sample relationship
-zed relationship create resource:sampleresource reader user:sampleuser {{if .GrpcNoTLS }}--insecure {{end}}
+zed relationship create resource:sampleresource reader user:sampleuser {{if not .GrpcTLSEnabled }}--insecure {{end}}
 </pre>
 
 					<h3>How to check a permission</h3>
 		<pre>
 		# Check a permission
-		zed permission check resource:sampleresource view user:sampleuser {{if .GrpcNoTLS }}--insecure {{end}}
+		zed permission check resource:sampleresource view user:sampleuser {{if not .GrpcTLSEnabled }}--insecure {{end}}
 		</pre>
 		{{ end }}
 		{{ end }}
@@ -107,7 +107,7 @@ spicedb migrate head --datastore-engine={{ .DatastoreEngine }} --datastore-conn-
 `
 
 // NewHandler returns an http.Handler capable of serving a developer dashboard.
-func NewHandler(grpcAddr string, grpcNoTLS bool, datastoreEngine string, ds datastore.Datastore) http.Handler {
+func NewHandler(grpcAddr string, grpcTLSEnabled bool, datastoreEngine string, ds datastore.Datastore) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tmpl, err := template.New("root").Parse(rootTemplate)
 		if err != nil {
@@ -156,7 +156,7 @@ func NewHandler(grpcAddr string, grpcNoTLS bool, datastoreEngine string, ds data
 
 		err = tmpl.Execute(w, struct {
 			GrpcAddr        string
-			GrpcNoTLS       bool
+			GrpcTLSEnabled  bool
 			DatastoreEngine string
 			IsReady         bool
 			IsEmpty         bool
@@ -164,7 +164,7 @@ func NewHandler(grpcAddr string, grpcNoTLS bool, datastoreEngine string, ds data
 			HasSampleSchema bool
 		}{
 			GrpcAddr:        grpcAddr,
-			GrpcNoTLS:       grpcNoTLS,
+			GrpcTLSEnabled:  grpcTLSEnabled,
 			DatastoreEngine: datastoreEngine,
 			IsReady:         isReady,
 			IsEmpty:         isReady && schema == "",

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"context"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -55,7 +54,7 @@ const rootTemplate = `
 brew install authzed/tap/zed
 
 # Login to SpiceDB
-zed context set first-dev-context {{ .Args.GrpcAddr }} "the preshared key here" {{if .Args.GrpcNoTLS }}--insecure {{end}}
+zed context set first-dev-context {{ .GrpcAddr }} "the preshared key here" {{if .GrpcNoTLS }}--insecure {{end}}
 
 # Save the sample schema
 cat > sample.zed << 'SCHEMA'
@@ -71,7 +70,7 @@ definition resource {
 SCHEMA
 
 # Write a sample schema
-zed schema write sample.zed {{if .Args.GrpcNoTLS }}--insecure {{end}}
+zed schema write sample.zed {{if .GrpcNoTLS }}--insecure {{end}}
 </pre>
 			</p>
 		{{ else }}
@@ -84,13 +83,13 @@ zed schema write sample.zed {{if .Args.GrpcNoTLS }}--insecure {{end}}
 			<h3>How to write a relationship</h3>
 <pre>
 # Write a sample relationship
-zed relationship create resource:sampleresource reader user:sampleuser {{if .Args.GrpcNoTLS }}--insecure {{end}}
+zed relationship create resource:sampleresource reader user:sampleuser {{if .GrpcNoTLS }}--insecure {{end}}
 </pre>
 
 					<h3>How to check a permission</h3>
 		<pre>
 		# Check a permission
-		zed permission check resource:sampleresource view user:sampleuser {{if .Args.GrpcNoTLS }}--insecure {{end}}
+		zed permission check resource:sampleresource view user:sampleuser {{if .GrpcNoTLS }}--insecure {{end}}
 		</pre>
 		{{ end }}
 		{{ end }}
@@ -100,118 +99,82 @@ zed relationship create resource:sampleresource reader user:sampleuser {{if .Arg
 		To get started with SpiceDB, please run the migrate command below to setup your backing data store:
 	</p>
 <pre>
-spicedb migrate head --datastore-engine={{ .Args.DatastoreEngine }} --datastore-conn-uri="your-connection-uri-here"
+spicedb migrate head --datastore-engine={{ .DatastoreEngine }} --datastore-conn-uri="your-connection-uri-here"
 </pre>
 	{{ end }}
 	</body>
 </html>
 `
 
-// NewDashboard instantiates a new dashboard server for the given addr.
-func NewDashboard(addr string, args Args, datastore datastore.Datastore) *Dashboard {
-	return &Dashboard{
-		addr:      addr,
-		server:    nil,
-		args:      args,
-		datastore: datastore,
-	}
-}
-
-// Args are various arguments passed to SpiceDB.
-type Args struct {
-	// GrpcAddr is the address of the GRPC endpoint.
-	GrpcAddr string
-
-	// GrpcNoTls is true if no TLS is being used.
-	GrpcNoTLS bool
-
-	// DatastoreEngine is the datastore engine being used.
-	DatastoreEngine string
-}
-
-// Dashboard is a dashboard for displaying usage information for SpiceDB.
-type Dashboard struct {
-	addr      string
-	server    *http.Server
-	args      Args
-	datastore datastore.Datastore
-}
-
-// ListenAndServe runs the dashboard on the configured HTTP address.
-func (db *Dashboard) ListenAndServe() error {
-	m := http.NewServeMux()
-	m.HandleFunc("/", db.rootHandler)
-	db.server = &http.Server{Addr: db.addr, Handler: m}
-	return db.server.ListenAndServe()
-}
-
-func (db *Dashboard) rootHandler(w http.ResponseWriter, r *http.Request) {
-	tmpl, err := template.New("root").Parse(rootTemplate)
-	if err != nil {
-		log.Error().AnErr("template-error", err).Msg("Got error when parsing template")
-		fmt.Fprintf(w, "Internal Error")
-		return
-	}
-
-	isReady, err := db.datastore.IsReady(r.Context())
-	if err != nil {
-		log.Error().AnErr("template-error", err).Msg("Got error when checking database")
-		fmt.Fprintf(w, "Internal Error")
-		return
-	}
-
-	schema := ""
-	hasSampleSchema := false
-
-	if isReady {
-		var objectDefs []string
-		userFound := false
-		resourceFound := false
-
-		nsDefs, err := db.datastore.ListNamespaces(r.Context())
+// NewHandler returns an http.Handler capable of serving a developer dashboard.
+func NewHandler(grpcAddr string, grpcNoTLS bool, datastoreEngine string, ds datastore.Datastore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tmpl, err := template.New("root").Parse(rootTemplate)
 		if err != nil {
-			log.Error().AnErr("datastore-error", err).Msg("Got error when trying to load namespaces")
+			log.Error().AnErr("template-error", err).Msg("Got error when parsing template")
 			fmt.Fprintf(w, "Internal Error")
 			return
 		}
 
-		for _, nsDef := range nsDefs {
-			objectDef, _ := generator.GenerateSource(nsDef)
-			objectDefs = append(objectDefs, objectDef)
-
-			if nsDef.Name == "user" {
-				userFound = true
-			}
-			if nsDef.Name == "resource" {
-				resourceFound = true
-			}
+		isReady, err := ds.IsReady(r.Context())
+		if err != nil {
+			log.Error().AnErr("template-error", err).Msg("Got error when checking database")
+			fmt.Fprintf(w, "Internal Error")
+			return
 		}
 
-		schema = strings.Join(objectDefs, "\n\n")
-		hasSampleSchema = userFound && resourceFound
-	}
+		schema := ""
+		hasSampleSchema := false
 
-	err = tmpl.Execute(w, struct {
-		Args            Args
-		IsReady         bool
-		IsEmpty         bool
-		Schema          string
-		HasSampleSchema bool
-	}{
-		Args:            db.args,
-		IsReady:         isReady,
-		IsEmpty:         isReady && schema == "",
-		Schema:          schema,
-		HasSampleSchema: hasSampleSchema,
+		if isReady {
+			var objectDefs []string
+			userFound := false
+			resourceFound := false
+
+			nsDefs, err := ds.ListNamespaces(r.Context())
+			if err != nil {
+				log.Error().AnErr("datastore-error", err).Msg("Got error when trying to load namespaces")
+				fmt.Fprintf(w, "Internal Error")
+				return
+			}
+
+			for _, nsDef := range nsDefs {
+				objectDef, _ := generator.GenerateSource(nsDef)
+				objectDefs = append(objectDefs, objectDef)
+
+				if nsDef.Name == "user" {
+					userFound = true
+				}
+				if nsDef.Name == "resource" {
+					resourceFound = true
+				}
+			}
+
+			schema = strings.Join(objectDefs, "\n\n")
+			hasSampleSchema = userFound && resourceFound
+		}
+
+		err = tmpl.Execute(w, struct {
+			GrpcAddr        string
+			GrpcNoTLS       bool
+			DatastoreEngine string
+			IsReady         bool
+			IsEmpty         bool
+			Schema          string
+			HasSampleSchema bool
+		}{
+			GrpcAddr:        grpcAddr,
+			GrpcNoTLS:       grpcNoTLS,
+			DatastoreEngine: datastoreEngine,
+			IsReady:         isReady,
+			IsEmpty:         isReady && schema == "",
+			Schema:          schema,
+			HasSampleSchema: hasSampleSchema,
+		})
+		if err != nil {
+			log.Error().AnErr("template-error", err).Msg("Got error when executing template")
+			fmt.Fprintf(w, "Internal Error")
+			return
+		}
 	})
-	if err != nil {
-		log.Error().AnErr("template-error", err).Msg("Got error when executing template")
-		fmt.Fprintf(w, "Internal Error")
-		return
-	}
-}
-
-// Close closes the dashboard server.
-func (db *Dashboard) Close() error {
-	return db.server.Shutdown(context.Background())
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -29,40 +29,24 @@ var histogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Help:      "A histogram of the duration spent processing requests to the SpiceDB REST Gateway.",
 }, []string{"method"})
 
-// UpstreamConfig represents the values used to configure the upstream gRPC
-// service for a REST gateway.
-type UpstreamConfig struct {
-	// UpstreamAddr is the address of the gRPC server to which requests will be
-	// forwarded.
-	UpstreamAddr string
-
-	// UpstreamTLSDisabled toggles whether or not the upstream connection will be
-	// secure.
-	UpstreamTLSDisabled bool
-
-	// UpstreamTLSCertPath is the filesystem location of the certificate used to
-	// secure the upstream connection.
-	UpstreamTLSCertPath string
-}
-
 // NewHandler creates an REST gateway HTTP Handler with the provided upstream
 // configuration.
-func NewHandler(ctx context.Context, cfg UpstreamConfig) (http.Handler, error) {
+func NewHandler(ctx context.Context, upstreamAddr, upstreamTLSCertPath string) (http.Handler, error) {
 	opts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
 		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
 	}
-	if cfg.UpstreamTLSDisabled {
+	if upstreamTLSCertPath == "" {
 		opts = append(opts, grpc.WithInsecure())
 	} else {
-		opts = append(opts, grpcutil.WithCustomCerts(cfg.UpstreamTLSCertPath, grpcutil.SkipVerifyCA))
+		opts = append(opts, grpcutil.WithCustomCerts(upstreamTLSCertPath, grpcutil.SkipVerifyCA))
 	}
 
 	gwMux := runtime.NewServeMux(runtime.WithMetadata(OtelAnnotator))
-	if err := v1.RegisterSchemaServiceHandlerFromEndpoint(ctx, gwMux, cfg.UpstreamAddr, opts); err != nil {
+	if err := v1.RegisterSchemaServiceHandlerFromEndpoint(ctx, gwMux, upstreamAddr, opts); err != nil {
 		return nil, err
 	}
-	if err := v1.RegisterPermissionsServiceHandlerFromEndpoint(ctx, gwMux, cfg.UpstreamAddr, opts); err != nil {
+	if err := v1.RegisterPermissionsServiceHandlerFromEndpoint(ctx, gwMux, upstreamAddr, opts); err != nil {
 		return nil, err
 	}
 

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -29,11 +29,9 @@ var histogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Help:      "A histogram of the duration spent processing requests to the SpiceDB REST Gateway.",
 }, []string{"method"})
 
-// Config represents the require configuration for initializing a REST gateway.
-type Config struct {
-	// Addr is the address on which the HTTP server will be configured to listen.
-	Addr string
-
+// UpstreamConfig represents the values used to configure the upstream gRPC
+// service for a REST gateway.
+type UpstreamConfig struct {
 	// UpstreamAddr is the address of the gRPC server to which requests will be
 	// forwarded.
 	UpstreamAddr string
@@ -47,8 +45,9 @@ type Config struct {
 	UpstreamTLSCertPath string
 }
 
-// NewHTTPServer initializes a new HTTP server with the provided configuration.
-func NewHTTPServer(ctx context.Context, cfg Config) (*http.Server, error) {
+// NewHandler creates an REST gateway HTTP Handler with the provided upstream
+// configuration.
+func NewHandler(ctx context.Context, cfg UpstreamConfig) (http.Handler, error) {
 	opts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
 		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
@@ -73,10 +72,7 @@ func NewHTTPServer(ctx context.Context, cfg Config) (*http.Server, error) {
 	}))
 	mux.Handle("/", gwMux)
 
-	return &http.Server{
-		Addr:    cfg.Addr,
-		Handler: promhttp.InstrumentHandlerDuration(histogram, otelhttp.NewHandler(mux, "gateway")),
-	}, nil
+	return promhttp.InstrumentHandlerDuration(histogram, otelhttp.NewHandler(mux, "gateway")), nil
 }
 
 var defaultOtelOpts = []otelgrpc.Option{

--- a/k8s/basic.yaml
+++ b/k8s/basic.yaml
@@ -60,8 +60,6 @@ spec:
           imagePullPolicy: "IfNotPresent"
           command: ["spicedb", "serve"]
           env:
-            - name: "SPICEDB_GRPC_NO_TLS"
-              value: "true"
             - name: "SPICEDB_GRPC_SHUTDOWN_GRACE_PERIOD"
               value: "1s"
             - name: "SPICEDB_LOG_LEVEL"


### PR DESCRIPTION
This commit also:
- renames internal-grpc flags to dispatch-redispatch
- fixes logging occurring during the version command
- adds a missing error to a log in `serve-devtools`
- adds missing flags to various servers
- refactors gateway & dashboard to return http.Handler