### PR TITLE
Update NewEnemy test for datastore v2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,6 +29,9 @@ jobs:
         with:
           go-version: "~1.18"
       - uses: "authzed/actions/gofumpt@main"
+      - uses: "authzed/actions/gofumpt@main"
+        with:
+          working_directory: "e2e"
       - uses: "authzed/actions/go-mod-tidy@main"
       - uses: "authzed/actions/go-mod-tidy@main"
         with:
@@ -38,6 +41,9 @@ jobs:
           working_directory: "tools/analyzers"
       - uses: "authzed/actions/go-generate@main"
       - uses: "authzed/actions/golangci-lint@main"
+      - uses: "authzed/actions/golangci-lint@main"
+        with:
+          working_directory: "e2e"
       - uses: "authzed/actions/go-build@main"
         with:
           working_directory: "tools/analyzers"

--- a/e2e/cockroach/cockroach.go
+++ b/e2e/cockroach/cockroach.go
@@ -139,11 +139,13 @@ func (cs Cluster) Started() bool {
 // Init runs the cockroach init command against the cluster
 func (cs Cluster) Init(ctx context.Context, out, errOut io.Writer) {
 	// this retries until it succeeds, it won't return unless it does
-	e2e.Run(ctx, out, errOut, "./cockroach",
+	if err := e2e.Run(ctx, out, errOut, "./cockroach",
 		"init",
 		"--insecure",
 		"--host="+cs[0].Addr,
-	)
+	); err != nil {
+		panic(err)
+	}
 }
 
 // SQL runs the set of SQL commands against the cluster

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rs/zerolog v1.26.1 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -65,7 +65,6 @@ github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/dave/astrid v0.0.0-20170323122508-8c2895878b14/go.mod h1:Sth2QfxfATb/nW4EsrSi2KyJmbcniZ8TgTaji17D6ms=
 github.com/dave/brenda v1.1.0/go.mod h1:4wCUr6gSlu5/1Tk7akE5X7UorwiQ8Rij0SKH3/BGMOM=
@@ -104,7 +103,6 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -264,11 +262,9 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
-github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=
-github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
@@ -296,7 +292,6 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -326,7 +321,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f h1:OeJjE6G4dgCY4PIXvIRQbE8+RX+uXZyGhUy/ksMGJoc=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -395,7 +389,6 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -458,7 +451,6 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -529,7 +521,6 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=

--- a/e2e/newenemy/newenemy_test.go
+++ b/e2e/newenemy/newenemy_test.go
@@ -14,7 +14,6 @@ import (
 	"text/template"
 	"time"
 
-	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/authzed-go/proto/authzed/api/v1alpha1"
 	"github.com/jackc/pgtype"
@@ -25,38 +24,41 @@ import (
 	"github.com/authzed/spicedb/e2e/cockroach"
 	"github.com/authzed/spicedb/e2e/generator"
 	"github.com/authzed/spicedb/e2e/spice"
-	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/zedtoken"
-	"github.com/authzed/spicedb/pkg/zookie"
 )
 
+type NamespaceNames struct {
+	Allowlist string
+	Blocklist string
+	User      string
+	Resource  string
+}
+
 type SchemaData struct {
-	Prefixes []string
+	Namespaces []NamespaceNames
 }
-
-const schemaText = `
-{{ range .Prefixes }}
-definition {{.}}/user {}
-definition {{.}}/resource {
-	relation direct: {{.}}/user
-	relation excluded: {{.}}/user
-	permission allowed = direct - excluded
-}
-{{ end }}
-`
-
-const schemaAllowAllText = `
-{{ range .Prefixes }}
-definition {{.}}/user {}
-definition {{.}}/resource {
-	relation direct: {{.}}/user
-	relation excluded: {{.}}/user
-	permission allowed = direct
-}
-{{ end }}
-`
 
 const (
+	schemaText = `
+{{ range .Namespaces }}
+
+definition {{.User}} {}
+
+definition {{.Blocklist}} {
+   relation user: {{.User}}
+}
+
+definition {{.Allowlist}} {
+   relation user: {{.User}}
+}
+
+definition {{.Resource}} {
+	relation direct: {{.Allowlist}}
+	relation excluded: {{.Blocklist}}
+	permission allowed = direct->user - excluded->user
+}
+{{ end }}
+`
 	objIDRegex           = "[a-zA-Z0-9_][a-zA-Z0-9/_-]{0,127}"
 	namespacePrefixRegex = "[a-z][a-z0-9_]{1,62}[a-z0-9]"
 )
@@ -65,8 +67,6 @@ var (
 	maxIterations = flag.Int("max-iterations", 1000, "iteration cap for statistic-based tests (0 for no limit)")
 
 	schemaTpl       = template.Must(template.New("schema").Parse(schemaText))
-	schemaAllowTpl  = template.Must(template.New("schema_allow").Parse(schemaAllowAllText))
-	objIdGenerator  = generator.NewUniqueGenerator(objIDRegex)
 	prefixGenerator = generator.NewUniqueGenerator(namespacePrefixRegex)
 
 	testCtx context.Context
@@ -82,7 +82,7 @@ func TestMain(m *testing.M) {
 
 const (
 	createDb       = "CREATE DATABASE %s;"
-	setSmallRanges = "ALTER DATABASE %s CONFIGURE ZONE USING range_min_bytes = 0, range_max_bytes = 65536, num_replicas = 1, gc.ttlseconds = 5;"
+	setSmallRanges = "ALTER DATABASE %s CONFIGURE ZONE USING range_min_bytes = 0, range_max_bytes = 65536, num_replicas = 1, gc.ttlseconds = 10;"
 	dbName         = "spicedbnetest"
 )
 
@@ -157,11 +157,11 @@ func TestNoNewEnemy(t *testing.T) {
 	// seems to make the test converge faster
 	schemaData := generateSchemaData(4000, 500)
 	fillSchema(t, schemaTpl, schemaData, vulnerableSpiceDb[1].Client().V1Alpha1().Schema())
-	slowNodeId, err := crdb[1].NodeID(ctx)
+	slowNodeID, err := crdb[1].NodeID(ctx)
 	require.NoError(t, err)
 
 	t.Log("modifying time")
-	require.NoError(t, crdb.TimeDelay(ctx, e2e.MustFile(ctx, t, "timeattack-1.log"), 1, -150*time.Millisecond))
+	require.NoError(t, crdb.TimeDelay(ctx, e2e.MustFile(ctx, t, "timeattack-1.log"), 1, -200*time.Millisecond))
 
 	tests := []struct {
 		name            string
@@ -171,32 +171,21 @@ func TestNoNewEnemy(t *testing.T) {
 		sampleSize      int
 	}{
 		{
-			name: "protected from schema newenemy",
-			vulnerableProbe: func(count int) (bool, int) {
-				return checkSchemaNoNewEnemy(ctx, t, schemaData, slowNodeId, crdb, vulnerableSpiceDb, count)
-			},
-			protectedProbe: func(count int) (bool, int) {
-				return checkSchemaNoNewEnemy(ctx, t, schemaData, slowNodeId, crdb, protectedSpiceDb, count)
-			},
-			vulnerableMax: 100,
-			sampleSize:    5,
-		},
-		{
 			name: "protected from data newenemy",
 			vulnerableProbe: func(count int) (bool, int) {
-				return checkDataNoNewEnemy(ctx, t, schemaData, slowNodeId, crdb, vulnerableSpiceDb, count)
+				return checkDataNoNewEnemy(ctx, t, slowNodeID, crdb, vulnerableSpiceDb, count, true)
 			},
 			protectedProbe: func(count int) (bool, int) {
-				return checkDataNoNewEnemy(ctx, t, schemaData, slowNodeId, crdb, protectedSpiceDb, count)
+				return checkDataNoNewEnemy(ctx, t, slowNodeID, crdb, protectedSpiceDb, count, false)
 			},
-			vulnerableMax: 100,
+			vulnerableMax: 20,
 			sampleSize:    5,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vulnerableFn, protectedFn := attemptFnsForProbeFns(20, tt.vulnerableProbe, tt.protectedProbe)
-			statTest(t, 5, vulnerableFn, protectedFn)
+			vulnerableFn, protectedFn := attemptFnsForProbeFns(tt.vulnerableMax, tt.vulnerableProbe, tt.protectedProbe)
+			statTest(t, tt.sampleSize, vulnerableFn, protectedFn)
 		})
 	}
 }
@@ -287,262 +276,126 @@ func iterationsForHighConfidence(samples []int) (iterations int) {
 	return
 }
 
-// checkDataNoNewEnemy returns true if the service is protected and false if it
-// is vulnerable.
-//
-// This subtest ensures protection from a "data-based" newenemy problem:
-//
-// 1. Use this schema:
-//      definition user {}
-//      definition resource {
-//	      relation direct: user
-//	      relation excluded: user
-//	      permission allowed = direct - excluded
-//      }
-// 2. Write resource:1#excluded@user:A
-// 3. Write resource:2#direct:@user:A
-// 4. If the timestamp from (3) is before the timestamp for (2), then:
-//       check(resource:1#allowed@user:A)
-//    may succeed, when it should fail. The timestamps can be reversed
-//    if the tx overlap protections are disabled, because cockroach only
-//    ensures overlapping transactions are linearizable.
-func checkDataNoNewEnemy(ctx context.Context, t testing.TB, schemaData []SchemaData, slowNodeId int, crdb cockroach.Cluster, spicedb spice.Cluster, maxAttempts int) (bool, int) {
-	prefix := prefixForNode(ctx, crdb[1].Conn(), schemaData, slowNodeId)
+func checkDataNoNewEnemy(ctx context.Context, t testing.TB, slowNodeID int, crdb cockroach.Cluster, spicedb spice.Cluster, maxAttempts int, exitEarly bool) (bool, int) {
+	prefix := namespacesForNode(ctx, t, crdb[1].Conn(), spicedb[0].Client().V1Alpha1().Schema(), slowNodeID)
 	t.Log("filling with data to span multiple ranges for prefix", prefix)
-	fill(ctx, t, spicedb[0].Client().V0().ACL(), prefix, 500, 100)
+	objIDGenerator := generator.NewUniqueGenerator(objIDRegex)
+	fill(ctx, t, spicedb[0].Client().V1().Permissions(), prefix, objIDGenerator, 100, 100)
+	allowlists, blocklists, allowusers, blockusers := generateTuples(prefix, maxAttempts, objIDGenerator)
 
-	for attempts := 1; attempts <= maxAttempts; attempts++ {
-		direct, exclude := generateTuple(prefix, objIdGenerator)
+	// write prereqs
+	for i := 0; i < maxAttempts; i++ {
+		_, err := spicedb[0].Client().V1().Permissions().WriteRelationships(ctx, &v1.WriteRelationshipsRequest{
+			Updates: []*v1.RelationshipUpdate{allowusers[i], blocklists[i]},
+		})
+		require.NoError(t, err)
+	}
 
-		// write to node 1
-		r1, err := spicedb[0].Client().V0().ACL().Write(ctx, &v0.WriteRequest{
-			Updates: []*v0.RelationTupleUpdate{exclude},
+	time.Sleep(500 * time.Millisecond)
+
+	for i := 0; i < maxAttempts; i++ {
+		// exclude user by connecting user to blocklist
+		r1, err := spicedb[0].Client().V1().Permissions().WriteRelationships(ctx, &v1.WriteRelationshipsRequest{
+			Updates: []*v1.RelationshipUpdate{blockusers[i]},
 		})
 		require.NoError(t, err)
 
-		// the first write has to read the namespaces from the second node,
-		// which will resync the timestamps. sleeping allows the clocks to get
-		// back out of sync
-		time.Sleep(100 * time.Millisecond)
+		// sleeping in between the writes seems to let cockroach clear out
+		// pending transactions in the background and has a better chance
+		// of a clock desync on the second write
+		sleep := (time.Duration(i) * 10) % 100 * time.Millisecond
+		time.Sleep(sleep)
 
 		// write to node 2 (clock is behind)
-		r2, err := spicedb[1].Client().V0().ACL().Write(ctx, &v0.WriteRequest{
-			Updates: []*v0.RelationTupleUpdate{direct},
+		// allow user by adding allowlist to resource
+		r2, err := spicedb[1].Client().V1().Permissions().WriteRelationships(ctx, &v1.WriteRelationshipsRequest{
+			Updates: []*v1.RelationshipUpdate{allowlists[i]},
 		})
 		require.NoError(t, err)
 
-		canHas, err := spicedb[1].Client().V0().ACL().Check(context.Background(), &v0.CheckRequest{
-			TestUserset: &v0.ObjectAndRelation{
-				Namespace: direct.Tuple.ObjectAndRelation.Namespace,
-				ObjectId:  direct.Tuple.ObjectAndRelation.ObjectId,
-				Relation:  "allowed",
+		canHas, err := spicedb[1].Client().V1().Permissions().CheckPermission(context.Background(), &v1.CheckPermissionRequest{
+			Consistency: &v1.Consistency{Requirement: &v1.Consistency_AtExactSnapshot{AtExactSnapshot: r2.WrittenAt}},
+			Resource: &v1.ObjectReference{
+				ObjectType: allowlists[i].Relationship.Resource.ObjectType,
+				ObjectId:   allowlists[i].Relationship.Resource.ObjectId,
 			},
-			User:       direct.Tuple.GetUser(),
-			AtRevision: r2.GetRevision(),
+			Permission: "allowed",
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: allowusers[i].Relationship.Subject.Object.ObjectType,
+					ObjectId:   allowusers[i].Relationship.Subject.Object.ObjectId,
+				},
+			},
 		})
 		require.NoError(t, err)
 
-		r1leader, r2leader := getLeaderNode(ctx, crdb[1].Conn(), exclude.Tuple), getLeaderNode(ctx, crdb[1].Conn(), direct.Tuple)
-		ns1Leader := getLeaderNodeForNamespace(ctx, crdb[1].Conn(), exclude.Tuple.ObjectAndRelation.Namespace)
-		ns2Leader := getLeaderNodeForNamespace(ctx, crdb[1].Conn(), exclude.Tuple.User.GetUserset().Namespace)
-		z1, _ := zookie.DecodeRevision(core.ToCoreZookie(r1.GetRevision()))
-		z2, _ := zookie.DecodeRevision(core.ToCoreZookie(r2.GetRevision()))
-		t.Log(z1, z2, z1.Sub(z2).String(), r1leader, r2leader, ns1Leader, ns2Leader)
+		ns1BlocklistLeader := getLeaderNodeForNamespace(ctx, crdb[2].Conn(), blockusers[i].Relationship.Resource.ObjectType)
+		ns1UserLeader := getLeaderNodeForNamespace(ctx, crdb[2].Conn(), blockusers[i].Relationship.Subject.Object.ObjectType)
+		ns2ResourceLeader := getLeaderNodeForNamespace(ctx, crdb[2].Conn(), allowlists[i].Relationship.Resource.ObjectType)
+		ns2AllowlistLeader := getLeaderNodeForNamespace(ctx, crdb[2].Conn(), allowlists[i].Relationship.Subject.Object.ObjectType)
 
-		if canHas.IsMember {
-			t.Log("service is subject to the new enemy problem")
-			return false, attempts
-		}
-
-		if ns1Leader != slowNodeId || ns2Leader != slowNodeId {
-			t.Log("namespace leader changed, pick new prefix and fill")
-			// returning true will re-run with a new prefix
-			return true, attempts
-		}
+		r1leader, r2leader := getLeaderNode(ctx, crdb[2].Conn(), blockusers[i].Relationship), getLeaderNode(ctx, crdb[2].Conn(), allowlists[i].Relationship)
+		z1, _ := zedtoken.DecodeRevision(r1.WrittenAt)
+		z2, _ := zedtoken.DecodeRevision(r2.WrittenAt)
+		t.Log(sleep, z1, z2, z1.Sub(z2).String(), r1leader, r2leader, ns1BlocklistLeader, ns1UserLeader, ns2ResourceLeader, ns2AllowlistLeader)
 
 		if z1.Sub(z2).IsPositive() {
-			t.Log("error in test, object id has been re-used.")
-			continue
+			t.Log("timestamps are reversed", canHas.Permissionship.String())
+		}
+
+		if canHas.Permissionship == v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION {
+			t.Log("service is subject to the new enemy problem")
+			return false, i + 1
+		}
+
+		if ns2ResourceLeader != slowNodeID || ns2AllowlistLeader != slowNodeID {
+			t.Log("namespace leader changed, pick new namespaces and fill")
+			// returning true will re-run with a new prefix
+			return true, i + 1
+		}
+
+		if r2leader == ns1UserLeader && i%5 == 4 && exitEarly {
+			t.Log("second write to fast node, pick new namespaces")
+			return true, i + 1
+		}
+
+		if r1leader == ns2ResourceLeader && i%5 == 4 && exitEarly {
+			t.Log("first write to slow node, pick new namespaces")
+			return true, i + 1
 		}
 
 		select {
 		case <-ctx.Done():
-			return false, attempts
+			return false, i + 1
 		default:
 			// this sleep helps the clocks get back out of sync after an attempt
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 			continue
 		}
 	}
 	return true, maxAttempts
 }
 
-// checkSchemaNoNewEnemy returns true if the service is protected, false if it
-// is vulnerable.
-//
-// This test ensures protection from a "schema and data" newenemy, i.e.
-// the new enemy conditions require linearizable changes to schema and data
-// 1. Start with this schema:
-//      definition user {}
-//      definition resource {
-//	      relation direct: user
-//	      relation excluded: user
-//	      permission allowed = direct
-//      }
-// 2. Write resource:1#direct:@user:A
-// 3. Write resource:1#excluded@user:A
-// 4. Update to this schema:
-//      definition user {}
-//      definition resource {
-//	      relation direct: user
-//	      relation excluded: user
-//	      permission allowed = direct - excluded
-//      }
-// 5. If the revision from (4) is before the timestamp for (3), then:
-//       check(revision from 3, resource:1#allowed@user:A)
-//    may fail, when it should succeed. The timestamps can be reversed
-//    if the tx overlap protections are disabled, because cockroach only
-//    ensures overlapping transactions are linearizable.
-//    In this case, we don't get an explicit revision back from the
-//    WriteSchema call, but the Schema write and the resource write are
-//    fully consistent.
-func checkSchemaNoNewEnemy(ctx context.Context, t testing.TB, schemaData []SchemaData, slowNodeId int, crdb cockroach.Cluster, spicedb spice.Cluster, maxAttempts int) (bool, int) {
-	prefix := prefixForNode(ctx, crdb[1].Conn(), schemaData, slowNodeId)
-	var b strings.Builder
-	require.NoError(t, schemaAllowTpl.Execute(&b, SchemaData{Prefixes: []string{prefix}}))
-	allowSchema := b.String()
-	b.Reset()
-	require.NoError(t, schemaTpl.Execute(&b, SchemaData{Prefixes: []string{prefix}}))
-	excludeSchema := b.String()
-
-	for attempts := 1; attempts <= maxAttempts; attempts++ {
-		direct, exclude := generateTuple(prefix, objIdGenerator)
-
-		// write the "allow" schema
-		require.NoError(t, getErr(spicedb[0].Client().V1Alpha1().Schema().WriteSchema(context.Background(), &v1alpha1.WriteSchemaRequest{
-			Schema: allowSchema,
-		})))
-
-		// write the "direct" tuple
-		require.NoError(t, getErr(spicedb[0].Client().V0().ACL().Write(ctx, &v0.WriteRequest{
-			Updates: []*v0.RelationTupleUpdate{direct},
-		})))
-
-		// write the "excludes" tuple
-		// writing to 1 primes the namespace cache on node 1 with the "allow" namespace
-		r2, err := spicedb[1].Client().V0().ACL().Write(ctx, &v0.WriteRequest{
-			Updates: []*v0.RelationTupleUpdate{exclude},
-		})
-		require.NoError(t, err)
-
-		// write the "exclude" schema. If this write hits the slow crdb node, it
-		// can get a revision in between the direct and exclude tuple writes
-		// which will cause check to fail, when it should succeed
-		require.NoError(t, getErr(spicedb[1].Client().V1Alpha1().Schema().WriteSchema(ctx, &v1alpha1.WriteSchemaRequest{
-			Schema: excludeSchema,
-		})))
-
-		rev, err := zookie.DecodeRevision(core.ToCoreZookie(r2.GetRevision()))
-		require.NoError(t, err)
-
-		var canHas *v1.CheckPermissionResponse
-		checkAccess := func() bool {
-			var err error
-
-			canHas, err = spicedb[0].Client().V1().Permissions().CheckPermission(ctx, &v1.CheckPermissionRequest{
-				Consistency: &v1.Consistency{
-					Requirement: &v1.Consistency_AtExactSnapshot{AtExactSnapshot: zedtoken.NewFromRevision(rev)},
-				},
-				Resource: &v1.ObjectReference{
-					ObjectType: direct.Tuple.ObjectAndRelation.Namespace,
-					ObjectId:   direct.Tuple.ObjectAndRelation.ObjectId,
-				},
-				Permission: "allowed",
-				Subject: &v1.SubjectReference{
-					Object: &v1.ObjectReference{
-						ObjectType: direct.Tuple.User.GetUserset().Namespace,
-						ObjectId:   direct.Tuple.User.GetUserset().ObjectId,
-					},
-				},
-			})
-			if err != nil {
-				t.Log(err)
-			}
-			return err == nil
-		}
-		require.Eventually(t, checkAccess, 10*time.Second, 10*time.Millisecond)
-
-		if canHas.Permissionship == v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION {
-			t.Log("service is subject to the new enemy problem")
-			return false, attempts
-		}
-
-		select {
-		case <-ctx.Done():
-			return false, attempts
-		default:
-			// this is not strictly needed, but helps avoid write contention
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-	}
-	return true, maxAttempts
-}
-
-func BenchmarkBatchWrites(b *testing.B) {
-	ctx, cancel := context.WithCancel(testCtx)
-	defer cancel()
-	crdb := initializeTestCRDBCluster(ctx, b)
-	spicedb := spice.NewClusterFromCockroachCluster(crdb, spice.WithDbName(dbName))
-	tlog := e2e.NewTLog(b)
-	require.NoError(b, spicedb.Start(ctx, tlog, ""))
-	require.NoError(b, spicedb.Connect(ctx, tlog))
-
-	directs, excludes := generateTuples("", b.N*20, objIdGenerator)
-	b.ResetTimer()
-	_, err := spicedb[0].Client().V0().ACL().Write(ctx, &v0.WriteRequest{
-		Updates: excludes,
-	})
-	if err != nil {
-		b.Log(err)
-	}
-	_, err = spicedb[0].Client().V0().ACL().Write(ctx, &v0.WriteRequest{
-		Updates: directs,
-	})
-	if err != nil {
-		b.Log(err)
-	}
-}
-
-func BenchmarkConflictingTupleWrites(b *testing.B) {
-	ctx, cancel := context.WithCancel(testCtx)
-	defer cancel()
-	crdb := initializeTestCRDBCluster(ctx, b)
-	spicedb := spice.NewClusterFromCockroachCluster(crdb, spice.WithDbName(dbName))
-	tlog := e2e.NewTLog(b)
-	require.NoError(b, spicedb.Start(ctx, tlog, ""))
-	require.NoError(b, spicedb.Connect(ctx, tlog))
-
-	// fill with tuples to ensure we span multiple ranges
-	fill(ctx, b, spicedb[0].Client().V0().ACL(), "", 2000, 100)
-
-	b.ResetTimer()
-
-	checkDataNoNewEnemy(ctx, b, generateSchemaData(1, 1), 1, crdb, spicedb, b.N)
-}
-
-func fill(ctx context.Context, t testing.TB, client v0.ACLServiceClient, prefix string, fillerCount, batchSize int) {
+func fill(ctx context.Context, t testing.TB, client v1.PermissionsServiceClient, prefix NamespaceNames, objIDGenerator *generator.UniqueGenerator, fillerCount, batchSize int) {
 	t.Log("filling prefix", prefix)
 	require := require.New(t)
-	directs, excludes := generateTuples(prefix, fillerCount, objIdGenerator)
+	allowlists, blocklists, allowusers, blockusers := generateTuples(prefix, fillerCount, objIDGenerator)
 	for i := 0; i < fillerCount/batchSize; i++ {
 		t.Log("filling", i*batchSize, "to", (i+1)*batchSize)
-		_, err := client.Write(ctx, &v0.WriteRequest{
-			Updates: excludes[i*batchSize : (i+1)*batchSize],
+		_, err := client.WriteRelationships(ctx, &v1.WriteRelationshipsRequest{
+			Updates: allowlists[i*batchSize : (i+1)*batchSize],
 		})
 		require.NoError(err)
-		_, err = client.Write(ctx, &v0.WriteRequest{
-			Updates: directs[i*batchSize : (i+1)*batchSize],
+		_, err = client.WriteRelationships(ctx, &v1.WriteRelationshipsRequest{
+			Updates: blocklists[i*batchSize : (i+1)*batchSize],
+		})
+		require.NoError(err)
+		_, err = client.WriteRelationships(ctx, &v1.WriteRelationshipsRequest{
+			Updates: allowusers[i*batchSize : (i+1)*batchSize],
+		})
+		require.NoError(err)
+		_, err = client.WriteRelationships(ctx, &v1.WriteRelationshipsRequest{
+			Updates: blockusers[i*batchSize : (i+1)*batchSize],
 		})
 		require.NoError(err)
 	}
@@ -551,7 +404,7 @@ func fill(ctx context.Context, t testing.TB, client v0.ACLServiceClient, prefix 
 // fillSchema generates the schema text for given SchemaData and applies it
 func fillSchema(t testing.TB, template *template.Template, data []SchemaData, schemaClient v1alpha1.SchemaServiceClient) {
 	var b strings.Builder
-	batchSize := len(data[0].Prefixes)
+	batchSize := len(data[0].Namespaces)
 	for i, d := range data {
 		t.Logf("filling %d to %d", i*batchSize, (i+1)*batchSize)
 		b.Reset()
@@ -563,22 +416,33 @@ func fillSchema(t testing.TB, template *template.Template, data []SchemaData, sc
 	}
 }
 
-// prefixForNode finds a prefix with namespace leaders on the node id
-func prefixForNode(ctx context.Context, conn *pgx.Conn, data []SchemaData, node int) string {
+// namespacesForNode finds a prefix with namespace leaders on the node id
+func namespacesForNode(ctx context.Context, t testing.TB, conn *pgx.Conn, schemaClient v1alpha1.SchemaServiceClient, node int) NamespaceNames {
 	for {
-		// get a random prefix
-		d := data[rand.Intn(len(data))]
-		candidate := d.Prefixes[rand.Intn(len(d.Prefixes))]
-		ns1 := candidate + "/user"
-		ns2 := candidate + "/resource"
-		leader1 := getLeaderNodeForNamespace(ctx, conn, ns1)
-		leader2 := getLeaderNodeForNamespace(ctx, conn, ns2)
-		if leader1 == leader2 && leader1 == node {
-			return candidate
+		newSchema := generateSchemaData(1, 1)
+		p := newSchema[0].Namespaces[0]
+		var b strings.Builder
+		require.NoError(t, schemaTpl.Execute(&b, newSchema[0]))
+		_, err := schemaClient.WriteSchema(context.Background(), &v1alpha1.WriteSchemaRequest{
+			Schema: b.String(),
+		})
+		require.NoError(t, err)
+
+		userLeader := getLeaderNodeForNamespace(ctx, conn, p.User)
+		resourceLeader := getLeaderNodeForNamespace(ctx, conn, p.Resource)
+		allowlistLeader := getLeaderNodeForNamespace(ctx, conn, p.Allowlist)
+		blocklistLeader := getLeaderNodeForNamespace(ctx, conn, p.Blocklist)
+
+		// allowlist and resource must be equal to node
+		// blocklist and user must not be equal to node
+		if blocklistLeader == userLeader && userLeader != node && allowlistLeader == resourceLeader && resourceLeader == node {
+			fmt.Println("found namespaces", p.User, userLeader, p.Resource, resourceLeader, p.Allowlist, allowlistLeader, p.Blocklist, blocklistLeader)
+			return p
 		}
+
 		select {
 		case <-ctx.Done():
-			return ""
+			return NamespaceNames{}
 		default:
 			continue
 		}
@@ -588,71 +452,107 @@ func prefixForNode(ctx context.Context, conn *pgx.Conn, data []SchemaData, node 
 func generateSchemaData(n int, batchSize int) (data []SchemaData) {
 	data = make([]SchemaData, 0, n/batchSize)
 	for i := 0; i < n/batchSize; i++ {
-		schema := SchemaData{Prefixes: make([]string, 0, batchSize)}
+		schema := SchemaData{Namespaces: make([]NamespaceNames, 0, batchSize)}
 		for j := i * batchSize; j < (i+1)*batchSize; j++ {
-			schema.Prefixes = append(schema.Prefixes, prefixGenerator.Next())
+			schema.Namespaces = append(schema.Namespaces, NamespaceNames{
+				User:      prefixGenerator.Next() + "user",
+				Resource:  prefixGenerator.Next() + "resource",
+				Allowlist: prefixGenerator.Next() + "allowlist",
+				Blocklist: prefixGenerator.Next() + "blocklist",
+			})
 		}
 		data = append(data, schema)
 	}
 	return
 }
 
-func generateTuple(prefix string, objIdGenerator *generator.UniqueGenerator) (direct *v0.RelationTupleUpdate, exclude *v0.RelationTupleUpdate) {
-	directs, excludes := generateTuples(prefix, 1, objIdGenerator)
-	return directs[0], excludes[0]
-}
+func generateTuples(names NamespaceNames, n int, objIDGenerator *generator.UniqueGenerator) (allowlists []*v1.RelationshipUpdate, blocklists []*v1.RelationshipUpdate, allowusers []*v1.RelationshipUpdate, blockusers []*v1.RelationshipUpdate) {
+	allowlists = make([]*v1.RelationshipUpdate, 0, n)
+	blocklists = make([]*v1.RelationshipUpdate, 0, n)
+	allowusers = make([]*v1.RelationshipUpdate, 0, n)
+	blockusers = make([]*v1.RelationshipUpdate, 0, n)
 
-func generateTuples(prefix string, n int, objIdGenerator *generator.UniqueGenerator) (directs []*v0.RelationTupleUpdate, excludes []*v0.RelationTupleUpdate) {
-	directs = make([]*v0.RelationTupleUpdate, 0, n)
-	excludes = make([]*v0.RelationTupleUpdate, 0, n)
 	for i := 0; i < n; i++ {
-		user := &v0.User{
-			UserOneof: &v0.User_Userset{
-				Userset: &v0.ObjectAndRelation{
-					Namespace: prefix + "/user",
-					ObjectId:  objIdGenerator.Next(),
-					Relation:  "...",
-				},
-			},
+		user := &v1.ObjectReference{
+			ObjectType: names.User,
+			ObjectId:   objIDGenerator.Next(),
 		}
-		tupleExclude := &v0.RelationTuple{
-			ObjectAndRelation: &v0.ObjectAndRelation{
-				Namespace: prefix + "/resource",
-				ObjectId:  "thegoods",
-				Relation:  "excluded",
+
+		allowlistID := objIDGenerator.Next()
+		blocklistID := objIDGenerator.Next()
+
+		tupleAllowuser := &v1.Relationship{
+			Resource: &v1.ObjectReference{
+				ObjectType: names.Allowlist,
+				ObjectId:   allowlistID,
 			},
-			User: user,
+			Relation: "user",
+			Subject:  &v1.SubjectReference{Object: user},
 		}
-		tupleDirect := &v0.RelationTuple{
-			ObjectAndRelation: &v0.ObjectAndRelation{
-				Namespace: prefix + "/resource",
-				ObjectId:  "thegoods",
-				Relation:  "direct",
+
+		tupleBlockuser := &v1.Relationship{
+			Resource: &v1.ObjectReference{
+				ObjectType: names.Blocklist,
+				ObjectId:   blocklistID,
 			},
-			User: user,
+			Relation: "user",
+			Subject:  &v1.SubjectReference{Object: user},
 		}
-		excludes = append(excludes, &v0.RelationTupleUpdate{
-			Operation: v0.RelationTupleUpdate_TOUCH,
-			Tuple:     tupleExclude,
+
+		tupleAllowlist := &v1.Relationship{
+			Resource: &v1.ObjectReference{
+				ObjectType: names.Resource,
+				ObjectId:   "thegoods",
+			},
+			Relation: "direct",
+			Subject: &v1.SubjectReference{Object: &v1.ObjectReference{
+				ObjectType: names.Allowlist,
+				ObjectId:   allowlistID,
+			}},
+		}
+
+		tupleBlocklist := &v1.Relationship{
+			Resource: &v1.ObjectReference{
+				ObjectType: names.Resource,
+				ObjectId:   "thegoods",
+			},
+			Relation: "excluded",
+			Subject: &v1.SubjectReference{Object: &v1.ObjectReference{
+				ObjectType: names.Blocklist,
+				ObjectId:   blocklistID,
+			}},
+		}
+
+		allowlists = append(allowlists, &v1.RelationshipUpdate{
+			Operation:    v1.RelationshipUpdate_OPERATION_TOUCH,
+			Relationship: tupleAllowlist,
 		})
-		directs = append(directs, &v0.RelationTupleUpdate{
-			Operation: v0.RelationTupleUpdate_TOUCH,
-			Tuple:     tupleDirect,
+		blocklists = append(blocklists, &v1.RelationshipUpdate{
+			Operation:    v1.RelationshipUpdate_OPERATION_TOUCH,
+			Relationship: tupleBlocklist,
+		})
+		allowusers = append(allowusers, &v1.RelationshipUpdate{
+			Operation:    v1.RelationshipUpdate_OPERATION_TOUCH,
+			Relationship: tupleAllowuser,
+		})
+		blockusers = append(blockusers, &v1.RelationshipUpdate{
+			Operation:    v1.RelationshipUpdate_OPERATION_TOUCH,
+			Relationship: tupleBlockuser,
 		})
 	}
 	return
 }
 
 // getLeaderNode returns the node with the lease leader for the range containing the tuple
-func getLeaderNode(ctx context.Context, conn *pgx.Conn, tuple *v0.RelationTuple) int {
+func getLeaderNode(ctx context.Context, conn *pgx.Conn, tuple *v1.Relationship) int {
 	t := tuple
 	rows, err := conn.Query(ctx, "SHOW RANGE FROM TABLE relation_tuple FOR ROW ($1::text,$2::text,$3::text,$4::text,$5::text,$6::text)",
-		t.ObjectAndRelation.Namespace,
-		t.ObjectAndRelation.ObjectId,
-		t.ObjectAndRelation.Relation,
-		t.User.GetUserset().Namespace,
-		t.User.GetUserset().ObjectId,
-		t.User.GetUserset().Relation,
+		t.Resource.ObjectType,
+		t.Resource.ObjectId,
+		t.Relation,
+		t.Subject.Object.ObjectType,
+		t.Subject.Object.ObjectId,
+		t.Subject.OptionalRelation,
 	)
 	defer rows.Close()
 	if err != nil {
@@ -693,18 +593,4 @@ func leaderFromRangeRow(rows pgx.Rows) int {
 		break
 	}
 	return leaseHolder
-}
-
-func getErr(vals ...interface{}) error {
-	if len(vals) == 0 {
-		return nil
-	}
-	err := vals[len(vals)-1]
-	if err == nil {
-		return nil
-	}
-	if err, ok := err.(error); ok {
-		return err
-	}
-	return nil
 }

--- a/e2e/run.go
+++ b/e2e/run.go
@@ -37,7 +37,7 @@ func GoRun(ctx context.Context, out, errOut io.Writer, args ...string) (int, err
 }
 
 func start(ctx context.Context, out, errOut io.Writer, args ...string) (*exec.Cmd, error) {
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec G204
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Stdout = out
 	cmd.Stderr = errOut

--- a/e2e/spice/spicedb.go
+++ b/e2e/spice/spicedb.go
@@ -25,7 +25,7 @@ type Node struct {
 	DbName         string
 	URI            string
 	GrpcPort       int
-	HttpPort       int
+	HTTPPort       int
 	DispatchPort   int
 	MetricsPort    int
 	DashboardPort  int
@@ -47,8 +47,8 @@ func WithTestDefaults(opts ...NodeOption) NodeOption {
 		if s.DispatchPort == 0 {
 			s.DispatchPort = 50052
 		}
-		if s.HttpPort == 0 {
-			s.HttpPort = 8443
+		if s.HTTPPort == 0 {
+			s.HTTPPort = 8443
 		}
 		if s.MetricsPort == 0 {
 			s.MetricsPort = 9090
@@ -81,7 +81,7 @@ func (s *Node) Start(ctx context.Context, logprefix string, args ...string) erro
 		"--datastore-engine=" + s.Datastore,
 		"--datastore-conn-uri=" + s.URI,
 		fmt.Sprintf("--grpc-addr=:%d", s.GrpcPort),
-		fmt.Sprintf("--http-addr=:%d", s.HttpPort),
+		fmt.Sprintf("--http-addr=:%d", s.HTTPPort),
 		fmt.Sprintf("--dispatch-cluster-addr=:%d", s.DispatchPort),
 		fmt.Sprintf("--metrics-addr=:%d", s.MetricsPort),
 		fmt.Sprintf("--dashboard-addr=:%d", s.DashboardPort),
@@ -147,7 +147,7 @@ func NewClusterFromCockroachCluster(c cockroach.Cluster, opts ...NodeOption) Clu
 			URI:           c[i].ConnectionString(proto.DbName),
 			GrpcPort:      proto.GrpcPort + 2*i,
 			DispatchPort:  proto.DispatchPort + 2*i,
-			HttpPort:      proto.HttpPort + 2*i,
+			HTTPPort:      proto.HTTPPort + 2*i,
 			MetricsPort:   proto.MetricsPort + i,
 			DashboardPort: proto.DashboardPort + i,
 		})

--- a/e2e/spice/spicedb_options.go
+++ b/e2e/spice/spicedb_options.go
@@ -64,10 +64,10 @@ func WithGrpcPort(grpcPort int) NodeOption {
 	}
 }
 
-// WithHttpPort returns an option that can set HttpPort on a Node
+// WithHttpPort returns an option that can set HTTPPort on a Node
 func WithHttpPort(httpPort int) NodeOption {
 	return func(n *Node) {
-		n.HttpPort = httpPort
+		n.HTTPPort = httpPort
 	}
 }
 

--- a/internal/middleware/consistency/consistency.go
+++ b/internal/middleware/consistency/consistency.go
@@ -292,7 +292,7 @@ func rewriteDatastoreError(ctx context.Context, err error) error {
 		return status.Errorf(codes.FailedPrecondition, "failed precondition: %s", err)
 
 	case errors.As(err, &datastore.ErrInvalidRevision{}):
-		return status.Errorf(codes.OutOfRange, "invalid zookie: %s", err)
+		return status.Errorf(codes.OutOfRange, "invalid revision: %s", err)
 
 	case errors.As(err, &datastore.ErrReadOnly{}):
 		return serviceerrors.ErrServiceReadOnly


### PR DESCRIPTION
The updated test passed multiple times in another branch (though against a slightly older version of dsv2 branch) but I don't have enough data to confidently say it has an acceptable flake rate.

Temporarily removed the schema-based newenemy test. It would be nice to restore it if possible, but the larger transactions in dsv2 may make that more difficult (it was certainly more difficult for the data-based newenemy test). The protections we have in place are the same for both cases, so schema newenemy test only serves to verify implementation bugs, unlike the data newenemy test which verifies SpiceDB's approach to dealing with timestamp drift in CRDB.