### PR TITLE
Add ability to enable the REST gateway for the test server

### DIFF
--- a/pkg/cmd/testing.go
+++ b/pkg/cmd/testing.go
@@ -13,6 +13,10 @@ import (
 func RegisterTestingFlags(cmd *cobra.Command, config *testserver.Config) {
 	util.RegisterGRPCServerFlags(cmd.Flags(), &config.GRPCServer, "grpc", "gRPC", ":50051", true)
 	util.RegisterGRPCServerFlags(cmd.Flags(), &config.ReadOnlyGRPCServer, "readonly-grpc", "read-only gRPC", ":50052", true)
+
+	util.RegisterHTTPServerFlags(cmd.Flags(), &config.HTTPGateway, "http", "http", ":8081", false)
+	util.RegisterHTTPServerFlags(cmd.Flags(), &config.ReadOnlyHTTPGateway, "readonly-http", "read-only HTTP", ":8082", false)
+
 	cmd.Flags().StringSliceVar(&config.LoadConfigs, "load-configs", []string{}, "configuration yaml files to load")
 }
 

--- a/pkg/cmd/testserver/zz_generated.options.go
+++ b/pkg/cmd/testserver/zz_generated.options.go
@@ -19,6 +19,8 @@ func (c *Config) ToOption() ConfigOption {
 	return func(to *Config) {
 		to.GRPCServer = c.GRPCServer
 		to.ReadOnlyGRPCServer = c.ReadOnlyGRPCServer
+		to.HTTPGateway = c.HTTPGateway
+		to.ReadOnlyHTTPGateway = c.ReadOnlyHTTPGateway
 		to.LoadConfigs = c.LoadConfigs
 	}
 }
@@ -42,6 +44,20 @@ func WithGRPCServer(gRPCServer util.GRPCServerConfig) ConfigOption {
 func WithReadOnlyGRPCServer(readOnlyGRPCServer util.GRPCServerConfig) ConfigOption {
 	return func(c *Config) {
 		c.ReadOnlyGRPCServer = readOnlyGRPCServer
+	}
+}
+
+// WithHTTPGateway returns an option that can set HTTPGateway on a Config
+func WithHTTPGateway(hTTPGateway util.HTTPServerConfig) ConfigOption {
+	return func(c *Config) {
+		c.HTTPGateway = hTTPGateway
+	}
+}
+
+// WithReadOnlyHTTPGateway returns an option that can set ReadOnlyHTTPGateway on a Config
+func WithReadOnlyHTTPGateway(readOnlyHTTPGateway util.HTTPServerConfig) ConfigOption {
+	return func(c *Config) {
+		c.ReadOnlyHTTPGateway = readOnlyHTTPGateway
 	}
 }
 


### PR DESCRIPTION
`serve-testing` can now have the REST gateway enabled for the normal and read-only endpoints via `--http-enabled` and `--readonly-http-enabled`, which will serve (by default) on ports `:8081` and `:8082`, respectively

Fixes #706