### PR TITLE
addresses server panic when malformed authorization header is sent

### DIFF
--- a/internal/auth/presharedkey.go
+++ b/internal/auth/presharedkey.go
@@ -9,8 +9,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const errInvalidPresharedKey = "invalid preshared key: %s"
-const errMissingPresharedKey = "missing preshared key"
+const (
+	errInvalidPresharedKey = "invalid preshared key: %s"
+	errMissingPresharedKey = "missing preshared key"
+)
 
 var errInvalidToken = "invalid token"
 

--- a/internal/auth/presharedkey.go
+++ b/internal/auth/presharedkey.go
@@ -10,6 +10,7 @@ import (
 )
 
 const errInvalidPresharedKey = "invalid preshared key: %s"
+const errMissingPresharedKey = "missing preshared key"
 
 var errInvalidToken = "invalid token"
 
@@ -33,7 +34,7 @@ func RequirePresharedKey(presharedKeys []string) grpcauth.AuthFunc {
 		}
 
 		if token == "" {
-			return nil, status.Errorf(codes.Unauthenticated, errInvalidPresharedKey, err.Error())
+			return nil, status.Errorf(codes.Unauthenticated, errMissingPresharedKey)
 		}
 
 		for _, presharedKey := range presharedKeys {

--- a/internal/auth/presharedkey_test.go
+++ b/internal/auth/presharedkey_test.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/authzed/grpcutil"
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestMultiplePresharedKeys(t *testing.T) {
+	f := RequirePresharedKey([]string{"one", "two"})
+	_, err := f(contextWithBearerToken("one"))
+	require.NoError(t, err)
+	_, err = f(contextWithBearerToken("two"))
+	require.NoError(t, err)
+}
+
+func TestWrongKey(t *testing.T) {
+	f := RequirePresharedKey([]string{"one", "two"})
+	_, err := f(contextWithBearerToken("three"))
+	require.Error(t, err)
+	grpcutil.RequireStatus(t, codes.PermissionDenied, err)
+}
+
+func TestMissingKey(t *testing.T) {
+	f := RequirePresharedKey([]string{"one", "two"})
+	_, err := f(contextWithBearerToken(""))
+	require.Error(t, err)
+	grpcutil.RequireStatus(t, codes.Unauthenticated, err)
+}
+
+func TestAuthorizationHeader(t *testing.T) {
+	f := RequirePresharedKey([]string{"one", "two"})
+	_, err := f(context.Background())
+	require.Error(t, err)
+	grpcutil.RequireStatus(t, codes.Unauthenticated, err)
+}
+
+func contextWithBearerToken(token string) context.Context {
+	md := metadata.Pairs("authorization", fmt.Sprintf("bearer %s", token))
+	return metautils.NiceMD(md).ToIncoming(context.Background())
+}


### PR DESCRIPTION
👋🏻 Good day good people of the land of authorization, a quick fix!

# What

addresses a server panic when a request with a malformed authorization header is received

# How

- added missing tests to the `presharedkey.go` file, including one that reproduces the problem
- adjusts the `status.Errorf` call that panics
