### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,6 @@
       "group:all"
    ],
    "postUpdateOptions":[
-      "gomodUpdateImportPaths",
       "gomodTidy"
    ]
 }


### PR DESCRIPTION
The error in https://github.com/authzed/spicedb/pull/463 appears to be due to the `gomodUpdateImportPaths` which runs https://github.com/marwan-at-work/mod

Locally, I tested by taking the command from the PR:
```
sudo docker run --platform=linux/amd64 --rm --name=renovate_go --label=renovate_child -v "$(pwd)":"/mnt/renovate/gh/authzed/spicedb" -v "/tmp/renovate-cache":"/tmp/renovate-cache" -e GOPATH -e GOPROXY -e GOFLAGS -e CGO_ENABLED -e GIT_CONFIG_KEY_0 -e GIT_CONFIG_VALUE_0 -e GIT_CONFIG_KEY_1 -e GIT_CONFIG_VALUE_1 -e GIT_CONFIG_KEY_2 -e GIT_CONFIG_VALUE_2 -e GIT_CONFIG_COUNT -e GIT_CONFIG_KEY_3 -e GIT_CONFIG_VALUE_3 -e GIT_CONFIG_KEY_4 -e GIT_CONFIG_VALUE_4 -e GIT_CONFIG_KEY_5 -e GIT_CONFIG_VALUE_5 -w "/mnt/renovate/gh/authzed/spicedb/e2e" docker.io/renovate/go:1.17.8 bash -l -c "go get -d -t ./... && go install github.com/marwan-at-work/mod/cmd/mod@latest && mod upgrade --mod-name=github.com/authzed/spicedb -t=3 && mod upgrade --mod-name=github.com/brianvoe/gofakeit/v6 -t=3 && go mod tidy && go mod tidy"
```
and removing the mod commands:

```
sudo docker run --platform=linux/amd64 --rm --name=renovate_go --label=renovate_child -v "$(pwd)":"/mnt/renovate/gh/authzed/spicedb" -v "/tmp/renovate-cache":"/tmp/renovate-cache" -e GOPATH -e GOPROXY -e GOFLAGS -e CGO_ENABLED -e GIT_CONFIG_KEY_0 -e GIT_CONFIG_VALUE_0 -e GIT_CONFIG_KEY_1 -e GIT_CONFIG_VALUE_1 -e GIT_CONFIG_KEY_2 -e GIT_CONFIG_VALUE_2 -e GIT_CONFIG_COUNT -e GIT_CONFIG_KEY_3 -e GIT_CONFIG_VALUE_3 -e GIT_CONFIG_KEY_4 -e GIT_CONFIG_VALUE_4 -e GIT_CONFIG_KEY_5 -e GIT_CONFIG_VALUE_5 -w "/mnt/renovate/gh/authzed/spicedb/e2e" docker.io/renovate/go:1.17.8 bash -l -c "go get -d -t ./... && go mod tidy"
```

The first command failed with the same error as the PR, the second one passed. so 🤞 this will fix renovate

