### PR TITLE
Have errors raised by the type system from schema construction in the devcontext be properly contextualized

### DIFF
--- a/internal/services/v0/developer_test.go
+++ b/internal/services/v0/developer_test.go
@@ -122,6 +122,27 @@ func TestEditCheck(t *testing.T) {
 			nil,
 		},
 		{
+			"invalid shared name",
+			`definition user {}
+			
+			definition resource {
+				relation writer: user
+				permission writer = writer
+			}
+`,
+			[]*v0.RelationTuple{},
+			[]*v0.RelationTuple{},
+			&v0.DeveloperError{
+				Message: "found duplicate relation/permission name writer",
+				Kind:    v0.DeveloperError_SCHEMA_ISSUE,
+				Source:  v0.DeveloperError_SCHEMA,
+				Line:    0,
+				Column:  0,
+				Context: "resource",
+			},
+			nil,
+		},
+		{
 			"valid namespace",
 			`definition foos {}`,
 			[]*v0.RelationTuple{},

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -196,7 +196,13 @@ func loadNamespaces(
 	for _, nsDef := range namespaces {
 		ts, terr := namespace.BuildNamespaceTypeSystemForDefs(nsDef, namespaces)
 		if terr != nil {
-			return errors, lastRevision, terr
+			errors = append(errors, &v0.DeveloperError{
+				Message: terr.Error(),
+				Kind:    v0.DeveloperError_SCHEMA_ISSUE,
+				Source:  v0.DeveloperError_SCHEMA,
+				Context: nsDef.Name,
+			})
+			continue
 		}
 
 		tverr := ts.Validate(ctx)


### PR DESCRIPTION
Otherwise, they show up as internal errors