### PR TITLE
fix cert rotation test flake

### DIFF
--- a/internal/services/cert_test.go
+++ b/internal/services/cert_test.go
@@ -33,7 +33,7 @@ import (
 func TestCertRotation(t *testing.T) {
 	const (
 		// length of time the initial cert is valid
-		initialValidDuration = 500 * time.Millisecond
+		initialValidDuration = 1 * time.Second
 		// continue making requests for waitFactor*initialValidDuration
 		waitFactor = 3
 	)


### PR DESCRIPTION
Sometimes 500ms is not enough time for the services to start and start responding to requests, so the cert is invalid by the time the first request is sent and the test hangs.

Doubling the time to 1s seems to make this not flake anymore.