### PR TITLE
Add quickstart examples

### DIFF
--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -27,3 +27,11 @@ docker compose -f postgres.yml down
 to shut down the containers.
 
 > Note: Most quickstarts have configuration services in them to properly set up the storage engine. This means it may take a minute or so before the quickstart is ready to use.
+
+## Available quickstarts
+
+- [CockroachDB](crdb.yml)
+- [Memory](memory.yml)
+- [MySQL](mysql.yml)
+- [Postgres](postgres.yml)
+- [Spanner](spanner.yml)

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -1,0 +1,30 @@
+# Quickstart examples
+
+This directory contains a variety of quickstart examples to start SpiceDB with various storage engines.
+
+:warning: These examples are **not** production-ready and are provided purely for local testing only :warning:
+
+
+## Usage
+
+To use a quickstart, run:
+
+```
+docker compose -f <file> up
+```
+
+For example, running the Postgres quickstart:
+
+```
+docker compose -f postgres.yml up
+```
+
+Use `Ctrl+C` to stop the quickstart and use
+
+```
+docker compose -f postgres.yml down
+```
+
+to shut down the containers.
+
+> Note: Most quickstarts have configuration services in them to properly set up the storage engine. This means it may take a minute or so before the quickstart is ready to use.

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -4,24 +4,23 @@ This directory contains a variety of quickstart examples to start SpiceDB with v
 
 :warning: These examples are **not** production-ready and are provided purely for local testing only :warning:
 
-
 ## Usage
 
 To use a quickstart, run:
 
-```
+```shell
 docker compose -f <file> up
 ```
 
 For example, running the Postgres quickstart:
 
-```
+```shell
 docker compose -f postgres.yml up
 ```
 
 Use `Ctrl+C` to stop the quickstart and use
 
