### PR TITLE
mysql: wire up the mysql datastore engine to the CLI

### DIFF
--- a/internal/datastore/mysql/migrations/zz_migration.0001_initial_schema.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0001_initial_schema.go
@@ -8,7 +8,7 @@ func createMigrationVersion(driver *MySQLDriver) string {
 	// -- https://github.com/github/gh-ost/blob/master/doc/shared-key.md
 	return fmt.Sprintf(`CREATE TABLE %s (
 		id int(11) NOT NULL PRIMARY KEY,
-		_meta_version_ VARCHAR(255) NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8;`,
+		_meta_version_ VARCHAR(255) NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`,
 		driver.migrationVersion(),
 	)
 }
@@ -21,7 +21,7 @@ func createNamespaceConfig(driver *MySQLDriver) string {
 		created_transaction BIGINT NOT NULL,
 		deleted_transaction BIGINT NOT NULL DEFAULT '9223372036854775807',
 		CONSTRAINT pk_namespace_config PRIMARY KEY (namespace, created_transaction),
-		CONSTRAINT uq_namespace_living UNIQUE (namespace, deleted_transaction)) ENGINE=InnoDB DEFAULT CHARSET=utf8;`,
+		CONSTRAINT uq_namespace_living UNIQUE (namespace, deleted_transaction)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`,
 		driver.Namespace(),
 	)
 }
@@ -44,7 +44,7 @@ func createRelationTuple(driver *MySQLDriver) string {
 		CONSTRAINT uq_relation_tuple_living UNIQUE (namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, deleted_transaction),
         INDEX ix_relation_tuple_by_subject (userset_object_id, userset_namespace, userset_relation, namespace, relation),
         INDEX ix_relation_tuple_by_subject_relation (userset_namespace, userset_relation, namespace, relation),
-        INDEX ix_relation_tuple_by_deleted_transaction (deleted_transaction)) ENGINE=InnoDB DEFAULT CHARSET=utf8;`,
+        INDEX ix_relation_tuple_by_deleted_transaction (deleted_transaction)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`,
 		driver.RelationTuple(),
 	)
 }
@@ -54,7 +54,7 @@ func createRelationTupleTransaction(driver *MySQLDriver) string {
 		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 		timestamp DATETIME(6) DEFAULT NOW(6) NOT NULL,
 		PRIMARY KEY (id),
-        INDEX ix_relation_tuple_transaction_by_timestamp (timestamp)) ENGINE=InnoDB DEFAULT CHARSET=utf8;`,
+        INDEX ix_relation_tuple_transaction_by_timestamp (timestamp)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`,
 		driver.RelationTupleTransaction(),
 	)
 }

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -12,6 +12,7 @@ import (
 	"github.com/authzed/spicedb/internal/datastore"
 	"github.com/authzed/spicedb/internal/datastore/crdb"
 	"github.com/authzed/spicedb/internal/datastore/memdb"
+	"github.com/authzed/spicedb/internal/datastore/mysql"
 	"github.com/authzed/spicedb/internal/datastore/postgres"
 	"github.com/authzed/spicedb/internal/datastore/proxy"
 	"github.com/authzed/spicedb/internal/datastore/spanner"
@@ -25,6 +26,7 @@ const (
 	PostgresEngine  = "postgres"
 	CockroachEngine = "cockroachdb"
 	SpannerEngine   = "spanner"
+	MySQLEngine     = "mysql"
 )
 
 var BuilderForEngine = map[string]engineBuilderFunc{
@@ -32,6 +34,7 @@ var BuilderForEngine = map[string]engineBuilderFunc{
 	PostgresEngine:  newPostgresDatastore,
 	MemoryEngine:    newMemoryDatstore,
 	SpannerEngine:   newSpannerDatastore,
+	MySQLEngine:     newMySQLDatastore,
 }
 
 //go:generate go run github.com/ecordell/optgen -output zz_generated.options.go . Config
@@ -76,6 +79,9 @@ type Config struct {
 	// Internal
 	WatchBufferLength      uint16
 	EnableDatastoreMetrics bool
+
+	// MySQL
+	TablePrefix string
 }
 
 // RegisterDatastoreFlags adds datastore flags to a cobra command
@@ -105,6 +111,7 @@ func RegisterDatastoreFlags(cmd *cobra.Command, opts *Config) {
 	cmd.Flags().StringVar(&opts.OverlapStrategy, "datastore-tx-overlap-strategy", "static", `strategy to generate transaction overlap keys ("prefix", "static", "insecure") (cockroach driver only)`)
 	cmd.Flags().StringVar(&opts.OverlapKey, "datastore-tx-overlap-key", "key", "static key to touch when writing to ensure transactions overlap (only used if --datastore-tx-overlap-strategy=static is set; cockroach driver only)")
 	cmd.Flags().StringVar(&opts.SpannerCredentialsFile, "datastore-spanner-credentials", "", "path to service account key credentials file with access to the cloud spanner instance")
+	cmd.Flags().StringVar(&opts.TablePrefix, "datastore-mysql-table-prefix", "", "prefix to add to the name of all SpiceDB database tables")
 }
 
 func DefaultDatastoreConfig() *Config {
@@ -234,6 +241,21 @@ func newSpannerDatastore(opts Config) (datastore.Datastore, error) {
 		spanner.CredentialsFile(opts.SpannerCredentialsFile),
 		spanner.WatchBufferLength(opts.WatchBufferLength),
 	)
+}
+
+func newMySQLDatastore(opts Config) (datastore.Datastore, error) {
+	mysqlOpts := []mysql.Option{
+		mysql.GCInterval(opts.GCInterval),
+		mysql.GCWindow(opts.GCWindow),
+		mysql.GCInterval(opts.GCInterval),
+		mysql.ConnMaxIdleTime(opts.MaxIdleTime),
+		mysql.ConnMaxLifetime(opts.MaxLifetime),
+		mysql.MaxOpenConns(opts.MaxOpenConns),
+		mysql.RevisionFuzzingTimedelta(opts.RevisionQuantization),
+		mysql.TablePrefix(opts.TablePrefix),
+		mysql.EnablePrometheusStats(),
+	}
+	return mysql.NewMySQLDatastore(opts.URI, mysqlOpts...)
 }
 
 func newMemoryDatstore(opts Config) (datastore.Datastore, error) {

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -76,12 +76,12 @@ type Config struct {
 	// Spanner
 	SpannerCredentialsFile string
 
+	// MySQL
+	TablePrefix string
+
 	// Internal
 	WatchBufferLength      uint16
 	EnableDatastoreMetrics bool
-
-	// MySQL
-	TablePrefix string
 }
 
 // RegisterDatastoreFlags adds datastore flags to a cobra command

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -43,6 +43,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.SpannerCredentialsFile = c.SpannerCredentialsFile
 		to.WatchBufferLength = c.WatchBufferLength
 		to.EnableDatastoreMetrics = c.EnableDatastoreMetrics
+		to.TablePrefix = c.TablePrefix
 	}
 }
 
@@ -240,5 +241,12 @@ func WithWatchBufferLength(watchBufferLength uint16) ConfigOption {
 func WithEnableDatastoreMetrics(enableDatastoreMetrics bool) ConfigOption {
 	return func(c *Config) {
 		c.EnableDatastoreMetrics = enableDatastoreMetrics
+	}
+}
+
+// WithTablePrefix returns an option that can set TablePrefix on a Config
+func WithTablePrefix(tablePrefix string) ConfigOption {
+	return func(c *Config) {
+		c.TablePrefix = tablePrefix
 	}
 }

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -41,9 +41,9 @@ func (c *Config) ToOption() ConfigOption {
 		to.GCInterval = c.GCInterval
 		to.GCMaxOperationTime = c.GCMaxOperationTime
 		to.SpannerCredentialsFile = c.SpannerCredentialsFile
+		to.TablePrefix = c.TablePrefix
 		to.WatchBufferLength = c.WatchBufferLength
 		to.EnableDatastoreMetrics = c.EnableDatastoreMetrics
-		to.TablePrefix = c.TablePrefix
 	}
 }
 
@@ -230,6 +230,13 @@ func WithSpannerCredentialsFile(spannerCredentialsFile string) ConfigOption {
 	}
 }
 
+// WithTablePrefix returns an option that can set TablePrefix on a Config
+func WithTablePrefix(tablePrefix string) ConfigOption {
+	return func(c *Config) {
+		c.TablePrefix = tablePrefix
+	}
+}
+
 // WithWatchBufferLength returns an option that can set WatchBufferLength on a Config
 func WithWatchBufferLength(watchBufferLength uint16) ConfigOption {
 	return func(c *Config) {
@@ -241,12 +248,5 @@ func WithWatchBufferLength(watchBufferLength uint16) ConfigOption {
 func WithEnableDatastoreMetrics(enableDatastoreMetrics bool) ConfigOption {
 	return func(c *Config) {
 		c.EnableDatastoreMetrics = enableDatastoreMetrics
-	}
-}
-
-// WithTablePrefix returns an option that can set TablePrefix on a Config
-func WithTablePrefix(tablePrefix string) ConfigOption {
-	return func(c *Config) {
-		c.TablePrefix = tablePrefix
 	}
 }

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	crdbmigrations "github.com/authzed/spicedb/internal/datastore/crdb/migrations"
+	mysqlmigrations "github.com/authzed/spicedb/internal/datastore/mysql/migrations"
 	"github.com/authzed/spicedb/internal/datastore/postgres/migrations"
 	spannermigrations "github.com/authzed/spicedb/internal/datastore/spanner/migrations"
 	"github.com/authzed/spicedb/pkg/cmd/server"
@@ -16,9 +17,10 @@ import (
 )
 
 func RegisterMigrateFlags(cmd *cobra.Command) {
-	cmd.Flags().String("datastore-engine", "memory", `type of datastore to initialize ("memory", "postgres", "cockroachdb")`)
+	cmd.Flags().String("datastore-engine", "memory", `type of datastore to initialize ("memory", "postgres", "cockroachdb", "mysql")`)
 	cmd.Flags().String("datastore-conn-uri", "", `connection string used by remote datastores (e.g. "postgres://postgres:password@localhost:5432/spicedb")`)
 	cmd.Flags().String("datastore-spanner-credentials", "", "path to service account key credentials file with access to the cloud spanner instance")
+	cmd.Flags().String("datastore-mysql-table-prefix", "", "prefix to add to the name of all mysql database tables")
 }
 
 func NewMigrateCommand(programName string) *cobra.Command {
@@ -67,6 +69,19 @@ func migrateRun(cmd *cobra.Command, args []string) error {
 			log.Fatal().Err(err).Msg("unable to create migration driver")
 		}
 		manager = spannermigrations.SpannerMigrations
+	} else if datastoreEngine == "mysql" {
+		log.Info().Msg("migrating mysql datastore")
+
+		var err error
+		tablePrefix, err := cmd.Flags().GetString("datastore-mysql-table-prefix")
+		if err != nil {
+			log.Fatal().Msg(fmt.Sprintf("unable to get table prefix: %s", err))
+		}
+
+		migrationDriver, err = mysqlmigrations.NewMySQLDriverFromDSN(dbURL, tablePrefix)
+		if err != nil {
+			log.Fatal().Err(err).Msg("unable to create migration driver")
+		}
 	} else {
 		return fmt.Errorf("cannot migrate datastore engine type: %s", datastoreEngine)
 	}
@@ -86,7 +101,7 @@ func migrateRun(cmd *cobra.Command, args []string) error {
 }
 
 func RegisterHeadFlags(cmd *cobra.Command) {
-	cmd.Flags().String("datastore-engine", "postgres", "type of datastore to initialize (e.g. postgres, cockroachdb, memory")
+	cmd.Flags().String("datastore-engine", "postgres", "type of datastore to initialize (e.g. postgres, cockroachdb, memory, mysql")
 }
 
 func NewHeadCommand(programName string) *cobra.Command {
@@ -113,6 +128,8 @@ func HeadRevision(engine string) (string, error) {
 		return crdbmigrations.CRDBMigrations.HeadRevision()
 	case "postgres":
 		return migrations.DatabaseMigrations.HeadRevision()
+	case "mysql":
+		return mysqlmigrations.Manager.HeadRevision()
 	default:
 		return "", fmt.Errorf("cannot migrate datastore engine type: %s", engine)
 	}

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -101,7 +101,7 @@ func migrateRun(cmd *cobra.Command, args []string) error {
 }
 
 func RegisterHeadFlags(cmd *cobra.Command) {
-	cmd.Flags().String("datastore-engine", "postgres", "type of datastore to initialize (e.g. postgres, cockroachdb, memory, mysql")
+	cmd.Flags().String("datastore-engine", "postgres", "type of datastore to initialize (e.g. postgres, cockroachdb, memory, mysql, spanner")
 }
 
 func NewHeadCommand(programName string) *cobra.Command {

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -17,7 +17,7 @@ import (
 )
 
 func RegisterMigrateFlags(cmd *cobra.Command) {
-	cmd.Flags().String("datastore-engine", "memory", `type of datastore to initialize ("memory", "postgres", "cockroachdb", "mysql")`)
+	cmd.Flags().String("datastore-engine", "memory", `type of datastore to initialize ("memory", "postgres", "cockroachdb", "mysql", "spanner")`)
 	cmd.Flags().String("datastore-conn-uri", "", `connection string used by remote datastores (e.g. "postgres://postgres:password@localhost:5432/spicedb")`)
 	cmd.Flags().String("datastore-spanner-credentials", "", "path to service account key credentials file with access to the cloud spanner instance")
 	cmd.Flags().String("datastore-mysql-table-prefix", "", "prefix to add to the name of all mysql database tables")
@@ -130,6 +130,8 @@ func HeadRevision(engine string) (string, error) {
 		return migrations.DatabaseMigrations.HeadRevision()
 	case "mysql":
 		return mysqlmigrations.Manager.HeadRevision()
+	case "spanner":
+		return spannermigrations.SpannerMigrations.HeadRevision()
 	default:
 		return "", fmt.Errorf("cannot migrate datastore engine type: %s", engine)
 	}


### PR DESCRIPTION
This PR adds the mysql datastore options to the CLI.

- add datastore-engine mysql
- `datastore-mysql-table-prefix` support
- `spicedb migrate` support