### PR TITLE
remove rangefeed config from crdb migrations

### DIFF
--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -35,7 +35,7 @@ func TestCRDBDatastore(t *testing.T) {
 	}))
 }
 
-func CRDBDatastoreWithFollowerReadsTest(t *testing.T, ds datastore.Datastore) {
+func TestCRDBDatastoreWithFollowerReads(t *testing.T) {
 	followerReadDelay := time.Duration(4.8 * float64(time.Second))
 	gcWindow := 100 * time.Second
 

--- a/internal/datastore/crdb/migrations/zz_migration.0001_initial_schema.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0001_initial_schema.go
@@ -30,17 +30,12 @@ const (
 
 	insertEmptyVersion = `INSERT INTO schema_version (version_num) VALUES ('');`
 
-	enableRangefeeds = `SET CLUSTER SETTING kv.rangefeed.enabled = true;`
-
 	createReverseQueryIndex = `CREATE INDEX ix_relation_tuple_by_subject ON relation_tuple (userset_object_id, userset_namespace, userset_relation, namespace, relation)`
 	createReverseCheckIndex = `CREATE INDEX ix_relation_tuple_by_subject_relation ON relation_tuple (userset_namespace, userset_relation, namespace, relation)`
 )
 
 func init() {
-	if err := CRDBMigrations.Register("initial", "", func(ctx context.Context, conn *pgx.Conn) error {
-		_, err := conn.Exec(ctx, enableRangefeeds)
-		return err
-	}, func(ctx context.Context, tx pgx.Tx) error {
+	if err := CRDBMigrations.Register("initial", "", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
 		statements := []string{
 			createNamespaceConfig,
 			createRelationTuple,

--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -241,6 +241,10 @@ func (mdb *memdbDatastore) IsReady(ctx context.Context) (bool, error) {
 	return len(mdb.revisions) > 0, nil
 }
 
+func (mdb *memdbDatastore) Features(ctx context.Context) (*datastore.Features, error) {
+	return &datastore.Features{Watch: datastore.Feature{Enabled: true}}, nil
+}
+
 func (mdb *memdbDatastore) Close() error {
 	mdb.Lock()
 	defer mdb.Unlock()

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -451,6 +451,10 @@ func (mds *Datastore) IsReady(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+func (mds *Datastore) Features(ctx context.Context) (*datastore.Features, error) {
+	return &datastore.Features{Watch: datastore.Feature{Enabled: true}}, nil
+}
+
 // isSeeded determines if the backing database has been seeded
 func (mds *Datastore) isSeeded(ctx context.Context) (bool, error) {
 	headRevision, err := mds.HeadRevision(ctx)

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -344,6 +344,10 @@ func (pgd *pgDatastore) IsReady(ctx context.Context) (bool, error) {
 	return version == headMigration, nil
 }
 
+func (pgd *pgDatastore) Features(ctx context.Context) (*datastore.Features, error) {
+	return &datastore.Features{Watch: datastore.Feature{Enabled: true}}, nil
+}
+
 func buildLivingObjectFilterForRevision(revision datastore.Revision) queryFilterer {
 	return func(original sq.SelectBuilder) sq.SelectBuilder {
 		return original.Where(sq.LtOrEq{colCreatedTxn: transactionFromRevision(revision)}).

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -59,6 +59,11 @@ func (dm *MockDatastore) IsReady(ctx context.Context) (bool, error) {
 	return args.Bool(0), args.Error(1)
 }
 
+func (dm *MockDatastore) Features(ctx context.Context) (*datastore.Features, error) {
+	args := dm.Called()
+	return args.Get(0).(*datastore.Features), args.Error(1)
+}
+
 func (dm *MockDatastore) Statistics(ctx context.Context) (datastore.Stats, error) {
 	args := dm.Called()
 	return args.Get(0).(datastore.Stats), args.Error(1)

--- a/internal/datastore/proxy/readonly.go
+++ b/internal/datastore/proxy/readonly.go
@@ -9,47 +9,15 @@ import (
 var errReadOnly = datastore.NewReadonlyErr()
 
 type roDatastore struct {
-	delegate datastore.Datastore
+	datastore.Datastore
 }
 
 // NewReadonlyDatastore creates a proxy which disables write operations to a downstream delegate
 // datastore.
 func NewReadonlyDatastore(delegate datastore.Datastore) datastore.Datastore {
-	return roDatastore{delegate: delegate}
-}
-
-func (rd roDatastore) SnapshotReader(rev datastore.Revision) datastore.Reader {
-	return rd.delegate.SnapshotReader(rev)
+	return roDatastore{Datastore: delegate}
 }
 
 func (rd roDatastore) ReadWriteTx(context.Context, datastore.TxUserFunc) (datastore.Revision, error) {
 	return datastore.NoRevision, errReadOnly
-}
-
-func (rd roDatastore) Close() error {
-	return rd.delegate.Close()
-}
-
-func (rd roDatastore) IsReady(ctx context.Context) (bool, error) {
-	return rd.delegate.IsReady(ctx)
-}
-
-func (rd roDatastore) OptimizedRevision(ctx context.Context) (datastore.Revision, error) {
-	return rd.delegate.OptimizedRevision(ctx)
-}
-
-func (rd roDatastore) HeadRevision(ctx context.Context) (datastore.Revision, error) {
-	return rd.delegate.HeadRevision(ctx)
-}
-
-func (rd roDatastore) CheckRevision(ctx context.Context, revision datastore.Revision) error {
-	return rd.delegate.CheckRevision(ctx, revision)
-}
-
-func (rd roDatastore) Watch(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
-	return rd.delegate.Watch(ctx, afterRevision)
-}
-
-func (rd roDatastore) Statistics(ctx context.Context) (datastore.Stats, error) {
-	return rd.delegate.Statistics(ctx)
 }

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -156,6 +156,10 @@ func (sd spannerDatastore) IsReady(ctx context.Context) (bool, error) {
 	return version == headMigration, nil
 }
 
+func (sd spannerDatastore) Features(ctx context.Context) (*datastore.Features, error) {
+	return &datastore.Features{Watch: datastore.Feature{Enabled: true}}, nil
+}
+
 func (sd spannerDatastore) Close() error {
 	sd.stopGC()
 	sd.client.Close()

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -14,8 +14,11 @@ import (
 	v1alpha1svc "github.com/authzed/spicedb/internal/services/v1alpha1"
 )
 
-// SchemaServiceOption defines the options for enabled or disabled the V1 Schema service.
+// SchemaServiceOption defines the options for enabling or disabling the V1 Schema service.
 type SchemaServiceOption int
+
+// WatchServiceOption defines the options for enabling or disabling the V1 Watch service.
+type WatchServiceOption int
 
 const (
 	// V1SchemaServiceDisabled indicates that the V1 schema service is disabled.
@@ -23,6 +26,12 @@ const (
 
 	// V1SchemaServiceEnabled indicates that the V1 schema service is enabled.
 	V1SchemaServiceEnabled SchemaServiceOption = 1
+
+	// WatchServiceDisabled indicates that the V1 watch service is disabled.
+	WatchServiceDisabled WatchServiceOption = 0
+
+	// WatchServiceEnabled indicates that the V1 watch service is enabled.
+	WatchServiceEnabled WatchServiceOption = 1
 )
 
 const (
@@ -38,6 +47,7 @@ func RegisterGrpcServices(
 	maxDepth uint32,
 	prefixRequired v1alpha1svc.PrefixRequiredOption,
 	schemaServiceOption SchemaServiceOption,
+	watchServiceOption WatchServiceOption,
 ) {
 	healthManager.RegisterReportedService(OverallServerHealthCheckKey)
 
@@ -47,8 +57,10 @@ func RegisterGrpcServices(
 	v1.RegisterPermissionsServiceServer(srv, v1svc.NewPermissionsServer(dispatch, maxDepth))
 	healthManager.RegisterReportedService(v1.PermissionsService_ServiceDesc.ServiceName)
 
-	v1.RegisterWatchServiceServer(srv, v1svc.NewWatchServer())
-	healthManager.RegisterReportedService(v1.WatchService_ServiceDesc.ServiceName)
+	if watchServiceOption == WatchServiceEnabled {
+		v1.RegisterWatchServiceServer(srv, v1svc.NewWatchServer())
+		healthManager.RegisterReportedService(v1.WatchService_ServiceDesc.ServiceName)
+	}
 
 	if schemaServiceOption == V1SchemaServiceEnabled {
 		v1.RegisterSchemaServiceServer(srv, v1svc.NewSchemaServer())

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -14,25 +14,17 @@ import (
 )
 
 type validatingDatastore struct {
-	delegate datastore.Datastore
+	datastore.Datastore
 }
 
 // NewValidatingDatastore creates a proxy which runs validation on all call parameters before
 // passing the call onward.
 func NewValidatingDatastore(delegate datastore.Datastore) datastore.Datastore {
-	return validatingDatastore{delegate: delegate}
-}
-
-func (vd validatingDatastore) Close() error {
-	return vd.delegate.Close()
-}
-
-func (vd validatingDatastore) IsReady(ctx context.Context) (bool, error) {
-	return vd.delegate.IsReady(ctx)
+	return validatingDatastore{Datastore: delegate}
 }
 
 func (vd validatingDatastore) SnapshotReader(revision datastore.Revision) datastore.Reader {
-	return validatingSnapshotReader{vd.delegate.SnapshotReader(revision)}
+	return validatingSnapshotReader{vd.Datastore.SnapshotReader(revision)}
 }
 
 func (vd validatingDatastore) ReadWriteTx(
@@ -43,30 +35,10 @@ func (vd validatingDatastore) ReadWriteTx(
 		return datastore.NoRevision, fmt.Errorf("nil delegate function")
 	}
 
-	return vd.delegate.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
+	return vd.Datastore.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 		txDelegate := validatingReadWriteTransaction{validatingSnapshotReader{rwt}, rwt}
 		return f(ctx, txDelegate)
 	})
-}
-
-func (vd validatingDatastore) OptimizedRevision(ctx context.Context) (datastore.Revision, error) {
-	return vd.delegate.OptimizedRevision(ctx)
-}
-
-func (vd validatingDatastore) HeadRevision(ctx context.Context) (datastore.Revision, error) {
-	return vd.delegate.HeadRevision(ctx)
-}
-
-func (vd validatingDatastore) CheckRevision(ctx context.Context, revision datastore.Revision) error {
-	return vd.delegate.CheckRevision(ctx, revision)
-}
-
-func (vd validatingDatastore) Watch(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
-	return vd.delegate.Watch(ctx, afterRevision)
-}
-
-func (vd validatingDatastore) Statistics(ctx context.Context) (datastore.Stats, error) {
-	return vd.delegate.Statistics(ctx)
 }
 
 type validatingSnapshotReader struct {

--- a/internal/testserver/datastore/crdb.go
+++ b/internal/testserver/datastore/crdb.go
@@ -16,6 +16,8 @@ import (
 	"github.com/authzed/spicedb/pkg/secrets"
 )
 
+const enableRangefeeds = `SET CLUSTER SETTING kv.rangefeed.enabled = true;`
+
 type crdbTester struct {
 	conn     *pgx.Conn
 	hostname string
@@ -61,7 +63,10 @@ func RunCRDBForTesting(t testing.TB, bridgeNetworkName string) RunningEngineForT
 		if err != nil {
 			return err
 		}
-		return nil
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, err = builder.conn.Exec(ctx, enableRangefeeds)
+		return err
 	}))
 
 	return builder

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -60,6 +60,7 @@ func (c *Config) Complete() (RunnableTestServer, error) {
 			maxDepth,
 			v1alpha1svc.PrefixNotRequired,
 			services.V1SchemaServiceEnabled,
+			services.WatchServiceEnabled,
 		)
 	}
 	gRPCSrv, err := c.GRPCServer.Complete(zerolog.InfoLevel, registerServices,

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -159,11 +159,28 @@ type Datastore interface {
 	// the necessary tables.
 	IsReady(ctx context.Context) (bool, error)
 
+	// Features returns an object representing what features this
+	// datastore can support.
+	Features(ctx context.Context) (*Features, error)
+
 	// Statistics returns relevant values about the data contained in this cluster.
 	Statistics(ctx context.Context) (Stats, error)
 
 	// Close closes the data store.
 	Close() error
+}
+
+// Feature represents a capability that a datastore can support, plus an
+// optional message explaining the feature is available (or not).
+type Feature struct {
+	Enabled bool
+	Reason  string
+}
+
+// Features holds values that represent what features a database can support.
+type Features struct {
+	// Watch is enabled if the underlying datastore can support the Watch api.
+	Watch Feature
 }
 
 // ObjectTypeStat represents statistics for a single object type (namespace).


### PR DESCRIPTION
`rangefeed` is a cluster-wide setting in cockroachdb that requires `admin` permission to change, and depending on how cockroach is running, it may not be user-configurable at all. It also affects the entire cockroach cluster (not just the logical database for spicedb) so there is a bit of an impedance mismatch by having the migrations set the flag.

For example, in cockroach serverless, attempting to enable rangefeeds gives this message:

```
{"level":"fatal","error":"error executing migration function: ERROR: cluster setting 'kv.rangefeed.enabled' is currently overridden by the operator (SQLSTATE XXUUU)","time":"2022-07-27T11:02:04-07:00","message":"unable to complete requested migrations"}
```
(thanks to @arashpayan for reporting this!)

This PR removes the rangefeed setting from the migrations. It adds a new `Features` method to the datastore interface which reports which features are enabled/disabled for a given datastore - the only one right now is `Watch`, and the only implementation that can disable it is cockroach, but we will likely find other uses for probing a datastore for settings in the future.

If the underlying cockroach doesn't support rangefeeds, the watch API is disabled, and a warning is printed on startup:
```json
{"level":"warn","reason":"Range feeds must be enabled in CockroachDB to support the Watch API. A CockroachDB admin can set kv.rangefeed.enabled = true to enable range feeds.","time":"2022-08-01T12:58:39Z","message":"watch api disabled; underlying datastore does not support it"}
```