### PR TITLE
use the grpc_health_probe binary from the official images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
 FROM golang:1.17.2-alpine3.13 AS spicedb-builder
-
-ARG GRPC_HEALTH_PROBE_VERSION=0.3.6
-RUN apk add curl
-RUN curl -Lo /go/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64
-RUN chmod +x /go/bin/grpc_health_probe
-
 WORKDIR /go/src/app
 
 # Prepare dependencies
@@ -17,6 +11,6 @@ RUN go build ./cmd/spicedb/
 FROM alpine:3.14.2
 
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
-COPY --from=spicedb-builder /go/bin/grpc_health_probe /usr/local/bin/
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.6 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY --from=spicedb-builder /go/src/app/spicedb /usr/local/bin/spicedb
 ENTRYPOINT ["spicedb"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,14 +1,5 @@
 # vim: syntax=dockerfile
-FROM alpine AS grpc
-ARG TARGETARCH
-ARG GRPC_HEALTH_PROBE_VERSION=0.3.6
-RUN apk update && \
-	apk add curl && \
-	curl -Lo /grpc_health_probe \
-	https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v$GRPC_HEALTH_PROBE_VERSION/grpc_health_probe-linux-$TARGETARCH && \
-	chmod +x /grpc_health_probe
-
 FROM gcr.io/distroless/base
-COPY --from=grpc /grpc_health_probe /usr/local/bin/grpc_health_probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.6 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY spicedb /usr/local/bin/spicedb
 ENTRYPOINT ["spicedb"]


### PR DESCRIPTION
Ran goreleaser locally and checked the output (on an arm mac):

```sh
$ docker run --entrypoint=grpc_health_probe quay.io/authzed/spicedb:v1.1.1-next-arm64
error: -addr not specified
$ docker run --entrypoint=grpc_health_probe quay.io/authzed/spicedb:v1.1.1-next-amd64
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
error: -addr not specified
```