-```
+```shell
 docker compose -f postgres.yml down
 ```
 

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -2,7 +2,8 @@
 
 This directory contains a variety of quickstart examples to start SpiceDB with various storage engines.
 
-:warning: These examples are **not** production-ready and are provided purely for local testing only :warning:
+> **Warning**
+> These examples are **not** production-ready and are provided purely for local testing only.
 
 ## Usage
 
@@ -26,7 +27,8 @@ docker compose -f postgres.yml down
 
 to shut down the containers.
 
-> Note: Most quickstarts have configuration services in them to properly set up the storage engine. This means it may take a minute or so before the quickstart is ready to use.
+> **Note**
+> Most quickstarts have configuration services in them to properly set up the storage engine. This means it may take a minute or so before the quickstart is ready to use.
 
 ## Available quickstarts
 

--- a/examples/compose/crdb.yml
+++ b/examples/compose/crdb.yml
@@ -1,5 +1,6 @@
 ---
-# This runs SpiceDB, using CockroachDB as the storage engine.
+# This runs SpiceDB, using CockroachDB as the storage engine. SpiceDB will not
+# have any schema written to it.
 #
 # Once the database service is running, the init_database service will
 # initialize CockroachDB for SpiceDB by creating the "spicedb" database. Next,

--- a/examples/compose/crdb.yml
+++ b/examples/compose/crdb.yml
@@ -1,4 +1,26 @@
 ---
+# This runs SpiceDB, using CockroachDB as the storage engine.
+#
+# Once the database service is running, the init_database service will
+# initialize CockroachDB for SpiceDB by creating the "spicedb" database. Next,
+# the migrate service executes, running "spicedb migrate head" to migrate
+# CockroachDB to the most current revision. After CockroachDB is intialized and
+# migrated, the init_database and migrate services will stop.
+#
+# Note: CockroachDB is run using a single node configuration.
+#
+# SpiceDB settings:
+#   pre-shared key: foobar
+#   dashboard address: http://localhost:8080
+#   metrics address: http://localhost:9090
+#   grpc address: http://localhost:50051
+#
+# CockroachDB settings:
+#   user: root
+#   password: secret
+#   port: 26257
+#   dashboard address: http://localhost:8081
+
 version: "3"
 
 services:

--- a/examples/compose/crdb.yml
+++ b/examples/compose/crdb.yml
@@ -1,0 +1,46 @@
+---
+version: "3"
+
+services:
+  spicedb:
+    image: "authzed/spicedb"
+    command: "serve"
+    restart: "always"
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+      - "50051:50051"
+    environment:
+      - "SPICEDB_GRPC_PRESHARED_KEY=foobar"
+      - "SPICEDB_DATASTORE_ENGINE=cockroachdb"
+      - "SPICEDB_DATASTORE_CONN_URI=postgresql://root:secret@database:26257/spicedb?sslmode=disable"
+    depends_on:
+      - "migrate"
+
+  migrate:
+    image: "authzed/spicedb"
+    command: "migrate head"
+    restart: "on-failure"
+    environment:
+      - "SPICEDB_DATASTORE_ENGINE=cockroachdb"
+      - "SPICEDB_DATASTORE_CONN_URI=postgresql://root:secret@database:26257/spicedb?sslmode=disable"
+    depends_on:
+      - "init_database"
+
+  init_database:
+    image: "cockroachdb/cockroach"
+    restart: "on-failure"
+    command: "sql --insecure -e 'CREATE DATABASE IF NOT EXISTS spicedb;'"
+    environment:
+      - "COCKROACH_HOST=database:26257"
+    depends_on:
+      - "database"
+
+  database:
+    image: "cockroachdb/cockroach"
+    command: "start-single-node --insecure"
+    ports:
+      - "26257:26257"
+      - "8081:8080" # Using 8081 because 8080 is used by SpiceDB
+    environment:
+      - "POSTGRES_PASSWORD=secret"

--- a/examples/compose/memory.yml
+++ b/examples/compose/memory.yml
@@ -1,0 +1,15 @@
+---
+version: "3"
+
+services:
+  spicedb:
+    image: "authzed/spicedb"
+    command: "serve"
+    restart: "always"
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+      - "50051:50051"
+    environment:
+      - "SPICEDB_GRPC_PRESHARED_KEY=foobar"
+      - "SPICEDB_DATASTORE_ENGINE=memory"

--- a/examples/compose/memory.yml
+++ b/examples/compose/memory.yml
@@ -1,4 +1,12 @@
 ---
+# This runs SpiceDB, using an in-memory datastore as a the storage engine.
+#
+# SpiceDB settings:
+#   pre-shared key: foobar
+#   dashboard address: http://localhost:8080
+#   metrics address: http://localhost:9090
+#   grpc address: http://localhost:50051
+
 version: "3"
 
 services:

--- a/examples/compose/memory.yml
+++ b/examples/compose/memory.yml
@@ -1,5 +1,6 @@
 ---
 # This runs SpiceDB, using an in-memory datastore as a the storage engine.
+# SpiceDB will not have any schema written to it.
 #
 # SpiceDB settings:
 #   pre-shared key: foobar

--- a/examples/compose/mysql.yml
+++ b/examples/compose/mysql.yml
@@ -1,0 +1,36 @@
+---
+version: "3"
+
+services:
+  spicedb:
+    image: "authzed/spicedb"
+    command: "serve"
+    restart: "always"
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+      - "50051:50051"
+    environment:
+      - "SPICEDB_GRPC_PRESHARED_KEY=foobar"
+      - "SPICEDB_DATASTORE_ENGINE=mysql"
+      - "SPICEDB_DATASTORE_CONN_URI=root:secret@tcp(database:3306)/spicedb?parseTime=true"
+    depends_on:
+      - "migrate"
+
+  migrate:
+    image: "authzed/spicedb"
+    command: "migrate head"
+    restart: "on-failure"
+    environment:
+      - "SPICEDB_DATASTORE_ENGINE=mysql"
+      - "SPICEDB_DATASTORE_CONN_URI=root:secret@tcp(database:3306)/spicedb?parseTime=true"
+    depends_on:
+      - "database"
+
+  database:
+    image: "mysql"
+    ports:
+      - "3306:3306"
+    environment:
+      - "MYSQL_ROOT_PASSWORD=secret"
+      - "MYSQL_DATABASE=spicedb"

--- a/examples/compose/mysql.yml
+++ b/examples/compose/mysql.yml
@@ -1,4 +1,21 @@
 ---
+# This runs SpiceDB, using MySQL as the storage engine.
+#
+# Once the database service is running, the migrate service executes, running
+# "spicedb migrate head" to migrate MySQL to the most current revision. After
+# MySQL is migrated, the migrate service will stop.
+#
+# SpiceDB settings:
+#   pre-shared key: foobar
+#   dashboard address: http://localhost:8080
+#   metrics address: http://localhost:9090
+#   grpc address: http://localhost:50051
+#
+# MySQL settings:
+#   user: root
+#   password: secret
+#   port: 3306
+
 version: "3"
 
 services:

--- a/examples/compose/mysql.yml
+++ b/examples/compose/mysql.yml
@@ -1,5 +1,6 @@
 ---
-# This runs SpiceDB, using MySQL as the storage engine.
+# This runs SpiceDB, using MySQL as the storage engine. SpiceDB will not have
+# any schema written to it.
 #
 # Once the database service is running, the migrate service executes, running
 # "spicedb migrate head" to migrate MySQL to the most current revision. After

--- a/examples/compose/postgres.yml
+++ b/examples/compose/postgres.yml
@@ -1,4 +1,21 @@
 ---
+# This runs SpiceDB, using Postgres as the storage engine.
+#
+# Once the database service is running, the migrate service executes, running
+# "spicedb migrate head" to migrate Postgres to the most current revision. After
+# Postgres is migrated, the migrate service will stop.
+#
+# SpiceDB settings:
+#   pre-shared key: foobar
+#   dashboard address: http://localhost:8080
+#   metrics address: http://localhost:9090
+#   grpc address: http://localhost:50051
+#
+# Postgres settings:
+#   user: postgres
+#   password: secret
+#   port: 5432
+
 version: "3"
 
 services:

--- a/examples/compose/postgres.yml
+++ b/examples/compose/postgres.yml
@@ -1,0 +1,36 @@
+---
+version: "3"
+
+services:
+  spicedb:
+    image: "authzed/spicedb"
+    command: "serve"
+    restart: "always"
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+      - "50051:50051"
+    environment:
+      - "SPICEDB_GRPC_PRESHARED_KEY=foobar"
+      - "SPICEDB_DATASTORE_ENGINE=postgres"
+      - "SPICEDB_DATASTORE_CONN_URI=postgres://postgres:secret@database:5432/spicedb?sslmode=disable"
+    depends_on:
+      - "migrate"
+
+  migrate:
+    image: "authzed/spicedb"
+    command: "migrate head"
+    restart: "on-failure"
+    environment:
+      - "SPICEDB_DATASTORE_ENGINE=postgres"
+      - "SPICEDB_DATASTORE_CONN_URI=postgres://postgres:secret@database:5432/spicedb?sslmode=disable"
+    depends_on:
+      - "database"
+
+  database:
+    image: "postgres"
+    ports:
+      - "5432:5432"
+    environment:
+      - "POSTGRES_PASSWORD=secret"
+      - "POSTGRES_DB=spicedb"

--- a/examples/compose/postgres.yml
+++ b/examples/compose/postgres.yml
@@ -1,5 +1,6 @@
 ---
-# This runs SpiceDB, using Postgres as the storage engine.
+# This runs SpiceDB, using Postgres as the storage engine. SpiceDB will not have
+# any schema written to it.
 #
 # Once the database service is running, the migrate service executes, running
 # "spicedb migrate head" to migrate Postgres to the most current revision. After

--- a/examples/compose/spanner.yml
+++ b/examples/compose/spanner.yml
@@ -1,0 +1,48 @@
+---
+version: "3"
+
+services:
+  spicedb:
+    image: "authzed/spicedb"
+    command: "serve"
+    restart: "always"
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+      - "50051:50051"
+    environment:
+      - "SPICEDB_GRPC_PRESHARED_KEY=foobar"
+      - "SPICEDB_DATASTORE_ENGINE=spanner"
+      - "SPICEDB_DATASTORE_CONN_URI=projects/project-spicedb/instances/instance-spicedb/databases/spicedb"
+      - "SPANNER_EMULATOR_HOST=database:9010"
+    depends_on:
+      - "migrate"
+
+  migrate:
+    image: "authzed/spicedb"
+    command: "migrate head"
+    restart: "on-failure"
+    environment:
+      - "SPICEDB_DATASTORE_ENGINE=spanner"
+      - "SPICEDB_DATASTORE_CONN_URI=projects/project-spicedb/instances/instance-spicedb/databases/spicedb"
+      - "SPANNER_EMULATOR_HOST=database:9010"
+    depends_on:
+      - "database_init"
+
+  database_init:
+    build:
+      context: "./spanner"
+      dockerfile: "Dockerfile.spanner"
+    restart: "on-failure"
+    environment:
+      - "EMULATOR_HOST=http://database:9020/"
+      - "INSTANCE_NAME=instance-spicedb"
+      - "PROJECT_ID=project-spicedb"
+    depends_on:
+      - "database"
+
+  database:
+    image: "gcr.io/cloud-spanner-emulator/emulator"
+    ports:
+      - "9010:9010"
+      - "9020:9020"

--- a/examples/compose/spanner.yml
+++ b/examples/compose/spanner.yml
@@ -1,5 +1,6 @@
 ---
-# This runs SpiceDB, using Spanner as the storage engine.
+# This runs SpiceDB, using Spanner as the storage engine. SpiceDB will not have
+# any schema written to it.
 #
 # In order to run Spanner locally, a Spanner emulator must be spun up. This is
 # done by the database service. Once that is complete, the emulator must be

--- a/examples/compose/spanner.yml
+++ b/examples/compose/spanner.yml
@@ -1,4 +1,31 @@
 ---
+# This runs SpiceDB, using Spanner as the storage engine.
+#
+# In order to run Spanner locally, a Spanner emulator must be spun up. This is
+# done by the database service. Once that is complete, the emulator must be
+# initialized with a project, instance, and database. This is accomplished by
+# the init_database service, which executes the init script found at
+# spanner/spanner-init. This script configures the Spanner emulator with the a
+# project, instance, and database. Finally, the migrate service executes,
+# running "spicedb migrate head" to migrate Spanner to the most current
+# revision. After Spanner is initialized and migrated, the init_database and
+# migrate services will stop.
+#
+# Note: Spanner is run using a single node configuration.
+#
+# SpiceDB settings:
+#   pre-shared key: foobar
+#   dashboard address: http://localhost:8080
+#   metrics address: http://localhost:9090
+#   grpc address: http://localhost:50051
+#
+# Spanner settings:
+#   project id: project-spicedb
+#   instance name: instance-spicedb
+#   database name: spicedb
+#   grpc port: 9010
+#   http port: 9020
+
 version: "3"
 
 services:

--- a/examples/compose/spanner/Dockerfile.spanner
+++ b/examples/compose/spanner/Dockerfile.spanner
@@ -1,0 +1,11 @@
+FROM google/cloud-sdk:slim
+
+RUN apt-get install -y google-cloud-sdk
+
+ENV EMULATOR_HOST=""
+ENV INSTANCE_NAME=""
+ENV PROJECT_ID=""
+
+COPY spanner-init .
+
+CMD ./spanner-init

--- a/examples/compose/spanner/spanner-init
+++ b/examples/compose/spanner/spanner-init
@@ -1,0 +1,24 @@
+#!/bin/bash
+#/ Sets up a spanner instance for SpiceDB.
+#/
+#/ Expects the following environment variables:
+#/   EMULATOR_HOST  Host of the the Spanner emulator (i.e. http://localhost:9020/)
+#/                    WARN: This must have a trailing /
+#/   INSTANCE_NAME  Name of the Spanner instance
+#/   PROJECT_ID     Name of the project id
+
+# configure gcloud cli to connect to emulator
+gcloud config set auth/disable_credentials true
+gcloud config set project $PROJECT_ID
+gcloud config set api_endpoint_overrides/spanner $EMULATOR_HOST
+
+# create spanner instance
+gcloud spanner instances create $INSTANCE_NAME \
+  --config=emulator-config \
+  --description="Test Instance" \
+  --nodes=1
+
+gcloud config set spanner/instance $INSTANCE_NAME
+
+# create database
+gcloud spanner databases create spicedb


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb/issues/469

This creates a collection of quickstart Docker Compose files to get new-comers quickly running with the datastore of their choosing. ~I also moved `k8s/example.yaml` under the `examples/` directory, since it seemed to fit well there. Though, I'm not sure if this breaks documentation links.~ I reverted this change, things broke when that file moved.

Most datastores were straightforward, but Cockroach and Spanner (especially Spanner) required some extra plumbing to get them operational.