### PR TITLE
sets mysql manager singleton

### DIFF
--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -82,6 +82,7 @@ func migrateRun(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			log.Fatal().Err(err).Msg("unable to create migration driver")
 		}
+		manager = mysqlmigrations.Manager
 	} else {
 		return fmt.Errorf("cannot migrate datastore engine type: %s", datastoreEngine)
 	}


### PR DESCRIPTION
Follow up to https://github.com/authzed/spicedb/pull/532

# What

fixes bug where the MySQL migration manager singleton was not selected when using `spicedb migrate` for the MySQL datastore

# Notes

`spicedb migrate` command has not tests whatsoever and I wonder if its worth adding some very basic smoke tests?