### PR TITLE
Report CLI configurations errors to `RunE`

### DIFF
--- a/pkg/cmd/serve/devtools.go
+++ b/pkg/cmd/serve/devtools.go
@@ -48,12 +48,12 @@ func NewDevtoolsCommand(programName string) *cobra.Command {
 		Short:   "runs the developer tools service",
 		Long:    "Serves the authzed.api.v0.DeveloperService which is used for development tooling such as the Authzed Playground",
 		PreRunE: cmdutil.DefaultPreRunE(programName),
-		Run:     runfunc,
+		RunE:    runfunc,
 		Args:    cobra.ExactArgs(0),
 	}
 }
 
-func runfunc(cmd *cobra.Command, args []string) {
+func runfunc(cmd *cobra.Command, args []string) error {
 	grpcServer, err := cobrautil.GrpcServerFromFlags(cmd, "grpc", grpc.ChainUnaryInterceptor(
 		grpclog.UnaryServerInterceptor(grpczerolog.InterceptorLogger(log.Logger)),
 		otelgrpc.UnaryServerInterceptor(),
@@ -100,6 +100,8 @@ func runfunc(cmd *cobra.Command, args []string) {
 	if err := metricsSrv.Close(); err != nil {
 		log.Fatal().Err(err).Msg("failed while shutting down metrics server")
 	}
+
+	return nil
 }
 
 func shareStoreFromCmd(cmd *cobra.Command) (v0svc.ShareStore, error) {

--- a/pkg/cmd/serve/testing.go
+++ b/pkg/cmd/serve/testing.go
@@ -56,11 +56,11 @@ func NewTestingCommand(programName string) *cobra.Command {
 		Short:   "test server with an in-memory datastore",
 		Long:    "An in-memory spicedb server which serves completely isolated datastores per client-supplied auth token used.",
 		PreRunE: cmdutil.DefaultPreRunE(programName),
-		Run:     runTestServer,
+		RunE:    runTestServer,
 	}
 }
 
-func runTestServer(cmd *cobra.Command, args []string) {
+func runTestServer(cmd *cobra.Command, args []string) error {
 	configFilePaths := cobrautil.MustGetStringSliceExpanded(cmd, "load-configs")
 
 	backendMiddleware := &perTokenBackendMiddleware{
@@ -107,6 +107,8 @@ func runTestServer(cmd *cobra.Command, args []string) {
 	log.Info().Msg("received interrupt")
 	grpcServer.GracefulStop()
 	readonlyServer.GracefulStop()
+
+	return nil
 }
 
 type dummyBackend struct {


### PR DESCRIPTION
closes https://github.com/authzed/spicedb/issues/265

This change updates CLI commands to use `RunE` in place of `Run` so user configuration errors can be reported and distinguished from actual system failures. Not all commands had obvious possible user configuration errors, but I migrated all commands to use `RunE` in the event that in the future the command may have possible user configuration errors.

Old:

```
$ spicedb migrate 1 --datastore-engine
9:08PM INF set log level new level=info
9:08PM INF set tracing provider new provider=none
9:08PM FTL cannot migrate datastore engine type datastore-engine=bad
exit status 1
```

New:

```
$ spicedb migrate 1 --datastore-engine bad 
9:10PM INF set log level new level=info
9:10PM INF set tracing provider new provider=none
Error: cannot migrate datastore engine type: bad
Usage:
  spicedb migrate [revision] [flags]

Flags:
      --datastore-conn-uri string   connection string used by remote datastores (e.g. "postgres://postgres:password@localhost:5432/spicedb")
      --datastore-engine string     type of datastore to initialize ("memory", "postgres", "cockroachdb") (default "memory")
  -h, --help                        help for migrate

Global Flags:
      --log-format string                 format of logs ("auto", "human", "json") (default "auto")
      --log-level string                  verbosity of logging ("trace", "debug", "info", "warn", "error") (default "info")
      --otel-jaeger-endpoint string       jaeger collector endpoint (default "http://jaeger:14268/api/traces")
      --otel-jaeger-service-name string   jaeger service name for trace data (default "spicedb")
      --otel-provider string              opentelemetry provider for tracing ("none", "jaeger") (default "none")
```