### PR TITLE
Avoid logging with testing.T after test has finished

### DIFF
--- a/e2e/run.go
+++ b/e2e/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -14,7 +15,7 @@ func Run(ctx context.Context, out, errOut io.Writer, args ...string) error {
 	if err != nil {
 		return err
 	}
-	cleanupOnDone(ctx.Done(), cmd.Process.Pid, errOut)
+	cleanupOnDone(ctx.Done(), cmd.Process.Pid, os.Stderr)
 	return cmd.Wait()
 }
 
@@ -25,7 +26,7 @@ func GoRun(ctx context.Context, out, errOut io.Writer, args ...string) (int, err
 		return 0, err
 	}
 	go func() {
-		cleanupOnDone(ctx.Done(), cmd.Process.Pid, errOut)
+		cleanupOnDone(ctx.Done(), cmd.Process.Pid, os.Stderr)
 
 		if err := cmd.Wait(); err != nil {
 			fmt.Fprintln(errOut, err)

--- a/e2e/run.go
+++ b/e2e/run.go
@@ -15,7 +15,7 @@ func Run(ctx context.Context, out, errOut io.Writer, args ...string) error {
 	if err != nil {
 		return err
 	}
-	cleanupOnDone(ctx.Done(), cmd.Process.Pid, os.Stderr)
+	cleanupOnDone(ctx.Done(), cmd.Process.Pid)
 	return cmd.Wait()
 }
 
@@ -26,7 +26,7 @@ func GoRun(ctx context.Context, out, errOut io.Writer, args ...string) (int, err
 		return 0, err
 	}
 	go func() {
-		cleanupOnDone(ctx.Done(), cmd.Process.Pid, os.Stderr)
+		cleanupOnDone(ctx.Done(), cmd.Process.Pid)
 
 		if err := cmd.Wait(); err != nil {
 			fmt.Fprintln(errOut, err)
@@ -48,12 +48,12 @@ func start(ctx context.Context, out, errOut io.Writer, args ...string) (*exec.Cm
 	return cmd, nil
 }
 
-func cleanupOnDone(done <-chan struct{}, pid int, errOut io.Writer) {
+func cleanupOnDone(done <-chan struct{}, pid int) {
 	go func() {
 		<-done
 		// negative Pid sends the signal to all child processes in the group
 		if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
-			fmt.Fprintln(errOut, err)
+			fmt.Fprintln(os.Stderr, err)
 		}
 	}()
 }


### PR DESCRIPTION
To keep the test output consistent, several test helpers use a wrapped `t.Log` as a writer for subprocess output. The cleanup code for these run in a goroutine that listens for context cancellation, and may still be running after the test. This can lead to issues where the test suite passes, but the logs still show a panic.

This always writes cleanup messages to stderr instead, so that it doesn't matter if they run after the test is done.

Fixes #394 