### PR TITLE
Remove Clone call on metadata filtering on namespaces

### DIFF
--- a/internal/namespace/caching.go
+++ b/internal/namespace/caching.go
@@ -99,7 +99,7 @@ func (nsc *cachingManager) ReadNamespace(ctx context.Context, nsName string, rev
 		}
 
 		// Remove user-defined metadata.
-		loaded = namespace.FilterUserDefinedMetadata(loaded)
+		namespace.FilterUserDefinedMetadataInPlace(loaded)
 
 		// Save it to the nsCache
 		nsc.c.Set(nsRevisionKey, loaded, int64(proto.Size(loaded)))

--- a/pkg/namespace/metadata.go
+++ b/pkg/namespace/metadata.go
@@ -2,23 +2,21 @@ package namespace
 
 import (
 	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	iv1 "github.com/authzed/spicedb/pkg/proto/impl/v1"
 )
 
 // userDefinedMetadataTypeUrls are the type URLs of any user-defined metadata found
-//  in the namespace proto. If placed here, FilterUserDefinedMetadata will remove the
+//  in the namespace proto. If placed here, FilterUserDefinedMetadataInPlace will remove the
 // metadata when called on the namespace.
 var userDefinedMetadataTypeUrls = map[string]struct{}{
 	"type.googleapis.com/impl.v1.DocComment": {},
 }
 
-// FilterUserDefinedMetadata removes user-defined metadata (e.g. comments) from the given namespace.
-func FilterUserDefinedMetadata(nsconfig *v0.NamespaceDefinition) *v0.NamespaceDefinition {
-	nsconfig = proto.Clone(nsconfig).(*v0.NamespaceDefinition)
-
+// FilterUserDefinedMetadataInPlace removes user-defined metadata (e.g. comments) from the given namespace
+// *in place*.
+func FilterUserDefinedMetadataInPlace(nsconfig *v0.NamespaceDefinition) {
 	nsconfig.Metadata = nil
 	for _, relation := range nsconfig.Relation {
 		if relation.Metadata != nil {
@@ -31,7 +29,6 @@ func FilterUserDefinedMetadata(nsconfig *v0.NamespaceDefinition) *v0.NamespaceDe
 			relation.Metadata.MetadataMessage = filteredMessages
 		}
 	}
-	return nsconfig
 }
 
 // GetComments returns the comment metadata found within the given metadata message.

--- a/pkg/namespace/metadata_test.go
+++ b/pkg/namespace/metadata_test.go
@@ -54,13 +54,9 @@ func TestMetadata(t *testing.T) {
 
 	require.Equal([]string{}, GetComments(ns.Relation[1].Metadata))
 
-	filtered := FilterUserDefinedMetadata(ns)
-	require.Equal([]string{}, GetComments(filtered.Metadata))
-	require.Equal([]string{}, GetComments(filtered.Relation[0].Metadata))
+	FilterUserDefinedMetadataInPlace(ns)
+	require.Equal([]string{}, GetComments(ns.Metadata))
+	require.Equal([]string{}, GetComments(ns.Relation[0].Metadata))
 
-	require.Equal([]string{"Hi there"}, GetComments(ns.Metadata))
-	require.Equal([]string{"Hi there"}, GetComments(ns.Relation[0].Metadata))
-
-	require.Equal(iv1.RelationMetadata_PERMISSION, GetRelationKind(filtered.Relation[0]))
 	require.Equal(iv1.RelationMetadata_PERMISSION, GetRelationKind(ns.Relation[0]))
 }


### PR DESCRIPTION
Should reduce memory usage a bit and make loading namespaces a bit faster