### PR TITLE
Add follower read delay option

### DIFF
--- a/cmd/spicedb/serve.go
+++ b/cmd/spicedb/serve.go
@@ -83,7 +83,7 @@ func registerServeCmd(rootCmd *cobra.Command) {
 	serveCmd.Flags().Duration("datastore-gc-max-operation-time", 1*time.Minute, "maximum amount of time a garbage collection pass can operate before timing out (postgres driver only)")
 	serveCmd.Flags().Duration("datastore-revision-fuzzing-duration", 5*time.Second, "amount of time to advertize stale revisions")
 	// See crdb doc for info about follower reads and how it is configured: https://www.cockroachlabs.com/docs/stable/follower-reads.html
-	serveCmd.Flags().Duration("datastore-follower-read-delay-duration", 0*time.Second, "amount of time to subtract from non-sync revision timestamps to ensure they are sufficiently in the past to enable follower reads (cockroach driver only)")
+	serveCmd.Flags().Duration("datastore-follower-read-delay-duration", 4_800*time.Millisecond, "amount of time to subtract from non-sync revision timestamps to ensure they are sufficiently in the past to enable follower reads (cockroach driver only)")
 	serveCmd.Flags().String("datastore-query-split-size", common.DefaultSplitAtEstimatedQuerySize.String(), "estimated number of bytes at which a query is split when using a remote datastore")
 	serveCmd.Flags().StringSlice("datastore-bootstrap-files", []string{}, "bootstrap data yaml files to load")
 	serveCmd.Flags().Bool("datastore-bootstrap-overwrite", false, "overwrite any existing data with bootstrap data")

--- a/cmd/spicedb/serve.go
+++ b/cmd/spicedb/serve.go
@@ -82,7 +82,8 @@ func registerServeCmd(rootCmd *cobra.Command) {
 	serveCmd.Flags().Duration("datastore-gc-interval", 3*time.Minute, "amount of time between passes of garbage collection (postgres driver only)")
 	serveCmd.Flags().Duration("datastore-gc-max-operation-time", 1*time.Minute, "maximum amount of time a garbage collection pass can operate before timing out (postgres driver only)")
 	serveCmd.Flags().Duration("datastore-revision-fuzzing-duration", 5*time.Second, "amount of time to advertize stale revisions")
-	serveCmd.Flags().Duration("datastore-follower-read-delay-duration", 0*time.Second, "amount of time to use as a delay to enable follower reads (cockroach driver only)")
+	// See crdb doc for info about follower reads and how it is configured: https://www.cockroachlabs.com/docs/stable/follower-reads.html
+	serveCmd.Flags().Duration("datastore-follower-read-delay-duration", 0*time.Second, "amount of time to subtract from non-sync revision timestamps to ensure they are sufficiently in the past to enable follower reads (cockroach driver only)")
 	serveCmd.Flags().String("datastore-query-split-size", common.DefaultSplitAtEstimatedQuerySize.String(), "estimated number of bytes at which a query is split when using a remote datastore")
 	serveCmd.Flags().StringSlice("datastore-bootstrap-files", []string{}, "bootstrap data yaml files to load")
 	serveCmd.Flags().Bool("datastore-bootstrap-overwrite", false, "overwrite any existing data with bootstrap data")

--- a/cmd/spicedb/serve.go
+++ b/cmd/spicedb/serve.go
@@ -82,6 +82,7 @@ func registerServeCmd(rootCmd *cobra.Command) {
 	serveCmd.Flags().Duration("datastore-gc-interval", 3*time.Minute, "amount of time between passes of garbage collection (postgres driver only)")
 	serveCmd.Flags().Duration("datastore-gc-max-operation-time", 1*time.Minute, "maximum amount of time a garbage collection pass can operate before timing out (postgres driver only)")
 	serveCmd.Flags().Duration("datastore-revision-fuzzing-duration", 5*time.Second, "amount of time to advertize stale revisions")
+	serveCmd.Flags().Duration("datastore-follower-read-delay-duration", 0*time.Second, "amount of time to use as a delay to enable follower reads (cockroach driver only)")
 	serveCmd.Flags().String("datastore-query-split-size", common.DefaultSplitAtEstimatedQuerySize.String(), "estimated number of bytes at which a query is split when using a remote datastore")
 	serveCmd.Flags().StringSlice("datastore-bootstrap-files", []string{}, "bootstrap data yaml files to load")
 	serveCmd.Flags().Bool("datastore-bootstrap-overwrite", false, "overwrite any existing data with bootstrap data")
@@ -159,6 +160,7 @@ func serveRun(cmd *cobra.Command, args []string) {
 			crdb.MaxOpenConns(cobrautil.MustGetInt(cmd, "datastore-conn-max-open")),
 			crdb.MinOpenConns(cobrautil.MustGetInt(cmd, "datastore-conn-min-open")),
 			crdb.RevisionQuantization(revisionFuzzingTimedelta),
+			crdb.FollowerReadDelay(cobrautil.MustGetDuration(cmd, "datastore-follower-read-delay-duration")),
 			crdb.GCWindow(gcWindow),
 			crdb.MaxRetries(maxRetries),
 			crdb.SplitAtEstimatedQuerySize(splitQuerySize),

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -199,7 +199,7 @@ func (cds *crdbDatastore) Revision(ctx context.Context) (datastore.Revision, err
 	}
 
 	// Round the revision down to the nearest quantization
-	// Apply a delay to enable historial reads
+	// Apply a delay to enable follower reads: https://www.cockroachlabs.com/docs/stable/follower-reads.html
 	crdbNow := nowHLC.IntPart() - cds.followerReadDelayNanos
 	quantized := crdbNow
 	if cds.quantizationNanos > 0 {

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -124,6 +124,8 @@ func NewCRDBDatastore(url string, options ...Option) (datastore.Datastore, error
 	maxRevisionStaleness := time.Duration(float64(config.revisionQuantization.Nanoseconds())*
 		config.maxRevisionStalenessPercent) * time.Nanosecond
 
+	followerReadDelayNanos := config.followerReadDelay.Nanoseconds()
+
 	return &crdbDatastore{
 		dburl:                     url,
 		conn:                      conn,
@@ -131,6 +133,7 @@ func NewCRDBDatastore(url string, options ...Option) (datastore.Datastore, error
 		quantizationNanos:         config.revisionQuantization.Nanoseconds(),
 		maxRevisionStaleness:      maxRevisionStaleness,
 		gcWindowNanos:             gcWindowNanos,
+		followerReadDelayNanos:    followerReadDelayNanos,
 		splitAtEstimatedQuerySize: config.splitAtEstimatedQuerySize,
 		execute:                   executeWithMaxRetries(config.maxRetries),
 		overlapKeyer:              keyer,
@@ -144,6 +147,7 @@ type crdbDatastore struct {
 	quantizationNanos         int64
 	maxRevisionStaleness      time.Duration
 	gcWindowNanos             int64
+	followerReadDelayNanos    int64
 	splitAtEstimatedQuerySize units.Base2Bytes
 	execute                   executeTxRetryFunc
 	overlapKeyer              overlapKeyer
@@ -195,7 +199,8 @@ func (cds *crdbDatastore) Revision(ctx context.Context) (datastore.Revision, err
 	}
 
 	// Round the revision down to the nearest quantization
-	crdbNow := nowHLC.IntPart()
+	// Apply a delay to enable historial reads
+	crdbNow := nowHLC.IntPart() - cds.followerReadDelayNanos
 	quantized := crdbNow
 	if cds.quantizationNanos > 0 {
 		quantized -= (crdbNow % cds.quantizationNanos)

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -151,5 +151,5 @@ func newTester(containerOpts *dockertest.RunOptions, creds string, portNum uint1
 		}
 	}
 
-	return &sqlTest{conn: conn, port: port, cleanup: cleanup, creds: creds, followerReadDelay: 0 * time.Second}
+	return &sqlTest{conn: conn, port: port, cleanup: cleanup, creds: creds}
 }

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -91,7 +91,7 @@ func TestCRDBDatastoreWithFollowerReads(t *testing.T) {
 		100 * time.Millisecond,
 	}
 	for _, quantization := range quantizationDurations {
-		t.Run(fmt.Sprintf("followReadDelayWithQuantization%s", quantization), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Quantization%s", quantization), func(t *testing.T) {
 			require := require.New(t)
 
 			tester := newTester(crdbContainer, "root:fake", 26257)

--- a/internal/datastore/crdb/options.go
+++ b/internal/datastore/crdb/options.go
@@ -17,6 +17,7 @@ type crdbOptions struct {
 
 	watchBufferLength           uint16
 	revisionQuantization        time.Duration
+	followerReadDelay           time.Duration
 	maxRevisionStalenessPercent float64
 	gcWindow                    time.Duration
 	maxRetries                  int
@@ -33,6 +34,7 @@ const (
 	overlapStrategyInsecure = "insecure"
 
 	defaultRevisionQuantization        = 5 * time.Second
+	defaultFollowerReadDelay           = 0 * time.Second
 	defaultMaxRevisionStalenessPercent = 0.1
 	defaultWatchBufferLength           = 128
 
@@ -50,6 +52,7 @@ func generateConfig(options []Option) (crdbOptions, error) {
 		gcWindow:                    24 * time.Hour,
 		watchBufferLength:           defaultWatchBufferLength,
 		revisionQuantization:        defaultRevisionQuantization,
+		followerReadDelay:           defaultFollowerReadDelay,
 		maxRevisionStalenessPercent: defaultMaxRevisionStalenessPercent,
 		splitAtEstimatedQuerySize:   common.DefaultSplitAtEstimatedQuerySize,
 		maxRetries:                  defaultMaxRetries,
@@ -140,6 +143,15 @@ func WatchBufferLength(watchBufferLength uint16) Option {
 func RevisionQuantization(bucketSize time.Duration) Option {
 	return func(po *crdbOptions) {
 		po.revisionQuantization = bucketSize
+	}
+}
+
+// FollowerReadDelay is the time delay to apply to enable historial reads.
+//
+// This value defaults to 0 seconds.
+func FollowerReadDelay(delay time.Duration) Option {
+	return func(po *crdbOptions) {
+		po.followerReadDelay = delay
 	}
 }
 


### PR DESCRIPTION
Add a new serve option to specify a read delay to enable [crdb follower reads](https://www.cockroachlabs.com/docs/stable/follower-reads.html). 

Follower reads will trade off a bit of staleness for reduced read latencies and hopefully also extra reliability as reads can go to a replica. 

Note: the option is set to zero by default and the default crdb delay value is 4.8s.