### PR TITLE
propagate context to migration functions

### DIFF
--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -263,7 +263,7 @@ func (cds *crdbDatastore) IsReady(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer currentRevision.Close()
+	defer currentRevision.Close(ctx)
 
 	version, err := currentRevision.Version(ctx)
 	if err != nil {

--- a/internal/datastore/crdb/migrations/driver.go
+++ b/internal/datastore/crdb/migrations/driver.go
@@ -80,7 +80,7 @@ func (apd *CRDBDriver) WriteVersion(ctx context.Context, version, replaced strin
 	return nil
 }
 
-// Dispose disposes the driver.
-func (apd *CRDBDriver) Close() error {
-	return apd.db.Close(context.Background())
+// Close disposes the driver.
+func (apd *CRDBDriver) Close(ctx context.Context) error {
+	return apd.db.Close(ctx)
 }

--- a/internal/datastore/crdb/migrations/manager.go
+++ b/internal/datastore/crdb/migrations/manager.go
@@ -3,4 +3,4 @@ package migrations
 import "github.com/authzed/spicedb/pkg/migrate"
 
 // CRDBMigrations implements a migration manager for the CRDBDriver.
-var CRDBMigrations = migrate.NewManager()
+var CRDBMigrations = migrate.NewManager[*CRDBDriver]()

--- a/internal/datastore/crdb/migrations/zz_migration.0001_initial_schema.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0001_initial_schema.go
@@ -37,9 +37,7 @@ const (
 )
 
 func init() {
-	if err := CRDBMigrations.Register("initial", "", func(apd *CRDBDriver) error {
-		ctx := context.Background()
-
+	if err := CRDBMigrations.Register("initial", "", func(ctx context.Context, apd *CRDBDriver) error {
 		_, err := apd.db.Exec(ctx, enableRangefeeds)
 		if err != nil {
 			return err

--- a/internal/datastore/crdb/migrations/zz_migration.0002_add_transactions.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0002_add_transactions.go
@@ -14,9 +14,7 @@ const (
 )
 
 func init() {
-	if err := CRDBMigrations.Register("add-transactions-table", "initial", func(apd *CRDBDriver) error {
-		ctx := context.Background()
-
+	if err := CRDBMigrations.Register("add-transactions-table", "initial", func(ctx context.Context, apd *CRDBDriver) error {
 		return apd.db.BeginFunc(ctx, func(tx pgx.Tx) error {
 			statements := []string{
 				createTransactions,

--- a/internal/datastore/crdb/migrations/zz_migration.0003_add_metadata_and_counters.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0003_add_metadata_and_counters.go
@@ -21,9 +21,7 @@ const (
 )
 
 func init() {
-	if err := CRDBMigrations.Register("add-metadata-and-counters", "add-transactions-table", func(apd *CRDBDriver) error {
-		ctx := context.Background()
-
+	if err := CRDBMigrations.Register("add-metadata-and-counters", "add-transactions-table", func(ctx context.Context, apd *CRDBDriver) error {
 		return apd.db.BeginFunc(ctx, func(tx pgx.Tx) error {
 			if _, err := tx.Exec(ctx, createMetadataTable); err != nil {
 				return err

--- a/internal/datastore/mysql/migrations/driver.go
+++ b/internal/datastore/mysql/migrations/driver.go
@@ -113,7 +113,7 @@ func (driver *MySQLDriver) WriteVersion(ctx context.Context, version, replaced s
 	return nil
 }
 
-func (driver *MySQLDriver) Close() error {
+func (driver *MySQLDriver) Close(_ context.Context) error {
 	return driver.db.Close()
 }
 

--- a/internal/datastore/mysql/migrations/manager.go
+++ b/internal/datastore/mysql/migrations/manager.go
@@ -13,16 +13,18 @@ var (
 	migrationNameRe = regexp.MustCompile(migrationNamePattern)
 
 	// Manager is the singleton migration manager instance for MySQL
-	Manager = migrate.NewManager()
+	Manager = migrate.NewManager[*MySQLDriver]()
 )
 
-func mustRegisterMigration(version, replaces string, up interface{}) {
+type mySQLMigrationFunc = migrate.MigrationFunc[*MySQLDriver]
+
+func mustRegisterMigration(version, replaces string, up mySQLMigrationFunc) {
 	if err := registerMigration(version, replaces, up); err != nil {
 		panic("failed to register migration  " + err.Error())
 	}
 }
 
-func registerMigration(version, replaces string, up interface{}) error {
+func registerMigration(version, replaces string, up mySQLMigrationFunc) error {
 	// validate migration names to ensure they are compatible with mysql column names
 	for _, v := range []string{version, replaces} {
 		if match := migrationNameRe.MatchString(version); !match {

--- a/internal/datastore/mysql/migrations/migrations_test.go
+++ b/internal/datastore/mysql/migrations/migrations_test.go
@@ -4,6 +4,7 @@
 package migrations
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,6 +12,8 @@ import (
 
 func TestMySQLMigrationsWithUnsupportedPrefix(t *testing.T) {
 	req := require.New(t)
-	err := registerMigration("888", "", struct{}{})
+	err := registerMigration("888", "", func(ctx context.Context, d *MySQLDriver) error {
+		return nil
+	})
 	req.Error(err)
 }

--- a/internal/datastore/options/options.go
+++ b/internal/datastore/options/options.go
@@ -18,7 +18,7 @@ type ReverseQueryOptions struct {
 	ResRelation  *ResourceRelation
 }
 
-// ResourceRelations combines a resource object type and relation.
+// ResourceRelation combines a resource object type and relation.
 type ResourceRelation struct {
 	Namespace string
 	Relation  string

--- a/internal/datastore/postgres/migrations/driver.go
+++ b/internal/datastore/postgres/migrations/driver.go
@@ -74,7 +74,7 @@ func (apd *AlembicPostgresDriver) WriteVersion(ctx context.Context, version, rep
 	return nil
 }
 
-// Dispose disposes the driver.
-func (apd *AlembicPostgresDriver) Close() error {
-	return apd.db.Close(context.Background())
+// Close disposes the driver.
+func (apd *AlembicPostgresDriver) Close(ctx context.Context) error {
+	return apd.db.Close(ctx)
 }

--- a/internal/datastore/postgres/migrations/manager.go
+++ b/internal/datastore/postgres/migrations/manager.go
@@ -3,4 +3,4 @@ package migrations
 import "github.com/authzed/spicedb/pkg/migrate"
 
 // DatabaseMigrations implements a migration manager for the Postgres Driver.
-var DatabaseMigrations = migrate.NewManager()
+var DatabaseMigrations = migrate.NewManager[*AlembicPostgresDriver]()

--- a/internal/datastore/postgres/migrations/zz_migration.0001_1eaeba4b8a73_initial.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0001_1eaeba4b8a73_initial.go
@@ -44,9 +44,7 @@ const createAlembicVersion = `CREATE TABLE alembic_version (
 const insertEmptyVersion = `INSERT INTO alembic_version (version_num) VALUES ('');`
 
 func init() {
-	if err := DatabaseMigrations.Register("1eaeba4b8a73", "", func(apd *AlembicPostgresDriver) error {
-		ctx := context.Background()
-
+	if err := DatabaseMigrations.Register("1eaeba4b8a73", "", func(ctx context.Context, apd *AlembicPostgresDriver) error {
 		statements := []string{
 			createRelationTupleTransaction,
 			createNamespaceConfig,

--- a/internal/datastore/postgres/migrations/zz_migration.0002_add_reverse_index.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0002_add_reverse_index.go
@@ -12,9 +12,7 @@ const (
 )
 
 func init() {
-	if err := DatabaseMigrations.Register("add-reverse-index", "1eaeba4b8a73", func(apd *AlembicPostgresDriver) error {
-		ctx := context.Background()
-
+	if err := DatabaseMigrations.Register("add-reverse-index", "1eaeba4b8a73", func(ctx context.Context, apd *AlembicPostgresDriver) error {
 		return apd.db.BeginFunc(ctx, func(tx pgx.Tx) error {
 			for _, stmt := range []string{
 				createReverseQueryIndex,

--- a/internal/datastore/postgres/migrations/zz_migration.0003_add_unique_living_ns.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0003_add_unique_living_ns.go
@@ -18,8 +18,7 @@ const deleteAllButNewestNamespace = `
 		SELECT namespace, max(created_transaction) from namespace_config where deleted_transaction = 9223372036854775807 GROUP BY namespace HAVING COUNT(created_transaction) > 1);`
 
 func init() {
-	if err := DatabaseMigrations.Register("add-unique-living-ns", "add-reverse-index", func(apd *AlembicPostgresDriver) error {
-		ctx := context.Background()
+	if err := DatabaseMigrations.Register("add-unique-living-ns", "add-reverse-index", func(ctx context.Context, apd *AlembicPostgresDriver) error {
 		return apd.db.BeginFunc(ctx, func(tx pgx.Tx) error {
 			if _, err := tx.Exec(ctx, deleteAllButNewestNamespace); err != nil {
 				return err

--- a/internal/datastore/postgres/migrations/zz_migration.0004_add_transaction_timestamp_index.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0004_add_transaction_timestamp_index.go
@@ -7,8 +7,8 @@ const createIndexOnTupleTransactionTimestamp = `
 `
 
 func init() {
-	if err := DatabaseMigrations.Register("add-transaction-timestamp-index", "add-unique-living-ns", func(apd *AlembicPostgresDriver) error {
-		_, err := apd.db.Exec(context.Background(), createIndexOnTupleTransactionTimestamp)
+	if err := DatabaseMigrations.Register("add-transaction-timestamp-index", "add-unique-living-ns", func(ctx context.Context, apd *AlembicPostgresDriver) error {
+		_, err := apd.db.Exec(ctx, createIndexOnTupleTransactionTimestamp)
 		return err
 	}); err != nil {
 		panic("failed to register migration: " + err.Error())

--- a/internal/datastore/postgres/migrations/zz_migration.0005_change_transaction_timestamp_default.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0005_change_transaction_timestamp_default.go
@@ -9,10 +9,11 @@ const alterTimestampDefaultValue = `
 		ALTER COLUMN timestamp SET DEFAULT (now() AT TIME ZONE 'UTC');`
 
 func init() {
-	if err := DatabaseMigrations.Register("change-transaction-timestamp-default", "add-transaction-timestamp-index", func(apd *AlembicPostgresDriver) error {
-		_, err := apd.db.Exec(context.Background(), alterTimestampDefaultValue)
-		return err
-	}); err != nil {
+	if err := DatabaseMigrations.Register("change-transaction-timestamp-default", "add-transaction-timestamp-index",
+		func(ctx context.Context, apd *AlembicPostgresDriver) error {
+			_, err := apd.db.Exec(ctx, alterTimestampDefaultValue)
+			return err
+		}); err != nil {
 		panic("failed to register migration: " + err.Error())
 	}
 }

--- a/internal/datastore/postgres/migrations/zz_migration.0006_add_gc_index.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0006_add_gc_index.go
@@ -7,8 +7,8 @@ const (
 )
 
 func init() {
-	if err := DatabaseMigrations.Register("add-gc-index", "change-transaction-timestamp-default", func(apd *AlembicPostgresDriver) error {
-		_, err := apd.db.Exec(context.Background(), createDeletedTransactionIndex)
+	if err := DatabaseMigrations.Register("add-gc-index", "change-transaction-timestamp-default", func(ctx context.Context, apd *AlembicPostgresDriver) error {
+		_, err := apd.db.Exec(ctx, createDeletedTransactionIndex)
 		return err
 	}); err != nil {
 		panic("failed to register migration: " + err.Error())

--- a/internal/datastore/postgres/migrations/zz_migration.0007_add_unique_datastore_id.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0007_add_unique_datastore_id.go
@@ -14,9 +14,7 @@ const createUniqueIDTable = `CREATE TABLE metadata (
 const insertUniqueID = `INSERT INTO metadata (unique_id) VALUES ($1);`
 
 func init() {
-	if err := DatabaseMigrations.Register("add-unique-datastore-id", "add-gc-index", func(apd *AlembicPostgresDriver) error {
-		ctx := context.Background()
-
+	if err := DatabaseMigrations.Register("add-unique-datastore-id", "add-gc-index", func(ctx context.Context, apd *AlembicPostgresDriver) error {
 		return apd.db.BeginFunc(ctx, func(tx pgx.Tx) error {
 			if _, err := tx.Exec(ctx, createUniqueIDTable); err != nil {
 				return err

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -380,7 +380,7 @@ func (pgd *pgDatastore) IsReady(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer currentRevision.Close()
+	defer currentRevision.Close(ctx)
 
 	version, err := currentRevision.Version(ctx)
 	if err != nil {

--- a/internal/datastore/spanner/migrations/driver.go
+++ b/internal/datastore/spanner/migrations/driver.go
@@ -82,7 +82,7 @@ func (smd SpannerMigrationDriver) WriteVersion(ctx context.Context, version, rep
 	return err
 }
 
-func (smd SpannerMigrationDriver) Close() error {
+func (smd SpannerMigrationDriver) Close(_ context.Context) error {
 	smd.client.Close()
 	return nil
 }

--- a/internal/datastore/spanner/migrations/driver.go
+++ b/internal/datastore/spanner/migrations/driver.go
@@ -27,7 +27,7 @@ type SpannerMigrationDriver struct {
 }
 
 // NewSpannerDriver returns a migration driver for the given Cloud Spanner instance
-func NewSpannerDriver(database, credentialsFilePath, emulatorHost string) (SpannerMigrationDriver, error) {
+func NewSpannerDriver(database, credentialsFilePath, emulatorHost string) (*SpannerMigrationDriver, error) {
 	ctx := context.Background()
 
 	if len(emulatorHost) > 0 {
@@ -37,18 +37,18 @@ func NewSpannerDriver(database, credentialsFilePath, emulatorHost string) (Spann
 	log.Info().Str("credentials", credentialsFilePath).Str("db", database).Msg("connecting")
 	client, err := spanner.NewClient(ctx, database, option.WithCredentialsFile(credentialsFilePath))
 	if err != nil {
-		return SpannerMigrationDriver{}, err
+		return nil, err
 	}
 
 	adminClient, err := admin.NewDatabaseAdminClient(ctx, option.WithCredentialsFile(credentialsFilePath))
 	if err != nil {
-		return SpannerMigrationDriver{}, err
+		return nil, err
 	}
 
-	return SpannerMigrationDriver{client, adminClient}, nil
+	return &SpannerMigrationDriver{client, adminClient}, nil
 }
 
-func (smd SpannerMigrationDriver) Version(ctx context.Context) (string, error) {
+func (smd *SpannerMigrationDriver) Version(ctx context.Context) (string, error) {
 	rows := smd.client.Single().Read(
 		ctx,
 		tableSchemaVersion,
@@ -72,7 +72,7 @@ func (smd SpannerMigrationDriver) Version(ctx context.Context) (string, error) {
 	return schemaRevision, nil
 }
 
-func (smd SpannerMigrationDriver) WriteVersion(ctx context.Context, version, replaced string) error {
+func (smd *SpannerMigrationDriver) WriteVersion(ctx context.Context, version, replaced string) error {
 	_, err := smd.client.ReadWriteTransaction(ctx, func(c context.Context, rwt *spanner.ReadWriteTransaction) error {
 		return rwt.BufferWrite([]*spanner.Mutation{
 			spanner.Delete(tableSchemaVersion, spanner.KeySetFromKeys(spanner.Key{replaced})),
@@ -82,9 +82,9 @@ func (smd SpannerMigrationDriver) WriteVersion(ctx context.Context, version, rep
 	return err
 }
 
-func (smd SpannerMigrationDriver) Close(_ context.Context) error {
+func (smd *SpannerMigrationDriver) Close(_ context.Context) error {
 	smd.client.Close()
 	return nil
 }
 
-var _ migrate.Driver = SpannerMigrationDriver{}
+var _ migrate.Driver = &SpannerMigrationDriver{}

--- a/internal/datastore/spanner/migrations/driver.go
+++ b/internal/datastore/spanner/migrations/driver.go
@@ -31,7 +31,10 @@ func NewSpannerDriver(database, credentialsFilePath, emulatorHost string) (*Span
 	ctx := context.Background()
 
 	if len(emulatorHost) > 0 {
-		os.Setenv(emulatorSettingKey, emulatorHost)
+		err := os.Setenv(emulatorSettingKey, emulatorHost)
+		if err != nil {
+			return nil, err
+		}
 	}
 	log.Info().Str("spanner-emulator-host", os.Getenv(emulatorSettingKey)).Msg("spanner emulator")
 	log.Info().Str("credentials", credentialsFilePath).Str("db", database).Msg("connecting")

--- a/internal/datastore/spanner/migrations/manager.go
+++ b/internal/datastore/spanner/migrations/manager.go
@@ -3,4 +3,4 @@ package migrations
 import "github.com/authzed/spicedb/pkg/migrate"
 
 // SpannerMigrations implements a migration manager for the Spanner datastore.
-var SpannerMigrations = migrate.NewManager()
+var SpannerMigrations = migrate.NewManager[*SpannerMigrationDriver]()

--- a/internal/datastore/spanner/migrations/zz_migration.0001_initial_schema.go
+++ b/internal/datastore/spanner/migrations/zz_migration.0001_initial_schema.go
@@ -48,9 +48,7 @@ const (
 )
 
 func init() {
-	if err := SpannerMigrations.Register("initial", "", func(smd SpannerMigrationDriver) error {
-		ctx := context.Background()
-
+	if err := SpannerMigrations.Register("initial", "", func(ctx context.Context, smd SpannerMigrationDriver) error {
 		updateOp, err := smd.adminClient.UpdateDatabaseDdl(ctx, &database.UpdateDatabaseDdlRequest{
 			Database: smd.client.DatabaseName(),
 			Statements: []string{

--- a/internal/datastore/spanner/migrations/zz_migration.0001_initial_schema.go
+++ b/internal/datastore/spanner/migrations/zz_migration.0001_initial_schema.go
@@ -48,7 +48,7 @@ const (
 )
 
 func init() {
-	if err := SpannerMigrations.Register("initial", "", func(ctx context.Context, smd SpannerMigrationDriver) error {
+	if err := SpannerMigrations.Register("initial", "", func(ctx context.Context, smd *SpannerMigrationDriver) error {
 		updateOp, err := smd.adminClient.UpdateDatabaseDdl(ctx, &database.UpdateDatabaseDdlRequest{
 			Database: smd.client.DatabaseName(),
 			Statements: []string{

--- a/internal/datastore/spanner/migrations/zz_migration.0002_add_metadata_and_counters.go
+++ b/internal/datastore/spanner/migrations/zz_migration.0002_add_metadata_and_counters.go
@@ -20,9 +20,7 @@ const (
 )
 
 func init() {
-	if err := SpannerMigrations.Register("add-metadata-and-counters", "initial", func(smd SpannerMigrationDriver) error {
-		ctx := context.Background()
-
+	if err := SpannerMigrations.Register("add-metadata-and-counters", "initial", func(ctx context.Context, smd SpannerMigrationDriver) error {
 		updateOp, err := smd.adminClient.UpdateDatabaseDdl(ctx, &database.UpdateDatabaseDdlRequest{
 			Database: smd.client.DatabaseName(),
 			Statements: []string{

--- a/internal/datastore/spanner/migrations/zz_migration.0002_add_metadata_and_counters.go
+++ b/internal/datastore/spanner/migrations/zz_migration.0002_add_metadata_and_counters.go
@@ -20,7 +20,7 @@ const (
 )
 
 func init() {
-	if err := SpannerMigrations.Register("add-metadata-and-counters", "initial", func(ctx context.Context, smd SpannerMigrationDriver) error {
+	if err := SpannerMigrations.Register("add-metadata-and-counters", "initial", func(ctx context.Context, smd *SpannerMigrationDriver) error {
 		updateOp, err := smd.adminClient.UpdateDatabaseDdl(ctx, &database.UpdateDatabaseDdlRequest{
 			Database: smd.client.DatabaseName(),
 			Statements: []string{

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -146,7 +146,7 @@ func (sd spannerDatastore) IsReady(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer currentRevision.Close()
+	defer currentRevision.Close(ctx)
 
 	version, err := currentRevision.Version(ctx)
 	if err != nil {

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -101,7 +101,7 @@ func migrateRun(cmd *cobra.Command, args []string) error {
 		log.Fatal().Err(err).Msg("unable to complete requested migrations")
 	}
 
-	if err := migrationDriver.Close(); err != nil {
+	if err := migrationDriver.Close(context.Background()); err != nil {
 		log.Fatal().Err(err).Msg("unable to close migration driver")
 	}
 

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -103,7 +103,7 @@ func migrateRun(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	if timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithDeadline(cmd.Context(), time.Now().Add(timeout))
+		ctx, cancel = context.WithTimeout(cmd.Context(), timeout)
 		defer cancel()
 	}
 	if err := manager.Run(ctx, migrationDriver, targetRevision, migrate.LiveRun); err != nil {

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -34,7 +34,7 @@ type Driver interface {
 	WriteVersion(ctx context.Context, version, replaced string) error
 
 	// Close frees up any resources in use by the driver.
-	Close() error
+	Close(ctx context.Context) error
 }
 
 type migration struct {

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -2,9 +2,7 @@ package migrate
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -37,23 +35,25 @@ type Driver interface {
 	Close(ctx context.Context) error
 }
 
-type migration struct {
+type migration[T Driver] struct {
 	version  string
 	replaces string
-	up       interface{}
+	up       MigrationFunc[T]
 }
+
+type MigrationFunc[T Driver] func(ctx context.Context, driver T) error
 
 // Manager is used to manage a self-contained set of migrations. Standard usage
 // would be to instantiate one at the package level for a particular application
 // and then statically register migrations to the single instantiation in init
 // functions.
-type Manager struct {
-	migrations map[string]migration
+type Manager[T Driver] struct {
+	migrations map[string]migration[T]
 }
 
 // NewManager creates a new empty instance of a migration manager.
-func NewManager() *Manager {
-	return &Manager{migrations: make(map[string]migration)}
+func NewManager[T Driver]() *Manager[T] {
+	return &Manager[T]{migrations: make(map[string]migration[T])}
 }
 
 // Register is used to associate a single migration with the migration engine.
@@ -62,7 +62,7 @@ func NewManager() *Manager {
 // interface as its only parameters, which will be passed direcly from the Run
 // method into the upgrade function. If not extra fields or data are required
 // the function can alternatively take a Driver interface param.
-func (m *Manager) Register(version, replaces string, up interface{}) error {
+func (m *Manager[T]) Register(version, replaces string, up MigrationFunc[T]) error {
 	if strings.ToLower(version) == Head {
 		return fmt.Errorf("unable to register version called head")
 	}
@@ -71,7 +71,7 @@ func (m *Manager) Register(version, replaces string, up interface{}) error {
 		return fmt.Errorf("revision already exists: %s", version)
 	}
 
-	m.migrations[version] = migration{
+	m.migrations[version] = migration[T]{
 		version:  version,
 		replaces: replaces,
 		up:       up,
@@ -82,7 +82,7 @@ func (m *Manager) Register(version, replaces string, up interface{}) error {
 
 // Run will actually perform the necessary migrations to bring the backing datastore
 // from its current revision to the specified revision.
-func (m *Manager) Run(ctx context.Context, driver Driver, throughRevision string, dryRun RunType) error {
+func (m *Manager[T]) Run(ctx context.Context, driver T, throughRevision string, dryRun RunType) error {
 	starting, err := driver.Version(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to compute target revision: %w", err)
@@ -100,16 +100,6 @@ func (m *Manager) Run(ctx context.Context, driver Driver, throughRevision string
 		return fmt.Errorf("unable to compute migration list: %w", err)
 	}
 
-	for _, oneMigration := range toRun {
-		// Check that the migration is actually a function that accepts one parameter, the type of
-		// which is a valid coercion of driver instance.
-		if err := checkTypes(driver, oneMigration.up); err != nil {
-			return fmt.Errorf("unable to validate up migration: %w", err)
-		}
-
-		log.Info().Str("from", oneMigration.replaces).Str("to", oneMigration.version).Msg("planned migration")
-	}
-
 	if !dryRun {
 		for _, migrationToRun := range toRun {
 			// Double check that the current version reported is the one we expect
@@ -123,13 +113,9 @@ func (m *Manager) Run(ctx context.Context, driver Driver, throughRevision string
 			}
 
 			log.Info().Str("from", migrationToRun.replaces).Str("to", migrationToRun.version).Msg("migrating")
-
-			in := []reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(driver)}
-			upFunction := reflect.ValueOf(migrationToRun.up)
-
-			errArg := upFunction.Call(in)[0]
-			if !errArg.IsNil() {
-				return fmt.Errorf("error running migration up function: %v", errArg)
+			err = migrationToRun.up(ctx, driver)
+			if err != nil {
+				return fmt.Errorf("error running migration up function: %w", err)
 			}
 
 			if err := driver.WriteVersion(ctx, migrationToRun.version, migrationToRun.replaces); err != nil {
@@ -141,7 +127,7 @@ func (m *Manager) Run(ctx context.Context, driver Driver, throughRevision string
 	return nil
 }
 
-func (m *Manager) HeadRevision() (string, error) {
+func (m *Manager[T]) HeadRevision() (string, error) {
 	candidates := make(map[string]struct{}, len(m.migrations))
 	for candidate := range m.migrations {
 		candidates[candidate] = struct{}{}
@@ -163,7 +149,7 @@ func (m *Manager) HeadRevision() (string, error) {
 	return allHeads[0], nil
 }
 
-func (m *Manager) IsHeadCompatible(revision string) (bool, error) {
+func (m *Manager[T]) IsHeadCompatible(revision string) (bool, error) {
 	headRevision, err := m.HeadRevision()
 	if err != nil {
 		return false, err
@@ -172,49 +158,19 @@ func (m *Manager) IsHeadCompatible(revision string) (bool, error) {
 	return revision == headMigration.version || revision == headMigration.replaces, nil
 }
 
-func collectMigrationsInRange(starting, through string, all map[string]migration) ([]migration, error) {
-	var found []migration
+func collectMigrationsInRange[T Driver](starting, through string, all map[string]migration[T]) ([]migration[T], error) {
+	var found []migration[T]
 
 	lookingForRevision := through
 	for lookingForRevision != starting {
 		foundMigration, ok := all[lookingForRevision]
 		if !ok {
-			return []migration{}, fmt.Errorf("unable to find migration for revision: %s", lookingForRevision)
+			return []migration[T]{}, fmt.Errorf("unable to find migration for revision: %s", lookingForRevision)
 		}
 
-		found = append([]migration{foundMigration}, found...)
+		found = append([]migration[T]{foundMigration}, found...)
 		lookingForRevision = foundMigration.replaces
 	}
 
 	return found, nil
-}
-
-func checkTypes(driver Driver, shouldBeFunction interface{}) error {
-	driverType := reflect.TypeOf(driver)
-	if driverType == nil {
-		return errors.New("driver is nil pointer")
-	}
-
-	funcType := reflect.TypeOf(shouldBeFunction)
-	if funcType == nil {
-		return errors.New("function pointer is nil")
-	}
-
-	if funcType.NumIn() != 2 {
-		return errors.New("function must take two arguments: context and driver")
-	}
-
-	ctxParam := funcType.In(0)
-	ctxType := reflect.TypeOf(context.Background())
-
-	if !ctxType.AssignableTo(ctxParam) {
-		return errors.New("context object must be assignable to first migration function parameter")
-	}
-
-	driveParam := funcType.In(1)
-	if !driverType.AssignableTo(driveParam) {
-		return errors.New("driver object must be assignable to second migration function parameter")
-	}
-
-	return nil
 }

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -17,7 +17,7 @@ func (*fakeDriver) WriteVersion(ctx context.Context, version, replaced string) e
 	return nil
 }
 
-func (*fakeDriver) Close() error {
+func (*fakeDriver) Close(ctx context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb/issues/347

# What

Introduces `context.Context` argument into the signature of the migration function

# Why

So that long running migrations can be timed out via `spicedb migrate` CLI command.

# Considerations

- The new flag is named `migration-timeout` - open to suggestions
- No timeout is defined by default to retain original behaviour
- Reflection is being used to for the migration function. An abstraction could be explored but decided to punt on it to keep the PR moderately sized
- `context.Context` argument was added to `migrate.Driver` as the PSQL/CRDB driver expect it. This would API breakage.

## Example

![example CLI output](https://user-images.githubusercontent.com/6774726/172375464-4fdff206-fa9c-4478-822d-434bf2ec937e.png)


