### PR TITLE
Concurrency limit

### DIFF
--- a/e2e/cockroach/cockroach.go
+++ b/e2e/cockroach/cockroach.go
@@ -90,19 +90,11 @@ func (c *Node) Conn() *pgx.Conn {
 // the value that is referenced by other crdb metadata to identify range leader,
 // follower nodes, etc.
 func (c *Node) NodeID(ctx context.Context) (int, error) {
-	rows, err := c.conn.Query(ctx, "SHOW node_id")
-	defer rows.Close()
-	if err != nil {
+	var nodeID string
+	if err := c.conn.QueryRow(ctx, "SHOW node_id").Scan(&nodeID); err != nil {
 		return -1, err
 	}
-	// despite being an int, crdb returns node id as a string
-	var nodeID string
-	for rows.Next() {
-		if err := rows.Scan(&nodeID); err != nil {
-			return -1, err
-		}
-		break
-	}
+
 	i, err := strconv.Atoi(nodeID)
 	if err != nil {
 		return -1, err

--- a/e2e/spice/spicedb_options.go
+++ b/e2e/spice/spicedb_options.go
@@ -14,6 +14,26 @@ func NewNodeWithOptions(opts ...NodeOption) *Node {
 	return n
 }
 
+// ToOption returns a new NodeOption that sets the values from the passed in Node
+func (n *Node) ToOption() NodeOption {
+	return func(to *Node) {
+		to.ID = n.ID
+		to.PresharedKey = n.PresharedKey
+		to.Datastore = n.Datastore
+		to.DBName = n.DBName
+		to.URI = n.URI
+		to.GrpcPort = n.GrpcPort
+		to.HTTPPort = n.HTTPPort
+		to.DispatchPort = n.DispatchPort
+		to.MetricsPort = n.MetricsPort
+		to.DashboardPort = n.DashboardPort
+		to.HedgingEnabled = n.HedgingEnabled
+		to.Pid = n.Pid
+		to.Cancel = n.Cancel
+		to.client = n.client
+	}
+}
+
 // NodeWithOptions configures an existing Node with the passed in options set
 func NodeWithOptions(n *Node, opts ...NodeOption) *Node {
 	for _, o := range opts {
@@ -43,10 +63,10 @@ func WithDatastore(datastore string) NodeOption {
 	}
 }
 
-// WithDbName returns an option that can set DbName on a Node
-func WithDbName(dbName string) NodeOption {
+// WithDBName returns an option that can set DBName on a Node
+func WithDBName(dBName string) NodeOption {
 	return func(n *Node) {
-		n.DbName = dbName
+		n.DBName = dBName
 	}
 }
 
@@ -64,10 +84,10 @@ func WithGrpcPort(grpcPort int) NodeOption {
 	}
 }
 
-// WithHttpPort returns an option that can set HTTPPort on a Node
-func WithHttpPort(httpPort int) NodeOption {
+// WithHTTPPort returns an option that can set HTTPPort on a Node
+func WithHTTPPort(hTTPPort int) NodeOption {
 	return func(n *Node) {
-		n.HTTPPort = httpPort
+		n.HTTPPort = hTTPPort
 	}
 }
 

--- a/e2e/util.go
+++ b/e2e/util.go
@@ -8,7 +8,6 @@ import (
 // TLogger wraps a testing.TB and makes it conform to io.Writer
 type TLogger struct {
 	testing.TB
-	skip int
 }
 
 // Write satisfied io.Writer

--- a/internal/dispatch/cluster/cluster.go
+++ b/internal/dispatch/cluster/cluster.go
@@ -8,12 +8,15 @@ import (
 	"github.com/authzed/spicedb/pkg/cache"
 )
 
+const defaultConcurrencyLimit = 50
+
 // Option is a function-style option for configuring a combined Dispatcher.
 type Option func(*optionState)
 
 type optionState struct {
 	prometheusSubsystem string
 	cacheConfig         *cache.Config
+	concurrencyLimit    uint16
 }
 
 // PrometheusSubsystem sets the subsystem name for the prometheus metrics
@@ -30,15 +33,28 @@ func CacheConfig(config *cache.Config) Option {
 	}
 }
 
+// ConcurrencyLimit sets the max number of goroutines per operation
+func ConcurrencyLimit(limit uint16) Option {
+	return func(state *optionState) {
+		state.concurrencyLimit = limit
+	}
+}
+
 // NewClusterDispatcher takes a dispatcher (such as one created by
 // combined.NewDispatcher) and returns a cluster dispatcher suitable for use as
 // the dispatcher for the dispatch grpc server.
 func NewClusterDispatcher(dispatch dispatch.Dispatcher, options ...Option) (dispatch.Dispatcher, error) {
-	clusterDispatch := graph.NewDispatcher(dispatch)
 	var opts optionState
 	for _, fn := range options {
 		fn(&opts)
 	}
+
+	var concurrencyLimit uint16 = defaultConcurrencyLimit
+	if opts.concurrencyLimit != 0 {
+		concurrencyLimit = opts.concurrencyLimit
+	}
+
+	clusterDispatch := graph.NewDispatcher(dispatch, concurrencyLimit)
 
 	if opts.prometheusSubsystem == "" {
 		opts.prometheusSubsystem = "dispatch"

--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -169,7 +169,7 @@ func TestMaxDepth(t *testing.T) {
 		},
 	}}
 
-	ctx := datastoremw.ContextWithHandle(context.Background())
+	ctx := log.Logger.WithContext(datastoremw.ContextWithHandle(context.Background()))
 	require.NoError(datastoremw.SetInContext(ctx, ds))
 
 	revision, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
@@ -299,7 +299,7 @@ func newLocalDispatcher(require *require.Assertions) (context.Context, dispatch.
 	cachingDispatcher.SetDelegate(dispatch)
 	require.NoError(err)
 
-	ctx := datastoremw.ContextWithHandle(context.Background())
+	ctx := log.Logger.WithContext(datastoremw.ContextWithHandle(context.Background()))
 	require.NoError(datastoremw.SetInContext(ctx, ds))
 
 	return ctx, cachingDispatcher, revision

--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -178,7 +178,7 @@ func TestMaxDepth(t *testing.T) {
 	require.NoError(err)
 	require.True(revision.GreaterThan(decimal.Zero))
 
-	dispatch := NewLocalOnlyDispatcher()
+	dispatch := NewLocalOnlyDispatcher(10)
 
 	checkResult, err := dispatch.DispatchCheck(ctx, &v1.DispatchCheckRequest{
 		ResourceAndRelation: ONR("folder", "oops", "owner"),
@@ -293,7 +293,7 @@ func newLocalDispatcher(require *require.Assertions) (context.Context, dispatch.
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	dispatch := NewLocalOnlyDispatcher()
+	dispatch := NewLocalOnlyDispatcher(10)
 
 	cachingDispatcher, err := caching.NewCachingDispatcher(nil, "", &keys.CanonicalKeyHandler{})
 	cachingDispatcher.SetDelegate(dispatch)

--- a/internal/dispatch/graph/expand_test.go
+++ b/internal/dispatch/graph/expand_test.go
@@ -299,7 +299,7 @@ func TestMaxDepthExpand(t *testing.T) {
 	require.True(revision.GreaterThan(decimal.Zero))
 	require.NoError(datastoremw.SetInContext(ctx, ds))
 
-	dispatch := NewLocalOnlyDispatcher()
+	dispatch := NewLocalOnlyDispatcher(10)
 
 	_, err = dispatch.DispatchExpand(ctx, &v1.DispatchExpandRequest{
 		ResourceAndRelation: ONR("folder", "oops", "view"),

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -30,7 +30,7 @@ func NewLocalOnlyDispatcher(concurrencyLimit uint16) dispatch.Dispatcher {
 	d.checker = graph.NewConcurrentChecker(d, concurrencyLimit)
 	d.expander = graph.NewConcurrentExpander(d)
 	d.lookupHandler = graph.NewConcurrentLookup(d, d, concurrencyLimit)
-	d.reachableResourcesHandler = graph.NewConcurrentReachableResources(d)
+	d.reachableResourcesHandler = graph.NewConcurrentReachableResources(d, concurrencyLimit)
 
 	return d
 }
@@ -41,7 +41,7 @@ func NewDispatcher(redispatcher dispatch.Dispatcher, concurrencyLimit uint16) di
 	checker := graph.NewConcurrentChecker(redispatcher, concurrencyLimit)
 	expander := graph.NewConcurrentExpander(redispatcher)
 	lookupHandler := graph.NewConcurrentLookup(redispatcher, redispatcher, concurrencyLimit)
-	reachableResourcesHandler := graph.NewConcurrentReachableResources(redispatcher)
+	reachableResourcesHandler := graph.NewConcurrentReachableResources(redispatcher, concurrencyLimit)
 
 	return &localDispatcher{
 		checker:                   checker,
@@ -304,6 +304,6 @@ func rewriteError(original error) error {
 	}
 }
 
-var emptyMetadata *v1.ResponseMeta = &v1.ResponseMeta{
+var emptyMetadata = &v1.ResponseMeta{
 	DispatchCount: 0,
 }

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -24,12 +24,12 @@ const errDispatch = "error dispatching request: %w"
 var tracer = otel.Tracer("spicedb/internal/dispatch/local")
 
 // NewLocalOnlyDispatcher creates a dispatcher that consults with the graph to formulate a response.
-func NewLocalOnlyDispatcher() dispatch.Dispatcher {
+func NewLocalOnlyDispatcher(concurrencyLimit uint16) dispatch.Dispatcher {
 	d := &localDispatcher{}
 
-	d.checker = graph.NewConcurrentChecker(d)
+	d.checker = graph.NewConcurrentChecker(d, concurrencyLimit)
 	d.expander = graph.NewConcurrentExpander(d)
-	d.lookupHandler = graph.NewConcurrentLookup(d, d)
+	d.lookupHandler = graph.NewConcurrentLookup(d, d, concurrencyLimit)
 	d.reachableResourcesHandler = graph.NewConcurrentReachableResources(d)
 
 	return d
@@ -37,10 +37,10 @@ func NewLocalOnlyDispatcher() dispatch.Dispatcher {
 
 // NewDispatcher creates a dispatcher that consults with the graph and redispatches subproblems to
 // the provided redispatcher.
-func NewDispatcher(redispatcher dispatch.Dispatcher) dispatch.Dispatcher {
-	checker := graph.NewConcurrentChecker(redispatcher)
+func NewDispatcher(redispatcher dispatch.Dispatcher, concurrencyLimit uint16) dispatch.Dispatcher {
+	checker := graph.NewConcurrentChecker(redispatcher, concurrencyLimit)
 	expander := graph.NewConcurrentExpander(redispatcher)
-	lookupHandler := graph.NewConcurrentLookup(redispatcher, redispatcher)
+	lookupHandler := graph.NewConcurrentLookup(redispatcher, redispatcher, concurrencyLimit)
 	reachableResourcesHandler := graph.NewConcurrentReachableResources(redispatcher)
 
 	return &localDispatcher{
@@ -277,7 +277,7 @@ func (ld *localDispatcher) DispatchReachableResources(
 		Revision:                          revision,
 	}
 
-	wrappedStream := dispatch.StreamWithContext[*v1.DispatchReachableResourcesResponse](ctx, stream)
+	wrappedStream := dispatch.StreamWithContext(ctx, stream)
 	return ld.reachableResourcesHandler.ReachableResources(validatedReq, wrappedStream)
 }
 

--- a/internal/dispatch/graph/lookup_test.go
+++ b/internal/dispatch/graph/lookup_test.go
@@ -166,7 +166,7 @@ func TestMaxDepthLookup(t *testing.T) {
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	dispatch := NewLocalOnlyDispatcher()
+	dispatch := NewLocalOnlyDispatcher(10)
 	ctx := datastoremw.ContextWithHandle(context.Background())
 	require.NoError(datastoremw.SetInContext(ctx, ds))
 

--- a/internal/dispatch/graph/reachableresources_test.go
+++ b/internal/dispatch/graph/reachableresources_test.go
@@ -247,7 +247,7 @@ func BenchmarkReachableResources(b *testing.B) {
 
 		ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-		dispatcher := NewLocalOnlyDispatcher()
+		dispatcher := NewLocalOnlyDispatcher(10)
 
 		ctx := datastoremw.ContextWithHandle(context.Background())
 		require.NoError(datastoremw.SetInContext(ctx, ds))

--- a/internal/dispatch/remote/cluster.go
+++ b/internal/dispatch/remote/cluster.go
@@ -134,10 +134,10 @@ func (cr *clusterDispatcher) IsReady() bool {
 // Always verify that we implement the interface
 var _ dispatch.Dispatcher = &clusterDispatcher{}
 
-var emptyMetadata *v1.ResponseMeta = &v1.ResponseMeta{
+var emptyMetadata = &v1.ResponseMeta{
 	DispatchCount: 0,
 }
 
-var requestFailureMetadata *v1.ResponseMeta = &v1.ResponseMeta{
+var requestFailureMetadata = &v1.ResponseMeta{
 	DispatchCount: 1,
 }

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	v1_proto "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/rs/zerolog/log"
@@ -20,14 +21,15 @@ import (
 )
 
 // NewConcurrentChecker creates an instance of ConcurrentChecker.
-func NewConcurrentChecker(d dispatch.Check) *ConcurrentChecker {
-	return &ConcurrentChecker{d: d}
+func NewConcurrentChecker(d dispatch.Check, concurrencyLimit uint16) *ConcurrentChecker {
+	return &ConcurrentChecker{d, concurrencyLimit}
 }
 
 // ConcurrentChecker exposes a method to perform Check requests, and delegates subproblems to the
 // provided dispatch.Check instance.
 type ConcurrentChecker struct {
-	d dispatch.Check
+	d                dispatch.Check
+	concurrencyLimit uint16
 }
 
 func onrEqual(lhs, rhs *core.ObjectAndRelation) bool {
@@ -61,7 +63,7 @@ func (cc *ConcurrentChecker) Check(ctx context.Context, req ValidatedCheckReques
 		}
 	}
 
-	resolved := union(ctx, []ReduceableCheckFunc{directFunc})
+	resolved := union(ctx, []ReduceableCheckFunc{directFunc}, cc.concurrencyLimit)
 	resolved.Resp.Metadata = addCallToResponseMetadata(resolved.Resp.Metadata)
 	if req.Debug != v1.DispatchCheckRequest_ENABLE_DEBUGGING {
 		return resolved.Resp, resolved.Err
@@ -141,7 +143,7 @@ func (cc *ConcurrentChecker) checkDirect(ctx context.Context, req ValidatedCheck
 			resultChan <- checkResultError(NewCheckFailureErr(it.Err()), emptyMetadata)
 			return
 		}
-		resultChan <- union(ctx, requestsToDispatch)
+		resultChan <- union(ctx, requestsToDispatch, cc.concurrencyLimit)
 	}
 }
 
@@ -178,7 +180,7 @@ func (cc *ConcurrentChecker) checkSetOperation(ctx context.Context, req Validate
 	}
 	return func(ctx context.Context, resultChan chan<- CheckResult) {
 		log.Ctx(ctx).Trace().Object("setOperation", req).Stringer("operation", so).Send()
-		resultChan <- reducer(ctx, requests)
+		resultChan <- reducer(ctx, requests, cc.concurrencyLimit)
 	}
 }
 
@@ -255,12 +257,12 @@ func (cc *ConcurrentChecker) checkTupleToUserset(ctx context.Context, req Valida
 			return
 		}
 
-		resultChan <- union(ctx, requestsToDispatch)
+		resultChan <- union(ctx, requestsToDispatch, cc.concurrencyLimit)
 	}
 }
 
 // all returns whether all of the lazy checks pass, and is used for intersection.
-func all(ctx context.Context, requests []ReduceableCheckFunc) CheckResult {
+func all(ctx context.Context, requests []ReduceableCheckFunc, concurrencyLimit uint16) CheckResult {
 	if len(requests) == 0 {
 		return checkResult(v1.DispatchCheckResponse_NOT_MEMBER, emptyMetadata)
 	}
@@ -268,11 +270,14 @@ func all(ctx context.Context, requests []ReduceableCheckFunc) CheckResult {
 	responseMetadata := emptyMetadata
 	resultChan := make(chan CheckResult, len(requests))
 	childCtx, cancelFn := context.WithCancel(ctx)
-	defer cancelFn()
 
-	for _, req := range requests {
-		go req(childCtx, resultChan)
-	}
+	cleanupFunc := dispatchAllAsync(childCtx, requests, resultChan, concurrencyLimit)
+
+	defer func() {
+		cancelFn()
+		cleanupFunc()
+		close(resultChan)
+	}()
 
 	for i := 0; i < len(requests); i++ {
 		select {
@@ -315,18 +320,21 @@ func notMember() ReduceableCheckFunc {
 }
 
 // union returns whether any one of the lazy checks pass, and is used for union.
-func union(ctx context.Context, requests []ReduceableCheckFunc) CheckResult {
+func union(ctx context.Context, requests []ReduceableCheckFunc, concurrencyLimit uint16) CheckResult {
 	if len(requests) == 0 {
 		return checkResult(v1.DispatchCheckResponse_NOT_MEMBER, emptyMetadata)
 	}
 
 	resultChan := make(chan CheckResult, len(requests))
 	childCtx, cancelFn := context.WithCancel(ctx)
-	defer cancelFn()
 
-	for _, req := range requests {
-		go req(childCtx, resultChan)
-	}
+	dispatcherCleanup := dispatchAllAsync(childCtx, requests, resultChan, concurrencyLimit)
+
+	defer func() {
+		cancelFn()
+		dispatcherCleanup()
+		close(resultChan)
+	}()
 
 	responseMetadata := emptyMetadata
 
@@ -353,17 +361,28 @@ func union(ctx context.Context, requests []ReduceableCheckFunc) CheckResult {
 }
 
 // difference returns whether the first lazy check passes and none of the supsequent checks pass.
-func difference(ctx context.Context, requests []ReduceableCheckFunc) CheckResult {
+func difference(ctx context.Context, requests []ReduceableCheckFunc, concurrencyLimit uint16) CheckResult {
 	childCtx, cancelFn := context.WithCancel(ctx)
-	defer cancelFn()
 
 	baseChan := make(chan CheckResult, 1)
 	othersChan := make(chan CheckResult, len(requests)-1)
 
-	go requests[0](childCtx, baseChan)
-	for _, req := range requests[1:] {
-		go req(childCtx, othersChan)
-	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		requests[0](childCtx, baseChan)
+		wg.Done()
+	}()
+
+	cleanupFunc := dispatchAllAsync(childCtx, requests[1:], othersChan, concurrencyLimit-1)
+
+	defer func() {
+		cancelFn()
+		cleanupFunc()
+		close(othersChan)
+		wg.Wait()
+		close(baseChan)
+	}()
 
 	responseMetadata := emptyMetadata
 
@@ -443,4 +462,39 @@ func combineResponseMetadata(existing *v1.ResponseMeta, responseMetadata *v1.Res
 
 	combined.DebugInfo = debugInfo
 	return combined
+}
+
+func dispatchAllAsync(
+	ctx context.Context,
+	requests []ReduceableCheckFunc,
+	resultChan chan<- CheckResult,
+	concurrencyLimit uint16,
+) func() {
+	sem := make(chan struct{}, concurrencyLimit)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+	dispatcher:
+		for _, req := range requests {
+			req := req
+			select {
+			case sem <- struct{}{}:
+				wg.Add(1)
+				go func() {
+					req(ctx, resultChan)
+					<-sem
+					wg.Done()
+				}()
+			case <-ctx.Done():
+				break dispatcher
+			}
+		}
+		wg.Done()
+	}()
+
+	return func() {
+		wg.Wait()
+		close(sem)
+	}
 }

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -1,0 +1,80 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsyncDispatch(t *testing.T) {
+	testCases := []struct {
+		numRequests      uint16
+		concurrencyLimit uint16
+	}{
+		{1, 1},
+		{10, 1},
+		{1, 50},
+		{50, 50},
+		{1000, 10},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%d/%d", tc.numRequests, tc.concurrencyLimit), func(t *testing.T) {
+			require := require.New(t)
+
+			ctx := context.Background()
+
+			l := &sync.Mutex{}
+			letFinish := sync.NewCond(l)
+			var dispatchedCount uint16
+			var completedCount uint16
+
+			reqs := make([]ReduceableCheckFunc, 0, tc.numRequests)
+
+			for i := 0; i < int(tc.numRequests); i++ {
+				reqs = append(reqs, func(ctx context.Context, resultChan chan<- CheckResult) {
+					l.Lock()
+					defer l.Unlock()
+					dispatchedCount++
+					letFinish.Wait()
+					completedCount++
+				})
+			}
+
+			dispatchAllAsync(ctx, reqs, nil, tc.concurrencyLimit)
+
+			require.Eventually(func() bool {
+				l.Lock()
+				defer l.Unlock()
+
+				return (tc.numRequests >= tc.concurrencyLimit && dispatchedCount == tc.concurrencyLimit) ||
+					(tc.numRequests < tc.concurrencyLimit && dispatchedCount == tc.numRequests)
+			}, 1*time.Second, 1*time.Millisecond)
+
+			l.Lock()
+			require.Equal(uint16(0), completedCount)
+			l.Unlock()
+
+			letFinish.Signal()
+
+			require.Eventually(func() bool {
+				l.Lock()
+				defer l.Unlock()
+
+				return completedCount == 1
+			}, 10*time.Millisecond, 10*time.Microsecond)
+
+			require.Eventually(func() bool {
+				l.Lock()
+				defer l.Unlock()
+
+				letFinish.Broadcast()
+				return tc.numRequests == dispatchedCount && tc.numRequests == completedCount
+			}, 1*time.Second, 1*time.Millisecond)
+		})
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -33,7 +33,7 @@ type LookupResult struct {
 type ReduceableCheckFunc func(ctx context.Context, resultChan chan<- CheckResult)
 
 // Reducer is a type for the functions Any and All which combine check results.
-type Reducer func(ctx context.Context, requests []ReduceableCheckFunc) CheckResult
+type Reducer func(ctx context.Context, requests []ReduceableCheckFunc, concurrencyLimit uint16) CheckResult
 
 // AlwaysFail is a ReduceableCheckFunc which will always fail when reduced.
 func AlwaysFail(ctx context.Context, resultChan chan<- CheckResult) {

--- a/internal/graph/parallelchecker.go
+++ b/internal/graph/parallelchecker.go
@@ -24,7 +24,7 @@ type ParallelChecker struct {
 	g             *errgroup.Group
 	checkCtx      context.Context
 	subject       *core.ObjectAndRelation
-	maxConcurrent uint8
+	maxConcurrent uint16
 	results       *tuple.ONRSet
 
 	dispatchCount       uint32
@@ -35,7 +35,7 @@ type ParallelChecker struct {
 }
 
 // NewParallelChecker creates a new parallel checker, for a given subject.
-func NewParallelChecker(ctx context.Context, c dispatch.Check, subject *core.ObjectAndRelation, maxConcurrent uint8) *ParallelChecker {
+func NewParallelChecker(ctx context.Context, c dispatch.Check, subject *core.ObjectAndRelation, maxConcurrent uint16) *ParallelChecker {
 	g, checkCtx := errgroup.WithContext(ctx)
 	toCheck := make(chan *v1.DispatchCheckRequest)
 	return &ParallelChecker{toCheck, tuple.NewONRSet(), c, g, checkCtx, subject, maxConcurrent, tuple.NewONRSet(), 0, 0, 0, sync.Mutex{}}

--- a/internal/services/cert_test.go
+++ b/internal/services/cert_test.go
@@ -112,7 +112,7 @@ func TestCertRotation(t *testing.T) {
 	ds, revision := tf.StandardDatastoreWithData(emptyDS, require.New(t))
 	srv, err := server.NewConfigWithOptions(
 		server.WithDatastore(ds),
-		server.WithDispatcher(graph.NewLocalOnlyDispatcher()),
+		server.WithDispatcher(graph.NewLocalOnlyDispatcher(1)),
 		server.WithDispatchMaxDepth(50),
 		server.WithGRPCServer(util.GRPCServerConfig{
 			Network:      util.BufferedNetwork,

--- a/internal/services/consistency_test.go
+++ b/internal/services/consistency_test.go
@@ -98,12 +98,12 @@ func TestConsistency(t *testing.T) {
 							}
 
 							// Run the consistency tests for each service.
-							dispatcher := graph.NewLocalOnlyDispatcher()
+							dispatcher := graph.NewLocalOnlyDispatcher(10)
 							if dispatcherKind == "caching" {
 								cachingDispatcher, err := caching.NewCachingDispatcher(nil, "", &keys.CanonicalKeyHandler{})
 								lrequire.NoError(err)
 
-								localDispatcher := graph.NewDispatcher(cachingDispatcher)
+								localDispatcher := graph.NewDispatcher(cachingDispatcher, 10)
 								defer localDispatcher.Close()
 								cachingDispatcher.SetDelegate(localDispatcher)
 								dispatcher = cachingDispatcher

--- a/internal/services/v0/download.go
+++ b/internal/services/v0/download.go
@@ -3,6 +3,7 @@ package v0
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
@@ -14,8 +15,9 @@ func NewHTTPDownloadServer(addr string, shareStore ShareStore) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc(downloadPath, downloadHandler(shareStore))
 	return &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 }
 

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/util"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/middleware/logging"
 )
 
 func NewTestServer(require *require.Assertions,
@@ -46,10 +47,12 @@ func NewTestServer(require *require.Assertions,
 	).Complete()
 	require.NoError(err)
 	srv.SetMiddleware([]grpc.UnaryServerInterceptor{
+		logging.UnaryServerInterceptor(),
 		datastoremw.UnaryServerInterceptor(ds),
 		consistency.UnaryServerInterceptor(),
 		servicespecific.UnaryServerInterceptor,
 	}, []grpc.StreamServerInterceptor{
+		logging.StreamServerInterceptor(),
 		datastoremw.StreamServerInterceptor(ds),
 		consistency.StreamServerInterceptor(),
 		servicespecific.StreamServerInterceptor,

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -30,7 +30,7 @@ func NewTestServer(require *require.Assertions,
 	ds, revision := dsInitFunc(emptyDS, require)
 	srv, err := server.NewConfigWithOptions(
 		server.WithDatastore(ds),
-		server.WithDispatcher(graph.NewLocalOnlyDispatcher()),
+		server.WithDispatcher(graph.NewLocalOnlyDispatcher(10)),
 		server.WithDispatchMaxDepth(50),
 		server.WithGRPCServer(util.GRPCServerConfig{
 			Network: util.BufferedNetwork,

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -64,6 +64,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) {
 	cmd.Flags().Uint32Var(&config.DispatchMaxDepth, "dispatch-max-depth", 50, "maximum recursion depth for nested calls")
 	cmd.Flags().StringVar(&config.DispatchUpstreamAddr, "dispatch-upstream-addr", "", "upstream grpc address to dispatch to")
 	cmd.Flags().StringVar(&config.DispatchUpstreamCAPath, "dispatch-upstream-ca-path", "", "local path to the TLS CA used when connecting to the dispatch cluster")
+	cmd.Flags().Uint16Var(&config.DispatchConcurrencyLimit, "dispatch-concurrency-limit", 50, "maximum number of parallel goroutines to create for each request or subrequest")
 
 	// Flags for configuring API behavior
 	cmd.Flags().BoolVar(&config.DisableV1SchemaAPI, "disable-v1-schema-api", false, "disables the V1 schema API")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -64,6 +64,7 @@ type Config struct {
 	// Dispatch options
 	DispatchServer               util.GRPCServerConfig
 	DispatchMaxDepth             uint32
+	DispatchConcurrencyLimit     uint16
 	DispatchUpstreamAddr         string
 	DispatchUpstreamCAPath       string
 	DispatchClientMetricsPrefix  string
@@ -162,6 +163,7 @@ func (c *Config) Complete() (RunnableServer, error) {
 			),
 			combineddispatch.PrometheusSubsystem(c.DispatchClientMetricsPrefix),
 			combineddispatch.CacheConfig(cc),
+			combineddispatch.ConcurrencyLimit(c.DispatchConcurrencyLimit),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create dispatcher: %w", err)

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -41,6 +41,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.SchemaPrefixesRequired = c.SchemaPrefixesRequired
 		to.DispatchServer = c.DispatchServer
 		to.DispatchMaxDepth = c.DispatchMaxDepth
+		to.DispatchConcurrencyLimit = c.DispatchConcurrencyLimit
 		to.DispatchUpstreamAddr = c.DispatchUpstreamAddr
 		to.DispatchUpstreamCAPath = c.DispatchUpstreamCAPath
 		to.DispatchClientMetricsPrefix = c.DispatchClientMetricsPrefix
@@ -193,6 +194,13 @@ func WithDispatchServer(dispatchServer util.GRPCServerConfig) ConfigOption {
 func WithDispatchMaxDepth(dispatchMaxDepth uint32) ConfigOption {
 	return func(c *Config) {
 		c.DispatchMaxDepth = dispatchMaxDepth
+	}
+}
+
+// WithDispatchConcurrencyLimit returns an option that can set DispatchConcurrencyLimit on a Config
+func WithDispatchConcurrencyLimit(dispatchConcurrencyLimit uint16) ConfigOption {
+	return func(c *Config) {
+		c.DispatchConcurrencyLimit = dispatchConcurrencyLimit
 	}
 }
 

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -42,7 +42,7 @@ func (dr datastoreReady) IsReady(ctx context.Context) (bool, error) {
 }
 
 func (c *Config) Complete() (RunnableTestServer, error) {
-	dispatcher := graph.NewLocalOnlyDispatcher()
+	dispatcher := graph.NewLocalOnlyDispatcher(10)
 
 	datastoreMiddleware := pertoken.NewMiddleware(c.LoadConfigs)
 

--- a/pkg/cmd/util/util.go
+++ b/pkg/cmd/util/util.go
@@ -298,8 +298,9 @@ func (c *HTTPServerConfig) Complete(level zerolog.Level, handler http.Handler) (
 		return &disabledHTTPServer{}, nil
 	}
 	srv := &http.Server{
-		Addr:    c.Address,
-		Handler: handler,
+		Addr:              c.Address,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 	var serveFunc func() error
 	switch {

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -112,7 +112,7 @@ func newDevContextWithDatastore(ctx context.Context, requestContext *devinterfac
 		Datastore:  ds,
 		Namespaces: namespaces,
 		Revision:   currentRevision,
-		Dispatcher: graph.NewLocalOnlyDispatcher(),
+		Dispatcher: graph.NewLocalOnlyDispatcher(10),
 	}, nil, nil
 }
 


### PR DESCRIPTION
This PR adds a concurrency limit to each step of graph resolution in order to limit the number of goroutines that are spawned at once. It does not add an overall global goroutine limit.