### PR TITLE
configure dispatch for tests

### DIFF
--- a/internal/datastore/common/revisions.go
+++ b/internal/datastore/common/revisions.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -20,15 +21,40 @@ type RemoteNowFunction func(context.Context) (datastore.Revision, error)
 // RemoteClockRevisions handles revision calculation for datastores that provide
 // their own clocks.
 type RemoteClockRevisions struct {
-	QuantizationNanos      int64
-	GCWindowNanos          int64
-	FollowerReadDelayNanos int64
-	MaxRevisionStaleness   time.Duration
-	NowFunc                RemoteNowFunction
+	quantizationNanos      int64
+	gcWindowNanos          int64
+	followerReadDelayNanos int64
+	maxRevisionStaleness   time.Duration
+	nowFunc                RemoteNowFunction
 
-	updateGroup           singleflight.Group
-	lastQuantizedRevision decimal.Decimal
-	revisionValidThrough  time.Time
+	// these values are read and set by multiple consumers, they're protected
+	// by atomic load/store
+	lastQuantizedRevision *safeRevision
+	revisionValidThrough  *safeTime
+
+	// the updategroup consolidates concurrent requests to the database into 1
+	updateGroup singleflight.Group
+}
+
+// NewRemoteClockRevisions returns a RemoteClockRevisions for the given configuration
+func NewRemoteClockRevisions(quantizationNanos, gcWindowNanos, followerReadDelayNanos int64, maxRevisionStaleness time.Duration) *RemoteClockRevisions {
+	rev := safeRevision{}
+	rev.set(decimal.Zero)
+	t := safeTime{}
+	t.set(time.Time{})
+	return &RemoteClockRevisions{
+		quantizationNanos:      quantizationNanos,
+		gcWindowNanos:          gcWindowNanos,
+		followerReadDelayNanos: followerReadDelayNanos,
+		maxRevisionStaleness:   maxRevisionStaleness,
+		lastQuantizedRevision:  &rev,
+		revisionValidThrough:   &t,
+	}
+}
+
+// SetNowFunc sets the function used to determine the head revision
+func (rcr *RemoteClockRevisions) SetNowFunc(nowFunc RemoteNowFunction) {
+	rcr.nowFunc = nowFunc
 }
 
 // OptimizedRevision picks a revision that is valid for the request's
