### PR TITLE
support xDS as a dispatch resolver option

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sercand/kuberesolver/v3"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/balancer"
+	_ "google.golang.org/grpc/xds"
 
 	consistentbalancer "github.com/authzed/spicedb/pkg/balancer"
 	"github.com/authzed/spicedb/pkg/cmd"


### PR DESCRIPTION
I haven't confirmed this with an xDS setup, but the client-side parsing seems to correctly accept `xds://` addresses and look for the xDS bootstrap file