### PR TITLE
Postgres datastore: make read tx REPEATABLE_READ

### DIFF
--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -208,7 +208,7 @@ func NewPostgresDatastore(
 		usersetBatchSize:        config.splitAtUsersetCount,
 		gcCtx:                   gcCtx,
 		cancelGc:                cancelGc,
-		readTxOptions:           pgx.TxOptions{IsoLevel: pgx.Serializable, AccessMode: pgx.ReadOnly},
+		readTxOptions:           pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly},
 		maxRetries:              config.maxRetries,
 	}
 


### PR DESCRIPTION
Since 1.8.0, if using Postgres all transactions have the isolation level `SERIALIZABLE` (https://github.com/authzed/spicedb/pull/581/files#diff-cc7f4962fde0ca83da82d95e2d7e23f00084437867c3cbe61eb70b4509576496R288). It is problematic if using a read replica: these do not support the SERIALIZABLE level (see last point in https://www.postgresql.org/docs/current/hot-standby.html#HOT-STANDBY-CAVEATS).

As a real-life use-case, I have some client-side code to direct all the checkPermission without a zedToken to a read replica (AWS Aurora). This means that I can't use a read replica at all with 1.8.0, which means I lose a lot of reliability and horizontal scalability. It would be better to handle RRs within SpiceDB, but that's a different discussion :)  😬 

Using `REPEATABLE_READ` for read transactions yields the same result as `SERIALISABLE`, and is compatible with read replicas.