### PR TITLE
Add a non-caching namespace manager

### DIFF
--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
 	v1_api "github.com/authzed/authzed-go/proto/authzed/api/v1"
@@ -181,7 +180,7 @@ func TestMaxDepth(t *testing.T) {
 	require.NoError(err)
 	require.True(revision.GreaterThan(decimal.Zero))
 
-	nsm, err := namespace.NewCachingNamespaceManager(1*time.Second, testCacheConfig)
+	nsm, err := namespace.NewCachingNamespaceManager(testCacheConfig)
 	require.NoError(err)
 
 	dispatch := NewLocalOnlyDispatcher(nsm)
@@ -299,7 +298,7 @@ func newLocalDispatcher(require *require.Assertions) (context.Context, dispatch.
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	nsm, err := namespace.NewCachingNamespaceManager(1*time.Second, testCacheConfig)
+	nsm, err := namespace.NewCachingNamespaceManager(testCacheConfig)
 	require.NoError(err)
 
 	dispatch := NewLocalOnlyDispatcher(nsm)

--- a/internal/dispatch/graph/expand_test.go
+++ b/internal/dispatch/graph/expand_test.go
@@ -8,7 +8,6 @@ import (
 	"go/token"
 	"os"
 	"testing"
-	"time"
 
 	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
 	v1_api "github.com/authzed/authzed-go/proto/authzed/api/v1"
@@ -280,7 +279,7 @@ func TestMaxDepthExpand(t *testing.T) {
 	require.True(revision.GreaterThan(decimal.Zero))
 	require.NoError(datastoremw.SetInContext(ctx, ds))
 
-	nsm, err := namespace.NewCachingNamespaceManager(1*time.Second, testCacheConfig)
+	nsm, err := namespace.NewCachingNamespaceManager(testCacheConfig)
 	require.NoError(err)
 
 	dispatch := NewLocalOnlyDispatcher(nsm)

--- a/internal/dispatch/graph/lookup_test.go
+++ b/internal/dispatch/graph/lookup_test.go
@@ -166,7 +166,7 @@ func TestMaxDepthLookup(t *testing.T) {
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	nsm, err := namespace.NewCachingNamespaceManager(1*time.Second, testCacheConfig)
+	nsm, err := namespace.NewCachingNamespaceManager(testCacheConfig)
 	require.NoError(err)
 
 	dispatch := NewLocalOnlyDispatcher(nsm)

--- a/internal/namespace/manager.go
+++ b/internal/namespace/manager.go
@@ -10,7 +10,7 @@ import (
 
 var tracer = otel.Tracer("spicedb/internal/namespace")
 
-// Manager is a subset of the datastore interface that can read (and possibly cache) namespaces.
+// Manager is a subset of the datastore interface that can read (and possibly nsCache) namespaces.
 type Manager interface {
 	// ReadNamespace reads a namespace definition and version and returns it if found.
 	//

--- a/internal/namespace/typesystem_test.go
+++ b/internal/namespace/typesystem_test.go
@@ -3,7 +3,6 @@ package namespace
 import (
 	"context"
 	"testing"
-	"time"
 
 	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
 	"github.com/shopspring/decimal"
@@ -223,7 +222,7 @@ func TestTypeSystem(t *testing.T) {
 			require.NoError(err)
 
 			ctx := datastoremw.ContextWithDatastore(context.Background(), ds)
-			nsm, err := NewCachingNamespaceManager(0*time.Second, nil)
+			nsm, err := NewCachingNamespaceManager(nil)
 			require.NoError(err)
 
 			var lastRevision decimal.Decimal

--- a/internal/services/consistency_test.go
+++ b/internal/services/consistency_test.go
@@ -77,7 +77,7 @@ func TestConsistency(t *testing.T) {
 							})
 							t.Cleanup(cleanup)
 
-							ns, err := namespace.NewCachingNamespaceManager(1*time.Second, nil)
+							ns, err := namespace.NewCachingNamespaceManager(nil)
 							lrequire.NoError(err)
 
 							dsCtx := datastoremw.ContextWithHandle(context.Background())

--- a/internal/services/v0/namespace.go
+++ b/internal/services/v0/namespace.go
@@ -3,7 +3,6 @@ package v0
 import (
 	"context"
 	"errors"
-	"time"
 
 	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
@@ -43,10 +42,7 @@ func NewNamespaceServer() v0.NamespaceServiceServer {
 
 func (nss *nsServer) WriteConfig(ctx context.Context, req *v0.WriteConfigRequest) (*v0.WriteConfigResponse, error) {
 	ds := datastoremw.MustFromContext(ctx)
-	nsm, err := namespace.NewCachingNamespaceManager(0*time.Second, nil)
-	if err != nil {
-		return nil, rewriteNamespaceError(ctx, err)
-	}
+	nsm := namespace.NewNonCachingNamespaceManager()
 
 	readRevision, _ := consistency.MustRevisionFromContext(ctx)
 

--- a/internal/services/v1alpha1/schema.go
+++ b/internal/services/v1alpha1/schema.go
@@ -98,11 +98,7 @@ func (ss *schemaServiceServer) ReadSchema(ctx context.Context, in *v1alpha1.Read
 func (ss *schemaServiceServer) WriteSchema(ctx context.Context, in *v1alpha1.WriteSchemaRequest) (*v1alpha1.WriteSchemaResponse, error) {
 	log.Ctx(ctx).Trace().Str("schema", in.GetSchema()).Msg("requested Schema to be written")
 	ds := datastoremw.MustFromContext(ctx)
-
-	nsm, err := namespace.NewCachingNamespaceManager(0, nil) // non-caching manager
-	if err != nil {
-		return nil, rewriteError(ctx, err)
-	}
+	nsm := namespace.NewNonCachingNamespaceManager()
 
 	inputSchema := compiler.InputSchema{
 		Source:       input.Source("schema"),

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -29,11 +29,10 @@ func NewTestServer(require *require.Assertions,
 	emptyDS, err := memdb.NewMemdbDatastore(0, revisionFuzzingTimedelta, gcWindow, simulatedLatency)
 	require.NoError(err)
 	ds, revision := dsInitFunc(emptyDS, require)
-	ns, err := namespace.NewCachingNamespaceManager(1*time.Second, nil)
+	ns, err := namespace.NewCachingNamespaceManager(nil)
 	require.NoError(err)
 	srv, err := server.NewConfigWithOptions(
 		server.WithDatastore(ds),
-		server.WithNamespaceCacheExpiration(1*time.Second),
 		server.WithDispatcher(graph.NewLocalOnlyDispatcher(ns)),
 		server.WithDispatchMaxDepth(50),
 		server.WithGRPCServer(util.GRPCServerConfig{
@@ -41,7 +40,6 @@ func NewTestServer(require *require.Assertions,
 			Enabled: true,
 		}),
 		server.WithSchemaPrefixesRequired(schemaPrefixRequired),
-		server.WithNamespaceCacheExpiration(1*time.Second),
 		server.WithGRPCAuthFunc(func(ctx context.Context) (context.Context, error) {
 			return ctx, nil
 		}),

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -26,7 +26,10 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) {
 	datastore.RegisterDatastoreFlags(cmd, &config.DatastoreConfig)
 
 	// Flags for the namespace manager
-	cmd.Flags().DurationVar(&config.NamespaceCacheExpiration, "ns-cache-expiration", 1*time.Minute, "amount of time a namespace entry should remain cached")
+	cmd.Flags().Duration("ns-cache-expiration", 1*time.Minute, "amount of time a namespace entry should remain cached")
+	if err := cmd.Flags().MarkHidden("ns-cache-expiration"); err != nil {
+		panic("failed to mark flag hidden: " + err.Error())
+	}
 
 	// Flags for parsing and validating schemas.
 	cmd.Flags().BoolVar(&config.SchemaPrefixesRequired, "schema-prefixes-required", false, "require prefixes on all object definitions in schemas")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -48,9 +48,6 @@ type Config struct {
 	DatastoreConfig datastorecfg.Config
 	Datastore       datastore.Datastore
 
-	// Namespace cache
-	NamespaceCacheExpiration time.Duration
-
 	// Schema options
 	SchemaPrefixesRequired bool
 
@@ -99,7 +96,7 @@ func (c *Config) Complete() (RunnableServer, error) {
 		}
 	}
 
-	nsm, err := namespace.NewCachingNamespaceManager(c.NamespaceCacheExpiration, nil)
+	nsm, err := namespace.NewCachingNamespaceManager(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create namespace manager: %w", err)
 	}

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -36,7 +36,6 @@ func (c *Config) ToOption() ConfigOption {
 		to.HTTPGatewayCorsAllowedOrigins = c.HTTPGatewayCorsAllowedOrigins
 		to.DatastoreConfig = c.DatastoreConfig
 		to.Datastore = c.Datastore
-		to.NamespaceCacheExpiration = c.NamespaceCacheExpiration
 		to.SchemaPrefixesRequired = c.SchemaPrefixesRequired
 		to.DispatchServer = c.DispatchServer
 		to.DispatchMaxDepth = c.DispatchMaxDepth
@@ -143,13 +142,6 @@ func WithDatastoreConfig(datastoreConfig datastore.Config) ConfigOption {
 func WithDatastore(datastore datastore1.Datastore) ConfigOption {
 	return func(c *Config) {
 		c.Datastore = datastore
-	}
-}
-
-// WithNamespaceCacheExpiration returns an option that can set NamespaceCacheExpiration on a Config
-func WithNamespaceCacheExpiration(namespaceCacheExpiration time.Duration) ConfigOption {
-	return func(c *Config) {
-		c.NamespaceCacheExpiration = namespaceCacheExpiration
 	}
 }
 

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -3,7 +3,6 @@ package testserver
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -22,10 +21,7 @@ import (
 	"github.com/authzed/spicedb/pkg/cmd/util"
 )
 
-const (
-	nsCacheExpiration = 0 * time.Minute // No caching
-	maxDepth          = 50
-)
+const maxDepth = 50
 
 //go:generate go run github.com/ecordell/optgen -output zz_generated.options.go . Config
 type Config struct {
@@ -41,7 +37,7 @@ type RunnableTestServer interface {
 }
 
 func (c *Config) Complete() (RunnableTestServer, error) {
-	nsm, err := namespace.NewCachingNamespaceManager(nsCacheExpiration, nil)
+	nsm, err := namespace.NewCachingNamespaceManager(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize namespace manager: %w", err)
 	}

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -54,10 +54,7 @@ func NewDevContext(ctx context.Context, developerRequestContext *v0.RequestConte
 	ctx = datastoremw.ContextWithDatastore(ctx, ds)
 
 	// Instantiate the namespace manager with *no caching*.
-	nsm, err := namespace.NewCachingNamespaceManager(0*time.Second, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	nsm := namespace.NewNonCachingNamespaceManager()
 
 	dctx, devErrs, nerr := newDevContextWithDatastore(ctx, developerRequestContext, ds, nsm)
 	if nerr != nil || devErrs != nil {


### PR DESCRIPTION
this allows certain operations to deal with non-persisted namespaces
with the same interface as persisted namespaces