@@ -38,15 +64,16 @@ func (rcr *RemoteClockRevisions) OptimizedRevision(ctx context.Context) (datasto
 	defer span.End()
 
 	localNow := time.Now()
-	if localNow.Before(rcr.revisionValidThrough) {
-		log.Debug().Time("now", localNow).Time("valid", rcr.revisionValidThrough).Msg("returning cached revision")
-		return rcr.lastQuantizedRevision, nil
+	revisionValidThrough := rcr.revisionValidThrough.get()
+	if localNow.Before(revisionValidThrough) {
+		log.Debug().Time("now", localNow).Time("valid", revisionValidThrough).Msg("returning cached revision")
+		return rcr.lastQuantizedRevision.get(), nil
 	}
 
 	lastQuantizedRevision, err, _ := rcr.updateGroup.Do("", func() (interface{}, error) {
-		log.Debug().Time("now", localNow).Time("valid", rcr.revisionValidThrough).Msg("computing new revision")
+		log.Debug().Time("now", localNow).Time("valid", revisionValidThrough).Msg("computing new revision")
 
-		nowHLC, err := rcr.NowFunc(ctx)
+		nowHLC, err := rcr.nowFunc(ctx)
 		if err != nil {
 			return datastore.NoRevision, err
 		}
@@ -54,22 +81,25 @@ func (rcr *RemoteClockRevisions) OptimizedRevision(ctx context.Context) (datasto
 		// Round the revision down to the nearest quantization
 		// Apply a delay to enable follower reads: https://www.cockroachlabs.com/docs/stable/follower-reads.html
 		// This is currently only used for crdb, but other datastores may have similar features in the future
-		now := nowHLC.IntPart() - rcr.FollowerReadDelayNanos
+		now := nowHLC.IntPart() - rcr.followerReadDelayNanos
 		quantized := now
-		if rcr.QuantizationNanos > 0 {
-			quantized -= (now % rcr.QuantizationNanos)
+		if rcr.quantizationNanos > 0 {
+			quantized -= (now % rcr.quantizationNanos)
 		}
-		log.Debug().Int64("readSkew", rcr.FollowerReadDelayNanos).Int64("totalSkew", nowHLC.IntPart()-quantized).Msg("revision skews")
+		log.Debug().Int64("readSkew", rcr.followerReadDelayNanos).Int64("totalSkew", nowHLC.IntPart()-quantized).Msg("revision skews")
 
-		validForNanos := (quantized + rcr.QuantizationNanos) - now
+		validForNanos := (quantized + rcr.quantizationNanos) - now
 
-		rcr.revisionValidThrough = localNow.
+		rvt := localNow.
 			Add(time.Duration(validForNanos) * time.Nanosecond).
-			Add(rcr.MaxRevisionStaleness)
-		log.Debug().Time("now", localNow).Time("valid", rcr.revisionValidThrough).Int64("validForNanos", validForNanos).Msg("setting valid through")
-		rcr.lastQuantizedRevision = decimal.NewFromInt(quantized)
+			Add(rcr.maxRevisionStaleness)
+		rcr.revisionValidThrough.set(rvt)
+		log.Debug().Time("now", localNow).Time("valid", rvt).Int64("validForNanos", validForNanos).Msg("setting valid through")
 
-		return rcr.lastQuantizedRevision, nil
+		lqr := decimal.NewFromInt(quantized)
+		rcr.lastQuantizedRevision.set(lqr)
+
+		return lqr, nil
 	})
 
 	return lastQuantizedRevision.(decimal.Decimal), err
@@ -81,7 +111,7 @@ func (rcr *RemoteClockRevisions) CheckRevision(ctx context.Context, revision dat
 	defer span.End()
 
 	// Make sure the system time indicated is within the software GC window
-	now, err := rcr.NowFunc(ctx)
+	now, err := rcr.nowFunc(ctx)
 	if err != nil {
 		return err
 	}
@@ -89,7 +119,7 @@ func (rcr *RemoteClockRevisions) CheckRevision(ctx context.Context, revision dat
 	nowNanos := now.IntPart()
 	revisionNanos := revision.IntPart()
 
-	isStale := revisionNanos < (nowNanos - rcr.GCWindowNanos)
+	isStale := revisionNanos < (nowNanos - rcr.gcWindowNanos)
 	if isStale {
 		log.Debug().Stringer("now", now).Stringer("revision", revision).Msg("stale revision")
 		return datastore.NewInvalidRevisionErr(revision, datastore.RevisionStale)
@@ -102,4 +132,30 @@ func (rcr *RemoteClockRevisions) CheckRevision(ctx context.Context, revision dat
 	}
 
 	return nil
+}
+
+// safeRevision is a wrapper that protects a revision with atomic
+type safeRevision struct {
+	v atomic.Value
+}
+
+func (r *safeRevision) get() decimal.Decimal {
+	return r.v.Load().(decimal.Decimal)
+}
+
+func (r *safeRevision) set(revision decimal.Decimal) {
+	r.v.Store(revision)
+}
+
+// safeTime is a wrapper that protects a time with atomic
+type safeTime struct {
+	v atomic.Value
+}
+
+func (t *safeTime) get() time.Time {
+	return t.v.Load().(time.Time)
+}
+
+func (t *safeTime) set(in time.Time) {
+	t.v.Store(in)
 }

--- a/internal/datastore/common/revisions.go
+++ b/internal/datastore/common/revisions.go
@@ -84,7 +84,7 @@ func (rcr *RemoteClockRevisions) OptimizedRevision(ctx context.Context) (datasto
 		now := nowHLC.IntPart() - rcr.followerReadDelayNanos
 		quantized := now
 		if rcr.quantizationNanos > 0 {
-			quantized -= (now % rcr.quantizationNanos)
+			quantized -= now % rcr.quantizationNanos
 		}
 		log.Debug().Int64("readSkew", rcr.followerReadDelayNanos).Int64("totalSkew", nowHLC.IntPart()-quantized).Msg("revision skews")
 

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -20,6 +20,10 @@ import (
 	"github.com/authzed/spicedb/internal/datastore/crdb/migrations"
 )
 
+func init() {
+	datastore.Engines = append(datastore.Engines, Engine)
+}
+
 var (
 	psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
@@ -29,7 +33,8 @@ var (
 )
 
 const (
-	tableNamespace    = "namespace_config"
+	Engine         = "cockroachdb"
+	tableNamespace = "namespace_config"
 	tableTuple        = "relation_tuple"
 	tableTransactions = "transactions"
 

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -33,8 +33,8 @@ var (
 )
 
 const (
-	Engine         = "cockroachdb"
-	tableNamespace = "namespace_config"
+	Engine            = "cockroachdb"
+	tableNamespace    = "namespace_config"
 	tableTuple        = "relation_tuple"
 	tableTransactions = "transactions"
 

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -130,12 +130,12 @@ func NewCRDBDatastore(url string, options ...Option) (datastore.Datastore, error
 	}
 
 	ds := &crdbDatastore{
-		&common.RemoteClockRevisions{
-			QuantizationNanos:      config.revisionQuantization.Nanoseconds(),
-			GCWindowNanos:          gcWindowNanos,
-			FollowerReadDelayNanos: config.followerReadDelay.Nanoseconds(),
-			MaxRevisionStaleness:   maxRevisionStaleness,
-		},
+		common.NewRemoteClockRevisions(
+			config.revisionQuantization.Nanoseconds(),
+			gcWindowNanos,
+			config.followerReadDelay.Nanoseconds(),
+			maxRevisionStaleness,
+		),
 		url,
 		conn,
 		config.watchBufferLength,
@@ -144,7 +144,7 @@ func NewCRDBDatastore(url string, options ...Option) (datastore.Datastore, error
 		keyer,
 	}
 
-	ds.RemoteClockRevisions.NowFunc = ds.HeadRevision
+	ds.RemoteClockRevisions.SetNowFunc(ds.HeadRevision)
 
 	return ds, nil
 }

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -6,80 +6,33 @@ package crdb
 import (
 	"context"
 	"fmt"
-	"log"
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v4"
-	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/authzed/spicedb/internal/datastore"
-	"github.com/authzed/spicedb/internal/datastore/crdb/migrations"
 	"github.com/authzed/spicedb/internal/datastore/test"
-	"github.com/authzed/spicedb/pkg/migrate"
-	"github.com/authzed/spicedb/pkg/secrets"
+	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
 )
 
-type sqlTest struct {
-	conn              *pgx.Conn
-	port              string
-	creds             string
-	followerReadDelay time.Duration
-
-	cleanup func()
-}
-
-var crdbContainer = &dockertest.RunOptions{
-	Repository: "cockroachdb/cockroach",
-	Tag:        "v21.1.3",
-	Cmd:        []string{"start-single-node", "--insecure", "--max-offset=50ms"},
-}
-
-func (st sqlTest) New(revisionFuzzingTimedelta, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
-	uniquePortion, err := secrets.TokenHex(4)
-	if err != nil {
-		return nil, err
-	}
-
-	newDBName := "db" + uniquePortion
-
-	_, err = st.conn.Exec(context.Background(), "CREATE DATABASE "+newDBName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create database: %w", err)
-	}
-
-	connectStr := fmt.Sprintf(
-		"postgres://%s@localhost:%s/%s?sslmode=disable",
-		st.creds,
-		st.port,
-		newDBName,
-	)
-
-	migrationDriver, err := migrations.NewCRDBDriver(connectStr)
-	if err != nil {
-		return nil, fmt.Errorf("unable to initialize migration engine: %w", err)
-	}
-
-	err = migrations.CRDBMigrations.Run(migrationDriver, migrate.Head, migrate.LiveRun)
-	if err != nil {
-		return nil, fmt.Errorf("unable to migrate database: %w", err)
-	}
-
-	return NewCRDBDatastore(
-		connectStr,
-		GCWindow(gcWindow),
-		RevisionQuantization(revisionFuzzingTimedelta),
-		WatchBufferLength(watchBufferLength),
-		FollowerReadDelay(st.followerReadDelay),
-	)
-}
-
 func TestCRDBDatastore(t *testing.T) {
-	tester := newTester(crdbContainer, "root:fake", 26257)
-	defer tester.cleanup()
+	b := testdatastore.NewCRDBBuilder(t)
+	test.All(t, test.DatastoreTesterFunc(func(revisionFuzzingTimedelta, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
+			ds, err := NewCRDBDatastore(
+				uri,
+				GCWindow(gcWindow),
+				RevisionQuantization(revisionFuzzingTimedelta),
+				WatchBufferLength(watchBufferLength),
+				OverlapStrategy(overlapStrategyPrefix),
+			)
+			require.NoError(t, err)
+			return ds
+		})
 
-	test.All(t, tester)
+		return ds, nil
+	}))
 }
 
 func TestCRDBDatastoreWithFollowerReads(t *testing.T) {
@@ -94,11 +47,17 @@ func TestCRDBDatastoreWithFollowerReads(t *testing.T) {
 		t.Run(fmt.Sprintf("Quantization%s", quantization), func(t *testing.T) {
 			require := require.New(t)
 
-			tester := newTester(crdbContainer, "root:fake", 26257)
-			tester.followerReadDelay = followerReadDelay
-
-			ds, err := tester.New(quantization, gcWindow, 1)
-			require.NoError(err)
+			ds := testdatastore.NewCRDBBuilder(t).NewDatastore(t, func(engine, uri string) datastore.Datastore {
+				ds, err := NewCRDBDatastore(
+					uri,
+					GCWindow(gcWindow),
+					RevisionQuantization(quantization),
+					FollowerReadDelay(followerReadDelay),
+				)
+				require.NoError(err)
+				return ds
+			})
+			defer ds.Close()
 
 			ctx := context.Background()
 			ok, err := ds.IsReady(ctx)
@@ -114,42 +73,6 @@ func TestCRDBDatastoreWithFollowerReads(t *testing.T) {
 				diff := nowRevision.IntPart() - testRevision.IntPart()
 				require.True(diff > followerReadDelay.Nanoseconds())
 			}
-			tester.cleanup()
-			ds.Close()
 		})
 	}
-}
-
-func newTester(containerOpts *dockertest.RunOptions, creds string, portNum uint16) *sqlTest {
-	pool, err := dockertest.NewPool("")
-	if err != nil {
-		log.Fatalf("Could not connect to docker: %s", err)
-	}
-
-	resource, err := pool.RunWithOptions(containerOpts)
-	if err != nil {
-		log.Fatalf("Could not start resource: %s", err)
-	}
-
-	var conn *pgx.Conn
-	port := resource.GetPort(fmt.Sprintf("%d/tcp", portNum))
-	if err = pool.Retry(func() error {
-		var err error
-		conn, err = pgx.Connect(context.Background(), fmt.Sprintf("postgres://%s@localhost:%s/defaultdb?sslmode=disable", creds, port))
-		if err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		log.Fatalf("Could not connect to docker: %s", err)
-	}
-
-	cleanup := func() {
-		// When you're done, kill and remove the container
-		if err = pool.Purge(resource); err != nil {
-			log.Fatalf("Could not purge resource: %s", err)
-		}
-	}
-
-	return &sqlTest{conn: conn, port: port, cleanup: cleanup, creds: creds}
 }

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -11,6 +11,8 @@ import (
 	"github.com/authzed/spicedb/internal/datastore/options"
 )
 
+var Engines = []string{}
+
 // Ellipsis is a special relation that is assumed to be valid on the right
 // hand side of a tuple.
 const Ellipsis = "..."

--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -18,11 +18,16 @@ import (
 	"github.com/authzed/spicedb/internal/datastore"
 )
 
+func init() {
+	datastore.Engines = append(datastore.Engines, Engine)
+}
+
 // DisableGC is a convenient constant for setting the garbage collection
 // interval high enough that it will never run.
 const DisableGC = time.Duration(math.MaxInt64)
 
 const (
+	Engine            = "memory"
 	tableRelationship = "relationship"
 	tableTransaction  = "transaction"
 	tableNamespace    = "namespaceConfig"

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -32,8 +32,8 @@ func init() {
 }
 
 const (
-	Engine         = "postgres"
-	tableNamespace = "namespace_config"
+	Engine           = "postgres"
+	tableNamespace   = "namespace_config"
 	tableTransaction = "relation_tuple_transaction"
 	tableTuple       = "relation_tuple"
 

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -27,8 +27,13 @@ import (
 	"github.com/authzed/spicedb/internal/datastore/postgres/migrations"
 )
 
+func init() {
+	datastore.Engines = append(datastore.Engines, Engine)
+}
+
 const (
-	tableNamespace   = "namespace_config"
+	Engine         = "postgres"
+	tableNamespace = "namespace_config"
 	tableTransaction = "relation_tuple_transaction"
 	tableTuple       = "relation_tuple"
 

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -67,18 +67,18 @@ func NewSpannerDatastore(database string, opts ...Option) (datastore.Datastore, 
 		config.maxRevisionStalenessPercent) * time.Nanosecond
 
 	ds := spannerDatastore{
-		RemoteClockRevisions: &common.RemoteClockRevisions{
-			QuantizationNanos:      config.revisionQuantization.Nanoseconds(),
-			GCWindowNanos:          config.gcWindow.Nanoseconds(),
-			FollowerReadDelayNanos: config.followerReadDelay.Nanoseconds(),
-			MaxRevisionStaleness:   maxRevisionStaleness,
-		},
+		RemoteClockRevisions: common.NewRemoteClockRevisions(
+			config.revisionQuantization.Nanoseconds(),
+			config.gcWindow.Nanoseconds(),
+			config.followerReadDelay.Nanoseconds(),
+			maxRevisionStaleness,
+		),
 		client:        client,
 		querySplitter: querySplitter,
 		config:        config,
 	}
+	ds.RemoteClockRevisions.SetNowFunc(ds.HeadRevision)
 
-	ds.RemoteClockRevisions.NowFunc = ds.HeadRevision
 	ctx, cancel := context.WithCancel(context.Background())
 	if err := ds.runGC(ctx); err != nil {
 		cancel()

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -16,7 +16,13 @@ import (
 	"github.com/authzed/spicedb/internal/datastore/spanner/migrations"
 )
 
+func init() {
+	datastore.Engines = append(datastore.Engines, Engine)
+}
+
 const (
+	Engine = "spanner"
+
 	errUnableToInstantiate = "unable to instantiate spanner client: %w"
 
 	errRevision = "unable to load revision: %w"

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -1,160 +1,27 @@
-// go:build ci
 //go:build ci
 // +build ci
 
 package spanner
 
 import (
-	"context"
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
-	database "cloud.google.com/go/spanner/admin/database/apiv1"
-	instances "cloud.google.com/go/spanner/admin/instance/apiv1"
-	"github.com/ory/dockertest/v3"
-	"github.com/rs/zerolog/log"
-	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
-	"google.golang.org/genproto/googleapis/spanner/admin/instance/v1"
+	"github.com/stretchr/testify/require"
 
 	"github.com/authzed/spicedb/internal/datastore"
-	"github.com/authzed/spicedb/internal/datastore/spanner/migrations"
 	"github.com/authzed/spicedb/internal/datastore/test"
-	"github.com/authzed/spicedb/pkg/migrate"
-	"github.com/authzed/spicedb/pkg/secrets"
+	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
 )
 
-type spannerTest struct {
-	cleanup func()
-}
-
-var spannerContainer = &dockertest.RunOptions{
-	Repository: "gcr.io/cloud-spanner-emulator/emulator",
-	Tag:        "latest",
-}
-
-func (st spannerTest) New(revisionFuzzingTimedelta, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
-	log.Info().Str("host", os.Getenv("SPANNER_EMULATOR_HOST")).Msg("using spanner emulator")
-
-	uniquePortion, err := secrets.TokenHex(4)
-	if err != nil {
-		log.Fatal().Err(err).Msg("unable to create random instance name")
-	}
-
-	newInstanceName := fmt.Sprintf("fake-instance-%s", uniquePortion)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	instancesClient, err := instances.NewInstanceAdminClient(ctx)
-	if err != nil {
-		log.Fatal().Err(err).Msg("error initializing instances client")
-	}
-	defer instancesClient.Close()
-
-	createInstanceOp, err := instancesClient.CreateInstance(ctx, &instance.CreateInstanceRequest{
-		Parent:     "projects/fake-project-id",
-		InstanceId: newInstanceName,
-		Instance: &instance.Instance{
-			Config:      "emulator-config",
-			DisplayName: "Test Instance",
-			NodeCount:   1,
-		},
-	})
-	if err != nil {
-		log.Fatal().Err(err).Msg("error creating instance")
-	}
-
-	instance, err := createInstanceOp.Wait(ctx)
-	if err != nil {
-		log.Fatal().Err(err).Msg("error waiting for instance")
-	}
-
-	adminClient, err := database.NewDatabaseAdminClient(ctx)
-	if err != nil {
-		log.Fatal().Err(err).Msg("error initializing admin client")
-	}
-	defer adminClient.Close()
-
-	dbID := "fake-database-id"
-	op, err := adminClient.CreateDatabase(ctx, &adminpb.CreateDatabaseRequest{
-		Parent:          instance.Name,
-		CreateStatement: "CREATE DATABASE `" + dbID + "`",
-	})
-	if err != nil {
-		log.Fatal().Err(err).Msg("error calling create database")
-	}
-
-	db, err := op.Wait(ctx)
-	if err != nil {
-		log.Fatal().Err(err).Msg("error waiting for database")
-	}
-
-	migrationDriver, err := migrations.NewSpannerDriver(db.Name, "")
-	if err != nil {
-		return nil, fmt.Errorf("unable to initialize migration engine: %w", err)
-	}
-
-	err = migrations.SpannerMigrations.Run(migrationDriver, migrate.Head, migrate.LiveRun)
-	if err != nil {
-		return nil, fmt.Errorf("unable to migrate database: %w", err)
-	}
-
-	return NewSpannerDatastore(db.Name, GCWindow(gcWindow), RevisionQuantization(revisionFuzzingTimedelta))
-}
-
 func TestSpannerDatastore(t *testing.T) {
-	tester := newTester(spannerContainer)
-	defer tester.cleanup()
-
-	test.All(t, tester)
-}
-
-func newTester(containerOpts *dockertest.RunOptions) *spannerTest {
-	pool, err := dockertest.NewPool("")
-	if err != nil {
-		log.Fatal().Err(err).Msg("could not connect to docker")
-	}
-
-	resource, err := pool.RunWithOptions(containerOpts)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Could not start resource")
-	}
-
-	port := resource.GetPort("9010/tcp")
-	spannerEmulatorAddr := fmt.Sprintf("localhost:%s", port)
-	os.Setenv("SPANNER_EMULATOR_HOST", spannerEmulatorAddr)
-
-	if err = pool.Retry(func() error {
-		ctx := context.Background()
-
-		instancesClient, err := instances.NewInstanceAdminClient(ctx)
-		if err != nil {
-			return err
-		}
-		defer instancesClient.Close()
-
-		_, err = instancesClient.CreateInstance(ctx, &instance.CreateInstanceRequest{
-			Parent:     "projects/fake-project-id",
-			InstanceId: "init",
-			Instance: &instance.Instance{
-				Config:      "emulator-config",
-				DisplayName: "Test Instance",
-				NodeCount:   1,
-			},
+	b := testdatastore.NewSpannerBuilder(t)
+	test.All(t, test.DatastoreTesterFunc(func(revisionFuzzingTimedelta, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
+			ds, err := NewSpannerDatastore(uri, RevisionQuantization(revisionFuzzingTimedelta), GCWindow(gcWindow), WatchBufferLength(watchBufferLength))
+			require.NoError(t, err)
+			return ds
 		})
-		return err
-	}); err != nil {
-		log.Fatal().Err(err).Msg("Could not connect to docker")
-	}
-
-	cleanup := func() {
-		// When you're done, kill and remove the container
-		if err = pool.Purge(resource); err != nil {
-			log.Fatal().Err(err).Msg("Could not purge resource")
-		}
-	}
-
-	return &spannerTest{cleanup: cleanup}
+		return ds, nil
+	}))
 }

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -1,3 +1,4 @@
+// go:build ci
 //go:build ci
 // +build ci
 

--- a/internal/datastore/test/datastore.go
+++ b/internal/datastore/test/datastore.go
@@ -26,6 +26,12 @@ type DatastoreTester interface {
 	New(revisionFuzzingTimedelta, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error)
 }
 
+type DatastoreTesterFunc func(revisionFuzzingTimedelta, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error)
+
+func (f DatastoreTesterFunc) New(revisionFuzzingTimedelta, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	return f(revisionFuzzingTimedelta, gcWindow, watchBufferLength)
+}
+
 // All runs all generic datastore tests on a DatastoreTester.
 func All(t *testing.T, tester DatastoreTester) {
 	t.Run("TestSimple", func(t *testing.T) { SimpleTest(t, tester) })

--- a/internal/dispatch/cluster/cluster.go
+++ b/internal/dispatch/cluster/cluster.go
@@ -1,0 +1,54 @@
+package cluster
+
+import (
+	"github.com/dgraph-io/ristretto"
+
+	"github.com/authzed/spicedb/internal/dispatch"
+	"github.com/authzed/spicedb/internal/dispatch/caching"
+	"github.com/authzed/spicedb/internal/dispatch/graph"
+	"github.com/authzed/spicedb/internal/namespace"
+)
+
+// Option is a function-style option for configuring a combined Dispatcher.
+type Option func(*optionState)
+
+type optionState struct {
+	prometheusSubsystem string
+	cacheConfig         *ristretto.Config
+}
+
+// PrometheusSubsystem sets the subsystem name for the prometheus metrics
+func PrometheusSubsystem(name string) Option {
+	return func(state *optionState) {
+		state.prometheusSubsystem = name
+	}
+}
+
+// CacheConfig sets the configuration for the local dispatcher's cache.
+func CacheConfig(config *ristretto.Config) Option {
+	return func(state *optionState) {
+		state.cacheConfig = config
+	}
+}
+
+// NewClusterDispatcher takes a dispatcher (such as one created by
+// combined.NewDispatcher) and returns a cluster dispatcher suitable for use as
+// the dispatcher for the dispatch grpc server.
+func NewClusterDispatcher(dispatch dispatch.Dispatcher, nsm namespace.Manager, options ...Option) (dispatch.Dispatcher, error) {
+	clusterDispatch := graph.NewDispatcher(dispatch, nsm)
+	var opts optionState
+	for _, fn := range options {
+		fn(&opts)
+	}
+
+	if opts.prometheusSubsystem == "" {
+		opts.prometheusSubsystem = "dispatch"
+	}
+
+	cachingClusterDispatch, err := caching.NewCachingDispatcher(opts.cacheConfig, opts.prometheusSubsystem)
+	if err != nil {
+		return nil, err
+	}
+	cachingClusterDispatch.SetDelegate(clusterDispatch)
+	return cachingClusterDispatch, nil
+}

--- a/internal/dispatch/combined/combined.go
+++ b/internal/dispatch/combined/combined.go
@@ -121,19 +121,3 @@ func NewDispatcher(nsm namespace.Manager, options ...Option) (dispatch.Dispatche
 
 	return cachingRedispatch, nil
 }
-
-// NewClusterDispatcher takes a caching redispatcher (such as one created by
-// NewDispatcher) and returns a cluster dispatcher suitable for use as the
-// dispatcher for the dispatch grpc server.
-func NewClusterDispatcher(cachingRedispatch dispatch.Dispatcher, nsm namespace.Manager, prometheusSubsystem string, config *ristretto.Config) (dispatch.Dispatcher, error) {
-	clusterDispatch := graph.NewDispatcher(cachingRedispatch, nsm)
-	if prometheusSubsystem == "" {
-		prometheusSubsystem = "dispatch"
-	}
-	cachingClusterDispatch, err := caching.NewCachingDispatcher(config, prometheusSubsystem)
-	if err != nil {
-		return nil, err
-	}
-	cachingClusterDispatch.SetDelegate(clusterDispatch)
-	return cachingClusterDispatch, nil
-}

--- a/internal/dispatch/combined/combined.go
+++ b/internal/dispatch/combined/combined.go
@@ -125,9 +125,12 @@ func NewDispatcher(nsm namespace.Manager, options ...Option) (dispatch.Dispatche
 // NewClusterDispatcher takes a caching redispatcher (such as one created by
 // NewDispatcher) and returns a cluster dispatcher suitable for use as the
 // dispatcher for the dispatch grpc server.
-func NewClusterDispatcher(cachingRedispatch dispatch.Dispatcher, nsm namespace.Manager, config *ristretto.Config) (dispatch.Dispatcher, error) {
+func NewClusterDispatcher(cachingRedispatch dispatch.Dispatcher, nsm namespace.Manager, prometheusSubsystem string, config *ristretto.Config) (dispatch.Dispatcher, error) {
 	clusterDispatch := graph.NewDispatcher(cachingRedispatch, nsm)
-	cachingClusterDispatch, err := caching.NewCachingDispatcher(config, "dispatch")
+	if prometheusSubsystem == "" {
+		prometheusSubsystem = "dispatch"
+	}
+	cachingClusterDispatch, err := caching.NewCachingDispatcher(config, prometheusSubsystem)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/logging/interceptor.go
+++ b/internal/logging/interceptor.go
@@ -1,0 +1,54 @@
+// Copyright (c) The go-grpc-middleware Authors.
+// Licensed under the Apache License 2.0.
+
+// Package logging is a copy of https://github.com/grpc-ecosystem/go-grpc-middleware/tree/v2/providers/zerolog
+// with race conditions removed
+package logging
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+)
+
+// Compatibility check.
+var _ logging.Logger = &Logger{}
+
+// Logger is a zerolog logging adapter compatible with logging middlewares.
+type Logger struct {
+	zerolog.Logger
+}
+
+// InterceptorLogger is a zerolog.Logger to Logger adapter.
+func InterceptorLogger(logger zerolog.Logger) *Logger {
+	return &Logger{logger}
+}
+
+// Log implements the logging.Logger interface.
+func (l *Logger) Log(lvl logging.Level, msg string) {
+	switch lvl {
+	case logging.DEBUG:
+		l.Debug().Msg(msg)
+	case logging.INFO:
+		l.Info().Msg(msg)
+	case logging.WARNING:
+		l.Warn().Msg(msg)
+	case logging.ERROR:
+		l.Error().Msg(msg)
+	default:
+		// TODO(kb): Perhaps this should be a logged warning, defaulting to ERROR to get attention
+		// without interrupting code flow?
+		panic(fmt.Sprintf("zerolog: unknown level %s", lvl))
+	}
+}
+
+// With implements the logging.Logger interface.
+func (l Logger) With(fields ...string) logging.Logger {
+	vals := make(map[string]interface{}, len(fields)/2)
+	for i := 0; i < len(fields); i += 2 {
+		vals[fields[i]] = fields[i+1]
+	}
+	return InterceptorLogger(l.Logger.With().Fields(vals).Logger())
+}

--- a/internal/services/dispatch/server.go
+++ b/internal/services/dispatch/server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/authzed/spicedb/internal/dispatch"
 	dispatch_v1 "github.com/authzed/spicedb/internal/services/dispatch/v1"
+	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 )
 
 // RegisterGrpcServices registers an internal dispatch service with the specified server.
@@ -15,10 +16,9 @@ func RegisterGrpcServices(
 	srv *grpc.Server,
 	d dispatch.Dispatcher,
 ) {
+	srv.RegisterService(&dispatchv1.DispatchService_ServiceDesc, dispatch_v1.NewDispatchServer(d))
 	healthSrv := grpcutil.NewAuthlessHealthServer()
-	healthSrv.SetServicesHealthy(
-		dispatch_v1.RegisterDispatchServer(srv, dispatch_v1.NewDispatchServer(d)),
-	)
+	healthSrv.SetServicesHealthy(&dispatchv1.DispatchService_ServiceDesc)
 	healthpb.RegisterHealthServer(srv, healthSrv)
 	reflection.Register(srv)
 }

--- a/internal/services/perf_test.go
+++ b/internal/services/perf_test.go
@@ -1,53 +1,75 @@
+//go:build ci
+// +build ci
+
 package services_test
 
 import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/authzed/spicedb/internal/datastore/memdb"
+	"github.com/authzed/spicedb/internal/datastore"
+	"github.com/authzed/spicedb/internal/datastore/spanner"
 	tf "github.com/authzed/spicedb/internal/testfixtures"
 	"github.com/authzed/spicedb/internal/testserver"
+	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
+	"github.com/authzed/spicedb/internal/testserver/datastore/config"
+	dsconfig "github.com/authzed/spicedb/pkg/cmd/datastore"
 	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/zedtoken"
 )
 
 func TestBurst(t *testing.T) {
-	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC, 0)
-	require.NoError(t, err)
-	ds, _ = tf.StandardDatastoreWithData(ds, require.New(t))
-
-	conns, cleanup := testserver.TestClusterWithDispatch(t, 1, ds)
-	t.Cleanup(cleanup)
-
-	zerolog.SetGlobalLevel(zerolog.Disabled)
-	client := v1.NewPermissionsServiceClient(conns[0])
-	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		rel := tuple.MustToRelationship(tuple.Parse(tf.StandardTuples[i%(len(tf.StandardTuples))]))
-		run := make(chan struct{})
-		wg.Add(1)
-		go func() {
-			<-run
-			defer wg.Done()
-			_, err := client.WriteRelationships(context.Background(), &v1.WriteRelationshipsRequest{
-				Updates: []*v1.RelationshipUpdate{{
-					Operation:    v1.RelationshipUpdate_OPERATION_TOUCH,
-					Relationship: rel,
-				}},
-			})
-			require.NoError(t, err)
-			_, err = client.CheckPermission(context.Background(), &v1.CheckPermissionRequest{
-				Resource:   &v1.ObjectReference{ObjectType: "document", ObjectId: "masterplan"},
-				Permission: "viewer",
-				Subject:    &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: "user", ObjectId: "eng_lead"}},
-			})
-			require.NoError(t, err)
-		}()
-		run <- struct{}{}
+	blacklist := []string{
+		spanner.Engine, // spanner emulator doesn't support parallel transactions
 	}
-	wg.Wait()
+
+	for _, engine := range datastore.Engines {
+		if stringz.SliceContains(blacklist, engine) {
+			continue
+		}
+		b := testdatastore.NewTestDatastoreBuilder(t, engine)
+		t.Run(engine, func(t *testing.T) {
+			ds := b.NewDatastore(t, config.DatastoreConfigInitFunc(t,
+				dsconfig.WithWatchBufferLength(0),
+				dsconfig.WithGCWindow(time.Duration(90_000_000_000_000)),
+				dsconfig.WithRevisionQuantization(10)))
+			ds, revision := tf.StandardDatastoreWithData(ds, require.New(t))
+
+			conns, cleanup := testserver.TestClusterWithDispatch(t, 1, ds)
+			t.Cleanup(cleanup)
+
+			zerolog.SetGlobalLevel(zerolog.Disabled)
+			client := v1.NewPermissionsServiceClient(conns[0])
+			var wg sync.WaitGroup
+			for i := 0; i < 100; i++ {
+				rel := tuple.MustToRelationship(tuple.Parse(tf.StandardTuples[i%(len(tf.StandardTuples))]))
+				run := make(chan struct{})
+				wg.Add(1)
+				go func() {
+					<-run
+					defer wg.Done()
+					_, err := client.CheckPermission(context.Background(), &v1.CheckPermissionRequest{
+						Consistency: &v1.Consistency{
+							Requirement: &v1.Consistency_AtLeastAsFresh{
+								AtLeastAsFresh: zedtoken.NewFromRevision(revision),
+							},
+						},
+						Resource:   rel.Resource,
+						Permission: "viewer",
+						Subject:    rel.Subject,
+					})
+					require.NoError(t, err)
+				}()
+				run <- struct{}{}
+			}
+			wg.Wait()
+		})
+	}
 }

--- a/internal/services/perf_test.go
+++ b/internal/services/perf_test.go
@@ -1,0 +1,53 @@
+package services_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore/memdb"
+	tf "github.com/authzed/spicedb/internal/testfixtures"
+	"github.com/authzed/spicedb/internal/testserver"
+	"github.com/authzed/spicedb/pkg/tuple"
+)
+
+func TestBurst(t *testing.T) {
+	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC, 0)
+	require.NoError(t, err)
+	ds, _ = tf.StandardDatastoreWithData(ds, require.New(t))
+
+	conns, cleanup := testserver.TestClusterWithDispatch(t, 1, ds)
+	t.Cleanup(cleanup)
+
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	client := v1.NewPermissionsServiceClient(conns[0])
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		rel := tuple.MustToRelationship(tuple.Parse(tf.StandardTuples[i%(len(tf.StandardTuples))]))
+		run := make(chan struct{})
+		wg.Add(1)
+		go func() {
+			<-run
+			defer wg.Done()
+			_, err := client.WriteRelationships(context.Background(), &v1.WriteRelationshipsRequest{
+				Updates: []*v1.RelationshipUpdate{{
+					Operation:    v1.RelationshipUpdate_OPERATION_TOUCH,
+					Relationship: rel,
+				}},
+			})
+			require.NoError(t, err)
+			_, err = client.CheckPermission(context.Background(), &v1.CheckPermissionRequest{
+				Resource:   &v1.ObjectReference{ObjectType: "document", ObjectId: "masterplan"},
+				Permission: "viewer",
+				Subject:    &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: "user", ObjectId: "eng_lead"}},
+			})
+			require.NoError(t, err)
+		}()
+		run <- struct{}{}
+	}
+	wg.Wait()
+}

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -24,6 +24,8 @@ import (
 	"github.com/authzed/spicedb/pkg/secrets"
 )
 
+const TestResolverScheme = "test"
+
 type TempError struct{}
 
 func (t TempError) Error() string {
@@ -64,14 +66,15 @@ func init() {
 	resolver.Register(testResolverBuilder)
 }
 
-// SafeManualResolverBuilder is a resolver builder
+// SafeManualResolverBuilder is a resolver builder that builds SafeManualResolvers
+// it is similar to manual.Resolver in grpc, but is thread safe
 type SafeManualResolverBuilder struct {
 	resolvers sync.Map
 	addrs     sync.Map
 }
 
 func (b *SafeManualResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
-	if target.URL.Scheme != "test" {
+	if target.URL.Scheme != TestResolverScheme {
 		return nil, fmt.Errorf("test resolver builder only works with test:// addresses")
 	}
 	var addrs []resolver.Address

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -1,0 +1,223 @@
+package testserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cespare/xxhash"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/resolver"
+
+	"github.com/authzed/spicedb/internal/datastore"
+	combineddispatch "github.com/authzed/spicedb/internal/dispatch/combined"
+	"github.com/authzed/spicedb/internal/namespace"
+	hashbalancer "github.com/authzed/spicedb/pkg/balancer"
+	"github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/cmd/util"
+	"github.com/authzed/spicedb/pkg/secrets"
+)
+
+type TempError struct{}
+
+func (t TempError) Error() string {
+	return "no dialers yet"
+}
+
+func (t TempError) Temporary() bool {
+	return true
+}
+
+type dialerFunc func(ctx context.Context, s string) (net.Conn, error)
+
+// track prefixes used for making test clusters to avoid registering the same
+// prometheus subsystem twice in one run
+var usedPrefixes sync.Map
+
+func getPrefix(t testing.TB) string {
+	for {
+		prefix, err := secrets.TokenHex(8)
+		require.NoError(t, err)
+		if _, ok := usedPrefixes.Load(prefix); !ok {
+			usedPrefixes.Store(prefix, struct{}{})
+			return prefix
+		}
+	}
+}
+
+var testResolverbuilder = &SafeManualResolverBuilder{}
+
+func init() {
+	// register hashring balancer
+	balancer.Register(hashbalancer.NewConsistentHashringBuilder(xxhash.Sum64, 20, 1))
+
+	// register a manual resolver that we can feed addresses during tests
+	resolver.Register(testResolverbuilder)
+}
+
+// SafeManualResolverBuilder is a resolver builder
+type SafeManualResolverBuilder struct {
+	resolvers sync.Map
+	addrs     sync.Map
+}
+
+func (b *SafeManualResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	if target.URL.Scheme != "test" {
+		return nil, fmt.Errorf("test resolver builder only works with test:// addresses")
+	}
+	var addrs []resolver.Address
+	addrVal, ok := b.addrs.Load(target.URL.Hostname())
+	if !ok {
+		addrs = make([]resolver.Address, 0)
+	} else {
+		addrs = addrVal.([]resolver.Address)
+	}
+	r := &SafeManualResolver{
+		prefix: target.URL.Hostname(),
+		cc:     cc,
+		opts:   opts,
+		addrs:  addrs,
+	}
+	b.resolvers.Store(target.URL.Hostname(), r)
+	return r, nil
+}
+
+func (b *SafeManualResolverBuilder) Scheme() string {
+	return "test"
+}
+
+func (b *SafeManualResolverBuilder) SetAddrs(prefix string, addrs []resolver.Address) {
+	b.addrs.Store(prefix, addrs)
+}
+
+func (b *SafeManualResolverBuilder) ResolveNow(prefix string) {
+	r, ok := b.resolvers.Load(prefix)
+	if !ok {
+		fmt.Println("NO RESOLVER YET") // shouldn't happen, but log
+		return
+	}
+	r.(*SafeManualResolver).ResolveNow(resolver.ResolveNowOptions{})
+}
+
+// SafeManualResolver is the resolver type that SafeManualResolverBuilder builds
+// it returns a static list of addresses
+type SafeManualResolver struct {
+	prefix string
+	cc     resolver.ClientConn
+	opts   resolver.BuildOptions
+	addrs  []resolver.Address
+}
+
+// ResolveNow implements the resolver.Resolver interface
+// It sends the static list of addresses to the underlying resolver.ClientConn
+func (r *SafeManualResolver) ResolveNow(options resolver.ResolveNowOptions) {
+	if r.cc == nil {
+		return
+	}
+	if err := r.cc.UpdateState(resolver.State{Addresses: r.addrs}); err != nil {
+		fmt.Println("ERROR UPDATING STATE", err) // shouldn't happen, log
+	}
+}
+
+// Close implements the resolver.Resolver interface
+func (r *SafeManualResolver) Close() {}
+
+// TestClusterWithDispatch creates a cluster with `size` nodes
+// The cluster has a real dispatch stack that uses bufconn grpc connections
+func TestClusterWithDispatch(t testing.TB, size int, ds datastore.Datastore) ([]*grpc.ClientConn, func()) {
+	// each cluster gets a unique prefix since grpc resolution is process-global
+	prefix := getPrefix(t)
+
+	// make placeholder resolved addresses, 1 per node
+	addresses := make([]resolver.Address, 0, size)
+	for i := 0; i < size; i++ {
+		addresses = append(addresses, resolver.Address{
+			Addr:       prefix + "_" + strconv.Itoa(i),
+			ServerName: "",
+		})
+	}
+	testResolverbuilder.SetAddrs(prefix, addresses)
+
+	dialers := make([]dialerFunc, 0, size)
+	conns := make([]*grpc.ClientConn, 0, size)
+	cancelFuncs := make([]func(), 0, size)
+
+	for i := 0; i < size; i++ {
+		nsm, err := namespace.NewCachingNamespaceManager(nil)
+		require.NoError(t, err)
+
+		dispatcher, err := combineddispatch.NewDispatcher(nsm,
+			combineddispatch.UpstreamAddr("test://"+prefix),
+			combineddispatch.PrometheusSubsystem(prefix+"_"+strconv.Itoa(i)+"_client_dispatch"),
+			combineddispatch.GrpcDialOpts(
+				grpc.WithDefaultServiceConfig(hashbalancer.BalancerServiceConfig),
+				grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+					// it's possible grpc tries to dial before we have set the
+					// buffconn dialers, we have to return a "TempError" so that
+					// grpc knows to retry the connection.
+					if len(dialers) == 0 {
+						return nil, TempError{}
+					}
+					// "s" here will be the address from the manual resolver
+					// like `<prefix>_<node number>`
+					i, err := strconv.Atoi(strings.TrimPrefix(s, prefix+"_"))
+					require.NoError(t, err)
+					return dialers[i](ctx, s)
+				}),
+			),
+		)
+		require.NoError(t, err)
+
+		srv, err := server.NewConfigWithOptions(
+			server.WithDatastore(ds),
+			server.WithDispatcher(dispatcher),
+			server.WithNamespaceManager(nsm),
+			server.WithDispatchMaxDepth(50),
+			server.WithGRPCServer(util.GRPCServerConfig{
+				Network: util.BufferedNetwork,
+				Enabled: true,
+			}),
+			server.WithSchemaPrefixesRequired(false),
+			server.WithGRPCAuthFunc(func(ctx context.Context) (context.Context, error) {
+				return ctx, nil
+			}),
+			server.WithHTTPGateway(util.HTTPServerConfig{Enabled: false}),
+			server.WithDashboardAPI(util.HTTPServerConfig{Enabled: false}),
+			server.WithMetricsAPI(util.HTTPServerConfig{Enabled: false}),
+			server.WithDispatchServer(util.GRPCServerConfig{
+				Enabled: true,
+				Network: util.BufferedNetwork,
+			}),
+			server.WithDispatchClusterMetricsPrefix(prefix+"_"+strconv.Itoa(i)+"_dispatch"),
+		).Complete()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			require.NoError(t, srv.Run(ctx))
+		}()
+		cancelFuncs = append(cancelFuncs, cancel)
+
+		dialers = append(dialers, srv.DispatchNetDialContext)
+		conn, err := srv.GRPCDialContext(ctx, grpc.WithBlock())
+		require.NoError(t, err)
+		conns = append(conns, conn)
+	}
+
+	// resolve after dialers have been set to initialize connections
+	testResolverbuilder.ResolveNow(prefix)
+
+	return conns, func() {
+		for _, c := range conns {
+			require.NoError(t, c.Close())
+		}
+		for _, c := range cancelFuncs {
+			c()
+		}
+	}
+}

--- a/internal/testserver/datastore/config/config.go
+++ b/internal/testserver/datastore/config/config.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore"
+	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
+	dsconfig "github.com/authzed/spicedb/pkg/cmd/datastore"
+)
+
+// DatastoreConfigInitFunc returns a InitFunc that constructs a ds
+// with the top-level cmd/datastore machinery.
+// It can't be used everywhere due to import cycles, but makes it easy to write
+// an independent test with CLI-like config where possible.
+func DatastoreConfigInitFunc(t testing.TB, options ...dsconfig.ConfigOption) testdatastore.InitFunc {
+	return func(engine, uri string) datastore.Datastore {
+		ds, err := dsconfig.NewDatastore(append(options, dsconfig.WithEngine(engine), dsconfig.WithURI(uri))...)
+		require.NoError(t, err)
+		return ds
+	}
+}

--- a/internal/testserver/datastore/crdb.go
+++ b/internal/testserver/datastore/crdb.go
@@ -1,0 +1,79 @@
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore"
+	crdbmigrations "github.com/authzed/spicedb/internal/datastore/crdb/migrations"
+	"github.com/authzed/spicedb/pkg/migrate"
+	"github.com/authzed/spicedb/pkg/secrets"
+)
+
+type crdbDSBuilder struct {
+	conn  *pgx.Conn
+	creds string
+	port  string
+}
+
+var crdbContainer = &dockertest.RunOptions{
+	Repository: "cockroachdb/cockroach",
+	Tag:        "v21.1.3",
+	Cmd:        []string{"start-single-node", "--insecure", "--max-offset=50ms"},
+}
+
+// NewCRDBBuilder returns a TestDatastoreBuilder for CRDB
+func NewCRDBBuilder(t testing.TB) TestDatastoreBuilder {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	resource, err := pool.RunWithOptions(crdbContainer)
+	require.NoError(t, err)
+
+	builder := &crdbDSBuilder{
+		creds: "root:fake",
+	}
+	t.Cleanup(func() {
+		require.NoError(t, pool.Purge(resource))
+	})
+
+	builder.port = resource.GetPort(fmt.Sprintf("%d/tcp", 26257))
+	uri := fmt.Sprintf("postgres://%s@localhost:%s/defaultdb?sslmode=disable", builder.creds, builder.port)
+	require.NoError(t, pool.Retry(func() error {
+		var err error
+		builder.conn, err = pgx.Connect(context.Background(), uri)
+		if err != nil {
+			return err
+		}
+		return nil
+	}))
+
+	return builder
+}
+
+func (b *crdbDSBuilder) NewDatastore(t testing.TB, initFunc InitFunc) datastore.Datastore {
+	uniquePortion, err := secrets.TokenHex(4)
+	require.NoError(t, err)
+
+	newDBName := "db" + uniquePortion
+
+	_, err = b.conn.Exec(context.Background(), "CREATE DATABASE "+newDBName)
+	require.NoError(t, err)
+
+	connectStr := fmt.Sprintf(
+		"postgres://%s@localhost:%s/%s?sslmode=disable",
+		b.creds,
+		b.port,
+		newDBName,
+	)
+	migrationDriver, err := crdbmigrations.NewCRDBDriver(connectStr)
+	require.NoError(t, err)
+	require.NoError(t, crdbmigrations.CRDBMigrations.Run(migrationDriver, migrate.Head, migrate.LiveRun))
+
+	return initFunc("cockroachdb", connectStr)
+}

--- a/internal/testserver/datastore/datastore.go
+++ b/internal/testserver/datastore/datastore.go
@@ -1,0 +1,47 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/authzed/spicedb/internal/datastore"
+)
+
+// InitFunc initialize a datastore instance from a uri that has been
+// generated from a TestDatastoreBuilder
+type InitFunc func(engine, uri string) datastore.Datastore
+
+// TestDatastoreBuilder stamps out new datastores from a backing service (like
+// a container running a database).
+type TestDatastoreBuilder interface {
+	// NewDatastore returns a new logical datastore initialized with the
+	// initFunc. For example, the sql based stores will create a new logical
+	// database in the database instance and provide the URI for it to initFunc
+	NewDatastore(t testing.TB, initFunc InitFunc) datastore.Datastore
+}
+
+// TestDatastoreBuilderFunc allows a function to implement TestDatastoreBuilder
+type TestDatastoreBuilderFunc func(t testing.TB, initFunc InitFunc) datastore.Datastore
+
+// NewDatastore implements TestDatastoreBuilder
+func (f TestDatastoreBuilderFunc) NewDatastore(t testing.TB, initFunc InitFunc) datastore.Datastore {
+	return f(t, initFunc)
+}
+
+// NewTestDatastoreBuilder returns a TestDatastoreBuilder for a given engine
+// this is primarily useful for tests against all datastores; most other tests
+// can directly build the datastore they want
+func NewTestDatastoreBuilder(t testing.TB, engine string) TestDatastoreBuilder {
+	switch engine {
+	case "memory":
+		return TestDatastoreBuilderFunc(func(t testing.TB, initFunc InitFunc) datastore.Datastore {
+			return initFunc("memory", "")
+		})
+	case "cockroachdb":
+		return NewCRDBBuilder(t)
+	case "postgres":
+		return NewPostgresBuilder(t)
+	case "spanner":
+		return NewSpannerBuilder(t)
+	}
+	return nil
+}

--- a/internal/testserver/datastore/pg_crdb.go
+++ b/internal/testserver/datastore/pg_crdb.go
@@ -1,0 +1,74 @@
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore"
+	pgmigrations "github.com/authzed/spicedb/internal/datastore/postgres/migrations"
+	"github.com/authzed/spicedb/pkg/migrate"
+	"github.com/authzed/spicedb/pkg/secrets"
+)
+
+type crdbPGDSBuilder struct {
+	conn  *pgx.Conn
+	creds string
+	port  string
+}
+
+// NewCRDBPGBuilder returns a TestDatastoreBuilder for the postgres driver
+// backed by a CRDB instance
+func NewCRDBPGBuilder(t testing.TB) TestDatastoreBuilder {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	resource, err := pool.RunWithOptions(crdbContainer)
+	require.NoError(t, err)
+
+	builder := &crdbPGDSBuilder{
+		creds: "root:fake",
+	}
+	t.Cleanup(func() {
+		require.NoError(t, pool.Purge(resource))
+	})
+
+	builder.port = resource.GetPort(fmt.Sprintf("%d/tcp", 26257))
+	uri := fmt.Sprintf("postgres://%s@localhost:%s/defaultdb?sslmode=disable", builder.creds, builder.port)
+	require.NoError(t, pool.Retry(func() error {
+		var err error
+		builder.conn, err = pgx.Connect(context.Background(), uri)
+		if err != nil {
+			return err
+		}
+		return nil
+	}))
+
+	return builder
+}
+
+func (b *crdbPGDSBuilder) NewDatastore(t testing.TB, initFunc InitFunc) datastore.Datastore {
+	uniquePortion, err := secrets.TokenHex(4)
+	require.NoError(t, err)
+
+	newDBName := "db" + uniquePortion
+
+	_, err = b.conn.Exec(context.Background(), "CREATE DATABASE "+newDBName)
+	require.NoError(t, err)
+
+	connectStr := fmt.Sprintf(
+		"postgres://%s@localhost:%s/%s?sslmode=disable",
+		b.creds,
+		b.port,
+		newDBName,
+	)
+	migrationDriver, err := pgmigrations.NewAlembicPostgresDriver(connectStr)
+	require.NoError(t, err)
+	require.NoError(t, pgmigrations.DatabaseMigrations.Run(migrationDriver, migrate.Head, migrate.LiveRun))
+
+	return initFunc("postgres", connectStr)
+}

--- a/internal/testserver/datastore/postgres.go
+++ b/internal/testserver/datastore/postgres.go
@@ -1,0 +1,78 @@
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore"
+	pgmigrations "github.com/authzed/spicedb/internal/datastore/postgres/migrations"
+	"github.com/authzed/spicedb/pkg/migrate"
+	"github.com/authzed/spicedb/pkg/secrets"
+)
+
+var postgresContainer = &dockertest.RunOptions{
+	Repository: "postgres",
+	Tag:        "9.6",
+	Env:        []string{"POSTGRES_PASSWORD=secret", "POSTGRES_DB=defaultdb"},
+}
+
+type postgresDSBuilder struct {
+	conn  *pgx.Conn
+	port  string
+	creds string
+}
+
+// NewPostgresBuilder returns a TestDatastoreBuilder for postgres
+func NewPostgresBuilder(t testing.TB) TestDatastoreBuilder {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	resource, err := pool.RunWithOptions(postgresContainer)
+	require.NoError(t, err)
+
+	builder := &postgresDSBuilder{
+		creds: "postgres:secret",
+	}
+	t.Cleanup(func() {
+		require.NoError(t, pool.Purge(resource))
+	})
+
+	builder.port = resource.GetPort(fmt.Sprintf("%d/tcp", 5432))
+	uri := fmt.Sprintf("postgres://%s@localhost:%s/defaultdb?sslmode=disable", builder.creds, builder.port)
+	require.NoError(t, pool.Retry(func() error {
+		var err error
+		builder.conn, err = pgx.Connect(context.Background(), uri)
+		if err != nil {
+			return err
+		}
+		return nil
+	}))
+	return builder
+}
+
+func (b *postgresDSBuilder) NewDatastore(t testing.TB, initFunc InitFunc) datastore.Datastore {
+	uniquePortion, err := secrets.TokenHex(4)
+	require.NoError(t, err)
+
+	newDBName := "db" + uniquePortion
+
+	_, err = b.conn.Exec(context.Background(), "CREATE DATABASE "+newDBName)
+	require.NoError(t, err)
+
+	connectStr := fmt.Sprintf(
+		"postgres://%s@localhost:%s/%s?sslmode=disable",
+		b.creds,
+		b.port,
+		newDBName,
+	)
+	migrationDriver, err := pgmigrations.NewAlembicPostgresDriver(connectStr)
+	require.NoError(t, err)
+	require.NoError(t, pgmigrations.DatabaseMigrations.Run(migrationDriver, migrate.Head, migrate.LiveRun))
+
+	return initFunc("postgres", connectStr)
+}

