### PR TITLE
introduce validate command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 dist/
-.idea

--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -18,6 +18,7 @@ func main() {
 	registerHeadCmd(rootCmd)
 	registerDeveloperServiceCmd(rootCmd)
 	registerTestserverCmd(rootCmd)
+	registerValidateCmd(rootCmd)
 
 	_ = rootCmd.Execute()
 }

--- a/cmd/spicedb/validate.go
+++ b/cmd/spicedb/validate.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
+	v0svc "github.com/authzed/spicedb/internal/services/v0"
+	"github.com/authzed/spicedb/pkg/validationfile"
+	"github.com/jzelinskie/cobrautil"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func registerValidateCmd(rootCmd *cobra.Command) {
+	testserveCmd := &cobra.Command{
+		Use:               "validate",
+		Short:             "validate a playground YAML file",
+		Long:              "validate a playground YAML file.",
+		PersistentPreRunE: persistentPreRunE,
+		Run:               runValidate,
+	}
+
+	testserveCmd.Flags().StringSlice("configs", []string{}, "configuration yaml files to load")
+
+	rootCmd.AddCommand(testserveCmd)
+}
+
+func runValidate(cmd *cobra.Command, _ []string) {
+	configFilePaths := cobrautil.MustGetStringSliceExpanded(cmd, "configs")
+	for _, path := range configFilePaths {
+		bytes, err := os.ReadFile(path)
+		if err != nil {
+			log.Fatal().Str("path", path).Msg("failed to load playground configuration file")
+		}
+		devErrors, err := validatePlaygroundYAML(bytes)
+		if err != nil {
+			log.Fatal().Str("path", path).Err(err).Msg("failed to validate playground file")
+		}
+
+		for _, devError := range devErrors {
+			log.Error().Uint32("line", devError.Line).Msg(devError.Message)
+		}
+		valid := len(devErrors) == 0
+		event := log.Info()
+		if !valid {
+			event = log.Fatal()
+		}
+		event.Str("path", path).Bool("valid", valid).Msg("playground file validated")
+	}
+}
+
+// v2 playground files are not yet exposed in the API
+type playgroundYAMLv2 struct {
+	Validations map[string][]string `json:"validation_yaml" yaml:"validation"`
+	Assertions  map[string][]string `json:"assertions_yaml" yaml:"assertions"`
+}
+
+func validatePlaygroundYAML(playgroundYaml []byte) ([]*v0.DeveloperError, error) {
+	var playgroundv2 playgroundYAMLv2
+	var validationFile validationfile.ValidationFile
+
+	err := yaml.Unmarshal(playgroundYaml, &playgroundv2)
+	if err != nil {
+		return nil, fmt.Errorf("failed unmarshal playground YAML: %w", err)
+	}
+	err = yaml.Unmarshal(playgroundYaml, &validationFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed unmarshal playground YAML: %w", err)
+	}
+
+	validationYAML, err := yaml.Marshal(playgroundv2.Validations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse playground YAML validations: %w", err)
+	}
+	assertionYAML, err := yaml.Marshal(playgroundv2.Assertions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse playground YAML assertions: %w", err)
+	}
+	tuples, err := validationfile.ParseRelationships(validationFile.Relationships)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse playground YAML relationships: %w", err)
+	}
+	dev := v0svc.NewDeveloperServer(v0svc.NewInMemoryShareStore("salt"))
+
+	resp, err := dev.Validate(context.Background(), &v0.ValidateRequest{
+		Context: &v0.RequestContext{
+			Schema:        validationFile.Schema,
+			Relationships: tuples,
+		},
+		AssertionsYaml:       string(assertionYAML),
+		ValidationYaml:       string(validationYAML),
+		UpdateValidationYaml: false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to validate playground YAML: %w", err)
+	}
+	return resp.ValidationErrors, nil
+}

--- a/internal/services/v0/devcontext.go
+++ b/internal/services/v0/devcontext.go
@@ -7,6 +7,7 @@ import (
 
 	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/validationfile"
 	"github.com/rs/zerolog/log"
 	"github.com/shopspring/decimal"
 
@@ -112,7 +113,7 @@ func newDevContext(ctx context.Context, requestContext *v0.RequestContext, ds da
 	}, len(requestErrors) == 0, nil
 }
 
