### PR TITLE
internal/dispatch: return cachingRedispatch

### DIFF
--- a/internal/dispatch/combined/combined.go
+++ b/internal/dispatch/combined/combined.go
@@ -108,5 +108,5 @@ func NewDispatcher(nsm namespace.Manager, ds datastore.Datastore, srv *grpc.Serv
 
 	dispatchSvc.RegisterGrpcServices(srv, cachingClusterDispatch)
 
-	return cachingClusterDispatch, nil
+	return cachingRedispatch, nil
 }


### PR DESCRIPTION
This was an autocomplete mistake and should've been the value returned.