### PR TITLE
Set bounds on the parsed line number int in developer API

### DIFF
--- a/internal/services/v0/developer.go
+++ b/internal/services/v0/developer.go
@@ -604,7 +604,7 @@ func convertYamlError(source v0.DeveloperError_Source, err error) *v0.DeveloperE
 	if len(pieces) == 3 {
 		// We can safely ignore the error here because it will default to 0, which is the not found
 		// case.
-		lineNumber, _ = strconv.ParseUint(pieces[1], 10, 0)
+		lineNumber, _ = strconv.ParseUint(pieces[1], 10, 32)
 		msg = pieces[2]
 	}
 


### PR DESCRIPTION
This ensures there is no overflow from the YAML line number when reported in the developer API

Fixes https://github.com/authzed/spicedb/security/code-scanning/1