### PR TITLE
WIP feat: add preliminary LookupWatch API implementation to `v1alpha1`

### DIFF
--- a/cmd/spicedb/lookupwatch.go
+++ b/cmd/spicedb/lookupwatch.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	v1alpha1 "github.com/authzed/authzed-go/proto/authzed/api/v1alpha1"
+	"github.com/authzed/grpcutil"
+	"github.com/authzed/spicedb/internal/auth"
+	"github.com/authzed/spicedb/internal/gateway"
+	"github.com/authzed/spicedb/internal/middleware/servicespecific"
+	v1alpha1svc "github.com/authzed/spicedb/internal/services/v1alpha1"
+	logmw "github.com/authzed/spicedb/pkg/middleware/logging"
+	"github.com/authzed/spicedb/pkg/middleware/requestid"
+	"github.com/fatih/color"
+	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	grpczerolog "github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2"
+	grpclog "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	grpcprom "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/jzelinskie/cobrautil"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+func registerServeLookupWatchCmd(rootCmd *cobra.Command) {
+	serveCmd := &cobra.Command{
+		Use:               "serve-lookupwatch",
+		Short:             "serve the Loookup Watch API",
+		Long:              "A database that stores, computes, and validates application permissions", // todo: fill out a better long description
+		PersistentPreRunE: defaultPreRunE,
+		Run:               serveLookupWatchRun,
+		Example: fmt.Sprintf(`	%s:
+		spicedb serve-lookupwatch --grpc-preshared-key "somerandomkeyhere"
+
+	%s:
+		spicedb serve --grpc-preshared-key "realkeyhere" --grpc-tls-cert-path path/to/tls/cert --grpc-tls-key-path path/to/tls/key \
+			--http-tls-cert-path path/to/tls/cert --http-tls-key-path path/to/tls/key
+`, color.YellowString("No TLS and in-memory"), color.GreenString("TLS and a real datastore")),
+	}
+
+	// Flags for the gRPC API server
+	cobrautil.RegisterGrpcServerFlags(serveCmd.Flags(), "grpc", "gRPC", ":50051", true)
+	serveCmd.Flags().String("grpc-preshared-key", "", "preshared key to require for authenticated requests")
+	serveCmd.Flags().Duration("grpc-shutdown-grace-period", 0*time.Second, "amount of time after receiving sigint to continue serving")
+	if err := serveCmd.MarkFlagRequired("grpc-preshared-key"); err != nil {
+		panic("failed to mark flag as required: " + err.Error())
+	}
+
+	// Flags for HTTP gateway
+	cobrautil.RegisterHttpServerFlags(serveCmd.Flags(), "http", "http", ":8443", false)
+
+	// Flags for misc services
+	cobrautil.RegisterHttpServerFlags(serveCmd.Flags(), "metrics", "metrics", ":9090", true)
+
+	// Flags for local dev dashboard
+	serveCmd.Flags().String("dashboard-addr", ":8080", "address to listen for the dashboard")
+
+	// Required flags.
+
+	rootCmd.AddCommand(serveCmd)
+}
+
+func serveLookupWatchRun(cmd *cobra.Command, args []string) {
+	token := cobrautil.MustGetStringExpanded(cmd, "grpc-preshared-key")
+	if len(token) < 1 {
+		log.Fatal().Msg("a preshared key must be provided via --grpc-preshared-key to authenticate API requests")
+	}
+
+	middleware := grpc.ChainUnaryInterceptor(
+		requestid.UnaryServerInterceptor(requestid.GenerateIfMissing(true)),
+		logmw.UnaryServerInterceptor(logmw.ExtractMetadataField("x-request-id", "requestID")),
+		grpclog.UnaryServerInterceptor(grpczerolog.InterceptorLogger(log.Logger)),
+		otelgrpc.UnaryServerInterceptor(),
+		grpcauth.UnaryServerInterceptor(auth.RequirePresharedKey(token)),
+		grpcprom.UnaryServerInterceptor,
+		servicespecific.UnaryServerInterceptor,
+	)
+
+	streamMiddleware := grpc.ChainStreamInterceptor(
+		requestid.StreamServerInterceptor(requestid.GenerateIfMissing(true)),
+		logmw.StreamServerInterceptor(logmw.ExtractMetadataField("x-request-id", "requestID")),
+		grpclog.StreamServerInterceptor(grpczerolog.InterceptorLogger(log.Logger)),
+		otelgrpc.StreamServerInterceptor(),
+		grpcauth.StreamServerInterceptor(auth.RequirePresharedKey(token)),
+		grpcprom.StreamServerInterceptor,
+		servicespecific.StreamServerInterceptor,
+	)
+
+	grpcServer, err := cobrautil.GrpcServerFromFlags(cmd, "grpc", middleware, streamMiddleware)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to create gRPC server")
+	}
+
+	healthSrv := grpcutil.NewAuthlessHealthServer()
+
+	v1alpha1.RegisterLookupWatchServiceServer(grpcServer, v1alpha1svc.NewLookupWatchServer(nil, nil))
+	healthSrv.SetServicesHealthy(&v1alpha1.LookupWatchService_ServiceDesc)
+
+	healthpb.RegisterHealthServer(grpcServer, healthSrv)
+
+	reflection.Register(grpcutil.NewAuthlessReflectionInterceptor(grpcServer))
+
+	go func() {
+		addr := cobrautil.MustGetStringExpanded(cmd, "grpc-addr")
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			log.Fatal().Str("addr", addr).Msg("failed to listen on addr for gRPC server")
+		}
+
+		log.Info().Str("addr", addr).Msg("gRPC server started listening")
+		err = grpcServer.Serve(l)
+		if err != nil {
+			log.Fatal().Msg("failed to start gRPC server")
+		}
+	}()
+
+	// Start the REST gateway to serve HTTP/JSON.
+	gatewayHandler, err := gateway.NewHandler(
+		context.TODO(),
+		cobrautil.MustGetStringExpanded(cmd, "grpc-addr"),
+		cobrautil.MustGetStringExpanded(cmd, "grpc-tls-cert-path"),
+	)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to initialize rest gateway")
+	}
+	gatewaySrv := cobrautil.HttpServerFromFlags(cmd, "http")
+	gatewaySrv.Handler = gatewayHandler
+	go func() {
+		if err := cobrautil.HttpListenFromFlags(cmd, "http", gatewaySrv, zerolog.InfoLevel); err != nil {
+			log.Fatal().Err(err).Msg("failed while serving http")
+		}
+	}()
+
+	// Start the metrics endpoint.
+	metricsSrv := cobrautil.HttpServerFromFlags(cmd, "metrics")
+	metricsSrv.Handler = metricsHandler()
+	go func() {
+		if err := cobrautil.HttpListenFromFlags(cmd, "metrics", metricsSrv, zerolog.InfoLevel); err != nil {
+			log.Fatal().Err(err).Msg("failed while serving metrics")
+		}
+	}()
+
+	signalctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	gracePeriod := cobrautil.MustGetDuration(cmd, "grpc-shutdown-grace-period")
+
+	<-signalctx.Done()
+	log.Info().Msg("received interrupt")
+
+	if gracePeriod > 0 {
+		interruptGrace, _ := signal.NotifyContext(context.Background(), os.Interrupt)
+		graceTimer := time.NewTimer(gracePeriod)
+
+		log.Info().Stringer("timeout", gracePeriod).Msg("starting shutdown grace period")
+
+		select {
+		case <-graceTimer.C:
+		case <-interruptGrace.Done():
+			log.Warn().Msg("interrupted shutdown grace period")
+		}
+	}
+
+	log.Info().Msg("shutting down")
+	grpcServer.GracefulStop()
+
+	if err := gatewaySrv.Close(); err != nil {
+		log.Fatal().Err(err).Msg("failed while shutting down rest gateway")
+	}
+
+	if err := metricsSrv.Close(); err != nil {
+		log.Fatal().Err(err).Msg("failed while shutting down metrics server")
+	}
+}

