### PR TITLE
Attempt to avoid failed crdb range splits in e2e

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,7 @@ on:
       - "go.sum"
       - "cmd/**"
       - "pkg/**"
+      - "e2e/**"
       - "internal/**"
       - "proto/**"
   pull_request:
@@ -27,6 +28,7 @@ on:
       - "go.sum"
       - "cmd/**"
       - "pkg/**"
+      - "e2e/**"
       - "internal/**"
       - "proto/**"
 jobs:

--- a/e2e/newenemy/newenemy_test.go
+++ b/e2e/newenemy/newenemy_test.go
@@ -98,6 +98,9 @@ func initializeTestCRDBCluster(ctx context.Context, t testing.TB) cockroach.Clus
 	tlog := e2e.NewTLog(t)
 	crdbCluster.Init(ctx, tlog, tlog)
 	require.NoError(crdbCluster.SQL(ctx, tlog, tlog,
+		"SET CLUSTER SETTING kv.range.backpressure_range_size_multiplier=0;",
+	))
+	require.NoError(crdbCluster.SQL(ctx, tlog, tlog,
 		fmt.Sprintf(createDb, dbName),
 	))
 


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/issues/63260 suggests that this setting will avoid the issue