### PR TITLE
Garbage collect namespaces

### DIFF
--- a/internal/datastore/common/gc.go
+++ b/internal/datastore/common/gc.go
@@ -1,0 +1,156 @@
+package common
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	gcDurationHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore",
+		Name:      "gc_duration_seconds",
+		Help:      "The duration of datastore garbage collection.",
+		Buckets:   []float64{0.01, 0.1, 0.5, 1, 5, 10, 25, 60, 120},
+	})
+
+	gcRelationshipsClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore",
+		Name:      "gc_relationships_total",
+		Help:      "The number of relationships cleared by the datastore garbage collection.",
+	})
+
+	gcTransactionsClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore",
+		Name:      "gc_transactions_total",
+		Help:      "The number of transactions cleared by the datastore garbage collection.",
+	})
+
+	gcNamespacesClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore",
+		Name:      "gc_namespaces_total",
+		Help:      "The number of namespaces cleared by the datastore garbage collection.",
+	})
+)
+
+// RegisterGCMetrics registers garbage collection metrics to the default
+// registry.
+func RegisterGCMetrics() error {
+	for _, metric := range []prometheus.Collector{
+		gcDurationHistogram,
+		gcRelationshipsClearedCounter,
+		gcTransactionsClearedCounter,
+		gcNamespacesClearedCounter,
+	} {
+		if err := prometheus.Register(metric); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GarbageCollector represents any datastore that supports external garbage
+// collection.
+type GarbageCollector interface {
+	IsReady(context.Context) (bool, error)
+	Now(context.Context) (time.Time, error)
+	TxIDBefore(context.Context, time.Time) (uint64, error)
+	DeleteBeforeTx(context.Context, uint64) (GarbageCollectedAmounts, error)
+}
+
+// GarbageCollectedAmounts is the collection of amounts of deletions from
+// an individual run of the garbage collector.
+type GarbageCollectedAmounts struct {
+	Relationships int64
+	Transactions  int64
+	Namespaces    int64
+}
+
+func (g GarbageCollectedAmounts) MarshalZerologObject(e *zerolog.Event) {
+	e.
+		Int64("relationships", g.Relationships).
+		Int64("transactions", g.Transactions).
+		Int64("namespaces", g.Namespaces)
+}
+
+// StartGarbageCollector loops forever until the context is canceled and
+// performs garbage collection on the provided interval.
+func StartGarbageCollector(ctx context.Context, gc GarbageCollector, interval, window, timeout time.Duration) error {
+	log.Ctx(ctx).Info().
+		Dur("interval", interval).
+		Msg("datastore garbage collection worker started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Ctx(ctx).Info().
+				Msg("shutting down datastore garbage collection worker")
+			return ctx.Err()
+
+		case <-time.After(interval):
+			err := collect(gc, window, timeout)
+			if err != nil {
+				log.Ctx(ctx).Warn().Err(err).
+					Msg("error attempting to perform garbage collection")
+			}
+		}
+	}
+}
+
+func collect(gc GarbageCollector, window, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// Before attempting anything, check if the datastore is ready.
+	ready, err := gc.IsReady(ctx)
+	if err != nil {
+		return err
+	}
+	if !ready {
+		log.Ctx(ctx).Warn().
+			Msg("datastore wasn't ready when attempting garbage collection")
+		return nil
+	}
+
+	var (
+		startTime = time.Now()
+		amounts   GarbageCollectedAmounts
+		watermark uint64
+	)
+
+	defer func() {
+		collectionDuration := time.Since(startTime)
+		gcDurationHistogram.Observe(collectionDuration.Seconds())
+
+		log.Ctx(ctx).Debug().
+			Uint64("highestTxID", watermark).
+			Dur("duration", collectionDuration).
+			Interface("collected", amounts).
+			Msg("datastore garbage collection completed")
+
+		gcRelationshipsClearedCounter.Add(float64(amounts.Relationships))
+		gcTransactionsClearedCounter.Add(float64(amounts.Transactions))
+		gcNamespacesClearedCounter.Add(float64(amounts.Namespaces))
+	}()
+
+	now, err := gc.Now(ctx)
+	if err != nil {
+		return err
+	}
+
+	watermark, err = gc.TxIDBefore(ctx, now.Add(-1*window))
+	if err != nil {
+		return err
+	}
+
+	amounts, err = gc.DeleteBeforeTx(ctx, watermark)
+	return err
+}

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -112,8 +112,11 @@ func NewMySQLDatastore(uri string, options ...Option) (*Datastore, error) {
 
 		db = sql.OpenDB(connector)
 		collector := sqlstats.NewStatsCollector("spicedb", db)
-		err := prometheus.Register(collector)
-		if err != nil {
+		if err := prometheus.Register(collector); err != nil {
+			return nil, fmt.Errorf(errUnableToInstantiate, err)
+		}
+
+		if err := registerGCMetrics(); err != nil {
 			return nil, fmt.Errorf(errUnableToInstantiate, err)
 		}
 	} else {
@@ -406,25 +409,6 @@ func (mds *Datastore) Close() error {
 }
 
 // TODO (@vroldanbet) dupe from postgres datastore - need to refactor
-func (mds *Datastore) runGarbageCollector() error {
-	log.Info().Dur("interval", mds.gcInterval).Msg("garbage collection worker started for mysql driver")
-
-	for {
-		select {
-		case <-mds.gcCtx.Done():
-			log.Info().Msg("shutting down garbage collection worker for mysql driver")
-			return mds.gcCtx.Err()
-
-		case <-time.After(mds.gcInterval):
-			err := mds.collectGarbage()
-			if err != nil {
-				log.Warn().Err(err).Msg("error when attempting to perform garbage collection")
-			}
-		}
-	}
-}
-
-// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
 func (mds *Datastore) getNow(ctx context.Context) (time.Time, error) {
 	// Retrieve the `now` time from the database.
 	nowSQL, nowArgs, err := getNow.ToSql()
@@ -442,116 +426,6 @@ func (mds *Datastore) getNow(ctx context.Context) (time.Time, error) {
 	now = now.UTC()
 
 	return now, nil
-}
-
-// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
-// - this implementation does not have metrics yet
-// - an additional useful logging message is added
-// - context is removed from logger because zerolog expects logger in the context
-func (mds *Datastore) collectGarbage() error {
-	ctx, cancel := context.WithTimeout(context.Background(), mds.gcMaxOperationTime)
-	defer cancel()
-
-	// Ensure the database is ready.
-	ready, err := mds.IsReady(ctx)
-	if err != nil {
-		return err
-	}
-
-	if !ready {
-		log.Warn().Msg("cannot perform mysql garbage collection: mysql driver is not yet ready")
-		return nil
-	}
-
-	now, err := mds.getNow(ctx)
-	if err != nil {
-		return err
-	}
-
-	before := now.Add(mds.gcWindowInverted)
-	log.Debug().Time("before", before).Msg("running mysql garbage collection")
-	relCount, transCount, err := mds.collectGarbageBefore(ctx, before)
-	log.Debug().Int64("relationshipsDeleted", relCount).Int64("transactionsDeleted", transCount).Msg("garbage collection completed for mysql")
-	return err
-}
-
-// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
-// - main difference is how the PSQL driver handles null values
-func (mds *Datastore) collectGarbageBefore(ctx context.Context, before time.Time) (int64, int64, error) {
-	// Find the highest transaction ID before the GC window.
-	query, args, err := mds.GetLastRevision.Where(sq.Lt{colTimestamp: before}).ToSql()
-	if err != nil {
-		return 0, 0, err
-	}
-
-	var value sql.NullInt64
-	err = mds.db.QueryRowContext(
-		datastore.SeparateContextWithTracing(ctx), query, args...,
-	).Scan(&value)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	if !value.Valid {
-		log.Debug().Time("before", before).Msg("no stale transactions found in the datastore")
-		return 0, 0, nil
-	}
-	highest := uint64(value.Int64)
-
-	log.Trace().Uint64("highestTransactionId", highest).Msg("retrieved transaction ID for GC")
-
-	return mds.collectGarbageForTransaction(ctx, highest)
-}
-
-// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
-// - implementation misses metrics
-func (mds *Datastore) collectGarbageForTransaction(ctx context.Context, highest uint64) (int64, int64, error) {
-	// Delete any relationship rows with deleted_transaction <= the transaction ID.
-	relCount, err := mds.batchDelete(ctx, mds.driver.RelationTuple(), sq.LtOrEq{colDeletedTxn: highest})
-	if err != nil {
-		return 0, 0, err
-	}
-
-	log.Trace().Uint64("highestTransactionId", highest).Int64("relationshipsDeleted", relCount).Msg("deleted stale relationships")
-
-	// Delete all transaction rows with ID < the transaction ID. We don't delete the transaction
-	// itself to ensure there is always at least one transaction present.
-	transactionCount, err := mds.batchDelete(ctx, mds.driver.RelationTupleTransaction(), sq.Lt{colID: highest})
-	if err != nil {
-		return relCount, 0, err
-	}
-
-	log.Trace().Uint64("highestTransactionId", highest).Int64("transactionsDeleted", transactionCount).Msg("deleted stale transactions")
-	return relCount, transactionCount, nil
-}
-
-// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
-// - query was reworked to make it compatible with Vitess
-// - API differences with PSQL driver
-func (mds *Datastore) batchDelete(ctx context.Context, tableName string, filter sqlFilter) (int64, error) {
-	query, args, err := sb.Delete(tableName).Where(filter).Limit(batchDeleteSize).ToSql()
-	if err != nil {
-		return -1, err
-	}
-
-	var deletedCount int64
-	for {
-		cr, err := mds.db.ExecContext(ctx, query, args...)
-		if err != nil {
-			return deletedCount, err
-		}
-
-		rowsDeleted, err := cr.RowsAffected()
-		if err != nil {
-			return deletedCount, err
-		}
-		deletedCount += rowsDeleted
-		if rowsDeleted < batchDeleteSize {
-			break
-		}
-	}
-
-	return deletedCount, nil
 }
 
 // IsReady returns whether the datastore is ready to accept data. Datastores that require

--- a/internal/datastore/mysql/gc.go
+++ b/internal/datastore/mysql/gc.go
@@ -6,134 +6,36 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/pkg/datastore"
 )
 
-var (
-	gcDurationHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: "spicedb",
-		Subsystem: "datastore_mysql",
-		Name:      "gc_duration_seconds",
-		Help:      "The duration of MySQL datastore garbage collection.",
-		Buckets:   []float64{0.01, 0.1, 0.5, 1, 5, 10, 25, 60, 120},
-	})
-
-	gcRelationshipsClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "spicedb",
-		Subsystem: "datastore_mysql",
-		Name:      "gc_relationships_total",
-		Help:      "The number of relationships cleared by the MySQL datastore garbage collection.",
-	})
-
-	gcTransactionsClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "spicedb",
-		Subsystem: "datastore_mysql",
-		Name:      "gc_transactions_total",
-		Help:      "The number of transactions cleared by the MySQL datastore garbage collection.",
-	})
-
-	gcNamespacesClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "spicedb",
-		Subsystem: "datastore_mysql",
-		Name:      "gc_namespaces_total",
-		Help:      "The number of namespaces cleared by the MySQL datastore garbage collection.",
-	})
-)
-
-func registerGCMetrics() error {
-	for _, metric := range []prometheus.Collector{
-		gcDurationHistogram,
-		gcRelationshipsClearedCounter,
-		gcTransactionsClearedCounter,
-		gcNamespacesClearedCounter,
-	} {
-		if err := prometheus.Register(metric); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
+var _ common.GarbageCollector = (*Datastore)(nil)
 
 // TODO (@vroldanbet) dupe from postgres datastore - need to refactor
-func (mds *Datastore) runGarbageCollector() error {
-	log.Info().Dur("interval", mds.gcInterval).Msg("garbage collection worker started for mysql driver")
-
-	for {
-		select {
-		case <-mds.gcCtx.Done():
-			log.Info().Msg("shutting down garbage collection worker for mysql driver")
-			return mds.gcCtx.Err()
-
-		case <-time.After(mds.gcInterval):
-			err := mds.collectGarbage()
-			if err != nil {
-				log.Warn().Err(err).Msg("error when attempting to perform garbage collection")
-			}
-		}
-	}
-}
-
-// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
-// - an additional useful logging message is added
-// - context is removed from logger because zerolog expects logger in the context
-func (mds *Datastore) collectGarbage() error {
-	ctx, cancel := context.WithTimeout(context.Background(), mds.gcMaxOperationTime)
-	defer cancel()
-
-	var (
-		startTime = time.Now()
-		amounts   garbageAmounts
-		watermark uint64
-	)
-
-	defer func() {
-		collectionDuration := time.Since(startTime)
-		gcDurationHistogram.Observe(collectionDuration.Seconds())
-
-		log.Ctx(ctx).Trace().
-			Uint64("highestTxID", watermark).
-			Dur("duration", collectionDuration).
-			Interface("collected", amounts).
-			Msg("datastore garbage collection completed")
-
-		gcRelationshipsClearedCounter.Add(float64(amounts.relationships))
-		gcTransactionsClearedCounter.Add(float64(amounts.transactions))
-		gcNamespacesClearedCounter.Add(float64(amounts.namespaces))
-	}()
-
-	// Ensure the database is ready.
-	ready, err := mds.IsReady(ctx)
+func (mds *Datastore) Now(ctx context.Context) (time.Time, error) {
+	// Retrieve the `now` time from the database.
+	nowSQL, nowArgs, err := getNow.ToSql()
 	if err != nil {
-		return err
+		return time.Time{}, err
 	}
 
-	if !ready {
-		log.Ctx(ctx).Warn().Msg("cannot perform datastore garbage collection: datastore is not yet ready")
-		return nil
-	}
-
-	now, err := mds.getNow(ctx)
+	var now time.Time
+	err = mds.db.QueryRowContext(datastore.SeparateContextWithTracing(ctx), nowSQL, nowArgs...).Scan(&now)
 	if err != nil {
-		return err
+		return time.Time{}, err
 	}
 
-	watermark, err = mds.mostRecentTxBefore(ctx, now.Add(mds.gcWindowInverted))
-	if err != nil {
-		return err
-	}
-
-	amounts, err = mds.deleteBefore(ctx, watermark)
-	return err
+	// This conversion should just be for convenience while debugging --
+	// MySQL and the driver do properly timezones properly.
+	return now.UTC(), nil
 }
 
 // TODO (@vroldanbet) dupe from postgres datastore - need to refactor
 // - main difference is how the PSQL driver handles null values
-func (mds *Datastore) mostRecentTxBefore(ctx context.Context, before time.Time) (uint64, error) {
+func (mds *Datastore) TxIDBefore(ctx context.Context, before time.Time) (uint64, error) {
 	// Find the highest transaction ID before the GC window.
 	query, args, err := mds.GetLastRevision.Where(sq.Lt{colTimestamp: before}).ToSql()
 	if err != nil {
@@ -155,24 +57,11 @@ func (mds *Datastore) mostRecentTxBefore(ctx context.Context, before time.Time) 
 	return uint64(value.Int64), nil
 }
 
-type garbageAmounts struct {
-	relationships int64
-	transactions  int64
-	namespaces    int64
-}
-
-func (g garbageAmounts) MarshalZerologObject(e *zerolog.Event) {
-	e.
-		Int64("relationships", g.relationships).
-		Int64("transactions", g.transactions).
-		Int64("namespaces", g.namespaces)
-}
-
 // TODO (@vroldanbet) dupe from postgres datastore - need to refactor
 // - implementation misses metrics
-func (mds *Datastore) deleteBefore(ctx context.Context, txID uint64) (amounts garbageAmounts, err error) {
+func (mds *Datastore) DeleteBeforeTx(ctx context.Context, txID uint64) (amounts common.GarbageCollectedAmounts, err error) {
 	// Delete any relationship rows with deleted_transaction <= the transaction ID.
-	amounts.relationships, err = mds.batchDelete(ctx, mds.driver.RelationTuple(), sq.LtOrEq{colDeletedTxn: txID})
+	amounts.Relationships, err = mds.batchDelete(ctx, mds.driver.RelationTuple(), sq.LtOrEq{colDeletedTxn: txID})
 	if err != nil {
 		return
 	}
@@ -181,13 +70,13 @@ func (mds *Datastore) deleteBefore(ctx context.Context, txID uint64) (amounts ga
 	//
 	// We don't delete the transaction itself to ensure there is always at least
 	// one transaction present.
-	amounts.transactions, err = mds.batchDelete(ctx, mds.driver.RelationTupleTransaction(), sq.Lt{colID: txID})
+	amounts.Transactions, err = mds.batchDelete(ctx, mds.driver.RelationTupleTransaction(), sq.Lt{colID: txID})
 	if err != nil {
 		return
 	}
 
 	// Delete any namespace rows with deleted_transaction <= the transaction ID.
-	amounts.namespaces, err = mds.batchDelete(ctx, mds.driver.Namespace(), sq.Lt{colID: txID})
+	amounts.Namespaces, err = mds.batchDelete(ctx, mds.driver.Namespace(), sq.LtOrEq{colDeletedTxn: txID})
 	return
 }
 

--- a/internal/datastore/mysql/gc.go
+++ b/internal/datastore/mysql/gc.go
@@ -1,0 +1,221 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/authzed/spicedb/pkg/datastore"
+)
+
+var (
+	gcDurationHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore_mysql",
+		Name:      "gc_duration_seconds",
+		Help:      "The duration of MySQL datastore garbage collection.",
+		Buckets:   []float64{0.01, 0.1, 0.5, 1, 5, 10, 25, 60, 120},
+	})
+
+	gcRelationshipsClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore_mysql",
+		Name:      "gc_relationships_total",
+		Help:      "The number of relationships cleared by the MySQL datastore garbage collection.",
+	})
+
+	gcTransactionsClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore_mysql",
+		Name:      "gc_transactions_total",
+		Help:      "The number of transactions cleared by the MySQL datastore garbage collection.",
+	})
+
+	gcNamespacesClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore_mysql",
+		Name:      "gc_namespaces_total",
+		Help:      "The number of namespaces cleared by the MySQL datastore garbage collection.",
+	})
+)
+
+func registerGCMetrics() error {
+	for _, metric := range []prometheus.Collector{
+		gcDurationHistogram,
+		gcRelationshipsClearedCounter,
+		gcTransactionsClearedCounter,
+		gcNamespacesClearedCounter,
+	} {
+		if err := prometheus.Register(metric); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
+func (mds *Datastore) runGarbageCollector() error {
+	log.Info().Dur("interval", mds.gcInterval).Msg("garbage collection worker started for mysql driver")
+
+	for {
+		select {
+		case <-mds.gcCtx.Done():
+			log.Info().Msg("shutting down garbage collection worker for mysql driver")
+			return mds.gcCtx.Err()
+
+		case <-time.After(mds.gcInterval):
+			err := mds.collectGarbage()
+			if err != nil {
+				log.Warn().Err(err).Msg("error when attempting to perform garbage collection")
+			}
+		}
+	}
+}
+
+// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
+// - an additional useful logging message is added
+// - context is removed from logger because zerolog expects logger in the context
+func (mds *Datastore) collectGarbage() error {
+	ctx, cancel := context.WithTimeout(context.Background(), mds.gcMaxOperationTime)
+	defer cancel()
+
+	var (
+		startTime = time.Now()
+		amounts   garbageAmounts
+		watermark uint64
+	)
+
+	defer func() {
+		collectionDuration := time.Since(startTime)
+		gcDurationHistogram.Observe(collectionDuration.Seconds())
+
+		log.Ctx(ctx).Trace().
+			Uint64("highestTxID", watermark).
+			Dur("duration", collectionDuration).
+			Interface("collected", amounts).
+			Msg("datastore garbage collection completed")
+
+		gcRelationshipsClearedCounter.Add(float64(amounts.relationships))
+		gcTransactionsClearedCounter.Add(float64(amounts.transactions))
+		gcNamespacesClearedCounter.Add(float64(amounts.namespaces))
+	}()
+
+	// Ensure the database is ready.
+	ready, err := mds.IsReady(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !ready {
+		log.Ctx(ctx).Warn().Msg("cannot perform datastore garbage collection: datastore is not yet ready")
+		return nil
+	}
+
+	now, err := mds.getNow(ctx)
+	if err != nil {
+		return err
+	}
+
+	watermark, err = mds.mostRecentTxBefore(ctx, now.Add(mds.gcWindowInverted))
+	if err != nil {
+		return err
+	}
+
+	amounts, err = mds.deleteBefore(ctx, watermark)
+	return err
+}
+
+// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
+// - main difference is how the PSQL driver handles null values
+func (mds *Datastore) mostRecentTxBefore(ctx context.Context, before time.Time) (uint64, error) {
+	// Find the highest transaction ID before the GC window.
+	query, args, err := mds.GetLastRevision.Where(sq.Lt{colTimestamp: before}).ToSql()
+	if err != nil {
+		return 0, err
+	}
+
+	var value sql.NullInt64
+	err = mds.db.QueryRowContext(
+		datastore.SeparateContextWithTracing(ctx), query, args...,
+	).Scan(&value)
+	if err != nil {
+		return 0, err
+	}
+
+	if !value.Valid {
+		log.Debug().Time("before", before).Msg("no stale transactions found in the datastore")
+		return 0, nil
+	}
+	return uint64(value.Int64), nil
+}
+
+type garbageAmounts struct {
+	relationships int64
+	transactions  int64
+	namespaces    int64
+}
+
+func (g garbageAmounts) MarshalZerologObject(e *zerolog.Event) {
+	e.
+		Int64("relationships", g.relationships).
+		Int64("transactions", g.transactions).
+		Int64("namespaces", g.namespaces)
+}
+
+// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
+// - implementation misses metrics
+func (mds *Datastore) deleteBefore(ctx context.Context, txID uint64) (amounts garbageAmounts, err error) {
+	// Delete any relationship rows with deleted_transaction <= the transaction ID.
+	amounts.relationships, err = mds.batchDelete(ctx, mds.driver.RelationTuple(), sq.LtOrEq{colDeletedTxn: txID})
+	if err != nil {
+		return
+	}
+
+	// Delete all transaction rows with ID < the transaction ID.
+	//
+	// We don't delete the transaction itself to ensure there is always at least
+	// one transaction present.
+	amounts.transactions, err = mds.batchDelete(ctx, mds.driver.RelationTupleTransaction(), sq.Lt{colID: txID})
+	if err != nil {
+		return
+	}
+
+	// Delete any namespace rows with deleted_transaction <= the transaction ID.
+	amounts.namespaces, err = mds.batchDelete(ctx, mds.driver.Namespace(), sq.Lt{colID: txID})
+	return
+}
+
+// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
+// - query was reworked to make it compatible with Vitess
+// - API differences with PSQL driver
+func (mds *Datastore) batchDelete(ctx context.Context, tableName string, filter sqlFilter) (int64, error) {
+	query, args, err := sb.Delete(tableName).Where(filter).Limit(batchDeleteSize).ToSql()
+	if err != nil {
+		return -1, err
+	}
+
+	var deletedCount int64
+	for {
+		cr, err := mds.db.ExecContext(ctx, query, args...)
+		if err != nil {
+			return deletedCount, err
+		}
+
+		rowsDeleted, err := cr.RowsAffected()
+		if err != nil {
+			return deletedCount, err
+		}
+		deletedCount += rowsDeleted
+		if rowsDeleted < batchDeleteSize {
+			break
+		}
+	}
+
+	return deletedCount, nil
+}

--- a/internal/datastore/mysql/migrations/zz_migration.0003_add_ns_config_id.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0003_add_ns_config_id.go
@@ -1,0 +1,26 @@
+package migrations
+
+import "fmt"
+
+func dropNSConfigPK(t *tables) string {
+	return fmt.Sprintf(
+		`ALTER TABLE %s DROP PRIMARY KEY;`,
+		t.tableNamespace,
+	)
+}
+
+func createNSConfigID(t *tables) string {
+	return fmt.Sprintf(
+		`ALTER TABLE %s ADD COLUMN id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;`,
+		t.tableNamespace,
+	)
+}
+
+func init() {
+	mustRegisterMigration("add_ns_config_id", "add_unique_datastore_id", noNonatomicMigration,
+		newStatementBatch(
+			dropNSConfigPK,
+			createNSConfigID,
+		).execute,
+	)
+}

--- a/internal/datastore/postgres/gc.go
+++ b/internal/datastore/postgres/gc.go
@@ -7,10 +7,58 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/jackc/pgtype"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"github.com/authzed/spicedb/pkg/datastore"
 )
+
+var (
+	gcDurationHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore_postgres",
+		Name:      "gc_duration_seconds",
+		Help:      "The duration of Postgres datastore garbage collection.",
+		Buckets:   []float64{0.01, 0.1, 0.5, 1, 5, 10, 25, 60, 120},
+	})
+
+	gcRelationshipsClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore_postgres",
+		Name:      "gc_relationships_total",
+		Help:      "The number of relationships cleared by the Postgres datastore garbage collection.",
+	})
+
+	gcTransactionsClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore_postgres",
+		Name:      "gc_transactions_total",
+		Help:      "The number of transactions cleared by the Postgres datastore garbage collection.",
+	})
+
+	gcNamespacesClearedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "spicedb",
+		Subsystem: "datastore_postgres",
+		Name:      "gc_namespaces_total",
+		Help:      "The number of namespaces cleared by the Postgres datastore garbage collection.",
+	})
+)
+
+func registerGCMetrics() error {
+	for _, metric := range []prometheus.Collector{
+		gcDurationHistogram,
+		gcRelationshipsClearedCounter,
+		gcTransactionsClearedCounter,
+		gcNamespacesClearedCounter,
+	} {
+		if err := prometheus.Register(metric); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 func (pgd *pgDatastore) runGarbageCollector() error {
 	log.Info().Dur("interval", pgd.gcInterval).Msg("garbage collection worker started for postgres driver")
@@ -33,13 +81,29 @@ func (pgd *pgDatastore) runGarbageCollector() error {
 }
 
 func (pgd *pgDatastore) collectGarbage() error {
-	startTime := time.Now()
-	defer func() {
-		gcDurationHistogram.Observe(time.Since(startTime).Seconds())
-	}()
-
 	ctx, cancel := context.WithTimeout(context.Background(), pgd.gcMaxOperationTime)
 	defer cancel()
+
+	var (
+		startTime = time.Now()
+		amounts   garbageAmounts
+		watermark uint64
+	)
+
+	defer func() {
+		collectionDuration := time.Since(startTime)
+		gcDurationHistogram.Observe(collectionDuration.Seconds())
+
+		log.Ctx(ctx).Trace().
+			Uint64("highestTxID", watermark).
+			Dur("duration", collectionDuration).
+			Interface("collected", amounts).
+			Msg("datastore garbage collection completed")
+
+		gcRelationshipsClearedCounter.Add(float64(amounts.relationships))
+		gcTransactionsClearedCounter.Add(float64(amounts.transactions))
+		gcNamespacesClearedCounter.Add(float64(amounts.namespaces))
+	}()
 
 	// Ensure the database is ready.
 	ready, err := pgd.IsReady(ctx)
@@ -48,7 +112,7 @@ func (pgd *pgDatastore) collectGarbage() error {
 	}
 
 	if !ready {
-		log.Ctx(ctx).Warn().Msg("cannot perform postgres garbage collection: postgres driver is not yet ready")
+		log.Ctx(ctx).Warn().Msg("cannot perform datastore garbage collection: datastore is not yet ready")
 		return nil
 	}
 
@@ -57,17 +121,20 @@ func (pgd *pgDatastore) collectGarbage() error {
 		return err
 	}
 
-	before := now.Add(pgd.gcWindowInverted)
-	log.Ctx(ctx).Debug().Time("before", before).Msg("running postgres garbage collection")
-	_, _, err = pgd.collectGarbageBefore(ctx, before)
+	watermark, err = pgd.mostRecentTxBefore(ctx, now.Add(pgd.gcWindowInverted))
+	if err != nil {
+		return err
+	}
+
+	amounts, err = pgd.deleteBefore(ctx, watermark)
 	return err
 }
 
-func (pgd *pgDatastore) collectGarbageBefore(ctx context.Context, before time.Time) (int64, int64, error) {
+func (pgd *pgDatastore) mostRecentTxBefore(ctx context.Context, before time.Time) (uint64, error) {
 	// Find the highest transaction ID before the GC window.
 	sql, args, err := getRevision.Where(sq.Lt{colTimestamp: before}).ToSql()
 	if err != nil {
-		return 0, 0, err
+		return 0, err
 	}
 
 	value := pgtype.Int8{}
@@ -75,45 +142,59 @@ func (pgd *pgDatastore) collectGarbageBefore(ctx context.Context, before time.Ti
 		datastore.SeparateContextWithTracing(ctx), sql, args...,
 	).Scan(&value)
 	if err != nil {
-		return 0, 0, err
+		return 0, err
 	}
 
 	if value.Status != pgtype.Present {
 		log.Ctx(ctx).Debug().Time("before", before).Msg("no stale transactions found in the datastore")
-		return 0, 0, nil
+		return 0, err
 	}
 
 	var highest uint64
 	err = value.AssignTo(&highest)
 	if err != nil {
-		return 0, 0, err
+		return 0, err
 	}
 
-	log.Ctx(ctx).Trace().Uint64("highestTransactionId", highest).Msg("retrieved transaction ID for GC")
-
-	return pgd.collectGarbageForTransaction(ctx, highest)
+	return highest, nil
 }
 
-func (pgd *pgDatastore) collectGarbageForTransaction(ctx context.Context, highest uint64) (int64, int64, error) {
+type garbageAmounts struct {
+	relationships int64
+	transactions  int64
+	namespaces    int64
+}
+
+func (g garbageAmounts) MarshalZerologObject(e *zerolog.Event) {
+	e.
+		Int64("relationships", g.relationships).
+		Int64("transactions", g.transactions).
+		Int64("namespaces", g.namespaces)
+}
+
+func (pgd *pgDatastore) deleteBefore(ctx context.Context, txID uint64) (amounts garbageAmounts, err error) {
 	// Delete any relationship rows with deleted_transaction <= the transaction ID.
-	relCount, err := pgd.batchDelete(ctx, tableTuple, sq.LtOrEq{colDeletedTxn: highest})
+	amounts.relationships, err = pgd.batchDelete(ctx, tableTuple, sq.LtOrEq{colDeletedTxn: txID})
 	if err != nil {
-		return 0, 0, err
+		return
 	}
 
-	log.Ctx(ctx).Trace().Uint64("highestTransactionId", highest).Int64("relationshipsDeleted", relCount).Msg("deleted stale relationships")
-	gcRelationshipsClearedGauge.Set(float64(relCount))
-
-	// Delete all transaction rows with ID < the transaction ID. We don't delete the transaction
-	// itself to ensure there is always at least one transaction present.
-	transactionCount, err := pgd.batchDelete(ctx, tableTransaction, sq.Lt{colID: highest})
+	// Delete all transaction rows with ID < the transaction ID.
+	//
+	// We don't delete the transaction itself to ensure there is always at least
+	// one transaction present.
+	amounts.transactions, err = pgd.batchDelete(ctx, tableTransaction, sq.Lt{colID: txID})
 	if err != nil {
-		return relCount, 0, err
+		return
 	}
 
-	log.Ctx(ctx).Trace().Uint64("highestTransactionId", highest).Int64("transactionsDeleted", transactionCount).Msg("deleted stale transactions")
-	gcTransactionsClearedGauge.Set(float64(transactionCount))
-	return relCount, transactionCount, nil
+	// Delete any namespace rows with deleted_transaction <= the transaction ID.
+	amounts.namespaces, err = pgd.batchDelete(ctx, tableNamespace, sq.Lt{colID: txID})
+	if err != nil {
+		return
+	}
+
+	return
 }
 
 func (pgd *pgDatastore) batchDelete(ctx context.Context, tableName string, filter sqlFilter) (int64, error) {

--- a/internal/datastore/postgres/migrations/zz_migration.0008_add_ns_config_id.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0008_add_ns_config_id.go
@@ -12,17 +12,21 @@ const (
 )
 
 func init() {
-	if err := DatabaseMigrations.Register("add-ns-config-id", "add-unique-datastore-id", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
-		if _, err := tx.Exec(ctx, dropNSConfigPK); err != nil {
-			return err
-		}
+	if err := DatabaseMigrations.Register(
+		"add-ns-config-id",
+		"add-unique-datastore-id",
+		noNonatomicMigration,
+		func(ctx context.Context, tx pgx.Tx) error {
+			if _, err := tx.Exec(ctx, dropNSConfigPK); err != nil {
+				return err
+			}
 
-		if _, err := tx.Exec(ctx, createNSConfigID); err != nil {
-			return err
-		}
+			if _, err := tx.Exec(ctx, createNSConfigID); err != nil {
+				return err
+			}
 
-		return nil
-	}); err != nil {
+			return nil
+		}); err != nil {
 		panic("failed to register migration: " + err.Error())
 	}
 }

--- a/internal/datastore/postgres/migrations/zz_migration.0008_add_ns_config_id.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0008_add_ns_config_id.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+)
+
+const (
+	dropNSConfigPK   = `ALTER TABLE namespace_config DROP CONSTRAINT IF EXISTS pk_namespace_config`
+	createNSConfigID = `ALTER TABLE namespace_config ADD COLUMN id BIGSERIAL PRIMARY KEY`
+)
+
+func init() {
+	if err := DatabaseMigrations.Register("add-ns-config-id", "add-unique-datastore-id", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, dropNSConfigPK); err != nil {
+			return err
+		}
+
+		if _, err := tx.Exec(ctx, createNSConfigID); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -133,9 +133,9 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	// Run GC at the transaction and ensure no relationships are removed.
 	pds := ds.(*pgDatastore)
 
-	relsDeleted, _, err := pds.collectGarbageForTransaction(ctx, uint64(writtenAt.IntPart()))
-	require.Equal(int64(0), relsDeleted)
+	amounts, err := pds.DeleteBeforeTx(ctx, uint64(writtenAt.IntPart()))
 	require.NoError(err)
+	require.Zero(amounts.Relationships)
 
 	// Write a relationship.
 	tpl := &core.RelationTuple{
@@ -161,16 +161,16 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Run GC at the transaction and ensure no relationships are removed, but 1 transaction (the previous write namespace) is.
-	relsDeleted, transactionsDeleted, err := pds.collectGarbageForTransaction(ctx, uint64(relWrittenAt.IntPart()))
-	require.Equal(int64(0), relsDeleted)
-	require.Equal(int64(1), transactionsDeleted)
+	amounts, err = pds.DeleteBeforeTx(ctx, uint64(relWrittenAt.IntPart()))
 	require.NoError(err)
+	require.Zero(amounts.Relationships)
+	require.Equal(int64(1), amounts.Transactions)
 
 	// Run GC again and ensure there are no changes.
-	relsDeleted, transactionsDeleted, err = pds.collectGarbageForTransaction(ctx, uint64(relWrittenAt.IntPart()))
-	require.Equal(int64(0), relsDeleted)
-	require.Equal(int64(0), transactionsDeleted)
+	amounts, err = pds.DeleteBeforeTx(ctx, uint64(relWrittenAt.IntPart()))
 	require.NoError(err)
+	require.Zero(amounts.Relationships)
+	require.Zero(amounts.Transactions)
 
 	// Ensure the relationship is still present.
 	tRequire := testfixtures.TupleChecker{Require: require, DS: ds}
@@ -186,16 +186,16 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Run GC at the transaction and ensure the (older copy of the) relationship is removed, as well as 1 transaction (the write).
-	relsDeleted, transactionsDeleted, err = pds.collectGarbageForTransaction(ctx, uint64(relOverwrittenAt.IntPart()))
-	require.Equal(int64(1), relsDeleted)
-	require.Equal(int64(1), transactionsDeleted)
+	amounts, err = pds.DeleteBeforeTx(ctx, uint64(relOverwrittenAt.IntPart()))
 	require.NoError(err)
+	require.Equal(int64(1), amounts.Relationships)
+	require.Equal(int64(1), amounts.Transactions)
 
 	// Run GC again and ensure there are no changes.
-	relsDeleted, transactionsDeleted, err = pds.collectGarbageForTransaction(ctx, uint64(relOverwrittenAt.IntPart()))
-	require.Equal(int64(0), relsDeleted)
-	require.Equal(int64(0), transactionsDeleted)
+	amounts, err = pds.DeleteBeforeTx(ctx, uint64(relOverwrittenAt.IntPart()))
 	require.NoError(err)
+	require.Zero(amounts.Relationships)
+	require.Zero(amounts.Transactions)
 
 	// Ensure the relationship is still present.
 	tRequire.TupleExists(ctx, tpl, relOverwrittenAt)
@@ -213,16 +213,16 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	tRequire.NoTupleExists(ctx, tpl, relDeletedAt)
 
 	// Run GC at the transaction and ensure the relationship is removed, as well as 1 transaction (the overwrite).
-	relsDeleted, transactionsDeleted, err = pds.collectGarbageForTransaction(ctx, uint64(relDeletedAt.IntPart()))
-	require.Equal(int64(1), relsDeleted)
-	require.Equal(int64(1), transactionsDeleted)
+	amounts, err = pds.DeleteBeforeTx(ctx, uint64(relDeletedAt.IntPart()))
 	require.NoError(err)
+	require.Equal(int64(1), amounts.Relationships)
+	require.Equal(int64(1), amounts.Transactions)
 
 	// Run GC again and ensure there are no changes.
-	relsDeleted, transactionsDeleted, err = pds.collectGarbageForTransaction(ctx, uint64(relDeletedAt.IntPart()))
-	require.Equal(int64(0), relsDeleted)
-	require.Equal(int64(0), transactionsDeleted)
+	amounts, err = pds.DeleteBeforeTx(ctx, uint64(relDeletedAt.IntPart()))
 	require.NoError(err)
+	require.Zero(amounts.Relationships)
+	require.Zero(amounts.Transactions)
 
 	// Write a the relationship a few times.
 	var relLastWriteAt datastore.Revision
@@ -239,10 +239,10 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 
 	// Run GC at the transaction and ensure the older copies of the relationships are removed,
 	// as well as the 2 older write transactions and the older delete transaction.
-	relsDeleted, transactionsDeleted, err = pds.collectGarbageForTransaction(ctx, uint64(relLastWriteAt.IntPart()))
-	require.Equal(int64(2), relsDeleted)
-	require.Equal(int64(3), transactionsDeleted)
+	amounts, err = pds.DeleteBeforeTx(ctx, uint64(relLastWriteAt.IntPart()))
 	require.NoError(err)
+	require.Equal(int64(2), amounts.Relationships)
+	require.Equal(int64(3), amounts.Transactions)
 
 	// Ensure the relationship is still present.
 	tRequire.TupleExists(ctx, tpl, relLastWriteAt)
@@ -262,7 +262,7 @@ func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Get timestamp in UTC as reference
-	startTimeUTC, err := pgd.getNow(ctx)
+	startTimeUTC, err := pgd.Now(ctx)
 	require.NoError(err)
 
 	// Transaction timestamp should not be stored in system time zone
@@ -334,13 +334,16 @@ func GarbageCollectionByTimeTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Run GC and ensure only transactions were removed.
-	afterWrite, err := pds.getNow(ctx)
+	afterWrite, err := pds.Now(ctx)
 	require.NoError(err)
 
-	relsDeleted, transactionsDeleted, err := pds.collectGarbageBefore(ctx, afterWrite)
-	require.Equal(int64(0), relsDeleted)
-	require.True(transactionsDeleted > 0)
+	afterWriteTx, err := pds.TxIDBefore(ctx, afterWrite)
 	require.NoError(err)
+
+	amounts, err := pds.DeleteBeforeTx(ctx, afterWriteTx)
+	require.NoError(err)
+	require.Zero(amounts.Relationships)
+	require.True(amounts.Transactions > 0)
 
 	// Ensure the relationship is still present.
 	tRequire := testfixtures.TupleChecker{Require: require, DS: ds}
@@ -359,13 +362,16 @@ func GarbageCollectionByTimeTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Run GC and ensure the relationship is removed.
-	afterDelete, err := pds.getNow(ctx)
+	afterDelete, err := pds.Now(ctx)
 	require.NoError(err)
 
-	relsDeleted, transactionsDeleted, err = pds.collectGarbageBefore(ctx, afterDelete)
-	require.Equal(int64(1), relsDeleted)
-	require.Equal(int64(1), transactionsDeleted)
+	afterDeleteTx, err := pds.TxIDBefore(ctx, afterDelete)
 	require.NoError(err)
+
+	amounts, err = pds.DeleteBeforeTx(ctx, afterDeleteTx)
+	require.NoError(err)
+	require.Equal(int64(1), amounts.Relationships)
+	require.Equal(int64(1), amounts.Transactions)
 
 	// Ensure the relationship is still not present.
 	tRequire.NoTupleExists(ctx, tpl, relDeletedAt)
@@ -432,13 +438,16 @@ func ChunkedGarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	}
 
 	// Run GC and ensure only transactions were removed.
-	afterWrite, err := pds.getNow(ctx)
+	afterWrite, err := pds.Now(ctx)
 	require.NoError(err)
 
-	relsDeleted, transactionsDeleted, err := pds.collectGarbageBefore(ctx, afterWrite)
-	require.Equal(int64(0), relsDeleted)
-	require.True(transactionsDeleted > 0)
+	afterWriteTx, err := pds.TxIDBefore(ctx, afterWrite)
 	require.NoError(err)
+
+	amounts, err := pds.DeleteBeforeTx(ctx, afterWriteTx)
+	require.NoError(err)
+	require.Zero(amounts.Relationships)
+	require.True(amounts.Transactions > 0)
 
 	// Sleep to ensure the relationships will GC.
 	time.Sleep(1 * time.Millisecond)
@@ -467,13 +476,16 @@ func ChunkedGarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	time.Sleep(1 * time.Millisecond)
 
 	// Run GC and ensure all the stale relationships are removed.
-	afterDelete, err := pds.getNow(ctx)
+	afterDelete, err := pds.Now(ctx)
 	require.NoError(err)
 
-	relsDeleted, transactionsDeleted, err = pds.collectGarbageBefore(ctx, afterDelete)
-	require.Equal(int64(chunkRelationshipCount), relsDeleted)
-	require.Equal(int64(1), transactionsDeleted)
+	afterDeleteTx, err := pds.TxIDBefore(ctx, afterDelete)
 	require.NoError(err)
+
+	amounts, err = pds.DeleteBeforeTx(ctx, afterDeleteTx)
+	require.NoError(err)
+	require.Equal(int64(chunkRelationshipCount), amounts.Relationships)
+	require.Equal(int64(1), amounts.Transactions)
 }
 
 func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {


### PR DESCRIPTION
Fixes #660

Most of this change is clean-up.

- Converts gc metrics into counters
- Introduces a type for the amounts collected
- Hoists logging to one central defer
- Slight refactor to separate concerns between the various gc methods
- Shares GC logic in a common package
- Adds an `id` column to namespace tables for MySQL and Postgres datastores ⚠️ **WARNING DB MIGRATION**