### PR TITLE
Add a flag for disabling stat writes

### DIFF
--- a/e2e/spice/spicedb.go
+++ b/e2e/spice/spicedb.go
@@ -85,6 +85,7 @@ func (s *Node) Start(ctx context.Context, logprefix string, args ...string) erro
 		fmt.Sprintf("--dispatch-cluster-addr=:%d", s.DispatchPort),
 		fmt.Sprintf("--metrics-addr=:%d", s.MetricsPort),
 		fmt.Sprintf("--dashboard-addr=:%d", s.DashboardPort),
+		"--datastore-disable-stats=true",
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/internal/datastore/crdb/options.go
+++ b/internal/datastore/crdb/options.go
@@ -20,6 +20,7 @@ type crdbOptions struct {
 	splitAtUsersetCount         uint16
 	overlapStrategy             string
 	overlapKey                  string
+	disableStats                bool
 }
 
 const (
@@ -55,6 +56,7 @@ func generateConfig(options []Option) (crdbOptions, error) {
 		maxRetries:                  defaultMaxRetries,
 		overlapKey:                  defaultOverlapKey,
 		overlapStrategy:             defaultOverlapStrategy,
+		disableStats:                false,
 	}
 
 	for _, option := range options {
@@ -195,5 +197,12 @@ func OverlapStrategy(strategy string) Option {
 func OverlapKey(key string) Option {
 	return func(po *crdbOptions) {
 		po.overlapKey = key
+	}
+}
+
+// DisableStats disables recording counts to the stats table
+func DisableStats(disable bool) Option {
+	return func(po *crdbOptions) {
+		po.disableStats = disable
 	}
 }

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -29,6 +29,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.SplitQueryCount = c.SplitQueryCount
 		to.ReadOnly = c.ReadOnly
 		to.EnableDatastoreMetrics = c.EnableDatastoreMetrics
+		to.DisableStats = c.DisableStats
 		to.BootstrapFiles = c.BootstrapFiles
 		to.BootstrapOverwrite = c.BootstrapOverwrite
 		to.RequestHedgingEnabled = c.RequestHedgingEnabled
@@ -138,6 +139,13 @@ func WithReadOnly(readOnly bool) ConfigOption {
 func WithEnableDatastoreMetrics(enableDatastoreMetrics bool) ConfigOption {
 	return func(c *Config) {
 		c.EnableDatastoreMetrics = enableDatastoreMetrics
+	}
+}
+
+// WithDisableStats returns an option that can set DisableStats on a Config
+func WithDisableStats(disableStats bool) ConfigOption {
+	return func(c *Config) {
+		c.DisableStats = disableStats
 	}
 }
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -291,6 +291,8 @@ func (c *Config) Complete() (RunnableServer, error) {
 	reporter := telemetry.DisabledReporter
 	if c.SilentlyDisableTelemetry {
 		reporter = telemetry.SilentlyDisabledReporter
+	} else if c.TelemetryEndpoint != "" && c.DatastoreConfig.DisableStats {
+		reporter = telemetry.DisabledReporter
 	} else if c.TelemetryEndpoint != "" && registry != nil {
 		var err error
 		reporter, err = telemetry.RemoteReporter(


### PR DESCRIPTION
Writes to the stats table were making the e2e test flow less predictable.