### PR TITLE
wip: test crdb global tables

### DIFF
--- a/e2e/cockroach/cockroach.go
+++ b/e2e/cockroach/cockroach.go
@@ -23,6 +23,7 @@ type Node struct {
 	Httpaddr  string
 	ID        string
 	MaxOffset time.Duration
+	Region    string
 	Cancel    context.CancelFunc
 	// only available after Start()
 	pid  int
@@ -45,6 +46,7 @@ func (c *Node) Start(ctx context.Context) error {
 		"--http-addr=" + c.Httpaddr,
 		"--join=" + strings.Join(c.Peers, ","),
 		"--max-offset=" + c.MaxOffset.String(),
+		"--locality=region=" + c.Region,
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -129,6 +131,7 @@ func NewCluster(n int) Cluster {
 			Addr:      addr,
 			Httpaddr:  net.JoinHostPort("localhost", strconv.Itoa(http+i)),
 			MaxOffset: 5 * time.Second,
+			Region:    fmt.Sprintf("region-%d", i),
 		})
 	}
 	for i := range cs {

--- a/internal/datastore/crdb/migrations/zz_migration.0004_set_global_tables.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0004_set_global_tables.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+)
+
+const (
+	makeNamespaceGlobal = `ALTER TABLE namespace_config SET LOCALITY GLOBAL`
+	makeTuplesGlobal    = `ALTER TABLE relation_tuple SET LOCALITY GLOBAL`
+	makeCountersGlobal  = `ALTER TABLE relationship_estimate_counters SET LOCALITY GLOBAL`
+)
+
+func init() {
+	if err := CRDBMigrations.Register("set-global-tables", "add-metadata-and-counters", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, makeNamespaceGlobal); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, makeTuplesGlobal); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, makeCountersGlobal); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}


### PR DESCRIPTION
In theory, global tables have the properties we need for new enemy prevention without "overlap keys".

This PR switches the test suite over to using global tables to see how they perform.



