### PR TITLE
Fix version command

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -38,7 +38,7 @@ func main() {
 	cmd.RegisterRootFlags(rootCmd)
 
 	// Add a version command
-	versionCmd := cmd.NewRootCommand(rootCmd.Use)
+	versionCmd := cmd.NewVersionCommand(rootCmd.Use)
 	cmd.RegisterVersionFlags(versionCmd)
 	rootCmd.AddCommand(versionCmd)
 


### PR DESCRIPTION
`spicedb version` doesn't work as of https://github.com/authzed/spicedb/commit/b928d39562c0a46c840b17d60b5491ba478eb0c2. This should fix it by creating the correct command.