--- a/internal/testserver/datastore/spanner.go
+++ b/internal/testserver/datastore/spanner.go
@@ -1,0 +1,120 @@
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	instances "cloud.google.com/go/spanner/admin/instance/apiv1"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
+	"google.golang.org/genproto/googleapis/spanner/admin/instance/v1"
+
+	"github.com/authzed/spicedb/internal/datastore"
+	"github.com/authzed/spicedb/internal/datastore/spanner/migrations"
+	"github.com/authzed/spicedb/pkg/migrate"
+	"github.com/authzed/spicedb/pkg/secrets"
+)
+
+var spannerContainer = &dockertest.RunOptions{
+	Repository: "gcr.io/cloud-spanner-emulator/emulator",
+	Tag:        "latest",
+}
+
+type spannerDSBuilder struct{}
+
+// NewSpannerBuilder returns a TestDatastoreBuilder for spanner
+func NewSpannerBuilder(t testing.TB) TestDatastoreBuilder {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	resource, err := pool.RunWithOptions(spannerContainer)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, pool.Purge(resource))
+	})
+
+	port := resource.GetPort("9010/tcp")
+	spannerEmulatorAddr := fmt.Sprintf("localhost:%s", port)
+	require.NoError(t, os.Setenv("SPANNER_EMULATOR_HOST", spannerEmulatorAddr))
+
+	require.NoError(t, pool.Retry(func() error {
+		ctx := context.Background()
+
+		instancesClient, err := instances.NewInstanceAdminClient(ctx)
+		if err != nil {
+			return err
+		}
+		defer func() { require.NoError(t, instancesClient.Close()) }()
+
+		_, err = instancesClient.CreateInstance(ctx, &instance.CreateInstanceRequest{
+			Parent:     "projects/fake-project-id",
+			InstanceId: "init",
+			Instance: &instance.Instance{
+				Config:      "emulator-config",
+				DisplayName: "Test Instance",
+				NodeCount:   1,
+			},
+		})
+		return err
+	}))
+
+	return &spannerDSBuilder{}
+}
+
+func (b *spannerDSBuilder) NewDatastore(t testing.TB, initFunc InitFunc) datastore.Datastore {
+	t.Logf("using spanner emulator, host: %s", os.Getenv("SPANNER_EMULATOR_HOST"))
+
+	uniquePortion, err := secrets.TokenHex(4)
+	require.NoError(t, err)
+
+	newInstanceName := fmt.Sprintf("fake-instance-%s", uniquePortion)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	instancesClient, err := instances.NewInstanceAdminClient(ctx)
+	require.NoError(t, err)
+	defer instancesClient.Close()
+
+	createInstanceOp, err := instancesClient.CreateInstance(ctx, &instance.CreateInstanceRequest{
+		Parent:     "projects/fake-project-id",
+		InstanceId: newInstanceName,
+		Instance: &instance.Instance{
+			Config:      "emulator-config",
+			DisplayName: "Test Instance",
+			NodeCount:   1,
+		},
+	})
+	require.NoError(t, err)
+
+	spannerInstance, err := createInstanceOp.Wait(ctx)
+	require.NoError(t, err)
+
+	adminClient, err := database.NewDatabaseAdminClient(ctx)
+	require.NoError(t, err)
+	defer adminClient.Close()
+
+	dbID := "fake-database-id"
+	op, err := adminClient.CreateDatabase(ctx, &adminpb.CreateDatabaseRequest{
+		Parent:          spannerInstance.Name,
+		CreateStatement: "CREATE DATABASE `" + dbID + "`",
+	})
+	require.NoError(t, err)
+
+	db, err := op.Wait(ctx)
+	require.NoError(t, err)
+
+	migrationDriver, err := migrations.NewSpannerDriver(db.Name, "")
+	require.NoError(t, err)
+
+	err = migrations.SpannerMigrations.Run(migrationDriver, migrate.Head, migrate.LiveRun)
+	require.NoError(t, err)
+
+	return initFunc("spanner", db.Name)
+}

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -68,7 +68,9 @@ func NewTestServer(require *require.Assertions,
 	require.NoError(err)
 
 	return conn, func() {
-		require.NoError(conn.Close())
+		if conn != nil {
+			require.NoError(conn.Close())
+		}
 		cancel()
 	}, revision
 }

