### PR TITLE
fix watch index in the memdb datastore implementation

### DIFF
--- a/internal/datastore/memdb/watch.go
+++ b/internal/datastore/memdb/watch.go
@@ -65,7 +65,7 @@ func (mds *memdbDatastore) loadChanges(currentTxn uint64) ([]*datastore.Revision
 	loadNewTxn := mds.db.Txn(false)
 	defer loadNewTxn.Abort()
 
-	it, err := loadNewTxn.LowerBound(tableChangelog, indexID, currentTxn+1)
+	it, err := loadNewTxn.LowerBound(tableChangelog, indexID, currentTxn-1)
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf(errWatchError, err)
 	}

--- a/internal/datastore/memdb/watch_test.go
+++ b/internal/datastore/memdb/watch_test.go
@@ -1,0 +1,84 @@
+package memdb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/internal/datastore"
+	"github.com/authzed/spicedb/internal/testfixtures"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatch(t *testing.T) {
+	require := require.New(t)
+
+	memdbStore, err := NewMemdbDatastore(0, 0, DisableGC, 0)
+	require.NoError(err)
+
+	ds, revision := testfixtures.StandardDatastoreWithSchema(memdbStore, require)
+	require.True(revision.GreaterThan(decimal.Zero))
+
+	receivedChangesChan := make(chan *datastore.RevisionChanges)
+
+	changes, errchan := ds.Watch(context.Background(), revision)
+	go func() {
+		for {
+			select {
+			case change, ok := <-changes:
+				if ok {
+					receivedChangesChan <- change
+				}
+			case err = <-errchan:
+				require.FailNow("received unexpected error: %v", err)
+			}
+		}
+	}()
+
+	for i := 0; i < 3; i++ {
+		update := &v1.RelationshipUpdate{
+			Operation: v1.RelationshipUpdate_OPERATION_CREATE,
+			Relationship: &v1.Relationship{
+				Resource: &v1.ObjectReference{
+					ObjectType: "document",
+					ObjectId:   fmt.Sprintf("document%d", i),
+				},
+				Relation: "viewer",
+				Subject: &v1.SubjectReference{
+					Object: &v1.ObjectReference{
+						ObjectType: "user",
+						ObjectId:   "user1",
+					},
+				},
+			},
+		}
+
+		revision, err = ds.WriteTuples(context.Background(), nil, []*v1.RelationshipUpdate{update})
+		require.True(revision.GreaterThan(decimal.Zero))
+		require.NoError(err)
+
+		ready := make(chan struct{})
+
+		var receivedChanges []*datastore.RevisionChanges
+		go func() {
+			defer func() {
+				ready <- struct{}{}
+			}()
+
+			select {
+			case change := <-receivedChangesChan:
+				receivedChanges = append(receivedChanges, change)
+			case <-time.After(3 * time.Second):
+				require.FailNow("timed out waiting for watch updates")
+				return
+			}
+		}()
+
+		<-ready
+
+		require.Equal(1, len(receivedChanges))
+	}
+}


### PR DESCRIPTION
@jakedt this fixes the memdb Watch implementation. With this change, tuples that are written after the revision provided to the memdb Watch API will show up properly.

The current implementation starts the watch over the lower range of keys starting at one commit ahead of the revision specified by the client. By the time Watch is invoked the transaction counter will be 1 greater than the last committed index, so nothing prior will have a Watch over it