### PR TITLE
feat: add v1 Watch API implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Masterminds/squirrel v1.5.1
 	github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a
-	github.com/authzed/authzed-go v0.3.0
+	github.com/authzed/authzed-go v0.3.1-0.20211109190421-0b30d667df2e
 	github.com/authzed/grpcutil v0.0.0-20211020204402-aba1876830e6
 	github.com/aws/aws-sdk-go v1.41.15
 	github.com/benbjohnson/clock v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/authzed/authzed-go v0.3.0 h1:m5eqPX9p1mhdbd8jrFhNORx5PvnHQ2e1bISweEwja+E=
-github.com/authzed/authzed-go v0.3.0/go.mod h1:bsUniBRroq4l5WZMYLO+T9osQa/P2qMwZ+Af8zoJK8Y=
+github.com/authzed/authzed-go v0.3.1-0.20211109190421-0b30d667df2e h1:UmsD/3lWJ3BXOGGvRTbLkrNOcaR4X+GIQldcX7e0Oyg=
+github.com/authzed/authzed-go v0.3.1-0.20211109190421-0b30d667df2e/go.mod h1:bsUniBRroq4l5WZMYLO+T9osQa/P2qMwZ+Af8zoJK8Y=
 github.com/authzed/grpcutil v0.0.0-20210913124023-cad23ae5a9e8/go.mod h1:HwO/KbRU3fWXEYHE96kvXnwxzi97tkXD1hfi5UaZ71Y=
 github.com/authzed/grpcutil v0.0.0-20211020204402-aba1876830e6 h1:izP/rEris51ZmomXb5J0ShyJKqsxTfVKDRnJz0QGbgg=
 github.com/authzed/grpcutil v0.0.0-20211020204402-aba1876830e6/go.mod h1:rqjY3zyK/YP7NID9+B2BdIRRkvnK+cdf9/qya/zaFZE=

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -55,6 +55,9 @@ func RegisterGrpcServices(
 	v1.RegisterPermissionsServiceServer(srv, v1svc.NewPermissionsServer(ds, nsm, dispatch, maxDepth))
 	healthSrv.SetServicesHealthy(&v1.PermissionsService_ServiceDesc)
 
+	v1.RegisterWatchServiceServer(srv, v1svc.NewWatchServer(ds))
+	healthSrv.SetServicesHealthy(&v1.WatchService_ServiceDesc)
+
 	if schemaServiceOption == V1SchemaServiceEnabled {
 		v1.RegisterSchemaServiceServer(srv, v1svc.NewSchemaServer(ds))
 		healthSrv.SetServicesHealthy(&v1.SchemaService_ServiceDesc)

--- a/internal/services/v1/watch_test.go
+++ b/internal/services/v1/watch_test.go
@@ -1,0 +1,208 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/grpcutil"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore"
+	"github.com/authzed/spicedb/internal/datastore/memdb"
+	"github.com/authzed/spicedb/internal/testfixtures"
+	"github.com/authzed/spicedb/pkg/zedtoken"
+)
+
+func update(
+	op v1.RelationshipUpdate_Operation,
+	resourceObjType,
+	resourceObjID,
+	relation,
+	subObjType,
+	subObjectID string,
+) *v1.RelationshipUpdate {
+	return &v1.RelationshipUpdate{
+		Operation: op,
+		Relationship: &v1.Relationship{
+			Resource: &v1.ObjectReference{
+				ObjectType: resourceObjType,
+				ObjectId:   resourceObjID,
+			},
+			Relation: relation,
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: subObjType,
+					ObjectId:   subObjectID,
+				},
+			},
+		},
+	}
+}
+
+func TestWatch(t *testing.T) {
+	testCases := []struct {
+		name              string
+		objectTypesFilter []string
+		startCursor       *v1.ZedToken
+		mutations         []*v1.RelationshipUpdate
+		expectedCode      codes.Code
+		expectedUpdates   []*v1.RelationshipUpdate
+	}{
+		{
+			name:         "unfiltered watch",
+			expectedCode: codes.OK,
+			mutations: []*v1.RelationshipUpdate{
+				update(v1.RelationshipUpdate_OPERATION_CREATE, "document", "document1", "viewer", "user", "user1"),
+				update(v1.RelationshipUpdate_OPERATION_DELETE, "folder", "folder1", "viewer", "user", "user1"),
+				update(v1.RelationshipUpdate_OPERATION_TOUCH, "folder", "folder2", "viewer", "user", "user1"),
+			},
+			expectedUpdates: []*v1.RelationshipUpdate{
+				update(v1.RelationshipUpdate_OPERATION_CREATE, "document", "document1", "viewer", "user", "user1"),
+				update(v1.RelationshipUpdate_OPERATION_DELETE, "folder", "folder1", "viewer", "user", "user1"),
+				update(v1.RelationshipUpdate_OPERATION_TOUCH, "folder", "folder2", "viewer", "user", "user1"),
+			},
+		},
+		{
+			name:              "watch with objectType filter",
+			expectedCode:      codes.OK,
+			objectTypesFilter: []string{"document"},
+			mutations: []*v1.RelationshipUpdate{
+				update(v1.RelationshipUpdate_OPERATION_CREATE, "document", "document1", "viewer", "user", "user1"),
+				update(v1.RelationshipUpdate_OPERATION_TOUCH, "document", "document2", "viewer", "user", "user1"),
+				update(v1.RelationshipUpdate_OPERATION_DELETE, "folder", "folder1", "viewer", "user", "user1"),
+			},
+			expectedUpdates: []*v1.RelationshipUpdate{
+				update(v1.RelationshipUpdate_OPERATION_CREATE, "document", "document1", "viewer", "user", "user1"),
+				update(v1.RelationshipUpdate_OPERATION_TOUCH, "document", "document2", "viewer", "user", "user1"),
+			},
+		},
+		{
+			name:         "invalid zedtoken",
+			startCursor:  &v1.ZedToken{Token: "bad-token"},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name:         "empty zedtoken fails validation",
+			startCursor:  &v1.ZedToken{Token: ""},
+			expectedCode: codes.InvalidArgument,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC, 0)
+			require.NoError(err)
+
+			ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
+
+			revision, err := ds.SyncRevision(context.Background())
+			require.NoError(err)
+			require.True(revision.GreaterThan(decimal.Zero))
+
+			client, stop := newWatchServicer(require, ds)
+			defer stop()
+
+			cursor := zedtoken.NewFromRevision(revision)
+			if tc.startCursor != nil {
+				cursor = tc.startCursor
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			stream, err := client.Watch(ctx, &v1.WatchRequest{
+				OptionalObjectTypes: tc.objectTypesFilter,
+				OptionalStartCursor: cursor,
+			})
+			require.NoError(err)
+
+			if tc.expectedCode == codes.OK {
+
+				updatesChan := make(chan []*v1.RelationshipUpdate, len(tc.mutations))
+
+				go func() {
+					defer close(updatesChan)
+
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						case <-time.After(3 * time.Second):
+							panic(fmt.Errorf("timed out waiting for stream updates"))
+						default:
+							resp, err := stream.Recv()
+							if err != nil {
+								errStatus, ok := status.FromError(err)
+								if (ok && (errStatus.Code() == codes.Canceled || errStatus.Code() == codes.Unavailable)) || err == io.EOF {
+									break
+								}
+
+								panic(fmt.Errorf("received a stream read error: %v", err))
+							}
+
+							updatesChan <- resp.Updates
+						}
+					}
+				}()
+
+				_, err = ds.WriteTuples(context.Background(), nil, tc.mutations)
+				require.NoError(err)
+
+				var receivedUpdates []*v1.RelationshipUpdate
+				select {
+				case updates := <-updatesChan:
+					receivedUpdates = updates
+				case <-time.After(3 * time.Second):
+					require.FailNow("timed out waiting for updates")
+					return
+				}
+
+				require.Equal(len(tc.expectedUpdates), len(receivedUpdates))
+
+			} else {
+				_, err := stream.Recv()
+				grpcutil.RequireStatus(t, tc.expectedCode, err)
+			}
+		})
+	}
+}
+
+func newWatchServicer(
+	require *require.Assertions,
+	ds datastore.Datastore,
+) (v1.WatchServiceClient, func()) {
+
+	lis := bufconn.Listen(1024 * 1024)
+	s := testfixtures.NewTestServer()
+
+	v1.RegisterWatchServiceServer(s, NewWatchServer(ds))
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			panic("failed to shutdown cleanly: " + err.Error())
+		}
+	}()
+
+	conn, err := grpc.Dial("", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithInsecure())
+	require.NoError(err)
+
+	return v1.NewWatchServiceClient(conn), func() {
+		require.NoError(conn.Close())
+		s.Stop()
+		require.NoError(lis.Close())
+	}
+}

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -188,6 +188,18 @@ func ToFilter(tpl *v0.RelationTuple) *v1.RelationshipFilter {
 	}
 }
 
+// UpdatesToRelationshipUpdates converts a slice of RelationTupleUpdate into a
+// slice of RelationshipUpdate.
+func UpdatesToRelationshipUpdates(updates []*v0.RelationTupleUpdate) []*v1.RelationshipUpdate {
+	relationshipUpdates := make([]*v1.RelationshipUpdate, 0, len(updates))
+
+	for _, update := range updates {
+		relationshipUpdates = append(relationshipUpdates, UpdateToRelationshipUpdate(update))
+	}
+
+	return relationshipUpdates
+}
+
 // UpdateToRelationshipUpdate converts a RelationTupleUpdate into a
 // RelationshipUpdate.
 func UpdateToRelationshipUpdate(update *v0.RelationTupleUpdate) *v1.RelationshipUpdate {


### PR DESCRIPTION
The changes herein add support for the v1 Watch API. The implementation chooses to implement a wildcard approach which allows the user to omit the `ObjectType` list if they wish to watch all object types. This approach was recommended by @ecordell and myself in the development channel of Discord and has also been discussed as an approach in the LookupSubjects API as discussed in #261.

https://discord.com/channels/844600078504951838/900405749405089812/906247932490158082
https://discord.com/channels/844600078504951838/900405749405089812/906274500004438036