--- a/pkg/balancer/hashring.go
+++ b/pkg/balancer/hashring.go
@@ -18,6 +18,10 @@ const (
 	// BalancerName is the name of consistent-hashring balancer.
 	BalancerName = "consistent-hashring"
 
+	// BalancerServiceConfig is a service config that sets the default balancer
+	// to the consistent-hashring balancer
+	BalancerServiceConfig = `{"loadBalancingPolicy":"consistent-hashring"}`
+
 	// CtxKey is the key for the grpc request's context.Context which points to
 	// the key to hash for the request. The value it points to must be []byte
 	CtxKey ctxKey = "requestKey"

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -41,6 +41,8 @@ func (c *Config) ToOption() ConfigOption {
 		to.GCInterval = c.GCInterval
 		to.GCMaxOperationTime = c.GCMaxOperationTime
 		to.SpannerCredentialsFile = c.SpannerCredentialsFile
+		to.WatchBufferLength = c.WatchBufferLength
+		to.EnableDatastoreMetrics = c.EnableDatastoreMetrics
 	}
 }
 
@@ -224,5 +226,19 @@ func WithGCMaxOperationTime(gCMaxOperationTime time.Duration) ConfigOption {
 func WithSpannerCredentialsFile(spannerCredentialsFile string) ConfigOption {
 	return func(c *Config) {
 		c.SpannerCredentialsFile = spannerCredentialsFile
+	}
+}
+
+// WithWatchBufferLength returns an option that can set WatchBufferLength on a Config
+func WithWatchBufferLength(watchBufferLength uint16) ConfigOption {
+	return func(c *Config) {
+		c.WatchBufferLength = watchBufferLength
+	}
+}
+
+// WithEnableDatastoreMetrics returns an option that can set EnableDatastoreMetrics on a Config
+func WithEnableDatastoreMetrics(enableDatastoreMetrics bool) ConfigOption {
+	return func(c *Config) {
+		c.EnableDatastoreMetrics = enableDatastoreMetrics
 	}
 }

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -176,7 +176,6 @@ func (c *Config) Complete() (RunnableServer, error) {
 		},
 		grpc.ChainUnaryInterceptor(c.DispatchUnaryMiddleware...),
 		grpc.ChainStreamInterceptor(c.DispatchStreamingMiddleware...),
-		// grpc.NumStreamWorkers(uint32(runtime.NumCPU())),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dispatch gRPC server: %w", err)
@@ -206,7 +205,6 @@ func (c *Config) Complete() (RunnableServer, error) {
 				v1SchemaServiceOption,
 			)
 		},
