### PR TITLE
pg: set timezone to utc for revision selection

### DIFF
--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -6,6 +6,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -574,6 +575,10 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 			defer ds.Close()
 
 			tx, err := conn.Begin(ctx)
+			require.NoError(err)
+
+			// set a random time zone to ensure the queries are unaffect by tz
+			_, err = tx.Exec(ctx, fmt.Sprintf("SET TIME ZONE -%d", rand.Intn(8)+1))
 			require.NoError(err)
 
 			var dbNow time.Time

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -28,7 +28,7 @@ const (
 	//   %[4] Quantization period (in nanoseconds)
 	querySelectRevision = `
 	SELECT COALESCE(
-		(SELECT MIN(%[1]s) FROM %[2]s WHERE %[3]s >= TO_TIMESTAMP(FLOOR(EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'utc') * 1000000000 / %[4]d) * %[4]d / 1000000000)),
+		(SELECT MIN(%[1]s) FROM %[2]s WHERE %[3]s >= TO_TIMESTAMP(FLOOR(EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'utc') * 1000000000 / %[4]d) * %[4]d / 1000000000) AT TIME ZONE 'utc'),
 		(SELECT MAX(%[1]s) FROM %[2]s)
 	),
 	%[4]d - CAST(EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'utc') * 1000000000 as bigint) %% %[4]d;`


### PR DESCRIPTION
I noticed this when reviewing #582

It looks like this does make a difference if the db has a timezone set: https://dbfiddle.uk/?rdbms=postgres_14&fiddle=a63a65dd0d6b02c771a2ad2a1d4ffa88