### PR TITLE
Add retries with a newly acquired connection

### DIFF
--- a/internal/datastore/crdb/tx.go
+++ b/internal/datastore/crdb/tx.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/jackc/pgx/v4/pgxpool"
-
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/prometheus/client_golang/prometheus"
@@ -40,7 +38,6 @@ func init() {
 type conn interface {
 	Begin(context.Context) (pgx.Tx, error)
 	BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error)
-	Acquire(ctx context.Context) (*pgxpool.Conn, error)
 }
 
 type transactionFn func(tx pgx.Tx) error
@@ -94,7 +91,7 @@ func execute(ctx context.Context, conn conn, txOptions pgx.TxOptions, fn transac
 		return nil
 	}
 
-	for i = 0; i < maxRetries; i++ {
+	for i = 0; i < maxRetries+1; i++ {
 		if err = releasedFn(tx); err != nil {
 			if retriable(ctx, err) {
 				if _, retryErr := tx.Exec(ctx, "ROLLBACK TO SAVEPOINT cockroach_restart"); retryErr != nil {
@@ -123,21 +120,13 @@ func execute(ctx context.Context, conn conn, txOptions pgx.TxOptions, fn transac
 	return errors.New(errReachedMaxRetry)
 }
 
-// tx will be rolled back and it's connection closed
+// tx will be rolled back and a new tx will be started
 func resetExecution(ctx context.Context, conn conn, tx *pgx.Tx, txOptions pgx.TxOptions) (newTx pgx.Tx, err error) {
 	err = (*tx).Rollback(ctx)
 	if err != nil {
 		return nil, err
 	}
-	err = (*tx).Conn().Close(ctx)
-	if err != nil {
-		return nil, err
-	}
-	newConn, err := conn.Acquire(ctx)
-	if err != nil {
-		return nil, err
-	}
-	newTx, err = newConn.BeginTx(ctx, txOptions)
+	newTx, err = conn.BeginTx(ctx, txOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datastore/crdb/tx_test.go
+++ b/internal/datastore/crdb/tx_test.go
@@ -1,0 +1,163 @@
+//go:build ci
+// +build ci
+
+package crdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore/crdb/migrations"
+	"github.com/authzed/spicedb/pkg/migrate"
+	"github.com/authzed/spicedb/pkg/namespace"
+	"github.com/authzed/spicedb/pkg/secrets"
+)
+
+const (
+	testUserNamespace = "test/user"
+)
+
+var testUserNS = namespace.Namespace(testUserNamespace)
+
+// Copied from crdb_test.go
+func (st sqlTest) newCRDB() (*crdbDatastore, error) {
+	uniquePortion, err := secrets.TokenHex(4)
+	if err != nil {
+		return nil, err
+	}
+
+	newDBName := "db" + uniquePortion
+
+	_, err = st.conn.Exec(context.Background(), "CREATE DATABASE "+newDBName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create database: %w", err)
+	}
+
+	connectStr := fmt.Sprintf(
+		"postgres://%s@localhost:%s/%s?sslmode=disable",
+		st.creds,
+		st.port,
+		newDBName,
+	)
+
+	migrationDriver, err := migrations.NewCRDBDriver(connectStr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize migration engine: %w", err)
+	}
+
+	err = migrations.CRDBMigrations.Run(migrationDriver, migrate.Head, migrate.LiveRun)
+	if err != nil {
+		return nil, fmt.Errorf("unable to migrate database: %w", err)
+	}
+
+	ds, err := NewCRDBDatastore(connectStr)
+	return ds.(*crdbDatastore), err
+}
+
+func executeWithErrors(errors *[]pgconn.PgError, maxRetries int) executeTxRetryFunc {
+	return func(ctx context.Context, conn conn, txOptions pgx.TxOptions, fn transactionFn) (err error) {
+		wrappedFn := func(tx pgx.Tx) error {
+			if len(*errors) > 0 {
+				retErr := (*errors)[0]
+				(*errors) = (*errors)[1:]
+				return &retErr
+			}
+
+			return fn(tx)
+		}
+
+		return execute(ctx, conn, txOptions, wrappedFn, maxRetries)
+	}
+}
+
+func TestTxReset(t *testing.T) {
+	cases := []struct {
+		name          string
+		maxRetries    int
+		errors        []pgconn.PgError
+		expectError   bool
+		expectedError error
+	}{
+		{
+			name:       "retryable",
+			maxRetries: 4,
+			errors: []pgconn.PgError{
+				{Code: crdbRetryErrCode},
+				{Code: crdbRetryErrCode},
+				{Code: crdbRetryErrCode},
+			},
+			expectError:   false,
+			expectedError: nil,
+		},
+		{
+			name:       "resettable",
+			maxRetries: 4,
+			errors: []pgconn.PgError{
+				{Code: crdbAmbiguousErrorCode},
+				{Code: crdbAmbiguousErrorCode},
+				{Code: crdbAmbiguousErrorCode},
+			},
+			expectError:   false,
+			expectedError: nil,
+		},
+		{
+			name:       "mixed",
+			maxRetries: 50,
+			errors: []pgconn.PgError{
+				{Code: crdbRetryErrCode},
+				{Code: crdbAmbiguousErrorCode},
+			},
+			expectError:   false,
+			expectedError: nil,
+		},
+		{
+			name:          "noErrors",
+			maxRetries:    50,
+			errors:        []pgconn.PgError{},
+			expectError:   false,
+			expectedError: nil,
+		},
+		{
+			name:       "nonRecoverable",
+			maxRetries: 1,
+			errors: []pgconn.PgError{
+				{Code: crdbRetryErrCode},
+				{Code: crdbAmbiguousErrorCode},
+			},
+			expectError:   true,
+			expectedError: errors.New(errReachedMaxRetry),
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			tester := newTester(crdbContainer, "root:fake", 26257)
+			ds, err := tester.newCRDB()
+			require.NoError(err)
+			ds.execute = executeWithErrors(&tt.errors, tt.maxRetries)
+
+			ctx := context.Background()
+			ok, err := ds.IsReady(ctx)
+			require.NoError(err)
+			require.True(ok)
+
+			// WriteNamespace utilizes execute so we'll use it
+			revision, err := ds.WriteNamespace(ctx, testUserNS)
+			if tt.expectedError != nil {
+				require.Error(err)
+			} else {
+				require.NoError(err)
+			}
+			require.NotNil(revision)
+
+			tester.cleanup()
+			ds.Close()
+		})
+	}
+}


### PR DESCRIPTION
* Add tx reset for "ambiguous result errors" which includes connection closed errors. 
* Tx retries will attempt to reset the tx if unable to rollback