-		// grpc.NumStreamWorkers(uint32(runtime.NumCPU())),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC server: %w", err)

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/authzed/grpcutil"
@@ -25,9 +26,16 @@ import (
 	"github.com/authzed/spicedb/internal/services"
 	dispatchSvc "github.com/authzed/spicedb/internal/services/dispatch"
 	v1alpha1svc "github.com/authzed/spicedb/internal/services/v1alpha1"
+	"github.com/authzed/spicedb/pkg/balancer"
 	datastorecfg "github.com/authzed/spicedb/pkg/cmd/datastore"
 	"github.com/authzed/spicedb/pkg/cmd/util"
 )
+
+func init() {
+	grpcprom.EnableHandlingTimeHistogram(grpcprom.WithHistogramBuckets(
+		[]float64{.006, .010, .018, .024, .032, .042, .056, .075, .100, .178, .316, .562, 1.000},
+	))
+}
 
 //go:generate go run github.com/ecordell/optgen -output zz_generated.options.go . Config
 type Config struct {
@@ -49,18 +57,20 @@ type Config struct {
 	Datastore       datastore.Datastore
 
 	// Namespace cache
+	NamespaceManager     namespace.Manager
 	NamespaceCacheConfig CacheConfig
 
 	// Schema options
 	SchemaPrefixesRequired bool
 
 	// Dispatch options
-	DispatchServer              util.GRPCServerConfig
-	DispatchMaxDepth            uint32
-	DispatchUpstreamAddr        string
-	DispatchUpstreamCAPath      string
-	DispatchClientMetricsPrefix string
-	Dispatcher                  dispatch.Dispatcher
+	DispatchServer               util.GRPCServerConfig
+	DispatchMaxDepth             uint32
+	DispatchUpstreamAddr         string
+	DispatchUpstreamCAPath       string
+	DispatchClientMetricsPrefix  string
+	DispatchClusterMetricsPrefix string
+	Dispatcher                   dispatch.Dispatcher
 
 	DispatchCacheConfig        CacheConfig
 	ClusterDispatchCacheConfig CacheConfig
@@ -105,19 +115,18 @@ func (c *Config) Complete() (RunnableServer, error) {
 		}
 	}
 
-	nscc, err := c.NamespaceCacheConfig.Complete()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create namespace manager: %w", err)
-	}
+	nsm := c.NamespaceManager
+	if nsm == nil {
+		nscc, err := c.NamespaceCacheConfig.Complete()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create namespace manager: %w", err)
+		}
 
