### PR TITLE
pkg/cmd: extract signal handling with grace period

### DIFF
--- a/pkg/cmd/defaults.go
+++ b/pkg/cmd/defaults.go
@@ -1,14 +1,20 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/jzelinskie/cobrautil"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 // ServeExample creates an example usage string with the provided program name.
@@ -48,4 +54,33 @@ func MetricsHandler() http.Handler {
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	return mux
+}
+
+// SignalContextWithGracePeriod creates a new context that will be cancelled
+// when an interrupt/SIGTERM signal is received and the provided grace period
+// subsequently finishes.
+func SignalContextWithGracePeriod(ctx context.Context, gracePeriod time.Duration) context.Context {
+	newCtx, cancelfn := context.WithCancel(ctx)
+	go func() {
+		signalctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		<-signalctx.Done()
+		log.Info().Msg("received interrupt")
+
+		if gracePeriod > 0 {
+			interruptGrace, _ := signal.NotifyContext(context.Background(), os.Interrupt)
+			graceTimer := time.NewTimer(gracePeriod)
+
+			log.Info().Stringer("timeout", gracePeriod).Msg("starting shutdown grace period")
+
+			select {
+			case <-graceTimer.C:
+			case <-interruptGrace.Done():
+				log.Warn().Msg("interrupted shutdown grace period")
+			}
+		}
+		log.Info().Msg("shutting down")
+		cancelfn()
+	}()
+
+	return newCtx
 }


### PR DESCRIPTION
This PR extracts the signal handling functionality from serve so that it only needs to handle a single context cancellation.