### PR TITLE
Have the GC index for Postgres be created concurrently

### DIFF
--- a/internal/datastore/postgres/migrations/zz_migration.0006_add_gc_index.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0006_add_gc_index.go
@@ -1,27 +1,13 @@
 package migrations
 
 const (
-	createDeletedTransactionIndex = `CREATE INDEX ix_relation_tuple_by_deleted_transaction ON relation_tuple (deleted_transaction)`
+	createDeletedTransactionIndex = `CREATE INDEX CONCURRENTLY ix_relation_tuple_by_deleted_transaction ON relation_tuple (deleted_transaction)`
 )
 
 func init() {
 	if err := DatabaseMigrations.Register("add-gc-index", "change-transaction-timestamp-default", func(apd *AlembicPostgresDriver) error {
-		tx, err := apd.db.Beginx()
-		if err != nil {
-			return err
-		}
-		defer tx.Rollback()
-
-		for _, stmt := range []string{
-			createDeletedTransactionIndex,
-		} {
-			_, err := tx.Exec(stmt)
-			if err != nil {
-				return err
-			}
-		}
-
-		return tx.Commit()
+		_, err := apd.db.Exec(createDeletedTransactionIndex)
+		return err
 	}); err != nil {
 		panic("failed to register migration: " + err.Error())
 	}


### PR DESCRIPTION
Prevents a write lock on the table