### PR TITLE
Reduce the namespace manager interface to the essentials

### DIFF
--- a/internal/dispatch/keys/keys.go
+++ b/internal/dispatch/keys/keys.go
@@ -42,7 +42,7 @@ func (c *CanonicalKeyHandler) ComputeCheckKey(ctx context.Context, req *v1.Dispa
 			return "", err
 		}
 
-		_, relation, err := nsm.ReadNamespaceAndRelation(ctx, req.ObjectAndRelation.Namespace, req.ObjectAndRelation.Relation, revision)
+		_, relation, err := namespace.ReadNamespaceAndRelation(ctx, req.ObjectAndRelation.Namespace, req.ObjectAndRelation.Relation, revision, nsm)
 		if err != nil {
 			return "", err
 		}

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -191,7 +191,7 @@ func (cc *ConcurrentChecker) checkComputedUserset(ctx context.Context, req Valid
 	}
 
 	// Check if the target relation exists. If not, return nothing.
-	err := cc.nsm.CheckNamespaceAndRelation(ctx, start.Namespace, cu.Relation, true, req.Revision)
+	err := namespace.CheckNamespaceAndRelation(ctx, start.Namespace, cu.Relation, true, req.Revision, cc.nsm)
 	if err != nil {
 		if errors.As(err, &namespace.ErrRelationNotFound{}) {
 			return notMember()

--- a/internal/graph/expand.go
+++ b/internal/graph/expand.go
@@ -216,7 +216,7 @@ func (ce *ConcurrentExpander) expandComputedUserset(ctx context.Context, req Val
 	}
 
 	// Check if the target relation exists. If not, return nothing.
-	err := ce.nsm.CheckNamespaceAndRelation(ctx, start.Namespace, cu.Relation, true, req.Revision)
+	err := namespace.CheckNamespaceAndRelation(ctx, start.Namespace, cu.Relation, true, req.Revision, ce.nsm)
 	if err != nil {
 		if errors.As(err, &namespace.ErrRelationNotFound{}) {
 			return emptyExpansion(req.ObjectAndRelation)

--- a/internal/graph/lookup.go
+++ b/internal/graph/lookup.go
@@ -196,7 +196,7 @@ func (cl *ConcurrentLookup) lookupInternal(ctx context.Context, req ValidatedLoo
 		objSet.Add(req.Subject)
 	}
 
-	nsdef, typeSystem, err := cl.nsm.ReadNamespaceAndTypes(ctx, req.ObjectRelation.Namespace, req.Revision)
+	nsdef, typeSystem, err := namespace.ReadNamespaceAndTypes(ctx, req.ObjectRelation.Namespace, req.Revision, cl.nsm)
 	if err != nil {
 		return returnResult(lookupResultError(req, err, emptyMetadata))
 	}
@@ -556,7 +556,7 @@ func (cl *ConcurrentLookup) processTupleToUserset(ctx context.Context, req Valid
 			continue
 		}
 
-		_, directRelTypeSystem, err := cl.nsm.ReadNamespaceAndTypes(ctx, directRelation.Namespace, req.Revision)
+		_, directRelTypeSystem, err := namespace.ReadNamespaceAndTypes(ctx, directRelation.Namespace, req.Revision, cl.nsm)
 		if err != nil {
 			return returnResult(lookupResultError(req, err, emptyMetadata))
 		}

--- a/internal/namespace/manager.go
+++ b/internal/namespace/manager.go
@@ -19,25 +19,6 @@ type Manager interface {
 	// Returns the direct downstream error for all other unknown error.
 	ReadNamespace(ctx context.Context, nsName string, revision decimal.Decimal) (*core.NamespaceDefinition, error)
 
-	// ReadNamespaceAndRelation checks that the specified namespace and relation exist in the
-	// datastore.
-	//
-	// Returns ErrNamespaceNotFound if the namespace cannot be found.
-	// Returns ErrRelationNotFound if the relation was not found in the namespace.
-	// Returns the direct downstream error for all other unknown error.
-	ReadNamespaceAndRelation(ctx context.Context, namespace, relation string, revision decimal.Decimal) (*core.NamespaceDefinition, *core.Relation, error)
-
-	// CheckNamespaceAndRelation checks that the specified namespace and relation exist in the
-	// datastore.
-	//
-	// Returns ErrNamespaceNotFound if the namespace cannot be found.
-	// Returns ErrRelationNotFound if the relation was not found in the namespace.
-	// Returns the direct downstream error for all other unknown error.
-	CheckNamespaceAndRelation(ctx context.Context, namespace, relation string, allowEllipsis bool, revision decimal.Decimal) error
-
-	// ReadNamespaceAndTypes reads a namespace definition, version, and type system and returns it if found.
-	ReadNamespaceAndTypes(ctx context.Context, nsName string, revision decimal.Decimal) (*core.NamespaceDefinition, *NamespaceTypeSystem, error)
-
 	// Close closes the namespace manager, disposing of any resources.
 	//
 	// NOTE: Should *not* call Close on the datastore.

--- a/internal/namespace/util.go
+++ b/internal/namespace/util.go
@@ -1,0 +1,67 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/authzed/spicedb/internal/datastore"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+)
+
+// ReadNamespaceAndRelation checks that the specified namespace and relation exist in the
+// datastore.
+//
+// Returns ErrNamespaceNotFound if the namespace cannot be found.
+// Returns ErrRelationNotFound if the relation was not found in the namespace.
+// Returns the direct downstream error for all other unknown error.
+func ReadNamespaceAndRelation(ctx context.Context, namespace, relation string, revision decimal.Decimal, manager Manager) (*core.NamespaceDefinition, *core.Relation, error) {
+	config, err := manager.ReadNamespace(ctx, namespace, revision)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, rel := range config.Relation {
+		if rel.Name == relation {
+			return config, rel, nil
+		}
+	}
+
+	return nil, nil, NewRelationNotFoundErr(namespace, relation)
+}
+
+// CheckNamespaceAndRelation checks that the specified namespace and relation exist in the
+// datastore.
+//
+// Returns ErrNamespaceNotFound if the namespace cannot be found.
+// Returns ErrRelationNotFound if the relation was not found in the namespace.
+// Returns the direct downstream error for all other unknown error.
+func CheckNamespaceAndRelation(ctx context.Context, namespace, relation string, allowEllipsis bool, revision decimal.Decimal, manager Manager) error {
+	config, err := manager.ReadNamespace(ctx, namespace, revision)
+	if err != nil {
+		return err
+	}
+
+	if allowEllipsis && relation == datastore.Ellipsis {
+		return nil
+	}
+
+	for _, rel := range config.Relation {
+		if rel.Name == relation {
+			return nil
+		}
+	}
+
+	return NewRelationNotFoundErr(namespace, relation)
+}
+
+// ReadNamespaceAndTypes reads a namespace definition, version, and type system and returns it if found.
+func ReadNamespaceAndTypes(ctx context.Context, nsName string, revision decimal.Decimal, manager Manager) (*core.NamespaceDefinition, *NamespaceTypeSystem, error) {
+	nsDef, err := manager.ReadNamespace(ctx, nsName, revision)
+	if err != nil {
+		return nsDef, nil, err
+	}
+
+	ts, terr := BuildNamespaceTypeSystemForManager(nsDef, manager, revision)
+	return nsDef, ts, terr
+}

--- a/internal/services/consistency_test.go
+++ b/internal/services/consistency_test.go
@@ -83,7 +83,7 @@ func TestConsistency(t *testing.T) {
 
 							// Validate the type system for each namespace.
 							for _, nsDef := range fullyResolved.NamespaceDefinitions {
-								_, ts, err := ns.ReadNamespaceAndTypes(dsCtx, nsDef.Name, revision)
+								_, ts, err := namespace.ReadNamespaceAndTypes(dsCtx, nsDef.Name, revision, ns)
 								lrequire.NoError(err)
 
 								_, err = ts.Validate(dsCtx)

--- a/internal/services/v0/validation.go
+++ b/internal/services/v0/validation.go
@@ -33,12 +33,13 @@ func validateTupleWrite(
 		return err
 	}
 
-	if err := nsm.CheckNamespaceAndRelation(
+	if err := namespace.CheckNamespaceAndRelation(
 		ctx,
 		tpl.ObjectAndRelation.Namespace,
 		tpl.ObjectAndRelation.Relation,
 		false, // Disallow ellipsis
 		revision,
+		nsm,
 	); err != nil {
 		return err
 	}
@@ -54,17 +55,18 @@ func validateTupleWrite(
 		}
 	}
 
-	if err := nsm.CheckNamespaceAndRelation(
+	if err := namespace.CheckNamespaceAndRelation(
 		ctx,
 		tpl.User.GetUserset().Namespace,
 		tpl.User.GetUserset().Relation,
 		true, // Allow Ellipsis
 		revision,
+		nsm,
 	); err != nil {
 		return err
 	}
 
-	_, ts, err := nsm.ReadNamespaceAndTypes(ctx, tpl.ObjectAndRelation.Namespace, revision)
+	_, ts, err := namespace.ReadNamespaceAndTypes(ctx, tpl.ObjectAndRelation.Namespace, revision, nsm)
 	if err != nil {
 		return err
 	}

--- a/internal/services/v0/watch.go
+++ b/internal/services/v0/watch.go
@@ -59,7 +59,7 @@ func (ws *watchServer) Watch(req *v0.WatchRequest, stream v0.WatchService_WatchS
 
 	namespaceMap := make(map[string]struct{})
 	for _, ns := range req.Namespaces {
-		err := ws.nsm.CheckNamespaceAndRelation(ctx, ns, datastore.Ellipsis, true, afterRevision)
+		err := namespace.CheckNamespaceAndRelation(ctx, ns, datastore.Ellipsis, true, afterRevision, ws.nsm)
 		if err != nil {
 			return status.Errorf(codes.FailedPrecondition, "invalid namespace: %s", err)
 		}

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -66,7 +66,7 @@ type permissionServer struct {
 func (ps *permissionServer) checkFilterComponent(ctx context.Context, objectType, optionalRelation string, revision decimal.Decimal) error {
 	relationToTest := stringz.DefaultEmpty(optionalRelation, datastore.Ellipsis)
 	allowEllipsis := optionalRelation == ""
-	return ps.nsm.CheckNamespaceAndRelation(ctx, objectType, relationToTest, allowEllipsis, revision)
+	return namespace.CheckNamespaceAndRelation(ctx, objectType, relationToTest, allowEllipsis, revision, ps.nsm)
 }
 
 func (ps *permissionServer) checkFilterNamespaces(ctx context.Context, filter *v1.RelationshipFilter, revision decimal.Decimal) error {
@@ -169,27 +169,29 @@ func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.Writ
 				return err
 			}
 
-			if err := ps.nsm.CheckNamespaceAndRelation(
+			if err := namespace.CheckNamespaceAndRelation(
 				groupCtx,
 				update.Relationship.Resource.ObjectType,
 				update.Relationship.Relation,
 				false,
 				readRevision,
+				ps.nsm,
 			); err != nil {
 				return err
 			}
 
-			if err := ps.nsm.CheckNamespaceAndRelation(
+			if err := namespace.CheckNamespaceAndRelation(
 				groupCtx,
 				update.Relationship.Subject.Object.ObjectType,
 				stringz.DefaultEmpty(update.Relationship.Subject.OptionalRelation, datastore.Ellipsis),
 				true,
 				readRevision,
+				ps.nsm,
 			); err != nil {
 				return err
 			}
 
-			_, ts, err := ps.nsm.ReadNamespaceAndTypes(groupCtx, update.Relationship.Resource.ObjectType, readRevision)
+			_, ts, err := namespace.ReadNamespaceAndTypes(groupCtx, update.Relationship.Resource.ObjectType, readRevision, ps.nsm)
 			if err != nil {
 				return err
 			}

--- a/pkg/development/internal.go
+++ b/pkg/development/internal.go
@@ -33,12 +33,13 @@ func validateTupleWrite(
 		return err
 	}
 
-	if err := nsm.CheckNamespaceAndRelation(
+	if err := namespace.CheckNamespaceAndRelation(
 		ctx,
 		tpl.ObjectAndRelation.Namespace,
 		tpl.ObjectAndRelation.Relation,
 		false, // Disallow ellipsis
 		revision,
+		nsm,
 	); err != nil {
 		return err
 	}
@@ -54,17 +55,18 @@ func validateTupleWrite(
 		}
 	}
 
-	if err := nsm.CheckNamespaceAndRelation(
+	if err := namespace.CheckNamespaceAndRelation(
 		ctx,
 		tpl.User.GetUserset().Namespace,
 		tpl.User.GetUserset().Relation,
 		true, // Allow Ellipsis
 		revision,
+		nsm,
 	); err != nil {
 		return err
 	}
 
-	_, ts, err := nsm.ReadNamespaceAndTypes(ctx, tpl.ObjectAndRelation.Namespace, revision)
+	_, ts, err := namespace.ReadNamespaceAndTypes(ctx, tpl.ObjectAndRelation.Namespace, revision, nsm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
All other methods are moved into utility methods, as their implementations are shared