### PR TITLE
Return an error instead of calling panic() when debug.ReadBuildInfo() is unavailable

### DIFF
--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -39,7 +39,7 @@ func RegisterTelemetryCollector(datastoreEngine string, ds datastore.Datastore) 
 	clusterID := dbStats.UniqueID
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
-		panic("failed to read build info")
+		return nil, fmt.Errorf("failed to read BuildInfo")
 	}
 
 	if err := registry.Register(&collector{


### PR DESCRIPTION
This PR changes the behaviour of `internal/telemetry/metrics.go` to avoid `panic()` when debug.ReadBuildInfo() is unavailable as same as `pkg/releases/versions.go`.

As a background, I'm using Bazel and `rules_go` to build and integrate SpiceDB for some of my private projects. However, the bazel rule is not currently supporting `debug.BuildInfo`(https://github.com/bazelbuild/rules_go/issues/3090) as of now. Just avoiding the `panic()` at `internal/telemetry/metrics.go` helps!