-	nsm, err := namespace.NewCachingNamespaceManager(nscc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create namespace manager: %w", err)
+		nsm, err = namespace.NewCachingNamespaceManager(nscc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create namespace manager: %w", err)
+		}
 	}
-
-	grpcprom.EnableHandlingTimeHistogram(grpcprom.WithHistogramBuckets(
-		[]float64{.006, .010, .018, .024, .032, .042, .056, .075, .100, .178, .316, .562, 1.000},
-	))
 
 	dispatcher := c.Dispatcher
 	if dispatcher == nil {
@@ -133,7 +142,7 @@ func (c *Config) Complete() (RunnableServer, error) {
 			combineddispatch.GrpcPresharedKey(c.PresharedKey),
 			combineddispatch.GrpcDialOpts(
 				grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
-				grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"consistent-hashring"}`),
+				grpc.WithDefaultServiceConfig(balancer.BalancerServiceConfig),
 			),
 			combineddispatch.PrometheusSubsystem(c.DispatchClientMetricsPrefix),
 			combineddispatch.CacheConfig(cc),
@@ -155,7 +164,7 @@ func (c *Config) Complete() (RunnableServer, error) {
 		}
 
 		var err error
-		cachingClusterDispatch, err = combineddispatch.NewClusterDispatcher(dispatcher, nsm, cdcc)
+		cachingClusterDispatch, err = combineddispatch.NewClusterDispatcher(dispatcher, nsm, c.DispatchClusterMetricsPrefix, cdcc)
 		if err != nil {
 			return nil, fmt.Errorf("failed to configure cluster dispatch: %w", err)
 		}
@@ -167,6 +176,7 @@ func (c *Config) Complete() (RunnableServer, error) {
 		},
 		grpc.ChainUnaryInterceptor(c.DispatchUnaryMiddleware...),
 		grpc.ChainStreamInterceptor(c.DispatchStreamingMiddleware...),
+		// grpc.NumStreamWorkers(uint32(runtime.NumCPU())),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dispatch gRPC server: %w", err)
@@ -196,6 +206,7 @@ func (c *Config) Complete() (RunnableServer, error) {
 				v1SchemaServiceOption,
 			)
 		},
+		// grpc.NumStreamWorkers(uint32(runtime.NumCPU())),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC server: %w", err)
@@ -269,6 +280,7 @@ type RunnableServer interface {
 	Middleware() ([]grpc.UnaryServerInterceptor, []grpc.StreamServerInterceptor)
 	SetMiddleware(unaryInterceptors []grpc.UnaryServerInterceptor, streamingInterceptors []grpc.StreamServerInterceptor) RunnableServer
 	GRPCDialContext(ctx context.Context, opts ...grpc.DialOption) (*grpc.ClientConn, error)
+	DispatchNetDialContext(ctx context.Context, s string) (net.Conn, error)
 }
 
 // completedServerConfig holds the full configuration to run a spicedb server,
@@ -307,6 +319,10 @@ func (c *completedServerConfig) GRPCDialContext(ctx context.Context, opts ...grp
 		opts = append(opts, grpcutil.WithBearerToken(c.presharedKey))
 	}
 	return c.gRPCServer.DialContext(ctx, opts...)
+}
+
+func (c *completedServerConfig) DispatchNetDialContext(ctx context.Context, s string) (net.Conn, error) {
+	return c.dispatchGRPCServer.NetDialContext(ctx, s)
 }
 
 func (c *completedServerConfig) Run(ctx context.Context) error {

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/authzed/spicedb/internal/dashboard"
 	"github.com/authzed/spicedb/internal/datastore"
 	"github.com/authzed/spicedb/internal/dispatch"
+	clusterdispatch "github.com/authzed/spicedb/internal/dispatch/cluster"
 	combineddispatch "github.com/authzed/spicedb/internal/dispatch/combined"
 	"github.com/authzed/spicedb/internal/gateway"
 	"github.com/authzed/spicedb/internal/namespace"
@@ -164,7 +165,12 @@ func (c *Config) Complete() (RunnableServer, error) {
 		}
 
 		var err error
-		cachingClusterDispatch, err = combineddispatch.NewClusterDispatcher(dispatcher, nsm, c.DispatchClusterMetricsPrefix, cdcc)
+		cachingClusterDispatch, err = clusterdispatch.NewClusterDispatcher(
+			dispatcher,
+			nsm,
+			clusterdispatch.PrometheusSubsystem(c.DispatchClusterMetricsPrefix),
+			clusterdispatch.CacheConfig(cdcc),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to configure cluster dispatch: %w", err)
 		}

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -4,6 +4,7 @@ package server
 import (
 	datastore1 "github.com/authzed/spicedb/internal/datastore"
 	dispatch "github.com/authzed/spicedb/internal/dispatch"
+	namespace "github.com/authzed/spicedb/internal/namespace"
 	datastore "github.com/authzed/spicedb/pkg/cmd/datastore"
 	util "github.com/authzed/spicedb/pkg/cmd/util"
 	auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
@@ -36,6 +37,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.HTTPGatewayCorsAllowedOrigins = c.HTTPGatewayCorsAllowedOrigins
 		to.DatastoreConfig = c.DatastoreConfig
 		to.Datastore = c.Datastore
+		to.NamespaceManager = c.NamespaceManager
 		to.NamespaceCacheConfig = c.NamespaceCacheConfig
 		to.SchemaPrefixesRequired = c.SchemaPrefixesRequired
 		to.DispatchServer = c.DispatchServer
@@ -43,6 +45,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.DispatchUpstreamAddr = c.DispatchUpstreamAddr
 		to.DispatchUpstreamCAPath = c.DispatchUpstreamCAPath
 		to.DispatchClientMetricsPrefix = c.DispatchClientMetricsPrefix
+		to.DispatchClusterMetricsPrefix = c.DispatchClusterMetricsPrefix
 		to.Dispatcher = c.Dispatcher
 		to.DispatchCacheConfig = c.DispatchCacheConfig
 		to.ClusterDispatchCacheConfig = c.ClusterDispatchCacheConfig
@@ -148,6 +151,13 @@ func WithDatastore(datastore datastore1.Datastore) ConfigOption {
 	}
 }
 
+// WithNamespaceManager returns an option that can set NamespaceManager on a Config
+func WithNamespaceManager(namespaceManager namespace.Manager) ConfigOption {
+	return func(c *Config) {
+		c.NamespaceManager = namespaceManager
+	}
+}
+
 // WithNamespaceCacheConfig returns an option that can set NamespaceCacheConfig on a Config
 func WithNamespaceCacheConfig(namespaceCacheConfig CacheConfig) ConfigOption {
 	return func(c *Config) {
@@ -194,6 +204,13 @@ func WithDispatchUpstreamCAPath(dispatchUpstreamCAPath string) ConfigOption {
 func WithDispatchClientMetricsPrefix(dispatchClientMetricsPrefix string) ConfigOption {
 	return func(c *Config) {
 		c.DispatchClientMetricsPrefix = dispatchClientMetricsPrefix
+	}
+}
+
+// WithDispatchClusterMetricsPrefix returns an option that can set DispatchClusterMetricsPrefix on a Config
+func WithDispatchClusterMetricsPrefix(dispatchClusterMetricsPrefix string) ConfigOption {
+	return func(c *Config) {
+		c.DispatchClusterMetricsPrefix = dispatchClusterMetricsPrefix
 	}
 }
 


### PR DESCRIPTION
This adds a test that can fire a large set of requests at the same time to see how spicedb handles the load (likely should make it a benchmark)

This sets up spicedb with a custom resolver that will return `bufconn` connections to the dispatch api, meaning that we can easily test full cluster behavior in "unit" tests. 

This also addresses a long-standing comment in the consistency tests (to run with dispatch) and runs the dispatch tests in parallel.