-func (dc *DevContext) dispose() {
+func (dc *DevContext) Dispose() {
 	datastore := dc.Datastore
 	if datastore != nil {
 		err := dc.NamespaceManager.Close()
@@ -176,7 +177,7 @@ func loadTuples(ctx context.Context, tuples []*v0.RelationTuple, nsm namespace.M
 
 		err := validateTupleWrite(ctx, tpl, nsm)
 		if err != nil {
-			verrs, wireErr := rewriteGraphError(v0.DeveloperError_RELATIONSHIP, 0, 0, tuple.String(tpl), err)
+			verrs, wireErr := validationfile.RewriteGraphError(v0.DeveloperError_RELATIONSHIP, 0, 0, tuple.String(tpl), err)
 			if wireErr == nil {
 				errors = append(errors, verrs...)
 				continue

--- a/internal/services/v0/developer.go
+++ b/internal/services/v0/developer.go
@@ -2,27 +2,22 @@ package v0
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"regexp"
-	"sort"
-	"strconv"
 	"strings"
 
 	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
 	"github.com/authzed/grpcutil"
-	"github.com/google/go-cmp/cmp"
+	v1 "github.com/authzed/spicedb/internal/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/prototext"
 
-	v1 "github.com/authzed/spicedb/internal/proto/dispatch/v1"
-	"github.com/authzed/spicedb/internal/sharederrors"
-	"github.com/authzed/spicedb/pkg/membership"
 	"github.com/authzed/spicedb/pkg/schemadsl/generator"
-	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/authzed/spicedb/pkg/validationfile"
 )
+
+const maxDepth = 25
 
 type devServer struct {
 	v0.UnimplementedDeveloperServiceServer
@@ -30,8 +25,6 @@ type devServer struct {
 
 	shareStore ShareStore
 }
-
-const maxDepth = 25
 
 // RegisterDeveloperServer adds the Developer Server to a grpc service registrar
 // This is preferred over manually registering the service; it will add required middleware
@@ -149,7 +142,7 @@ func (ds *devServer) EditCheck(ctx context.Context, req *v0.EditCheckRequest) (*
 			RequestErrors: devContext.RequestErrors,
 		}, nil
 	}
-	defer devContext.dispose()
+	defer devContext.Dispose()
 
 	// Run the checks and store their output.
 	var results []*v0.EditCheckResult
@@ -163,7 +156,7 @@ func (ds *devServer) EditCheck(ctx context.Context, req *v0.EditCheckRequest) (*
 			},
 		})
 		if err != nil {
-			requestErrors, wireErr := rewriteGraphError(v0.DeveloperError_CHECK_WATCH, 0, 0, tuple.String(checkTpl), err)
+			requestErrors, wireErr := validationfile.RewriteGraphError(v0.DeveloperError_CHECK_WATCH, 0, 0, tuple.String(checkTpl), err)
 			if len(requestErrors) == 1 {
 				results = append(results, &v0.EditCheckResult{
 					Relationship: checkTpl,
@@ -200,386 +193,8 @@ func (ds *devServer) Validate(ctx context.Context, req *v0.ValidateRequest) (*v0
 			RequestErrors: devContext.RequestErrors,
 		}, nil
 	}
-	defer devContext.dispose()
-
-	// Parse the validation YAML.
-	validation, err := validationfile.ParseValidationBlock([]byte(req.ValidationYaml))
-	if err != nil {
-		return &v0.ValidateResponse{
-			RequestErrors: []*v0.DeveloperError{
-				convertYamlError(v0.DeveloperError_VALIDATION_YAML, err),
-			},
-		}, nil
-	}
-
-	// Parse the assertions YAML.
-	assertions, err := validationfile.ParseAssertionsBlock([]byte(req.AssertionsYaml))
-	if err != nil {
-		return &v0.ValidateResponse{
-			RequestErrors: []*v0.DeveloperError{
-				convertYamlError(v0.DeveloperError_ASSERTION, err),
-			},
-		}, nil
-	}
-
-	// Run assertions.
-	assertTrueRelationships, aerr := assertions.AssertTrueRelationships()
-	if aerr != nil {
-		return &v0.ValidateResponse{
-			RequestErrors: []*v0.DeveloperError{
-				convertSourceError(v0.DeveloperError_ASSERTION, aerr),
-			},
-		}, nil
-	}
-
-	assertFalseRelationships, aerr := assertions.AssertFalseRelationships()
-	if aerr != nil {
-		return &v0.ValidateResponse{
-			RequestErrors: []*v0.DeveloperError{
-				convertSourceError(v0.DeveloperError_ASSERTION, aerr),
-			},
-		}, nil
-	}
-
-	trueFailures, err := runAssertions(ctx, devContext, assertTrueRelationships, true, "Expected relation or permission %s to exist")
-	if err != nil {
-		return nil, err
-	}
-
-	falseFailures, err := runAssertions(ctx, devContext, assertFalseRelationships, false, "Expected relation or permission %s to not exist")
-	if err != nil {
-		return nil, err
-	}
-
-	failures := append(trueFailures, falseFailures...)
-
-	// Run validation.
-	membershipSet, validationFailures, wireErr := runValidation(ctx, devContext, validation)
-	if wireErr != nil {
-		return nil, wireErr
-	}
-
-	// If requested, regenerate the validation YAML.
-	updatedValidationYaml := ""
-	if membershipSet != nil && req.UpdateValidationYaml {
-		updatedValidationYaml, err = generateValidation(membershipSet)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return &v0.ValidateResponse{
-		ValidationErrors:      append(failures, validationFailures...),
-		UpdatedValidationYaml: updatedValidationYaml,
-	}, nil
-}
-
-func runAssertions(ctx context.Context, devContext *DevContext, assertions []validationfile.ParsedAssertion, expected bool, fmtString string) ([]*v0.DeveloperError, error) {
-	var failures []*v0.DeveloperError
-	for _, assertion := range assertions {
-		cr, err := devContext.Dispatcher.DispatchCheck(ctx, &v1.DispatchCheckRequest{
-			ObjectAndRelation: assertion.Relationship.ObjectAndRelation,
-			Subject:           assertion.Relationship.User.GetUserset(),
-			Metadata: &v1.ResolverMeta{
-				AtRevision:     devContext.Revision.String(),
-				DepthRemaining: maxDepth,
-			},
-		})
-		if err != nil {
-			validationErrs, wireErr := rewriteGraphError(
-				v0.DeveloperError_ASSERTION,
-				assertion.LineNumber,
-				assertion.ColumnPosition,
-				tuple.String(assertion.Relationship),
-				err,
-			)
-			failures = append(failures, validationErrs...)
-			if wireErr != nil {
-				return nil, wireErr
-			}
-		} else if (cr.Membership == v1.DispatchCheckResponse_MEMBER) != expected {
-			failures = append(failures, &v0.DeveloperError{
-				Message: fmt.Sprintf(fmtString, tuple.String(assertion.Relationship)),
-				Source:  v0.DeveloperError_ASSERTION,
-				Kind:    v0.DeveloperError_ASSERTION_FAILED,
-				Context: tuple.String(assertion.Relationship),
-				Line:    assertion.LineNumber,
-				Column:  assertion.ColumnPosition,
-			})
-		}
-	}
-
-	return failures, nil
-}
-
-func generateValidation(membershipSet *membership.MembershipSet) (string, error) {
-	validationMap := validationfile.ValidationMap{}
-	subjectsByONR := membershipSet.SubjectsByONR()
-
-	var onrStrings []string
-	for onrString := range subjectsByONR {
-		onrStrings = append(onrStrings, onrString)
-	}
-
-	// Sort to ensure stability of output.
-	sort.Strings(onrStrings)
-
-	for _, onrString := range onrStrings {
-		foundSubjects := subjectsByONR[onrString]
-		var strs []string
-		for _, fs := range foundSubjects.ListFound() {
-			strs = append(strs,
-				fmt.Sprintf("[%s] is %s",
-					tuple.StringONR(fs.Subject()),
-					strings.Join(wrapRelationships(tuple.StringsONRs(fs.Relationships())), "/"),
-				))
-		}
-
-		// Sort to ensure stability of output.
-		sort.Strings(strs)
-
-		var validationStrings []validationfile.ValidationString
-		for _, s := range strs {
-			validationStrings = append(validationStrings, validationfile.ValidationString(s))
-		}
-
-		validationMap[validationfile.ObjectRelationString(onrString)] = validationStrings
-	}
-
-	return validationMap.AsYAML()
-}
-
-func runValidation(ctx context.Context, devContext *DevContext, validation validationfile.ValidationMap) (*membership.MembershipSet, []*v0.DeveloperError, error) {
-	var failures []*v0.DeveloperError
-	membershipSet := membership.NewMembershipSet()
-
-	for onrKey, validationStrings := range validation {
-		// Unmarshal the ONR to expand from its string form.
-		onr, err := onrKey.ONR()
-		if err != nil {
-			failures = append(failures,
-				&v0.DeveloperError{
-					Message: err.Error(),
-					Source:  v0.DeveloperError_VALIDATION_YAML,
-					Kind:    v0.DeveloperError_PARSE_ERROR,
-					Context: err.Source,
-				},
-			)
-			continue
-		}
-
-		// Run a full recursive expansion over the ONR.
-		er, dispatchErr := devContext.Dispatcher.DispatchExpand(ctx, &v1.DispatchExpandRequest{
-			ObjectAndRelation: onr,
-			Metadata: &v1.ResolverMeta{
-				AtRevision:     devContext.Revision.String(),
-				DepthRemaining: maxDepth,
-			},
-			ExpansionMode: v1.DispatchExpandRequest_RECURSIVE,
-		})
-		if dispatchErr != nil {
-			validationErrs, wireErr := rewriteGraphError(v0.DeveloperError_VALIDATION_YAML, 0, 0, string(onrKey), dispatchErr)
-			if validationErrs != nil {
-				failures = append(failures, validationErrs...)
-				return nil, failures, nil
-			}
-
-			return nil, nil, wireErr
-		}
-
-		// Add the ONR and its expansion to the membership set.
-		foundSubjects, _, aerr := membershipSet.AddExpansion(onr, er.TreeNode)
-		if aerr != nil {
-			validationErrs, wireErr := rewriteGraphError(v0.DeveloperError_VALIDATION_YAML, 0, 0, string(onrKey), aerr)
-			if validationErrs != nil {
-				failures = append(failures, validationErrs...)
-				continue
-			}
-
-			return nil, nil, wireErr
-		}
-
-		// Compare the terminal subjects found to those specified.
-		errs := validateSubjects(onr, foundSubjects, validationStrings)
-		failures = append(failures, errs...)
-	}
-
-	return membershipSet, failures, nil
-}
-
-func wrapRelationships(onrStrings []string) []string {
-	var wrapped []string
-	for _, str := range onrStrings {
-		wrapped = append(wrapped, fmt.Sprintf("<%s>", str))
-	}
-
-	// Sort to ensure stability.
-	sort.Strings(wrapped)
-	return wrapped
-}
-
-func validateSubjects(onr *v0.ObjectAndRelation, fs membership.FoundSubjects, validationStrings []validationfile.ValidationString) []*v0.DeveloperError {
-	var failures []*v0.DeveloperError
-
-	// Verify that every referenced subject is found in the membership.
-	encounteredSubjects := map[string]struct{}{}
-	for _, validationString := range validationStrings {
-		subjectONR, err := validationString.Subject()
-		if err != nil {
-			failures = append(failures, &v0.DeveloperError{
-				Message: fmt.Sprintf("For object and permission/relation `%s`, %s", tuple.StringONR(onr), err.Error()),
-				Source:  v0.DeveloperError_VALIDATION_YAML,
-				Kind:    v0.DeveloperError_PARSE_ERROR,
-				Context: fmt.Sprintf("[%s]", err.Source),
-			})
-			continue
-		}
-
-		if subjectONR == nil {
-			continue
-		}
-
-		encounteredSubjects[tuple.StringONR(subjectONR)] = struct{}{}
-
-		expectedRelationships, err := validationString.ONRS()
-		if err != nil {
-			failures = append(failures, &v0.DeveloperError{
-				Message: fmt.Sprintf("For object and permission/relation `%s`, %s", tuple.StringONR(onr), err.Error()),
-				Source:  v0.DeveloperError_VALIDATION_YAML,
-				Kind:    v0.DeveloperError_PARSE_ERROR,
-				Context: fmt.Sprintf("<%s>", err.Source),
-			})
-			continue
-		}
-
-		subject, ok := fs.LookupSubject(subjectONR)
-		if !ok {
-			failures = append(failures, &v0.DeveloperError{
-				Message: fmt.Sprintf("For object and permission/relation `%s`, missing expected subject `%s`", tuple.StringONR(onr), tuple.StringONR(subjectONR)),
-				Source:  v0.DeveloperError_VALIDATION_YAML,
-				Kind:    v0.DeveloperError_MISSING_EXPECTED_RELATIONSHIP,
-				Context: tuple.StringONR(subjectONR),
-			})
-			continue
-		}
-
-		foundRelationships := subject.Relationships()
-
-		// Verify that the relationships are the same.
-		expectedONRStrings := tuple.StringsONRs(expectedRelationships)
-		foundONRStrings := tuple.StringsONRs(foundRelationships)
-		if !cmp.Equal(expectedONRStrings, foundONRStrings) {
-			failures = append(failures, &v0.DeveloperError{
-				Message: fmt.Sprintf("For object and permission/relation `%s`, found different relationships for subject `%s`: Specified: `%s`, Computed: `%s`",
-					tuple.StringONR(onr),
-					tuple.StringONR(subjectONR),
-					strings.Join(wrapRelationships(expectedONRStrings), "/"),
-					strings.Join(wrapRelationships(foundONRStrings), "/"),
-				),
-				Source:  v0.DeveloperError_VALIDATION_YAML,
-				Kind:    v0.DeveloperError_MISSING_EXPECTED_RELATIONSHIP,
-				Context: string(validationString),
-			})
-		}
-	}
-
-	// Verify that every subject found was referenced.
-	for _, foundSubject := range fs.ListFound() {
-		_, ok := encounteredSubjects[tuple.StringONR(foundSubject.Subject())]
-		if !ok {
-			failures = append(failures, &v0.DeveloperError{
-				Message: fmt.Sprintf("For object and permission/relation `%s`, subject `%s` found but missing from specified",
-					tuple.StringONR(onr),
-					tuple.StringONR(foundSubject.Subject()),
-				),
-				Source:  v0.DeveloperError_VALIDATION_YAML,
-				Kind:    v0.DeveloperError_EXTRA_RELATIONSHIP_FOUND,
-				Context: tuple.StringONR(onr),
-			})
-		}
-	}
-
-	return failures
-}
-
-func rewriteGraphError(source v0.DeveloperError_Source, line uint32, column uint32, context string, checkError error) ([]*v0.DeveloperError, error) {
-	var nsNotFoundError sharederrors.UnknownNamespaceError
-	var relNotFoundError sharederrors.UnknownRelationError
-
-	if errors.As(checkError, &nsNotFoundError) {
-		return []*v0.DeveloperError{
-			{
-				Message: checkError.Error(),
-				Source:  source,
-				Kind:    v0.DeveloperError_UNKNOWN_OBJECT_TYPE,
-				Line:    line,
-				Column:  column,
-				Context: context,
-			},
-		}, nil
-	}
-
-	if errors.As(checkError, &relNotFoundError) {
-		return []*v0.DeveloperError{
-			{
-				Message: checkError.Error(),
-				Source:  source,
-				Kind:    v0.DeveloperError_UNKNOWN_RELATION,
-				Line:    line,
-				Column:  column,
-				Context: context,
-			},
-		}, nil
-	}
-
-	var ire invalidRelationError
-	if errors.As(checkError, &ire) {
-		return []*v0.DeveloperError{
-			{
-				Message: checkError.Error(),
-				Source:  source,
-				Kind:    v0.DeveloperError_UNKNOWN_RELATION,
-				Line:    line,
-				Column:  column,
-				Context: context,
-			},
-		}, nil
-	}
-
-	return nil, rewriteACLError(checkError)
-}
-
-func convertSourceError(source v0.DeveloperError_Source, err *validationfile.ErrorWithSource) *v0.DeveloperError {
-	return &v0.DeveloperError{
-		Message: err.Error(),
-		Kind:    v0.DeveloperError_PARSE_ERROR,
-		Source:  source,
-		Line:    err.LineNumber,
-		Column:  err.ColumnPosition,
-		Context: err.Source,
-	}
-}
-
-var yamlLineRegex = regexp.MustCompile(`line ([0-9]+): (.+)`)
-
-func convertYamlError(source v0.DeveloperError_Source, err error) *v0.DeveloperError {
-	var lineNumber uint64
-	msg := err.Error()
-
-	pieces := yamlLineRegex.FindStringSubmatch(err.Error())
-	if len(pieces) == 3 {
-		// We can safely ignore the error here because it will default to 0, which is the not found
-		// case.
-		lineNumber, _ = strconv.ParseUint(pieces[1], 10, 0)
-		msg = pieces[2]
-	}
-
-	return &v0.DeveloperError{
-		Message: msg,
-		Kind:    v0.DeveloperError_PARSE_ERROR,
-		Source:  source,
-		Line:    uint32(lineNumber),
-	}
+	defer devContext.Dispose()
+	return validationfile.Validate(ctx, req, devContext.Dispatcher, devContext.Revision)
 }
 
 func upgradeSchema(configs []string) (string, error) {

--- a/pkg/validationfile/fileformat.go
+++ b/pkg/validationfile/fileformat.go
@@ -81,7 +81,7 @@ func ParseRelationships(relationshipsBlock ...string) ([]*v0.RelationTuple, erro
 
 				tpl := tuple.Parse(trimmed)
 				if tpl == nil {
-					return nil, fmt.Errorf("Error parsing relationship #%v: %s", index, trimmed)
+					return nil, fmt.Errorf("error parsing relationship #%v: %s", index, trimmed)
 				}
 				_, ok := tupleExists[tuple.String(tpl)]
 				if ok {

--- a/pkg/validationfile/fileformat.go
+++ b/pkg/validationfile/fileformat.go
@@ -67,6 +67,35 @@ func ParseValidationBlock(contents []byte) (ValidationMap, error) {
 	return block, err
 }
 
+func ParseRelationships(relationshipsBlock ...string) ([]*v0.RelationTuple, error) {
+	var tuples []*v0.RelationTuple
+	tupleExists := map[string]bool{}
+	for _, block := range relationshipsBlock {
+		if block != "" {
+			lines := strings.Split(block, "\n")
+			for index, line := range lines {
+				trimmed := strings.TrimSpace(line)
+				if len(trimmed) == 0 {
+					continue
+				}
+
+				tpl := tuple.Parse(trimmed)
+				if tpl == nil {
+					return nil, fmt.Errorf("Error parsing relationship #%v: %s", index, trimmed)
+				}
+				_, ok := tupleExists[tuple.String(tpl)]
+				if ok {
+					continue
+				}
+				tupleExists[tuple.String(tpl)] = true
+				tuples = append(tuples, tpl)
+			}
+		}
+	}
+
+	return tuples, nil
+}
+
 // ParseAssertionsBlock attempts to parse the given contents as a YAML assertions block.
 func ParseAssertionsBlock(contents []byte) (Assertions, error) {
 	var node yamlv3.Node

--- a/pkg/validationfile/fileformat.go
+++ b/pkg/validationfile/fileformat.go
@@ -35,6 +35,10 @@ type ValidationFile struct {
 	// ValidationTuples are the validation tuples, in tuple string syntax. Optional if Relationships
 	// are specified.
 	ValidationTuples []string `yaml:"validation_tuples"`
+
+	Validations map[string][]string `yaml:"validation"`
+
+	Assertions map[string][]string `yaml:"assertions"`
 }
 
 // ErrorWithSource is an error that includes the source text and position information.

--- a/pkg/validationfile/validation.go
+++ b/pkg/validationfile/validation.go
@@ -1,0 +1,434 @@
+package validationfile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
+	"github.com/authzed/spicedb/internal/dispatch"
+	v1 "github.com/authzed/spicedb/internal/proto/dispatch/v1"
+	"github.com/authzed/spicedb/internal/sharederrors"
+	"github.com/authzed/spicedb/pkg/membership"
+	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/google/go-cmp/cmp"
+	"github.com/shopspring/decimal"
+	"gopkg.in/yaml.v3"
+)
+
+const maxDepth = 25
+
+var yamlLineRegex = regexp.MustCompile(`line ([0-9]+): (.+)`)
+
+func RequestFromFile(ctx context.Context, validationFile ValidationFile) (*v0.ValidateRequest, error) {
+	validationYAML, err := yaml.Marshal(validationFile.Validations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse playground YAML validations: %w", err)
+	}
+	assertionYAML, err := yaml.Marshal(validationFile.Assertions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse playground YAML assertions: %w", err)
+	}
+	tuples, err := ParseRelationships(validationFile.Relationships)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse playground YAML relationships: %w", err)
+	}
+	return &v0.ValidateRequest{
+		Context: &v0.RequestContext{
+			Schema:        validationFile.Schema,
+			Relationships: tuples,
+		},
+		AssertionsYaml:       string(assertionYAML),
+		ValidationYaml:       string(validationYAML),
+		UpdateValidationYaml: false,
+	}, nil
+}
+
+func Validate(ctx context.Context, req *v0.ValidateRequest, dispatcher dispatch.Dispatcher, revision decimal.Decimal) (*v0.ValidateResponse, error) {
+	// Parse the validation YAML.
+	validation, err := ParseValidationBlock([]byte(req.ValidationYaml))
+	if err != nil {
+		return &v0.ValidateResponse{
+			RequestErrors: []*v0.DeveloperError{
+				convertYamlError(v0.DeveloperError_VALIDATION_YAML, err),
+			},
+		}, nil
+	}
+
+	// Parse the assertions YAML.
+	assertions, err := ParseAssertionsBlock([]byte(req.AssertionsYaml))
+	if err != nil {
+		return &v0.ValidateResponse{
+			RequestErrors: []*v0.DeveloperError{
+				convertYamlError(v0.DeveloperError_ASSERTION, err),
+			},
+		}, nil
+	}
+
+	// Run assertions.
+	assertTrueRelationships, aerr := assertions.AssertTrueRelationships()
+	if aerr != nil {
+		return &v0.ValidateResponse{
+			RequestErrors: []*v0.DeveloperError{
+				convertSourceError(v0.DeveloperError_ASSERTION, aerr),
+			},
+		}, nil
+	}
+
+	assertFalseRelationships, aerr := assertions.AssertFalseRelationships()
+	if aerr != nil {
+		return &v0.ValidateResponse{
+			RequestErrors: []*v0.DeveloperError{
+				convertSourceError(v0.DeveloperError_ASSERTION, aerr),
+			},
+		}, nil
+	}
+
+	trueFailures, err := runAssertions(ctx, dispatcher, revision, assertTrueRelationships, true, "Expected relation or permission %s to exist")
+	if err != nil {
+		return nil, err
+	}
+
+	falseFailures, err := runAssertions(ctx, dispatcher, revision, assertFalseRelationships, false, "Expected relation or permission %s to not exist")
+	if err != nil {
+		return nil, err
+	}
+
+	failures := append(trueFailures, falseFailures...)
+
+	// Run validation.
+	membershipSet, validationFailures, wireErr := runValidation(ctx, dispatcher, revision, validation)
+	if wireErr != nil {
+		return nil, wireErr
+	}
+
+	// If requested, regenerate the validation YAML.
+	updatedValidationYaml := ""
+	if membershipSet != nil && req.UpdateValidationYaml {
+		updatedValidationYaml, err = generateValidation(membershipSet)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &v0.ValidateResponse{
+		ValidationErrors:      append(failures, validationFailures...),
+		UpdatedValidationYaml: updatedValidationYaml,
+	}, nil
+}
+
+func runValidation(ctx context.Context, dispatcher dispatch.Dispatcher, revision decimal.Decimal, validation ValidationMap) (*membership.MembershipSet, []*v0.DeveloperError, error) {
+	var failures []*v0.DeveloperError
+	membershipSet := membership.NewMembershipSet()
+
+	for onrKey, validationStrings := range validation {
+		// Unmarshal the ONR to expand from its string form.
+		onr, err := onrKey.ONR()
+		if err != nil {
+			failures = append(failures,
+				&v0.DeveloperError{
+					Message: err.Error(),
+					Source:  v0.DeveloperError_VALIDATION_YAML,
+					Kind:    v0.DeveloperError_PARSE_ERROR,
+					Context: err.Source,
+				},
+			)
+			continue
+		}
+
+		// Run a full recursive expansion over the ONR.
+		er, dispatchErr := dispatcher.DispatchExpand(ctx, &v1.DispatchExpandRequest{
+			ObjectAndRelation: onr,
+			Metadata: &v1.ResolverMeta{
+				AtRevision:     revision.String(),
+				DepthRemaining: maxDepth,
+			},
+			ExpansionMode: v1.DispatchExpandRequest_RECURSIVE,
+		})
+		if dispatchErr != nil {
+			validationErrs, wireErr := RewriteGraphError(v0.DeveloperError_VALIDATION_YAML, 0, 0, string(onrKey), dispatchErr)
+			if validationErrs != nil {
+				failures = append(failures, validationErrs...)
+				return nil, failures, nil
+			}
+
+			return nil, nil, wireErr
+		}
+
+		// Add the ONR and its expansion to the membership set.
+		foundSubjects, _, aerr := membershipSet.AddExpansion(onr, er.TreeNode)
+		if aerr != nil {
+			validationErrs, wireErr := RewriteGraphError(v0.DeveloperError_VALIDATION_YAML, 0, 0, string(onrKey), aerr)
+			if validationErrs != nil {
+				failures = append(failures, validationErrs...)
+				continue
+			}
+
+			return nil, nil, wireErr
+		}
+
+		// Compare the terminal subjects found to those specified.
+		errs := validateSubjects(onr, foundSubjects, validationStrings)
+		failures = append(failures, errs...)
+	}
+
+	return membershipSet, failures, nil
+}
+
+func validateSubjects(onr *v0.ObjectAndRelation, fs membership.FoundSubjects, validationStrings []ValidationString) []*v0.DeveloperError {
+	var failures []*v0.DeveloperError
+
+	// Verify that every referenced subject is found in the membership.
+	encounteredSubjects := map[string]struct{}{}
+	for _, validationString := range validationStrings {
+		subjectONR, err := validationString.Subject()
+		if err != nil {
+			failures = append(failures, &v0.DeveloperError{
+				Message: fmt.Sprintf("For object and permission/relation `%s`, %s", tuple.StringONR(onr), err.Error()),
+				Source:  v0.DeveloperError_VALIDATION_YAML,
+				Kind:    v0.DeveloperError_PARSE_ERROR,
+				Context: fmt.Sprintf("[%s]", err.Source),
+			})
+			continue
+		}
+
+		if subjectONR == nil {
+			continue
+		}
+
+		encounteredSubjects[tuple.StringONR(subjectONR)] = struct{}{}
+
+		expectedRelationships, err := validationString.ONRS()
+		if err != nil {
+			failures = append(failures, &v0.DeveloperError{
+				Message: fmt.Sprintf("For object and permission/relation `%s`, %s", tuple.StringONR(onr), err.Error()),
+				Source:  v0.DeveloperError_VALIDATION_YAML,
+				Kind:    v0.DeveloperError_PARSE_ERROR,
+				Context: fmt.Sprintf("<%s>", err.Source),
+			})
+			continue
+		}
+
+		subject, ok := fs.LookupSubject(subjectONR)
+		if !ok {
+			failures = append(failures, &v0.DeveloperError{
+				Message: fmt.Sprintf("For object and permission/relation `%s`, missing expected subject `%s`", tuple.StringONR(onr), tuple.StringONR(subjectONR)),
+				Source:  v0.DeveloperError_VALIDATION_YAML,
+				Kind:    v0.DeveloperError_MISSING_EXPECTED_RELATIONSHIP,
+				Context: tuple.StringONR(subjectONR),
+			})
+			continue
+		}
+
+		foundRelationships := subject.Relationships()
+
+		// Verify that the relationships are the same.
+		expectedONRStrings := tuple.StringsONRs(expectedRelationships)
+		foundONRStrings := tuple.StringsONRs(foundRelationships)
+		if !cmp.Equal(expectedONRStrings, foundONRStrings) {
+			failures = append(failures, &v0.DeveloperError{
+				Message: fmt.Sprintf("For object and permission/relation `%s`, found different relationships for subject `%s`: Specified: `%s`, Computed: `%s`",
+					tuple.StringONR(onr),
+					tuple.StringONR(subjectONR),
+					strings.Join(wrapRelationships(expectedONRStrings), "/"),
+					strings.Join(wrapRelationships(foundONRStrings), "/"),
+				),
+				Source:  v0.DeveloperError_VALIDATION_YAML,
+				Kind:    v0.DeveloperError_MISSING_EXPECTED_RELATIONSHIP,
+				Context: string(validationString),
+			})
+		}
+	}
+
+	// Verify that every subject found was referenced.
+	for _, foundSubject := range fs.ListFound() {
+		_, ok := encounteredSubjects[tuple.StringONR(foundSubject.Subject())]
+		if !ok {
+			failures = append(failures, &v0.DeveloperError{
+				Message: fmt.Sprintf("For object and permission/relation `%s`, subject `%s` found but missing from specified",
+					tuple.StringONR(onr),
+					tuple.StringONR(foundSubject.Subject()),
+				),
+				Source:  v0.DeveloperError_VALIDATION_YAML,
+				Kind:    v0.DeveloperError_EXTRA_RELATIONSHIP_FOUND,
+				Context: tuple.StringONR(onr),
+			})
+		}
+	}
+
+	return failures
+}
+
+func wrapRelationships(onrStrings []string) []string {
+	var wrapped []string
+	for _, str := range onrStrings {
+		wrapped = append(wrapped, fmt.Sprintf("<%s>", str))
+	}
+
+	// Sort to ensure stability.
+	sort.Strings(wrapped)
+	return wrapped
+}
+
+func convertSourceError(source v0.DeveloperError_Source, err *ErrorWithSource) *v0.DeveloperError {
+	return &v0.DeveloperError{
+		Message: err.Error(),
+		Kind:    v0.DeveloperError_PARSE_ERROR,
+		Source:  source,
+		Line:    err.LineNumber,
+		Column:  err.ColumnPosition,
+		Context: err.Source,
+	}
+}
+
+func convertYamlError(source v0.DeveloperError_Source, err error) *v0.DeveloperError {
+	var lineNumber uint64
+	msg := err.Error()
+
+	pieces := yamlLineRegex.FindStringSubmatch(err.Error())
+	if len(pieces) == 3 {
+		// We can safely ignore the error here because it will default to 0, which is the not found
+		// case.
+		lineNumber, _ = strconv.ParseUint(pieces[1], 10, 0)
+		msg = pieces[2]
+	}
+
+	return &v0.DeveloperError{
+		Message: msg,
+		Kind:    v0.DeveloperError_PARSE_ERROR,
+		Source:  source,
+		Line:    uint32(lineNumber),
+	}
+}
+
+func runAssertions(ctx context.Context, dispatcher dispatch.Dispatcher, revision decimal.Decimal, assertions []ParsedAssertion, expected bool, fmtString string) ([]*v0.DeveloperError, error) {
+	var failures []*v0.DeveloperError
+	for _, assertion := range assertions {
+		cr, err := dispatcher.DispatchCheck(ctx, &v1.DispatchCheckRequest{
+			ObjectAndRelation: assertion.Relationship.ObjectAndRelation,
+			Subject:           assertion.Relationship.User.GetUserset(),
+			Metadata: &v1.ResolverMeta{
+				AtRevision:     revision.String(),
+				DepthRemaining: maxDepth,
+			},
+		})
+		if err != nil {
+			validationErrs, wireErr := RewriteGraphError(
+				v0.DeveloperError_ASSERTION,
+				assertion.LineNumber,
+				assertion.ColumnPosition,
+				tuple.String(assertion.Relationship),
+				err,
+			)
+			failures = append(failures, validationErrs...)
+			if wireErr != nil {
+				return nil, wireErr
+			}
+		} else if (cr.Membership == v1.DispatchCheckResponse_MEMBER) != expected {
+			failures = append(failures, &v0.DeveloperError{
+				Message: fmt.Sprintf(fmtString, tuple.String(assertion.Relationship)),
+				Source:  v0.DeveloperError_ASSERTION,
+				Kind:    v0.DeveloperError_ASSERTION_FAILED,
+				Context: tuple.String(assertion.Relationship),
+				Line:    assertion.LineNumber,
+				Column:  assertion.ColumnPosition,
+			})
+		}
+	}
+
+	return failures, nil
+}
+
+type invalidRelationError struct {
+	error
+	subject *v0.User
+	onr     *v0.ObjectAndRelation
+}
+
+func generateValidation(membershipSet *membership.MembershipSet) (string, error) {
+	validationMap := ValidationMap{}
+	subjectsByONR := membershipSet.SubjectsByONR()
+
+	var onrStrings []string
+	for onrString := range subjectsByONR {
+		onrStrings = append(onrStrings, onrString)
+	}
+
+	// Sort to ensure stability of output.
+	sort.Strings(onrStrings)
+
+	for _, onrString := range onrStrings {
+		foundSubjects := subjectsByONR[onrString]
+		var strs []string
+		for _, fs := range foundSubjects.ListFound() {
+			strs = append(strs,
+				fmt.Sprintf("[%s] is %s",
+					tuple.StringONR(fs.Subject()),
+					strings.Join(wrapRelationships(tuple.StringsONRs(fs.Relationships())), "/"),
+				))
+		}
+
+		// Sort to ensure stability of output.
+		sort.Strings(strs)
+
+		var validationStrings []ValidationString
+		for _, s := range strs {
+			validationStrings = append(validationStrings, ValidationString(s))
+		}
+
+		validationMap[ObjectRelationString(onrString)] = validationStrings
+	}
+
+	return validationMap.AsYAML()
+}
+
+func RewriteGraphError(source v0.DeveloperError_Source, line uint32, column uint32, context string, checkError error) ([]*v0.DeveloperError, error) {
+	var nsNotFoundError sharederrors.UnknownNamespaceError
+	var relNotFoundError sharederrors.UnknownRelationError
+
+	if errors.As(checkError, &nsNotFoundError) {
+		return []*v0.DeveloperError{
+			{
+				Message: checkError.Error(),
+				Source:  source,
+				Kind:    v0.DeveloperError_UNKNOWN_OBJECT_TYPE,
+				Line:    line,
+				Column:  column,
+				Context: context,
+			},
+		}, nil
+	}
+
+	if errors.As(checkError, &relNotFoundError) {
+		return []*v0.DeveloperError{
+			{
+				Message: checkError.Error(),
+				Source:  source,
+				Kind:    v0.DeveloperError_UNKNOWN_RELATION,
+				Line:    line,
+				Column:  column,
+				Context: context,
+			},
+		}, nil
+	}
+
+	var ire invalidRelationError
+	if errors.As(checkError, &ire) {
+		return []*v0.DeveloperError{
+			{
+				Message: checkError.Error(),
+				Source:  source,
+				Kind:    v0.DeveloperError_UNKNOWN_RELATION,
+				Line:    line,
+				Column:  column,
+				Context: context,
+			},
+		}, nil
+	}
+
+	return nil, checkError
+}


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb/issues/290

## What

The purpose of this command is to take a playground file and run the assertions and validations defined.

The rationale is that schema development happens in the playground, but once the YAML is downloaded, there is nothing developers can do other than loading it with testserve command, or uploading it back to the playground. This attempts to reuse and run the assertions and validations as test-suite outside of the the playground, and in a programmatic way rather than only interactively. Rather than duplicating the same tests in the client application, the playground tests become the canonical representation for the business rules defined in the schema.

Example:
1. developers introduce changes in schema via the playground
2. YAML file is downloaded and persisted in git repository
3. changes are pushed, PR is opened, CI runs spicedb validate, demonstrating changes are sound.

## Assumptions
- Introducing a new CLI command is cool, exposing new API in the go code requires more consideration
- Version 2 of the Playground file is not really API, so instead of updating the public structures, in parsed the file in two phases: one time with the public stuff, and one with the v2 fields
- I'm not sure I got right the versioning strategy y'all have with the API. It sounds like `v0` is like "it's public, but may be broken anytime". I assumed it's OK to expose methods reusing v0 types, but would definitely appreciate some guidance here  

## Features
- accepts multiple playground files as input
- process returns 0 if valid, non-zero if invalid
- errors by line and message are logged (e.g. can be surfaced in the GitHub PR)

## TODO
- Planning to add tests if this is the design seems sound