### PR TITLE
Fix bounds on check test

### DIFF
--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -217,7 +217,7 @@ func TestCheckMetadata(t *testing.T) {
 				[]expected{
 					{"owner", true, 1, 1},
 					{"edit", true, 3, 2},
-					{"view", true, 5, 3},
+					{"view", true, 21, 3},
 				},
 			},
 			{


### PR DESCRIPTION
Sometimes we get the other branches, and it is more than 5 dispatches