### PR TITLE
fix: skip comments when loading test relationships

### DIFF
--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -94,7 +94,7 @@ func PopulateFromFiles(ds datastore.Datastore, filePaths []string) (*FullyParsed
 			lines := strings.Split(relationships, "\n")
 			for index, line := range lines {
 				trimmed := strings.TrimSpace(line)
-				if len(trimmed) == 0 {
+				if len(trimmed) == 0 || strings.HasPrefix(trimmed, "//") {
 					continue
 				}
 

--- a/pkg/validationfile/loader_test.go
+++ b/pkg/validationfile/loader_test.go
@@ -1,0 +1,50 @@
+package validationfile
+
+import (
+	"testing"
+
+	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore/memdb"
+	"github.com/authzed/spicedb/pkg/tuple"
+)
+
+func TestPopulateFromFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		filePaths []string
+		want      []*v0.RelationTuple
+	}{
+		{
+			name:      "no comment",
+			filePaths: []string{"testdata/loader_no_comment.yaml"},
+			want: []*v0.RelationTuple{
+				tuple.Parse("example/project:pied_piper#owner@example/user:milburga"),
+				tuple.Parse("example/project:pied_piper#reader@example/user:tarben"),
+				tuple.Parse("example/project:pied_piper#writer@example/user:freyja"),
+			},
+		},
+		{
+			name:      "with comment",
+			filePaths: []string{"testdata/loader_with_comment.yaml"},
+			want: []*v0.RelationTuple{
+				tuple.Parse("example/project:pied_piper#owner@example/user:milburga"),
+				tuple.Parse("example/project:pied_piper#reader@example/user:tarben"),
+				tuple.Parse("example/project:pied_piper#writer@example/user:freyja"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ds, err := memdb.NewMemdbDatastore(0, 0, 0, 0)
+			require.NoError(err)
+
+			parsed, _, err := PopulateFromFiles(ds, tt.filePaths)
+			require.NoError(err)
+			require.Equal(tt.want, parsed.Tuples)
+		})
+	}
+}

--- a/pkg/validationfile/testdata/loader_no_comment.yaml
+++ b/pkg/validationfile/testdata/loader_no_comment.yaml
@@ -1,0 +1,23 @@
+schema: >-
+  definition example/user {}
+
+
+  definition example/project {
+      relation reader: example/user
+      relation writer: example/user
+      relation owner: example/user
+
+      permission read = reader + write
+      permission write = writer + admin
+      permission admin = owner
+  }
+relationships: >-
+  example/project:pied_piper#owner@example/user:milburga
+
+  example/project:pied_piper#reader@example/user:tarben
+
+  example/project:pied_piper#writer@example/user:freyja
+assertions:
+  assertTrue: []
+  assertFalse: []
+validation: null

--- a/pkg/validationfile/testdata/loader_with_comment.yaml
+++ b/pkg/validationfile/testdata/loader_with_comment.yaml
@@ -1,0 +1,27 @@
+schema: >-
+  definition example/user {}
+
+
+  definition example/project {
+      relation reader: example/user
+      relation writer: example/user
+      relation owner: example/user
+
+      permission read = reader + write
+      permission write = writer + admin
+      permission admin = owner
+  }
+relationships: >-
+  // Some comment
+
+  example/project:pied_piper#owner@example/user:milburga
+
+  example/project:pied_piper#reader@example/user:tarben
+
+  // Some other comment
+
+  example/project:pied_piper#writer@example/user:freyja
+assertions:
+  assertTrue: []
+  assertFalse: []
+validation: null


### PR DESCRIPTION
Fixes https://github.com/authzed/spicedb/issues/329

From a brief test in the playground, comments in the Test Relationships are only of the format `// my comment` and not `/** my comment */`. This may need to be fact check though 😁 