### PR TITLE
Follow-up adding CLI options to mysql datastore

### DIFF
--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -124,7 +124,7 @@ func NewMySQLDatastore(uri string, options ...Option) (*Datastore, error) {
 	gcCtx, cancelGc := context.WithCancel(context.Background())
 	querySplitter := common.TupleQuerySplitter{
 		Executor:         newMySQLExecutor(db),
-		UsersetBatchSize: config.splitAtUsersetCount,
+		UsersetBatchSize: int(config.splitAtUsersetCount),
 	}
 
 	maxRevisionStaleness := time.Duration(float64(config.revisionQuantization.Nanoseconds())*

--- a/internal/datastore/mysql/options.go
+++ b/internal/datastore/mysql/options.go
@@ -33,7 +33,7 @@ type mysqlOptions struct {
 	maxOpenConns                int
 	connMaxIdleTime             time.Duration
 	connMaxLifetime             time.Duration
-	splitAtUsersetCount         int
+	splitAtUsersetCount         uint16
 	analyzeBeforeStats          bool
 }
 
@@ -122,6 +122,16 @@ func GCInterval(interval time.Duration) Option {
 	}
 }
 
+// GCMaxOperationTime is the maximum operation time of a garbage collection
+// pass before it times out.
+//
+// This value defaults to 1 minute.
+func GCMaxOperationTime(time time.Duration) Option {
+	return func(mo *mysqlOptions) {
+		mo.gcMaxOperationTime = time
+	}
+}
+
 // TablePrefix allows defining a MySQL table name prefix.
 //
 // No prefix is set by default
@@ -138,6 +148,16 @@ func TablePrefix(prefix string) Option {
 func WithEnablePrometheusStats(enablePrometheusStats bool) Option {
 	return func(mo *mysqlOptions) {
 		mo.enablePrometheusStats = enablePrometheusStats
+	}
+}
+
+// SplitAtUsersetCount is the batch size for which userset queries will be
+// split into smaller queries.
+//
+// This defaults to 1024.
+func SplitAtUsersetCount(splitAtUsersetCount uint16) Option {
+	return func(mo *mysqlOptions) {
+		mo.splitAtUsersetCount = splitAtUsersetCount
 	}
 }
 
@@ -179,7 +199,7 @@ func MaxOpenConns(conns int) Option {
 //
 // Disabled by default.
 func DebugAnalyzeBeforeStatistics() Option {
-	return func(po *mysqlOptions) {
-		po.analyzeBeforeStats = true
+	return func(mo *mysqlOptions) {
+		mo.analyzeBeforeStats = true
 	}
 }


### PR DESCRIPTION
This is a Follow-up PR from the MySQL Datastore implementation.

It updates the `SplitQueryCount` because that is what is being fetched from `cobra`.

The following CLI options are now supported by the MySQL Datastore:

- `SplitAtUsersetCount`
- `GCMaxOperationTime`


Authors: @bryanhuhta and @cjs