--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -49,6 +49,7 @@ func main() {
 	rootCmd := newRootCmd()
 	registerVersionCmd(rootCmd)
 	registerServeCmd(rootCmd)
+	registerServeLookupWatchCmd(rootCmd)
 	registerMigrateCmd(rootCmd)
 	registerHeadCmd(rootCmd)
 	registerDeveloperServiceCmd(rootCmd)

--- a/internal/services/v1alpha1/lookupwatch.go
+++ b/internal/services/v1alpha1/lookupwatch.go
@@ -1,0 +1,204 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"io"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	v1alpha1 "github.com/authzed/authzed-go/proto/authzed/api/v1alpha1"
+	"github.com/authzed/grpcutil"
+	"github.com/authzed/spicedb/internal/services/shared"
+	grpcmw "github.com/grpc-ecosystem/go-grpc-middleware"
+)
+
+type lookupWatchServiceServer struct {
+	v1alpha1.UnimplementedLookupWatchServiceServer
+	shared.WithUnaryServiceSpecificInterceptor
+
+	permissionsClient v1.PermissionsServiceClient
+	watchClient       v1.WatchServiceClient
+}
+
+// NewLookupWatchServer returns an new instance of a server that implements
+// authzed.api.v1alpha1.LookupWatchService.
+func NewLookupWatchServer(watchClient v1.WatchServiceClient, permissionsClient v1.PermissionsServiceClient) v1alpha1.LookupWatchServiceServer {
+
+	if watchClient == nil {
+		panic("A non-nil watchClient must be provided")
+	}
+
+	if permissionsClient == nil {
+		panic("A non-nil permissionsClient must be provided")
+	}
+
+	return &lookupWatchServiceServer{
+		WithUnaryServiceSpecificInterceptor: shared.WithUnaryServiceSpecificInterceptor{
+			Unary: grpcmw.ChainUnaryServer(grpcutil.DefaultUnaryMiddleware...),
+		},
+		permissionsClient: permissionsClient,
+		watchClient:       watchClient,
+	}
+}
+
+func (lws *lookupWatchServiceServer) WatchAccessibleResources(req *v1alpha1.WatchAccessibleResourcesRequest, resp v1alpha1.LookupWatchService_WatchAccessibleResourcesServer) error {
+
+	ctx := resp.Context()
+
+	done := make(chan bool)
+	errCh := make(chan error, 1)
+
+	go func() {
+
+		// start a watch over all changes
+		stream, err := lws.watchClient.Watch(ctx, &v1.WatchRequest{
+			OptionalStartCursor: req.GetOptionalStartCursor(),
+		})
+		if err != nil {
+			errCh <- fmt.Errorf("todo(jon-whit): come up with a better error")
+			return
+		}
+
+		for {
+			watchResponse, err := stream.Recv()
+			if err == io.EOF {
+				done <- true
+				return
+			}
+			if err != nil {
+				errCh <- fmt.Errorf("todo(jon-whit): come up with a better error")
+				return
+			}
+
+			updates := watchResponse.GetUpdates()
+			revision := watchResponse.GetChangesThrough()
+
+			permissionUpdates := []*v1alpha1.PermissionUpdate{}
+
+			maxConcurrentUpdates := 10
+			limiter := make(chan struct{}, maxConcurrentUpdates)
+
+			for _, update := range updates {
+
+				operation := update.GetOperation()
+				if operation == v1.RelationshipUpdate_OPERATION_UNSPECIFIED {
+					continue
+				}
+
+				limiter <- struct{}{}
+
+				go func(update *v1.RelationshipUpdate) {
+
+					// todo(jon-whit): figure out how to do this in a more memory efficient manner
+
+					resources := []*v1.ObjectReference{}
+					_ = resources
+					subjects := []*v1.SubjectReference{}
+					_ = subjects
+
+					go func() {
+						// resourceStream, err := v1alpha1.ReachableResources(context.TODO(), &v1alpha1.ReachResourcesRequest{
+						// 	StartingResource: update.GetRelationship().GetResource(),
+						// 	TargetObjectType: req.GetResourceObjectType(),
+						// })
+						// if err != nil {
+						// 	// handle error
+						// }
+
+						// for {
+						// 	resp, err := resourceStream.Recv()
+						// 	if err == io.EOF {
+						// 		return
+						// 	}
+						// 	if err != nil {
+						// 		// handle error
+						// 	}
+
+						// 	resources = append(resources, resp.GetFoundResource())
+						// }
+					}()
+
+					go func() {
+						// subjectStream, err := v1alpha1.LookupSubjects(context.TODO(), &v1alpha1.LookupSubjectsRequest{
+						// 	Resource:          update.GetRelationship().GetResource(),
+						// 	TargetSubjectType: req.GetSubjectObjectType(),
+						// })
+						// if err != nil {
+						// 	// handle error
+						// }
+
+						// for {
+						// 	resp, err := subjectStream.Recv()
+						// 	if err == io.EOF {
+						// 		return
+						// 	}
+						// 	if err != nil {
+						// 		// handle error
+						// 	}
+
+						// 	subjects = append(subjects, resp.GetFoundRelationship().GetSubject())
+						// }
+					}()
+
+					for _, resource := range resources {
+						for _, subject := range subjects {
+
+							checkResponse, err := lws.permissionsClient.CheckPermission(ctx, &v1.CheckPermissionRequest{
+								Resource:   resource,
+								Subject:    subject,
+								Permission: req.GetPermission(),
+							})
+							if err != nil {
+								errCh <- fmt.Errorf("todo(jon-whit): come up with a better error")
+								return
+							}
+
+							var updatedPermissionship v1alpha1.PermissionUpdate_Permissionship
+
+							switch checkResponse.GetPermissionship() {
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION:
+								updatedPermissionship = v1alpha1.PermissionUpdate_PERMISSIONSHIP_HAS_PERMISSION
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION:
+								updatedPermissionship = v1alpha1.PermissionUpdate_PERMISSIONSHIP_NO_PERMISSION
+							default:
+								updatedPermissionship = v1alpha1.PermissionUpdate_PERMISSIONSHIP_UNSPECIFIED
+							}
+
+							// todo(jon-whit): verify the safety of this concurrent append
+							permissionUpdates = append(permissionUpdates, &v1alpha1.PermissionUpdate{
+								Subject:           subject,
+								Resource:          resource,
+								Relation:          "todo(jon-whit): rename this to permission?",
+								UpdatedPermission: updatedPermissionship,
+							})
+						}
+					}
+
+					<-limiter
+
+				}(update)
+			}
+
+			err = resp.Send(&v1alpha1.WatchAccessibleResourcesResponse{
+				Updates:        permissionUpdates,
+				ChangesThrough: revision,
+			})
+			if err != nil {
+				errCh <- fmt.Errorf("todo(jon-whit): come up with a better error")
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		if err := ctx.Err(); err != nil {
+			// todo(jon-whit): handle ctx error better
+			return err
+		}
+		return nil
+	case <-done:
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}


### PR DESCRIPTION
The changes here add a preliminary implementation of the LookupWatch API as proposed in issue #207. The LookupWatch API will provide clients with a stream of updates indicating changes in the accessibility of one or more kinds of resources.