### PR TITLE
Fix revive lint warnings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,9 +48,6 @@ linters:
     - "whitespace"
 issues:
   exclude-rules:
-    - path: "pkg/namespace"
-      linters:
-        - "revive"
     - text: "tx.Rollback()"
       linters:
         - "errcheck"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,9 +48,6 @@ linters:
     - "whitespace"
 issues:
   exclude-rules:
-    - path: "internal/namespace"
-      linters:
-        - "revive"
     - path: "pkg/namespace"
       linters:
         - "revive"

--- a/internal/graph/lookup.go
+++ b/internal/graph/lookup.go
@@ -272,7 +272,7 @@ func (cl *ConcurrentLookup) lookupInternal(ctx context.Context, req ValidatedLoo
 	return returnResult(lookupResult(req, limitedSlice(objSet.AsSlice(), req.Limit), responseMetadata))
 }
 
-func (cl *ConcurrentLookup) lookupDirect(ctx context.Context, req ValidatedLookupRequest, typeSystem *namespace.NamespaceTypeSystem) ReduceableLookupFunc {
+func (cl *ConcurrentLookup) lookupDirect(ctx context.Context, req ValidatedLookupRequest, typeSystem *namespace.TypeSystem) ReduceableLookupFunc {
 	requests := []ReduceableLookupFunc{}
 
 	// Ensure type informatione exists on the relation.
@@ -473,7 +473,7 @@ func (cl *ConcurrentLookup) lookupDirect(ctx context.Context, req ValidatedLooku
 	}
 }
 
-func (cl *ConcurrentLookup) processRewrite(ctx context.Context, req ValidatedLookupRequest, nsdef *core.NamespaceDefinition, typeSystem *namespace.NamespaceTypeSystem, usr *core.UsersetRewrite) ReduceableLookupFunc {
+func (cl *ConcurrentLookup) processRewrite(ctx context.Context, req ValidatedLookupRequest, nsdef *core.NamespaceDefinition, typeSystem *namespace.TypeSystem, usr *core.UsersetRewrite) ReduceableLookupFunc {
 	switch rw := usr.RewriteOperation.(type) {
 	case *core.UsersetRewrite_Union:
 		return cl.processSetOperation(ctx, req, nsdef, typeSystem, rw.Union, lookupAny)
@@ -486,7 +486,7 @@ func (cl *ConcurrentLookup) processRewrite(ctx context.Context, req ValidatedLoo
 	}
 }
 
-func (cl *ConcurrentLookup) processSetOperation(ctx context.Context, req ValidatedLookupRequest, nsdef *core.NamespaceDefinition, typeSystem *namespace.NamespaceTypeSystem, so *core.SetOperation, reducer LookupReducer) ReduceableLookupFunc {
+func (cl *ConcurrentLookup) processSetOperation(ctx context.Context, req ValidatedLookupRequest, nsdef *core.NamespaceDefinition, typeSystem *namespace.TypeSystem, so *core.SetOperation, reducer LookupReducer) ReduceableLookupFunc {
 	var requests []ReduceableLookupFunc
 
 	for _, childOneof := range so.Child {
@@ -529,7 +529,7 @@ func findRelation(nsdef *core.NamespaceDefinition, relationName string) (*core.R
 	return nil, false
 }
 
-func (cl *ConcurrentLookup) processTupleToUserset(ctx context.Context, req ValidatedLookupRequest, nsdef *core.NamespaceDefinition, typeSystem *namespace.NamespaceTypeSystem, ttu *core.TupleToUserset) ReduceableLookupFunc {
+func (cl *ConcurrentLookup) processTupleToUserset(ctx context.Context, req ValidatedLookupRequest, nsdef *core.NamespaceDefinition, typeSystem *namespace.TypeSystem, ttu *core.TupleToUserset) ReduceableLookupFunc {
 	// Ensure that we don't process TTUs recursively, as that can cause an infinite loop.
 	nr := &core.RelationReference{
 		Namespace: req.ObjectRelation.Namespace,

--- a/internal/namespace/caching.go
+++ b/internal/namespace/caching.go
@@ -64,7 +64,7 @@ func NewNonCachingNamespaceManager() Manager {
 	return &cachingManager{c: noCache{}}
 }
 
-func (nsc *cachingManager) ReadNamespaceAndTypes(ctx context.Context, nsName string, revision decimal.Decimal) (*core.NamespaceDefinition, *NamespaceTypeSystem, error) {
+func (nsc *cachingManager) ReadNamespaceAndTypes(ctx context.Context, nsName string, revision decimal.Decimal) (*core.NamespaceDefinition, *TypeSystem, error) {
 	nsDef, err := nsc.ReadNamespace(ctx, nsName, revision)
 	if err != nil {
 		return nsDef, nil, err

--- a/internal/namespace/diff.go
+++ b/internal/namespace/diff.go
@@ -48,15 +48,15 @@ const (
 	RelationDirectWildcardTypeRemoved DeltaType = "relation-wildcard-type-removed"
 )
 
-// NamespaceDiff holds the diff between two namespaces.
-type NamespaceDiff struct {
+// Diff holds the diff between two namespaces.
+type Diff struct {
 	existing *core.NamespaceDefinition
 	updated  *core.NamespaceDefinition
 	deltas   []Delta
 }
 
 // Deltas returns the deltas between the two namespaces.
-func (nd NamespaceDiff) Deltas() []Delta {
+func (nd Diff) Deltas() []Delta {
 	return nd.deltas
 }
 
@@ -76,14 +76,14 @@ type Delta struct {
 
 // DiffNamespaces performs a diff between two namespace definitions. One or both of the definitions
 // can be `nil`, which will be treated as an add/remove as applicable.
-func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceDefinition) (*NamespaceDiff, error) {
+func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceDefinition) (*Diff, error) {
 	// Check for the namespaces themselves.
 	if existing == nil && updated == nil {
-		return &NamespaceDiff{existing, updated, []Delta{}}, nil
+		return &Diff{existing, updated, []Delta{}}, nil
 	}
 
 	if existing != nil && updated == nil {
-		return &NamespaceDiff{
+		return &Diff{
 			existing: existing,
 			updated:  updated,
 			deltas: []Delta{
@@ -95,7 +95,7 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 	}
 
 	if existing == nil && updated != nil {
-		return &NamespaceDiff{
+		return &Diff{
 			existing: existing,
 			updated:  updated,
 			deltas: []Delta{
@@ -253,7 +253,7 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 		}
 	}
 
-	return &NamespaceDiff{
+	return &Diff{
 		existing: existing,
 		updated:  updated,
 		deltas:   deltas,

--- a/internal/namespace/manager.go
+++ b/internal/namespace/manager.go
@@ -36,7 +36,7 @@ type Manager interface {
 	CheckNamespaceAndRelation(ctx context.Context, namespace, relation string, allowEllipsis bool, revision decimal.Decimal) error
 
 	// ReadNamespaceAndTypes reads a namespace definition, version, and type system and returns it if found.
-	ReadNamespaceAndTypes(ctx context.Context, nsName string, revision decimal.Decimal) (*core.NamespaceDefinition, *NamespaceTypeSystem, error)
+	ReadNamespaceAndTypes(ctx context.Context, nsName string, revision decimal.Decimal) (*core.NamespaceDefinition, *TypeSystem, error)
 
 	// Close closes the namespace manager, disposing of any resources.
 	//

--- a/pkg/namespace/builder.go
+++ b/pkg/namespace/builder.go
@@ -14,8 +14,8 @@ func Namespace(name string, relations ...*core.Relation) *core.NamespaceDefiniti
 	}
 }
 
-// NamespaceWithComment creates a namespace definition with one or more defined relations.
-func NamespaceWithComment(name string, comment string, relations ...*core.Relation) *core.NamespaceDefinition {
+// WithComment creates a namespace definition with one or more defined relations.
+func WithComment(name string, comment string, relations ...*core.Relation) *core.NamespaceDefinition {
 	nd := Namespace(name, relations...)
 	nd.Metadata, _ = AddComment(nd.Metadata, comment)
 	return nd

--- a/pkg/schemadsl/compiler/compiler_test.go
+++ b/pkg/schemadsl/compiler/compiler_test.go
@@ -488,10 +488,10 @@ func TestCompile(t *testing.T) {
 			}`,
 			"",
 			[]*core.NamespaceDefinition{
-				namespace.NamespaceWithComment("sometenant/user", `/**
+				namespace.WithComment("sometenant/user", `/**
 * user is a user
 */`),
-				namespace.NamespaceWithComment("sometenant/single", `/**
+				namespace.WithComment("sometenant/single", `/**
 * single is a thing
 */`,
 					namespace.RelationWithComment("first", `/**

--- a/pkg/schemadsl/generator/generator_test.go
+++ b/pkg/schemadsl/generator/generator_test.go
@@ -114,7 +114,7 @@ func TestGenerator(t *testing.T) {
 
 		{
 			"full example",
-			namespace.NamespaceWithComment("foos/document", `/**
+			namespace.WithComment("foos/document", `/**
 * Some comment goes here
 */`,
 				namespace.Relation("owner", nil,


### PR DESCRIPTION
This is related to issue https://github.com/authzed/spicedb/issues/36

All issues involve renaming function to drop a prefix corresponding to the package name.
The fix has been done automatically with a refactoring tool.

This creates a change in the public API as namespace.NamespaceWithComment is renamed to namespace.WithComment.
