### PR TITLE
makes cli application return non-zero error code on errors

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -23,9 +23,7 @@ const (
 	backendsPerKey            = 1
 )
 
-var (
-	parsingError = errors.New("parsing error")
-)
+var errParsing = errors.New("parsing error")
 
 func main() {
 	// Set up a seed for randomness
@@ -46,7 +44,7 @@ func main() {
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		cmd.Println(err)
 		cmd.Println(cmd.UsageString())
-		return parsingError
+		return errParsing
 	})
 	cmd.RegisterRootFlags(rootCmd)
 
@@ -79,7 +77,7 @@ func main() {
 	cmd.RegisterTestingFlags(testingCmd, &testServerConfig)
 	rootCmd.AddCommand(testingCmd)
 	if err := rootCmd.Execute(); err != nil {
-		if !errors.Is(err, parsingError) {
+		if !errors.Is(err, errParsing) {
 			log.Err(err).Msg("terminated with errors")
 		}
 		os.Exit(1)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -14,9 +14,11 @@ func RegisterRootFlags(cmd *cobra.Command) {
 
 func NewRootCommand(programName string) *cobra.Command {
 	return &cobra.Command{
-		Use:     programName,
-		Short:   "A modern permissions database",
-		Long:    "A database that stores, computes, and validates application permissions",
-		Example: server.ServeExample(programName),
+		Use:           programName,
+		Short:         "A modern permissions database",
+		Long:          "A database that stores, computes, and validates application permissions",
+		Example:       server.ServeExample(programName),
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 }


### PR DESCRIPTION
fixes https://github.com/authzed/spicedb/issues/538

changes the application to return non-zero error codes when an `error` is returned by the root command. 

I attempted to make the output of the CLI _"pretty"_:

- if the error is a parsing error, command usage will be printed
- if the error is an application error, the error is logged using `zerolog` so that it shows up nicely just like any other application log message

If we wanted the flag values to be recognized as a "parsing/cli error" (e.g. unrecognized datastore) we could signal it with a specific error, but we would need to adjust every part of the application that initializes spicedb to return an error deemed to be considered "cli error". I considered that to be out of scope of this PR.

### example: unrecognized flag: error code 1, prints command usage
 
![Screen Shot 2022-04-19 at 19 39 22](https://user-images.githubusercontent.com/6774726/164063187-d0d56e4a-bc56-4113-89f3-1e57ff2461dc.png)

### example: incorrect flag value: error code 1, does not print command usage

![Screen Shot 2022-04-19 at 19 25 20](https://user-images.githubusercontent.com/6774726/164062796-33981cf4-7a19-4161-b9bd-64313ffb37b1.png)

### example: SIGTERM: error code 0

![Screen Shot 2022-04-19 at 19 29 03](https://user-images.githubusercontent.com/6774726/164062791-3adf7b43-336c-42a4-8ad8-9fed86172cb0.png)
