### PR TITLE
Fix `datastore-engine` help text

### DIFF
--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -87,7 +89,14 @@ type Config struct {
 
 // RegisterDatastoreFlags adds datastore flags to a cobra command
 func RegisterDatastoreFlags(cmd *cobra.Command, opts *Config) {
-	cmd.Flags().StringVar(&opts.Engine, "datastore-engine", "memory", `type of datastore to initialize ("memory", "postgres", "cockroachdb", "spanner")`)
+	engines := []string{}
+	for engine := range BuilderForEngine {
+		engines = append(engines, fmt.Sprintf("%q", engine))
+	}
+	sort.Strings(engines) // Sort for stability.
+	egineOpts := strings.Join(engines, ", ")
+
+	cmd.Flags().StringVar(&opts.Engine, "datastore-engine", "memory", fmt.Sprintf(`type of datastore to initialize (%s)`, egineOpts))
 	cmd.Flags().StringVar(&opts.URI, "datastore-conn-uri", "", `connection string used by remote datastores (e.g. "postgres://postgres:password@localhost:5432/spicedb")`)
 	cmd.Flags().IntVar(&opts.MaxOpenConns, "datastore-conn-max-open", 20, "number of concurrent connections open in a remote datastore's connection pool")
 	cmd.Flags().IntVar(&opts.MinOpenConns, "datastore-conn-min-open", 10, "number of minimum concurrent connections open in a remote datastore's connection pool")


### PR DESCRIPTION
The `datastore-engine` flag doesn't include MySQL as an option, even though it is legal to select. This PR adds it to the example list.

Also, instead of hard-coding all the possible datastores, I sorted the keys in `BuilderForEngine` and displayed them. This way, any new datastore will automatically get added to the options list and there won't be any accidental drift.

Before:

```
--datastore-engine string    type of datastore to initialize ("memory", "postgres", "cockroachdb", "spanner") (default "memory")
```

After:

```
--datastore-engine string    type of datastore to initialize ("cockroachdb", "memory", "mysql", "postgres", "spanner") (default "memory")
```