### PR TITLE
Better usage metrics on non-permissions endpoints

### DIFF
--- a/internal/middleware/usagemetrics/usagemetrics.go
+++ b/internal/middleware/usagemetrics/usagemetrics.go
@@ -61,13 +61,15 @@ type serverReporter struct {
 	methodName string
 }
 
-func (r *serverReporter) PostCall(err error, rpcDuration time.Duration) {
+func (r *serverReporter) PostCall(_ error, _ time.Duration) {
 	responseMeta := FromContext(r.ctx)
-	if responseMeta != nil {
-		err := annotateAndReportForMetadata(r.ctx, r.methodName, responseMeta)
-		if err != nil {
-			log.Ctx(r.ctx).Err(err).Msg("could not report metadata")
-		}
+	if responseMeta == nil {
+		responseMeta = &dispatch.ResponseMeta{}
+	}
+
+	err := annotateAndReportForMetadata(r.ctx, r.methodName, responseMeta)
+	if err != nil {
+		log.Ctx(r.ctx).Err(err).Msg("could not report metadata")
 	}
 }
 

--- a/internal/services/v0/watch.go
+++ b/internal/services/v0/watch.go
@@ -10,7 +10,9 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/authzed/spicedb/internal/datastore"
+	"github.com/authzed/spicedb/internal/middleware/usagemetrics"
 	"github.com/authzed/spicedb/internal/namespace"
+	dispatchv1 "github.com/authzed/spicedb/internal/proto/dispatch/v1"
 	"github.com/authzed/spicedb/internal/services/shared"
 	"github.com/authzed/spicedb/pkg/zookie"
 )
@@ -35,6 +37,8 @@ func NewWatchServer(ds datastore.Datastore, nsm namespace.Manager) v0.WatchServi
 }
 
 func (ws *watchServer) Watch(req *v0.WatchRequest, stream v0.WatchService_WatchServer) error {
+	ctx := stream.Context()
+
 	var afterRevision decimal.Decimal
 	if req.StartRevision != nil && req.StartRevision.Token != "" {
 		decodedRevision, err := zookie.DecodeRevision(req.StartRevision)
@@ -45,7 +49,7 @@ func (ws *watchServer) Watch(req *v0.WatchRequest, stream v0.WatchService_WatchS
 		afterRevision = decodedRevision
 	} else {
 		var err error
-		afterRevision, err = ws.ds.OptimizedRevision(stream.Context())
+		afterRevision, err = ws.ds.OptimizedRevision(ctx)
 		if err != nil {
 			return status.Errorf(codes.Unavailable, "failed to start watch: %s", err)
 		}
@@ -53,7 +57,7 @@ func (ws *watchServer) Watch(req *v0.WatchRequest, stream v0.WatchService_WatchS
 
 	namespaceMap := make(map[string]struct{})
 	for _, ns := range req.Namespaces {
-		err := ws.nsm.CheckNamespaceAndRelation(stream.Context(), ns, datastore.Ellipsis, true, afterRevision)
+		err := ws.nsm.CheckNamespaceAndRelation(ctx, ns, datastore.Ellipsis, true, afterRevision)
 		if err != nil {
 			return status.Errorf(codes.FailedPrecondition, "invalid namespace: %s", err)
 		}
@@ -62,7 +66,11 @@ func (ws *watchServer) Watch(req *v0.WatchRequest, stream v0.WatchService_WatchS
 	}
 	filter := namespaceFilter{namespaces: namespaceMap}
 
-	updates, errchan := ws.ds.Watch(stream.Context(), afterRevision)
+	usagemetrics.SetInContext(ctx, &dispatchv1.ResponseMeta{
+		DispatchCount: 1,
+	})
+
+	updates, errchan := ws.ds.Watch(ctx, afterRevision)
 	for {
 		select {
 		case update, ok := <-updates:

--- a/internal/services/v1/permissions.go
+++ b/internal/services/v1/permissions.go
@@ -263,19 +263,21 @@ func (ps *permissionServer) LookupResources(req *v1.LookupResourcesRequest, resp
 	ctx := resp.Context()
 	atRevision, revisionReadAt := consistency.MustRevisionFromContext(ctx)
 
-	err := ps.nsm.CheckNamespaceAndRelation(
-		ctx,
-		req.Subject.Object.ObjectType,
-		normalizeSubjectRelation(req.Subject),
-		true,
-		atRevision,
-	)
-	if err != nil {
-		return rewritePermissionsError(ctx, err)
-	}
-
-	err = ps.nsm.CheckNamespaceAndRelation(ctx, req.ResourceObjectType, req.Permission, false, atRevision)
-	if err != nil {
+	// Perform our preflight checks in parallel
+	errG, checksCtx := errgroup.WithContext(ctx)
+	errG.Go(func() error {
+		return ps.nsm.CheckNamespaceAndRelation(
+			checksCtx,
+			req.Subject.Object.ObjectType,
+			normalizeSubjectRelation(req.Subject),
+			true,
+			atRevision,
+		)
+	})
+	errG.Go(func() error {
+		return ps.nsm.CheckNamespaceAndRelation(ctx, req.ResourceObjectType, req.Permission, false, atRevision)
+	})
+	if err := errG.Wait(); err != nil {
 		return rewritePermissionsError(ctx, err)
 	}
 

--- a/internal/services/v1alpha1/schema.go
+++ b/internal/services/v1alpha1/schema.go
@@ -12,7 +12,9 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/authzed/spicedb/internal/datastore"
+	"github.com/authzed/spicedb/internal/middleware/usagemetrics"
 	"github.com/authzed/spicedb/internal/namespace"
+	dispatchv1 "github.com/authzed/spicedb/internal/proto/dispatch/v1"
 	"github.com/authzed/spicedb/internal/services/serviceerrors"
 	"github.com/authzed/spicedb/internal/services/shared"
 	"github.com/authzed/spicedb/internal/sharederrors"
@@ -64,8 +66,10 @@ func (ss *schemaServiceServer) ReadSchema(ctx context.Context, in *v1alpha1.Read
 		return nil, rewriteError(ctx, err)
 	}
 
-	objectDefs := make([]string, 0, len(in.GetObjectDefinitionsNames()))
-	createdRevisions := make(map[string]datastore.Revision, len(in.GetObjectDefinitionsNames()))
+	numRequested := len(in.GetObjectDefinitionsNames())
+
+	objectDefs := make([]string, 0, numRequested)
+	createdRevisions := make(map[string]datastore.Revision, numRequested)
 	for _, objectDefName := range in.GetObjectDefinitionsNames() {
 		found, createdAt, err := ss.ds.ReadNamespace(ctx, objectDefName, headRevision)
 		if err != nil {
@@ -77,6 +81,10 @@ func (ss *schemaServiceServer) ReadSchema(ctx context.Context, in *v1alpha1.Read
 		objectDef, _ := generator.GenerateSource(found)
 		objectDefs = append(objectDefs, objectDef)
 	}
+
+	usagemetrics.SetInContext(ctx, &dispatchv1.ResponseMeta{
+		DispatchCount: uint32(numRequested),
+	})
 
 	computedRevision, err := nspkg.ComputeV1Alpha1Revision(createdRevisions)
 	if err != nil {
@@ -177,6 +185,10 @@ func (ss *schemaServiceServer) WriteSchema(ctx context.Context, in *v1alpha1.Wri
 		names = append(names, nsdef.Name)
 		revisions[nsdef.Name] = revision
 	}
+
+	usagemetrics.SetInContext(ctx, &dispatchv1.ResponseMeta{
+		DispatchCount: uint32(len(nsdefs)),
+	})
 
 	computedRevision, err := nspkg.ComputeV1Alpha1Revision(revisions)
 	if err != nil {


### PR DESCRIPTION
Originally I was going to write empty usage metrics on all error conditions, which is what prompted the `errgroup` work, to try to reduce the number of top level return calls. I ended up putting it in the middleware to make sure it still writes the trailers if other middlewares fail the request pre-emptively. We can either keep or drop the `errgroup` changes.