### PR TITLE
Prevent release version errors from blocking SpiceDB startup

### DIFF
--- a/pkg/releases/cli.go
+++ b/pkg/releases/cli.go
@@ -29,7 +29,8 @@ func CheckAndLogRunE() cobrautil.CobraRunFunc {
 
 		state, currentVersion, release, err := CheckIsLatestVersion(ctx, CurrentVersion, GetLatestRelease)
 		if err != nil {
-			return err
+			log.Warn().Str("this-version", currentVersion).Err(err).Msg("could not perform version checking; if this problem persists or to skip this check, add --skip-release-check=true")
+			return nil
 		}
 
 		switch state {


### PR DESCRIPTION
Instead, we log a warning, as these errors could be due to external API conditions, such as GitHub 403ing

Fixes #695