### PR TITLE
prevent crdb from crashing in e2e tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: "Run e2e"
         working-directory: "e2e/newenemy"
         run: |
-          go test -v -timeout 30m ./...
+          go test -v -timeout 11m ./...
       - uses: "actions/upload-artifact@v2"
         if: "always()"
         # this upload step is really flaky, don't fail the job if it fails

--- a/e2e/run.go
+++ b/e2e/run.go
@@ -51,6 +51,7 @@ func start(ctx context.Context, out, errOut io.Writer, args ...string) (*exec.Cm
 func cleanupOnDone(done <-chan struct{}, pid int) {
 	go func() {
 		<-done
+		fmt.Println("killing", pid)
 		// negative Pid sends the signal to all child processes in the group
 		if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
 			fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
#607 updated the e2e tests to work against #581 

But after that change, there seems to be some likelihood that cockroach will crash in the middle of the test and the step will time out.

We're doing a lot of "bad" things with cockroach in a resource constrained environment, so I'm using this PR to test out settings that keep CRDB running without breaking the test in other ways. 