### PR TITLE
pkg/testutil: ensure types in RequireEqualEmptyNil

### DIFF
--- a/pkg/testutil/require.go
+++ b/pkg/testutil/require.go
@@ -15,14 +15,16 @@ func RequireEqualEmptyNil(t *testing.T, expected, actual interface{}, msgAndArgs
 	expectedVal := reflect.ValueOf(expected)
 	actualVal := reflect.ValueOf(actual)
 
-	if hasLength(expectedVal) && hasLength(actualVal) && expectedVal.Len() == 0 && actualVal.Len() == 0 {
+	if expectedVal.Kind() == actualVal.Kind() &&
+		hasLength(expectedVal.Kind()) &&
+		expectedVal.Len() == 0 && actualVal.Len() == 0 {
 		return
 	}
 	require.Equal(t, expected, actual, msgAndArgs...)
 }
 
-func hasLength(v reflect.Value) bool {
-	switch v.Kind() {
+func hasLength(k reflect.Kind) bool {
+	switch k {
 	case reflect.Array, reflect.Slice, reflect.Map:
 		return true
 	}

--- a/pkg/testutil/require_test.go
+++ b/pkg/testutil/require_test.go
@@ -1,0 +1,10 @@
+package testutil
+
+import "testing"
+
+func TestRequireEqualEmptyNil(t *testing.T) {
+	RequireEqualEmptyNil(t, []int(nil), []int(nil))
+	RequireEqualEmptyNil(t, []int(nil), []int{})
+	RequireEqualEmptyNil(t, []int{}, []int(nil))
+	RequireEqualEmptyNil(t, []int{}, []int{})
+}


### PR DESCRIPTION
Previously we were not checking that the values were the same type, only types that had lengths.
This now ensures expected and actual are the same types.