### PR TITLE
introduces mysql migration driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/fatih/structs v1.1.0
 	github.com/go-co-op/gocron v1.13.0
-	github.com/go-sql-driver/mysql v1.6.0
+	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.5.7

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/fatih/structs v1.1.0
 	github.com/go-co-op/gocron v1.13.0
+	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.5.7

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,9 @@ github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
-github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/go.sum
+++ b/go.sum
@@ -251,9 +251,8 @@ github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
-github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/internal/datastore/mysql/migrations/driver.go
+++ b/internal/datastore/mysql/migrations/driver.go
@@ -1,0 +1,124 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	sq "github.com/Masterminds/squirrel"
+	sqlDriver "github.com/go-sql-driver/mysql"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	errUnableToInstantiate       = "unable to instantiate MysqlDriver: %w"
+	mysqlMissingTableErrorNumber = 1146
+
+	migrationVersionColumnPrefix = "_meta_version_"
+)
+
+var sb = sq.StatementBuilder.PlaceholderFormat(sq.Question)
+
+type MysqlDriver struct {
+	db *sql.DB
+	*tables
+}
+
+// NewMysqlDriverFromDSN creates a new migration driver with a connection pool to the database DSN specified.
+//
+// URI: [scheme://][user[:[password]]@]host[:port][/schema][?attribute1=value1&attribute2=value2...
+// See // https://dev.mysql.com/doc/refman/8.0/en/connecting-using-uri-or-key-value-pairs.html
+func NewMysqlDriverFromDSN(url string, tablePrefix string) (*MysqlDriver, error) {
+	dbConfig, err := sqlDriver.ParseDSN(url)
+	if err != nil {
+		return nil, fmt.Errorf(errUnableToInstantiate, err)
+	}
+
+	db, err := sql.Open("mysql", dbConfig.FormatDSN())
+	if err != nil {
+		return nil, fmt.Errorf(errUnableToInstantiate, err)
+	}
+	err = sqlDriver.SetLogger(&log.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("unable to set logging to mysql driver: %w", err)
+	}
+	return NewMysqlDriverFromDB(db, tablePrefix), nil
+}
+
+// NewMysqlDriverFromDB creates a new migration driver with a connection pool specified upfront.
+func NewMysqlDriverFromDB(db *sql.DB, tablePrefix string) *MysqlDriver {
+	return &MysqlDriver{db, newTables(tablePrefix)}
+}
+
+func revisionToColumnName(revision string) string {
+	return migrationVersionColumnPrefix + revision
+}
+
+func columnNameToRevision(columnName string) (string, bool) {
+	if !strings.HasPrefix(columnName, migrationVersionColumnPrefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(columnName, migrationVersionColumnPrefix), true
+}
+
+// Version returns the version of the schema to which the connected database
+// has been migrated.
+func (driver *MysqlDriver) Version() (string, error) {
+	query, args, err := sb.Select("*").From(driver.migrationVersion()).ToSql()
+	if err != nil {
+		return "", fmt.Errorf("unable to load driver migration revision: %w", err)
+	}
+
+	rows, err := driver.db.Query(query, args...)
+	if err != nil {
+		var mysqlError *sqlDriver.MySQLError
+		if errors.As(err, &mysqlError) && mysqlError.Number == mysqlMissingTableErrorNumber {
+			return "", nil
+		}
+		return "", fmt.Errorf("unable to load driver migration revision: %w", err)
+	}
+	defer LogOnError(context.Background(), rows.Close)
+	if rows.Err() != nil {
+		return "", fmt.Errorf("unable to load driver migration revision: %w", err)
+	}
+	cols, err := rows.Columns()
+	if err != nil {
+		return "", fmt.Errorf("failed to get columns: %w", err)
+	}
+
+	for _, col := range cols {
+		if revision, ok := columnNameToRevision(col); ok {
+			return revision, nil
+		}
+	}
+	return "", errors.New("no migration version detected")
+}
+
+// WriteVersion overwrites the _meta_version_ column name which encodes the version
+// of the database schema.
+func (driver *MysqlDriver) WriteVersion(version, replaced string) error {
+	stmt := fmt.Sprintf("ALTER TABLE %s CHANGE %s %s VARCHAR(255) NOT NULL",
+		driver.migrationVersion(),
+		revisionToColumnName(replaced),
+		revisionToColumnName(version),
+	)
+	if _, err := driver.db.Exec(stmt); err != nil {
+		return fmt.Errorf("unable to version: %w", err)
+	}
+
+	return nil
+}
+
+func (driver *MysqlDriver) Close() error {
+	return driver.db.Close()
+}
+
+// LogOnError executes the function and logs the error.
+// Useful to avoid silently ignoring errors in defer statements
+func LogOnError(ctx context.Context, f func() error) {
+	if err := f(); err != nil {
+		log.Ctx(ctx).Error().Err(err)
+	}
+}

--- a/internal/datastore/mysql/migrations/executor.go
+++ b/internal/datastore/mysql/migrations/executor.go
@@ -1,0 +1,40 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+type driverExecutor func(mysqlDriver *MysqlDriver) string
+
+type executor struct {
+	statements []driverExecutor
+}
+
+func newExecutor(statements ...driverExecutor) executor {
+	return executor{
+		statements: statements,
+	}
+}
+
+func (e executor) migrate(driver *MysqlDriver) error {
+	if len(e.statements) == 0 {
+		return errors.New("executor.migrate: No statements to migrate")
+	}
+
+	tx, err := driver.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer LogOnError(context.Background(), tx.Rollback)
+
+	for _, stmt := range e.statements {
+		_, err := tx.Exec(stmt(driver))
+		if err != nil {
+			return fmt.Errorf("executor.migrate: failed to run statement: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}

--- a/internal/datastore/mysql/migrations/manager.go
+++ b/internal/datastore/mysql/migrations/manager.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/authzed/spicedb/pkg/migrate"
+)
+
+const migrationNamePattern = `^[_a-zA-Z]*$`
+
+var (
+	migrationNameRe = regexp.MustCompile(migrationNamePattern)
+
+	Manager = migrate.NewManager()
+)
+
+func mustRegisterMigration(version, replaces string, up interface{}) {
+	if err := registerMigration(version, replaces, up); err != nil {
+		panic("failed to register migration  " + err.Error())
+	}
+}
+
+func registerMigration(version, replaces string, up interface{}) error {
+	// validate migration names to ensure they are compatible with mysql column names
+	for _, v := range []string{version, replaces} {
+		if match := migrationNameRe.MatchString(version); !match {
+			return fmt.Errorf("migration from '%s' to '%s': '%s' is an invalid mysql migration version, expected to match pattern '%s'",
+				replaces, version, v, migrationNamePattern,
+			)
+		}
+	}
+
+	// register the migration
+	return Manager.Register(version, replaces, up)
+}

--- a/internal/datastore/mysql/migrations/migrations_test.go
+++ b/internal/datastore/mysql/migrations/migrations_test.go
@@ -127,6 +127,12 @@ func TestMySQLMigrationsWithPrefix(t *testing.T) {
 	req.NoError(rows.Err())
 }
 
+func TestMySQLMigrationsWithUnsupportedPrefix(t *testing.T) {
+	req := require.New(t)
+	err := registerMigration("888", "", struct{}{})
+	req.Error(err)
+}
+
 func TestMain(m *testing.M) {
 	mysqlContainerRunOpts := &dockertest.RunOptions{
 		Repository: "mysql",

--- a/internal/datastore/mysql/migrations/migrations_test.go
+++ b/internal/datastore/mysql/migrations/migrations_test.go
@@ -1,0 +1,197 @@
+//go:build ci
+// +build ci
+
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/migrate"
+	"github.com/authzed/spicedb/pkg/secrets"
+)
+
+const (
+	mysqlPort    = 3306
+	testDBPrefix = "spicedb_test"
+	creds        = "root:secret"
+)
+
+var containerPort string
+
+func createMigrationDriver(connectStr string) (*MysqlDriver, error) {
+	return createMigrationDriverWithPrefix(connectStr, "")
+}
+
+func createMigrationDriverWithPrefix(connectStr string, prefix string) (*MysqlDriver, error) {
+	migrationDriver, err := NewMysqlDriverFromDSN(connectStr, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize migration engine: %w", err)
+	}
+
+	return migrationDriver, nil
+}
+
+func setupDatabase() string {
+	var db *sql.DB
+	connectStr := fmt.Sprintf("%s@(localhost:%s)/mysql", creds, containerPort)
+	db, err := sql.Open("mysql", connectStr)
+	if err != nil {
+		log.Fatalf("couldn't open DB: %s", err)
+	}
+	defer func() {
+		err := db.Close() // we do not want this connection to stay open
+		if err != nil {
+			log.Fatalf("failed to close db: %s", err)
+		}
+	}()
+
+	uniquePortion, err := secrets.TokenHex(4)
+	if err != nil {
+		log.Fatalf("Could not generate unique portion of db name: %s", err)
+	}
+	dbName := testDBPrefix + uniquePortion
+
+	tx, err := db.Begin()
+	_, err = tx.Exec(fmt.Sprintf("CREATE DATABASE %s;", dbName))
+	if err != nil {
+		log.Fatalf("failed to create database: %s: %s", dbName, err)
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		log.Fatalf("failed to commit: %s", err)
+	}
+
+	return fmt.Sprintf("%s@(localhost:%s)/%s?parseTime=true", creds, containerPort, dbName)
+}
+
+func TestMySQLMigrations(t *testing.T) {
+	req := require.New(t)
+
+	connectStr := setupDatabase()
+	migrationDriver, err := createMigrationDriver(connectStr)
+	req.NoError(err)
+
+	version, err := migrationDriver.Version()
+	req.NoError(err)
+	req.Equal("", version)
+
+	err = Manager.Run(migrationDriver, migrate.Head, migrate.LiveRun)
+	req.NoError(err)
+
+	version, err = migrationDriver.Version()
+	req.NoError(err)
+
+	headVersion, err := Manager.HeadRevision()
+	req.NoError(err)
+	req.Equal(headVersion, version)
+}
+
+func TestMySQLMigrationsWithPrefix(t *testing.T) {
+	req := require.New(t)
+
+	connectStr := setupDatabase()
+
+	migrationDriver, err := createMigrationDriverWithPrefix(connectStr, "spicedb_")
+	req.NoError(err)
+
+	version, err := migrationDriver.Version()
+	req.NoError(err)
+	req.Equal("", version)
+
+	err = Manager.Run(migrationDriver, migrate.Head, migrate.LiveRun)
+	req.NoError(err)
+
+	version, err = migrationDriver.Version()
+	req.NoError(err)
+
+	headVersion, err := Manager.HeadRevision()
+	req.NoError(err)
+	req.Equal(headVersion, version)
+
+	db, err := sql.Open("mysql", connectStr)
+	rows, err := db.Query("SHOW TABLES;")
+
+	for rows.Next() {
+		var tbl string
+		req.NoError(rows.Scan(&tbl))
+		req.Contains(tbl, "spicedb_")
+	}
+	req.NoError(rows.Err())
+}
+
+func TestMain(m *testing.M) {
+	mysqlContainerRunOpts := &dockertest.RunOptions{
+		Repository: "mysql",
+		Tag:        "5",
+		Env:        []string{"MYSQL_ROOT_PASSWORD=secret"},
+		// increase max connections (default 151) to accommodate tests using the same docker container
+		Cmd: []string{"--max-connections=500"},
+	}
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		fmt.Printf("could not connect to docker: %s\n", err)
+		os.Exit(1)
+	}
+
+	// only bring up the container once
+	containerResource, err := pool.RunWithOptions(mysqlContainerRunOpts)
+	if err != nil {
+		fmt.Printf("could not start resource: %s\n", err)
+		os.Exit(1)
+	}
+
+	containerCleanup := func() {
+		// When you're done, kill and remove the container
+		if err := pool.Purge(containerResource); err != nil {
+			fmt.Printf("could not purge resource: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
+	containerPort = containerResource.GetPort(fmt.Sprintf("%d/tcp", mysqlPort))
+	connectStr := fmt.Sprintf("%s@(localhost:%s)/mysql?parseTime=true", creds, containerPort)
+
+	db, err := sql.Open("mysql", connectStr)
+	if err != nil {
+		fmt.Printf("failed to open db: %s\n", err)
+		containerCleanup()
+		os.Exit(1)
+	}
+
+	defer func() {
+		err := db.Close() // we do not want this connection to stay open
+		if err != nil {
+			fmt.Printf("failed to close db: %s\n", err)
+			containerCleanup()
+			os.Exit(1)
+		}
+	}()
+
+	err = pool.Retry(func() error {
+		var err error
+		err = db.Ping()
+		if err != nil {
+			return fmt.Errorf("couldn't validate docker/mysql readiness: %w", err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		fmt.Printf("mysql database error: %s\n", err)
+		containerCleanup()
+		os.Exit(1)
+	}
+
+	exitStatus := m.Run()
+	containerCleanup()
+	os.Exit(exitStatus)
+}

--- a/internal/datastore/mysql/migrations/tables.go
+++ b/internal/datastore/mysql/migrations/tables.go
@@ -1,0 +1,42 @@
+package migrations
+
+import "fmt"
+
+const (
+	tableNamespaceDefault   = "namespace_config"
+	tableTransactionDefault = "relation_tuple_transaction"
+	tableTupleDefault       = "relation_tuple"
+	tableMigrationVersion   = "mysql_migration_version"
+)
+
+type tables struct {
+	tableMigrationVersion string
+	tableTransaction      string
+	tableTuple            string
+	tableNamespace        string
+}
+
+func newTables(prefix string) *tables {
+	return &tables{
+		tableMigrationVersion: fmt.Sprintf("%s%s", prefix, tableMigrationVersion),
+		tableTransaction:      fmt.Sprintf("%s%s", prefix, tableTransactionDefault),
+		tableTuple:            fmt.Sprintf("%s%s", prefix, tableTupleDefault),
+		tableNamespace:        fmt.Sprintf("%s%s", prefix, tableNamespaceDefault),
+	}
+}
+
+func (tn *tables) migrationVersion() string {
+	return tn.tableMigrationVersion
+}
+
+func (tn *tables) RelationTupleTransaction() string {
+	return tn.tableTransaction
+}
+
+func (tn *tables) RelationTuple() string {
+	return tn.tableTuple
+}
+
+func (tn *tables) Namespace() string {
+	return tn.tableNamespace
+}

--- a/internal/datastore/mysql/migrations/zz_migration.0001_initial_schema.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0001_initial_schema.go
@@ -1,0 +1,22 @@
+package migrations
+
+import "fmt"
+
+func createMysqlMigrationVersion(driver *MysqlDriver) string {
+	// we need the additional primary key column because github.com/github/gh-ost requires a shared, not-null
+	// key between the _to_ and _from_ table schemas to perform a schema migration.
+	// -- https://github.com/github/gh-ost/blob/master/doc/shared-key.md
+	return fmt.Sprintf("CREATE TABLE %s "+
+		`( id int(11) NOT NULL PRIMARY KEY,
+		_meta_version_ VARCHAR(255) NOT NULL
+		);`,
+		driver.migrationVersion())
+}
+
+func init() {
+	mustRegisterMigration("initial", "",
+		newExecutor(
+			createMysqlMigrationVersion,
+		).migrate,
+	)
+}

--- a/internal/datastore/mysql/migrations/zz_migration.0002_namespace_tables.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0002_namespace_tables.go
@@ -1,0 +1,54 @@
+package migrations
+
+import (
+	"fmt"
+)
+
+// namespace max size: https://buf.build/authzed/api/file/main/authzed/api/v0/core.proto#L29
+func createNamespaceConfig(driver *MysqlDriver) string {
+	return fmt.Sprintf("CREATE TABLE %s", driver.Namespace()) +
+		` ( namespace VARCHAR(128) NOT NULL,
+		serialized_config BLOB NOT NULL,
+		created_transaction BIGINT NOT NULL,
+		deleted_transaction BIGINT NOT NULL DEFAULT '9223372036854775807',
+		CONSTRAINT pk_namespace_config PRIMARY KEY (namespace, created_transaction),
+		CONSTRAINT uq_namespace_living UNIQUE (namespace, deleted_transaction)
+  	);`
+}
+
+// relationship max size: https://buf.build/authzed/api/file/main/authzed/api/v1/core.proto#L33
+// object id max size: https://buf.build/authzed/api/file/main/authzed/api/v1/core.proto#L45
+func createRelationTuple(driver *MysqlDriver) string {
+	return fmt.Sprintf("CREATE TABLE %s", driver.RelationTuple()) +
+		` ( id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+		namespace VARCHAR(128) NOT NULL,
+		object_id VARCHAR(128) NOT NULL,
+		relation VARCHAR(64) NOT NULL,
+		userset_namespace VARCHAR(128) NOT NULL,
+		userset_object_id VARCHAR(128) NOT NULL,
+		userset_relation VARCHAR(64) NOT NULL,
+		created_transaction BIGINT NOT NULL,
+		deleted_transaction BIGINT NOT NULL DEFAULT '9223372036854775807',
+		PRIMARY KEY (id),
+		CONSTRAINT uq_relation_tuple_namespace UNIQUE (namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, created_transaction, deleted_transaction),
+		CONSTRAINT uq_relation_tuple_living UNIQUE (namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, deleted_transaction)
+	);`
+}
+
+func createRelationTupleTransaction(driver *MysqlDriver) string {
+	return fmt.Sprintf("CREATE TABLE %s", driver.RelationTupleTransaction()) +
+		` ( id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+		timestamp DATETIME(6) DEFAULT NOW(6) NOT NULL,
+		PRIMARY KEY (id)
+	);`
+}
+
+func init() {
+	mustRegisterMigration("namespace_tables", "initial",
+		newExecutor(
+			createNamespaceConfig,
+			createRelationTuple,
+			createRelationTupleTransaction,
+		).migrate,
+	)
+}

--- a/internal/datastore/mysql/migrations/zz_migration.0003_indexes.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0003_indexes.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"fmt"
+)
+
+func createReverseQueryIndex(driver *MysqlDriver) string {
+	return fmt.Sprintf("CREATE INDEX ix_relation_tuple_by_subject ON %s (userset_object_id, userset_namespace, userset_relation, namespace, relation)",
+		driver.RelationTuple())
+}
+
+func createReverseCheckIndex(driver *MysqlDriver) string {
+	return fmt.Sprintf("CREATE INDEX ix_relation_tuple_by_subject_relation ON %s (userset_namespace, userset_relation, namespace, relation)",
+		driver.RelationTuple())
+}
+
+func createIndexOnTupleTransactionTimestamp(driver *MysqlDriver) string {
+	return fmt.Sprintf("CREATE INDEX ix_relation_tuple_transaction_by_timestamp on %s (timestamp)",
+		driver.RelationTupleTransaction())
+}
+
+func init() {
+	mustRegisterMigration("indexes", "namespace_tables",
+		newExecutor(
+			createReverseQueryIndex,
+			createReverseCheckIndex,
+			createIndexOnTupleTransactionTimestamp,
+		).migrate,
+	)
+}

--- a/internal/datastore/mysql/migrations/zz_migration.0004_indexed_gc.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0004_indexed_gc.go
@@ -1,0 +1,16 @@
+package migrations
+
+import (
+	"fmt"
+)
+
+func createDeletedTransactionsIndex(driver *MysqlDriver) string {
+	return fmt.Sprintf("CREATE INDEX ix_relation_tuple_by_deleted_transaction ON %s (deleted_transaction)",
+		driver.RelationTuple())
+}
+
+func init() {
+	mustRegisterMigration("indexed_gc", "indexes",
+		newExecutor(createDeletedTransactionsIndex).migrate,
+	)
+}


### PR DESCRIPTION
This is an initial contribution of the MySQL Datastore implementation. It tries to decompose the submission into smaller PRs to help with the review.

# What

Implements SpiceDB migration logic to support MySQL as backing datastore

# Context

GitHub runs mysql schema migrations at scale using skeema (https://github.com/skeema/skeema) and gh-ost (https://github.com/github/gh-ost). The SpiceDB migration driver for MySQL is designed in a way it is compatible with migration workloads relying on those tools.

The main difference is how the MySQL migration driver maintains the metadata needed to know which version is currently running. The PSQL migration driver follows a pattern similar to what's proposed by SQLAlchemy's Alembic, with a table that keeps track of the migration run. Because Skeema does not support data migrations, and seeding the database
could be considered a data migration, we decided to encode the metadata into the database schema (DML) so we can expose the same information but only relying on schema migrations. As such the migration_version table
is empty, and maintains the running version in a table column. This turns every migration into a pure DML operations, which Skeema understands well.

The way we run these then is by executing `spicedb migrate` in development DB, and letting skeema detect the changes to the development database. These are then persisted, and deployed using our own internal migration automation build on top of skeema and gh-ost.

The other distinction with the PSQL migration driver is the support for table prefixes. This is necessary to align with our own internal conventions.

# Contributors

These series of PRs are the result of the work from various current and former hubbers which I've added as co-authors, in alphabetic order:

@ams11
@chriskirkland
@hagould
@johnpreed
@sbryant