### PR TITLE
Begin work on LookupSubjects

### DIFF
--- a/internal/datastore/common/sql.go
+++ b/internal/datastore/common/sql.go
@@ -105,7 +105,7 @@ func (sqf SchemaQueryFilterer) FilterToResourceIDs(resourceIds []string) SchemaQ
 	}
 
 	inClause := fmt.Sprintf("%s IN (", sqf.schema.ColObjectID)
-	args := make([]interface{}, 0, len(resourceIds))
+	args := make([]any, 0, len(resourceIds))
 
 	for index, resourceID := range resourceIds {
 		if len(resourceID) == 0 {
@@ -143,9 +143,7 @@ func (sqf SchemaQueryFilterer) FilterWithRelationshipsFilter(filter datastore.Re
 		sqf = sqf.FilterToRelation(filter.OptionalResourceRelation)
 	}
 
-	if len(filter.OptionalResourceIds) == 1 {
-		sqf = sqf.FilterToResourceID(filter.OptionalResourceIds[0])
-	} else if len(filter.OptionalResourceIds) > 1 {
+	if len(filter.OptionalResourceIds) > 0 {
 		sqf = sqf.FilterToResourceIDs(filter.OptionalResourceIds)
 	}
 
@@ -162,18 +160,14 @@ func (sqf SchemaQueryFilterer) FilterWithSubjectsFilter(filter datastore.Subject
 	sqf.queryBuilder = sqf.queryBuilder.Where(sq.Eq{sqf.schema.ColUsersetNamespace: filter.SubjectType})
 	sqf.tracerAttributes = append(sqf.tracerAttributes, SubNamespaceNameKey.String(filter.SubjectType))
 
-	if len(filter.OptionalSubjectIds) == 1 {
-		subjectID := filter.OptionalSubjectIds[0]
-		sqf.tracerAttributes = append(sqf.tracerAttributes, SubObjectIDKey.String(subjectID))
-		sqf.queryBuilder = sqf.queryBuilder.Where(sq.Eq{sqf.schema.ColUsersetObjectID: subjectID})
-	} else if len(filter.OptionalSubjectIds) > 1 {
+	if len(filter.OptionalSubjectIds) > 0 {
 		// TODO(jschorr): Change this panic into an automatic query split, if we find it necessary.
 		if len(filter.OptionalSubjectIds) > 100 {
 			panic("Cannot have more than 100 subject IDs in a single filter")
 		}
 
 		inClause := fmt.Sprintf("%s IN (", sqf.schema.ColUsersetObjectID)
-		args := make([]interface{}, 0, len(filter.OptionalSubjectIds))
+		args := make([]any, 0, len(filter.OptionalSubjectIds))
 
 		for index, subjectID := range filter.OptionalSubjectIds {
 			if len(subjectID) == 0 {

--- a/internal/datastore/common/sql.go
+++ b/internal/datastore/common/sql.go
@@ -100,8 +100,8 @@ func (sqf SchemaQueryFilterer) FilterToResourceID(objectID string) SchemaQueryFi
 // specified IDs.
 func (sqf SchemaQueryFilterer) FilterToResourceIDs(resourceIds []string) SchemaQueryFilterer {
 	// TODO(jschorr): Change this panic into an automatic query split, if we find it necessary.
-	if len(resourceIds) > 100 {
-		panic("Cannot have more than 100 resources IDs in a single filter")
+	if len(resourceIds) > datastore.FilterMaximumIDCount {
+		panic(fmt.Sprintf("Cannot have more than %d resources IDs in a single filter", datastore.FilterMaximumIDCount))
 	}
 
 	inClause := fmt.Sprintf("%s IN (", sqf.schema.ColObjectID)
@@ -162,8 +162,8 @@ func (sqf SchemaQueryFilterer) FilterWithSubjectsFilter(filter datastore.Subject
 
 	if len(filter.OptionalSubjectIds) > 0 {
 		// TODO(jschorr): Change this panic into an automatic query split, if we find it necessary.
-		if len(filter.OptionalSubjectIds) > 100 {
-			panic("Cannot have more than 100 subject IDs in a single filter")
+		if len(filter.OptionalSubjectIds) > datastore.FilterMaximumIDCount {
+			panic(fmt.Sprintf("Cannot have more than %d subject IDs in a single filter", datastore.FilterMaximumIDCount))
 		}
 
 		inClause := fmt.Sprintf("%s IN (", sqf.schema.ColUsersetObjectID)

--- a/internal/datastore/memdb/readonly.go
+++ b/internal/datastore/memdb/readonly.go
@@ -204,17 +204,14 @@ func (r *memdbReader) lockOrPanic() {
 }
 
 func iteratorForFilter(txn *memdb.Txn, filter datastore.RelationshipsFilter) (memdb.ResultIterator, error) {
-	switch {
-	case filter.OptionalResourceRelation != "":
-		return txn.Get(
-			tableRelationship,
-			indexNamespaceAndRelation,
-			filter.ResourceType,
-			filter.OptionalResourceRelation,
-		)
+	index := indexNamespace
+	args := []any{filter.ResourceType}
+	if filter.OptionalResourceRelation != "" {
+		args = append(args, filter.OptionalResourceRelation)
+		index = indexNamespaceAndRelation
 	}
 
-	iter, err := txn.Get(tableRelationship, indexNamespace, filter.ResourceType)
+	iter, err := txn.Get(tableRelationship, index, args...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get iterator for filter: %w", err)
 	}

--- a/internal/datastore/memdb/readwrite.go
+++ b/internal/datastore/memdb/readwrite.go
@@ -100,7 +100,7 @@ func (rwt *memdbReadWriteTx) DeleteRelationships(filter *v1.RelationshipFilter) 
 // caller must already hold the concurrent access lock
 func (rwt *memdbReadWriteTx) deleteWithLock(tx *memdb.Txn, filter *v1.RelationshipFilter) error {
 	// Create an iterator to find the relevant tuples
-	bestIter, err := iteratorForFilter(tx, filter)
+	bestIter, err := iteratorForFilter(tx, datastore.RelationshipsFilterFromPublicFilter(filter))
 	if err != nil {
 		return err
 	}

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -647,7 +647,7 @@ func BenchmarkPostgresQuery(b *testing.B) {
 		require := require.New(b)
 
 		for i := 0; i < b.N; i++ {
-			iter, err := ds.SnapshotReader(revision).QueryRelationships(context.Background(), &v1.RelationshipFilter{
+			iter, err := ds.SnapshotReader(revision).QueryRelationships(context.Background(), datastore.RelationshipsFilter{
 				ResourceType: testfixtures.DocumentNS.Name,
 			})
 			require.NoError(err)

--- a/internal/datastore/postgres/reader.go
+++ b/internal/datastore/postgres/reader.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/jackc/pgx/v4"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -55,24 +54,10 @@ const (
 
 func (r *pgReader) QueryRelationships(
 	ctx context.Context,
-	filter *v1.RelationshipFilter,
+	filter datastore.RelationshipsFilter,
 	opts ...options.QueryOptionsOption,
 ) (iter datastore.RelationshipIterator, err error) {
-	qBuilder := common.NewSchemaQueryFilterer(schema, r.filterer(queryTuples)).
-		FilterToResourceType(filter.ResourceType)
-
-	if filter.OptionalResourceId != "" {
-		qBuilder = qBuilder.FilterToResourceID(filter.OptionalResourceId)
-	}
-
-	if filter.OptionalRelation != "" {
-		qBuilder = qBuilder.FilterToRelation(filter.OptionalRelation)
-	}
-
-	if filter.OptionalSubjectFilter != nil {
-		qBuilder = qBuilder.FilterToSubjectFilter(filter.OptionalSubjectFilter)
-	}
-
+	qBuilder := common.NewSchemaQueryFilterer(schema, r.filterer(queryTuples)).FilterWithRelationshipsFilter(filter)
 	return r.querySplitter.SplitAndExecuteQuery(ctx, qBuilder, opts...)
 }
 

--- a/internal/datastore/proxy/hedging.go
+++ b/internal/datastore/proxy/hedging.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/benbjohnson/clock"
 	"github.com/influxdata/tdigest"
 	"github.com/prometheus/client_golang/prometheus"
@@ -238,7 +237,7 @@ func (hp hedgingReader) ReadNamespace(
 
 func (hp hedgingReader) QueryRelationships(
 	ctx context.Context,
-	filter *v1.RelationshipFilter,
+	filter datastore.RelationshipsFilter,
 	options ...options.QueryOptionsOption,
 ) (iter datastore.RelationshipIterator, err error) {
 	return hp.executeQuery(ctx, func(c context.Context) (datastore.RelationshipIterator, error) {

--- a/internal/datastore/proxy/hedging_test.go
+++ b/internal/datastore/proxy/hedging_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/benbjohnson/clock"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/mock"
@@ -105,7 +104,7 @@ func TestDatastoreRequestHedging(t *testing.T) {
 				require := require.New(t)
 				_, err := proxy.
 					SnapshotReader(datastore.NoRevision).
-					QueryRelationships(context.Background(), &v1.RelationshipFilter{})
+					QueryRelationships(context.Background(), datastore.RelationshipsFilter{})
 				if expectFirst {
 					require.ErrorIs(errKnown, err)
 				} else {
@@ -323,7 +322,7 @@ func TestDatastoreE2E(t *testing.T) {
 	autoAdvance(mockTime, slowQueryTime/2, 2*slowQueryTime)
 
 	it, err := proxy.SnapshotReader(revisionKnown).QueryRelationships(
-		context.Background(), &v1.RelationshipFilter{
+		context.Background(), datastore.RelationshipsFilter{
 			ResourceType: "test",
 		},
 	)

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -94,7 +94,7 @@ func (dm *MockReader) ReadNamespace(
 
 func (dm *MockReader) QueryRelationships(
 	ctx context.Context,
-	filter *v1.RelationshipFilter,
+	filter datastore.RelationshipsFilter,
 	options ...options.QueryOptionsOption,
 ) (datastore.RelationshipIterator, error) {
 	callArgs := make([]interface{}, 0, len(options)+1)
@@ -157,7 +157,7 @@ func (dm *MockReadWriteTransaction) ReadNamespace(
 
 func (dm *MockReadWriteTransaction) QueryRelationships(
 	ctx context.Context,
-	filter *v1.RelationshipFilter,
+	filter datastore.RelationshipsFilter,
 	options ...options.QueryOptionsOption,
 ) (datastore.RelationshipIterator, error) {
 	callArgs := make([]interface{}, 0, len(options)+1)

--- a/internal/datastore/spanner/reader.go
+++ b/internal/datastore/spanner/reader.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/spanner"
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
 
@@ -36,24 +35,10 @@ type spannerReader struct {
 
 func (sr spannerReader) QueryRelationships(
 	ctx context.Context,
-	filter *v1.RelationshipFilter,
+	filter datastore.RelationshipsFilter,
 	opts ...options.QueryOptionsOption,
 ) (iter datastore.RelationshipIterator, err error) {
-	qBuilder := common.NewSchemaQueryFilterer(schema, queryTuples).
-		FilterToResourceType(filter.ResourceType)
-
-	if filter.OptionalResourceId != "" {
-		qBuilder = qBuilder.FilterToResourceID(filter.OptionalResourceId)
-	}
-
-	if filter.OptionalRelation != "" {
-		qBuilder = qBuilder.FilterToRelation(filter.OptionalRelation)
-	}
-
-	if filter.OptionalSubjectFilter != nil {
-		qBuilder = qBuilder.FilterToSubjectFilter(filter.OptionalSubjectFilter)
-	}
-
+	qBuilder := common.NewSchemaQueryFilterer(schema, queryTuples).FilterWithRelationshipsFilter(filter)
 	return sr.querySplitter.SplitAndExecuteQuery(ctx, qBuilder, opts...)
 }
 

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -150,6 +150,10 @@ func (ddm delegateDispatchMock) DispatchReachableResources(req *v1.DispatchReach
 	return nil
 }
 
+func (ddm delegateDispatchMock) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsRequest, stream dispatch.LookupSubjectsStream) error {
+	return nil
+}
+
 func (ddm delegateDispatchMock) Close() error {
 	return nil
 }

--- a/internal/dispatch/caching/delegate.go
+++ b/internal/dispatch/caching/delegate.go
@@ -35,4 +35,8 @@ func (fd fakeDelegate) DispatchReachableResources(req *v1.DispatchReachableResou
 	panic(errMessage)
 }
 
+func (fd fakeDelegate) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsRequest, stream dispatch.LookupSubjectsStream) error {
+	panic(errMessage)
+}
+
 var _ dispatch.Dispatcher = fakeDelegate{}

--- a/internal/dispatch/graph/lookupsubjects_test.go
+++ b/internal/dispatch/graph/lookupsubjects_test.go
@@ -1,0 +1,268 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	v1_api "github.com/authzed/authzed-go/proto/authzed/api/v1"
+
+	"github.com/rs/zerolog/log"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore/memdb"
+	"github.com/authzed/spicedb/internal/dispatch"
+	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
+	"github.com/authzed/spicedb/internal/testfixtures"
+	"github.com/authzed/spicedb/pkg/datastore"
+	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+)
+
+func TestSimpleLookupSubjects(t *testing.T) {
+	testCases := []struct {
+		resourceType     string
+		resourceID       string
+		permission       string
+		subjectType      string
+		subjectRelation  string
+		expectedSubjects []string
+	}{
+		{
+			"document",
+			"masterplan",
+			"view",
+			"user",
+			"...",
+			[]string{"auditor", "chief_financial_officer", "eng_lead", "legal", "owner", "product_manager", "vp_product"},
+		},
+		{
+			"document",
+			"masterplan",
+			"edit",
+			"user",
+			"...",
+			[]string{"product_manager"},
+		},
+		{
+			"document",
+			"masterplan",
+			"view_and_edit",
+			"user",
+			"...",
+			[]string{},
+		},
+		{
+			"document",
+			"specialplan",
+			"view",
+			"user",
+			"...",
+			[]string{"multiroleguy"},
+		},
+		{
+			"document",
+			"specialplan",
+			"edit",
+			"user",
+			"...",
+			[]string{"multiroleguy"},
+		},
+		{
+			"document",
+			"specialplan",
+			"viewer_and_editor",
+			"user",
+			"...",
+			[]string{"multiroleguy", "missingrolegal"},
+		},
+		{
+			"document",
+			"specialplan",
+			"view_and_edit",
+			"user",
+			"...",
+			[]string{"multiroleguy"},
+		},
+		{
+			"folder",
+			"company",
+			"view",
+			"user",
+			"...",
+			[]string{"auditor", "legal", "owner"},
+		},
+		{
+			"folder",
+			"strategy",
+			"view",
+			"user",
+			"...",
+			[]string{"auditor", "legal", "owner", "vp_product"},
+		},
+		{
+			"document",
+			"masterplan",
+			"parent",
+			"folder",
+			"...",
+			[]string{"plans", "strategy"},
+		},
+		{
+			"document",
+			"masterplan",
+			"view",
+			"folder",
+			"...",
+			[]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("simple-lookup-subjects:%s:%s:%s:%s:%s", tc.resourceType, tc.resourceID, tc.permission, tc.subjectType, tc.subjectRelation), func(t *testing.T) {
+			require := require.New(t)
+
+			ctx, dis, revision := newLocalDispatcher(require)
+			stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupSubjectsResponse](ctx)
+
+			err := dis.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{
+				ResourceRelation: RR(tc.resourceType, tc.permission),
+				ResourceIds:      []string{tc.resourceID},
+				SubjectRelation:  RR(tc.subjectType, tc.subjectRelation),
+				Metadata: &v1.ResolverMeta{
+					AtRevision:     revision.String(),
+					DepthRemaining: 50,
+				},
+			}, stream)
+
+			require.NoError(err)
+
+			foundSubjectIds := []string{}
+			for _, result := range stream.Results() {
+				foundSubjectIds = append(foundSubjectIds, result.FoundSubjectIds...)
+			}
+
+			sort.Strings(foundSubjectIds)
+			sort.Strings(tc.expectedSubjects)
+			require.Equal(tc.expectedSubjects, foundSubjectIds)
+
+			// Ensure every subject found has access.
+			for _, subjectID := range foundSubjectIds {
+				checkResult, err := dis.DispatchCheck(ctx, &v1.DispatchCheckRequest{
+					ResourceAndRelation: ONR(tc.resourceType, tc.resourceID, tc.permission),
+					Subject:             ONR(tc.subjectType, subjectID, tc.subjectRelation),
+					Metadata: &v1.ResolverMeta{
+						AtRevision:     revision.String(),
+						DepthRemaining: 50,
+					},
+				})
+
+				require.NoError(err)
+				require.Equal(v1.DispatchCheckResponse_MEMBER, checkResult.Membership)
+			}
+		})
+	}
+}
+
+func TestLookupSubjectsMaxDepth(t *testing.T) {
+	require := require.New(t)
+
+	rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
+	require.NoError(err)
+
+	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
+
+	mutations := []*v1_api.RelationshipUpdate{{
+		Operation: v1_api.RelationshipUpdate_OPERATION_CREATE,
+		Relationship: &v1_api.Relationship{
+			Resource: &v1_api.ObjectReference{
+				ObjectType: "folder",
+				ObjectId:   "oops",
+			},
+			Relation: "owner",
+			Subject: &v1_api.SubjectReference{
+				Object: &v1_api.ObjectReference{
+					ObjectType: "folder",
+					ObjectId:   "oops",
+				},
+				OptionalRelation: "owner",
+			},
+		},
+	}}
+
+	ctx := log.Logger.WithContext(datastoremw.ContextWithHandle(context.Background()))
+	require.NoError(datastoremw.SetInContext(ctx, ds))
+
+	revision, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
+		return rwt.WriteRelationships(mutations)
+	})
+	require.NoError(err)
+	require.True(revision.GreaterThan(decimal.Zero))
+
+	dis := NewLocalOnlyDispatcher(10)
+	stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupSubjectsResponse](ctx)
+
+	err = dis.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{
+		ResourceRelation: RR("folder", "owner"),
+		ResourceIds:      []string{"oops"},
+		SubjectRelation:  RR("user", "..."),
+		Metadata: &v1.ResolverMeta{
+			AtRevision:     revision.String(),
+			DepthRemaining: 50,
+		},
+	}, stream)
+	require.Error(err)
+}
+
+func TestLookupSubjectsDispatchCount(t *testing.T) {
+	testCases := []struct {
+		resourceType          string
+		resourceID            string
+		permission            string
+		subjectType           string
+		subjectRelation       string
+		expectedDispatchCount int
+	}{
+		{
+			"document",
+			"masterplan",
+			"view",
+			"user",
+			"...",
+			4,
+		},
+		{
+			"document",
+			"masterplan",
+			"view_and_edit",
+			"user",
+			"...",
+			5,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("dispatch-count-lookup-subjects:%s:%s:%s:%s:%s", tc.resourceType, tc.resourceID, tc.permission, tc.subjectType, tc.subjectRelation), func(t *testing.T) {
+			require := require.New(t)
+
+			ctx, dis, revision := newLocalDispatcher(require)
+			stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupSubjectsResponse](ctx)
+
+			err := dis.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{
+				ResourceRelation: RR(tc.resourceType, tc.permission),
+				ResourceIds:      []string{tc.resourceID},
+				SubjectRelation:  RR(tc.subjectType, tc.subjectRelation),
+				Metadata: &v1.ResolverMeta{
+					AtRevision:     revision.String(),
+					DepthRemaining: 50,
+				},
+			}, stream)
+
+			require.NoError(err)
+			for _, result := range stream.Results() {
+				require.LessOrEqual(int(result.Metadata.DispatchCount), tc.expectedDispatchCount, "Found dispatch count greater than expected")
+			}
+		})
+	}
+}

--- a/internal/dispatch/stream.go
+++ b/internal/dispatch/stream.go
@@ -82,7 +82,7 @@ func (s *CollectingDispatchStream[T]) Publish(result T) error {
 type WrappedDispatchStream[T any] struct {
 	Stream    Stream[T]
 	Ctx       context.Context
-	Processor func(result T) (T, error)
+	Processor func(result T) (T, bool, error)
 }
 
 func (s *WrappedDispatchStream[T]) Publish(result T) error {
@@ -90,10 +90,14 @@ func (s *WrappedDispatchStream[T]) Publish(result T) error {
 		return s.Stream.Publish(result)
 	}
 
-	processed, err := s.Processor(result)
+	processed, ok, err := s.Processor(result)
 	if err != nil {
 		return err
 	}
+	if !ok {
+		return nil
+	}
+
 	return s.Stream.Publish(processed)
 }
 

--- a/internal/graph/expand.go
+++ b/internal/graph/expand.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	v1_proto "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/rs/zerolog/log"
 	"github.com/shopspring/decimal"
 
@@ -58,10 +58,10 @@ func (ce *ConcurrentExpander) expandDirect(
 	log.Ctx(ctx).Trace().Object("direct", req).Send()
 	return func(ctx context.Context, resultChan chan<- ExpandResult) {
 		ds := datastoremw.MustFromContext(ctx).SnapshotReader(req.Revision)
-		it, err := ds.QueryRelationships(ctx, &v1_proto.RelationshipFilter{
-			ResourceType:       req.ResourceAndRelation.Namespace,
-			OptionalResourceId: req.ResourceAndRelation.ObjectId,
-			OptionalRelation:   req.ResourceAndRelation.Relation,
+		it, err := ds.QueryRelationships(ctx, datastore.RelationshipsFilter{
+			ResourceType:             req.ResourceAndRelation.Namespace,
+			OptionalResourceIds:      []string{req.ResourceAndRelation.ObjectId},
+			OptionalResourceRelation: req.ResourceAndRelation.Relation,
 		})
 		if err != nil {
 			resultChan <- expandResultError(NewExpansionFailureErr(err), emptyMetadata)
@@ -226,10 +226,10 @@ func (ce *ConcurrentExpander) expandComputedUserset(ctx context.Context, req Val
 func (ce *ConcurrentExpander) expandTupleToUserset(ctx context.Context, req ValidatedExpandRequest, ttu *core.TupleToUserset) ReduceableExpandFunc {
 	return func(ctx context.Context, resultChan chan<- ExpandResult) {
 		ds := datastoremw.MustFromContext(ctx).SnapshotReader(req.Revision)
-		it, err := ds.QueryRelationships(ctx, &v1_proto.RelationshipFilter{
-			ResourceType:       req.ResourceAndRelation.Namespace,
-			OptionalResourceId: req.ResourceAndRelation.ObjectId,
-			OptionalRelation:   ttu.Tupleset.Relation,
+		it, err := ds.QueryRelationships(ctx, datastore.RelationshipsFilter{
+			ResourceType:             req.ResourceAndRelation.Namespace,
+			OptionalResourceIds:      []string{req.ResourceAndRelation.ObjectId},
+			OptionalResourceRelation: ttu.Tupleset.Relation,
 		})
 		if err != nil {
 			resultChan <- expandResultError(NewExpansionFailureErr(err), emptyMetadata)

--- a/internal/graph/expand.go
+++ b/internal/graph/expand.go
@@ -5,15 +5,14 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/rs/zerolog/log"
 	"github.com/shopspring/decimal"
-
-	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 
 	"github.com/authzed/spicedb/internal/dispatch"
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/internal/namespace"
+	"github.com/authzed/spicedb/pkg/datastore"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 )
 

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -5,11 +5,20 @@ import (
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 
+	"github.com/authzed/spicedb/pkg/datastore"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 )
 
 // Ellipsis relation is used to signify a semantic-free relationship.
 const Ellipsis = "..."
+
+// maxDispatchChunkSize is the maximum size for a dispatch chunk. Must be less than or equal
+// to the maximum ID count for filters in the datastore.
+const maxDispatchChunkSize = datastore.FilterMaximumIDCount
+
+// progressiveDispatchChunkSizes are chunk sizes growing over time for dispatching. All entries
+// must be less than or equal to the maximum ID count for filters in the datastore.
+var progressiveDispatchChunkSizes = []int{5, 10, 25, 50, maxDispatchChunkSize}
 
 // CheckResult is the data that is returned by a single check or sub-check.
 type CheckResult struct {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -1,0 +1,22 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/datastore"
+)
+
+func TestChunkSizes(t *testing.T) {
+	for index, cs := range progressiveDispatchChunkSizes {
+		require.LessOrEqual(t, cs, datastore.FilterMaximumIDCount)
+		if index > 0 {
+			require.Greater(t, cs, progressiveDispatchChunkSizes[index-1])
+		}
+	}
+}
+
+func TestMaxDispatchChunkSize(t *testing.T) {
+	require.LessOrEqual(t, maxDispatchChunkSize, datastore.FilterMaximumIDCount)
+}

--- a/internal/graph/lookupsubjects.go
+++ b/internal/graph/lookupsubjects.go
@@ -288,8 +288,6 @@ func (cl *ConcurrentLookupSubjects) lookupSetOperation(
 	return reducer.CompletedChildOperations()
 }
 
-const dispatchChunkSize = 100
-
 func (cl *ConcurrentLookupSubjects) dispatchTo(
 	ctx context.Context,
 	parentRequest ValidatedLookupSubjectsRequest,
@@ -318,7 +316,7 @@ func (cl *ConcurrentLookupSubjects) dispatchTo(
 	}
 
 	toDispatchByType.ForEachType(func(resourceType *core.RelationReference, resourceIds []string) {
-		util.ForEachChunk(resourceIds, dispatchChunkSize, func(resourceIdChunk []string) {
+		util.ForEachChunk(resourceIds, maxDispatchChunkSize, func(resourceIdChunk []string) {
 			g.Go(func() error {
 				return cl.d.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{
 					ResourceRelation: resourceType,

--- a/internal/graph/lookupsubjects.go
+++ b/internal/graph/lookupsubjects.go
@@ -1,0 +1,486 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"github.com/shopspring/decimal"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/authzed/spicedb/internal/dispatch"
+	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
+	"github.com/authzed/spicedb/internal/namespace"
+	"github.com/authzed/spicedb/internal/util"
+	"github.com/authzed/spicedb/pkg/datastore"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
+)
+
+// ValidatedLookupSubjectsRequest represents a request after it has been validated and parsed for internal
+// consumption.
+type ValidatedLookupSubjectsRequest struct {
+	*v1.DispatchLookupSubjectsRequest
+	Revision decimal.Decimal
+}
+
+// NewConcurrentLookupSubjects creates an instance of ConcurrentLookupSubjects.
+func NewConcurrentLookupSubjects(d dispatch.LookupSubjects, concurrencyLimit uint16) *ConcurrentLookupSubjects {
+	return &ConcurrentLookupSubjects{d, concurrencyLimit}
+}
+
+type ConcurrentLookupSubjects struct {
+	d                dispatch.LookupSubjects
+	concurrencyLimit uint16
+}
+
+func (cl *ConcurrentLookupSubjects) LookupSubjects(
+	req ValidatedLookupSubjectsRequest,
+	stream dispatch.LookupSubjectsStream,
+) error {
+	ctx := stream.Context()
+
+	if len(req.ResourceIds) == 0 {
+		return fmt.Errorf("no resources ids given to lookupsubjects dispatch")
+	}
+
+	// If the resource type matches the subject type, yield directly.
+	if req.SubjectRelation.Namespace == req.ResourceRelation.Namespace &&
+		req.SubjectRelation.Relation == req.ResourceRelation.Relation {
+		err := stream.Publish(&v1.DispatchLookupSubjectsResponse{
+			FoundSubjectIds: req.ResourceIds,
+			Metadata:        emptyMetadata,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	ds := datastoremw.MustFromContext(ctx)
+	reader := ds.SnapshotReader(req.Revision)
+	_, relation, err := namespace.ReadNamespaceAndRelation(
+		ctx,
+		req.ResourceRelation.Namespace,
+		req.ResourceRelation.Relation,
+		reader)
+	if err != nil {
+		return err
+	}
+
+	if relation.UsersetRewrite == nil {
+		// Direct lookup of subjects.
+		return cl.lookupDirectSubjects(ctx, req, stream, relation, reader)
+	}
+
+	return cl.lookupViaRewrite(ctx, req, stream, relation.UsersetRewrite)
+}
+
+func (cl *ConcurrentLookupSubjects) lookupDirectSubjects(
+	ctx context.Context,
+	req ValidatedLookupSubjectsRequest,
+	stream dispatch.LookupSubjectsStream,
+	relation *core.Relation,
+	reader datastore.Reader,
+) error {
+	// TODO(jschorr): use type information to skip subject relations that cannot reach the subject type.
+	it, err := reader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+		ResourceType:             req.ResourceRelation.Namespace,
+		OptionalResourceRelation: req.ResourceRelation.Relation,
+		OptionalResourceIds:      req.ResourceIds,
+	})
+	if err != nil {
+		return err
+	}
+	defer it.Close()
+
+	toDispatchByType := tuple.NewONRByTypeSet()
+	var foundSubjectIds []string
+	for tpl := it.Next(); tpl != nil; tpl = it.Next() {
+		if it.Err() != nil {
+			return err
+		}
+
+		if tpl.Subject.Namespace == req.SubjectRelation.Namespace &&
+			tpl.Subject.Relation == req.SubjectRelation.Relation {
+			foundSubjectIds = append(foundSubjectIds, tpl.Subject.ObjectId)
+		}
+
+		if tpl.Subject.Relation != tuple.Ellipsis {
+			toDispatchByType.Add(tpl.Subject)
+		}
+	}
+
+	if len(foundSubjectIds) > 0 {
+		err := stream.Publish(&v1.DispatchLookupSubjectsResponse{
+			FoundSubjectIds: foundSubjectIds,
+			Metadata:        emptyMetadata,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return cl.dispatchTo(ctx, req, toDispatchByType, stream)
+}
+
+func (cl *ConcurrentLookupSubjects) lookupViaComputed(
+	ctx context.Context,
+	parentRequest ValidatedLookupSubjectsRequest,
+	parentStream dispatch.LookupSubjectsStream,
+	cu *core.ComputedUserset,
+) error {
+	ds := datastoremw.MustFromContext(ctx).SnapshotReader(parentRequest.Revision)
+	err := namespace.CheckNamespaceAndRelation(ctx, parentRequest.ResourceRelation.Namespace, cu.Relation, true, ds)
+	if err != nil {
+		if errors.As(err, &namespace.ErrRelationNotFound{}) {
+			return nil
+		}
+
+		return err
+	}
+
+	stream := &dispatch.WrappedDispatchStream[*v1.DispatchLookupSubjectsResponse]{
+		Stream: parentStream,
+		Ctx:    ctx,
+		Processor: func(result *v1.DispatchLookupSubjectsResponse) (*v1.DispatchLookupSubjectsResponse, bool, error) {
+			return &v1.DispatchLookupSubjectsResponse{
+				FoundSubjectIds: result.FoundSubjectIds,
+				Metadata:        addCallToResponseMetadata(result.Metadata),
+			}, true, nil
+		},
+	}
+
+	return cl.d.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{
+		ResourceRelation: &core.RelationReference{
+			Namespace: parentRequest.ResourceRelation.Namespace,
+			Relation:  cu.Relation,
+		},
+		ResourceIds:     parentRequest.ResourceIds,
+		SubjectRelation: parentRequest.SubjectRelation,
+		Metadata: &v1.ResolverMeta{
+			AtRevision:     parentRequest.Revision.String(),
+			DepthRemaining: parentRequest.Metadata.DepthRemaining - 1,
+		},
+	}, stream)
+}
+
+func (cl *ConcurrentLookupSubjects) lookupViaTupleToUserset(
+	ctx context.Context,
+	parentRequest ValidatedLookupSubjectsRequest,
+	parentStream dispatch.LookupSubjectsStream,
+	ttu *core.TupleToUserset,
+) error {
+	ds := datastoremw.MustFromContext(ctx).SnapshotReader(parentRequest.Revision)
+	it, err := ds.QueryRelationships(ctx, datastore.RelationshipsFilter{
+		ResourceType:             parentRequest.ResourceRelation.Namespace,
+		OptionalResourceRelation: ttu.Tupleset.Relation,
+		OptionalResourceIds:      parentRequest.ResourceIds,
+	})
+	if err != nil {
+		return err
+	}
+	defer it.Close()
+
+	toDispatchByTuplesetType := tuple.NewONRByTypeSet()
+	for tpl := it.Next(); tpl != nil; tpl = it.Next() {
+		if it.Err() != nil {
+			return err
+		}
+
+		toDispatchByTuplesetType.Add(tpl.Subject)
+	}
+
+	// Map the found subject types by the computed userset relation, so that we dispatch to it.
+	toDispatchByComputedRelationType, err := toDispatchByTuplesetType.Map(func(resourceType *core.RelationReference) (*core.RelationReference, error) {
+		err := namespace.CheckNamespaceAndRelation(ctx, resourceType.Namespace, ttu.ComputedUserset.Relation, false, ds)
+		if err != nil {
+			if errors.As(err, &namespace.ErrRelationNotFound{}) {
+				return nil, nil
+			}
+
+			return nil, err
+		}
+
+		return &core.RelationReference{
+			Namespace: resourceType.Namespace,
+			Relation:  ttu.ComputedUserset.Relation,
+		}, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return cl.dispatchTo(ctx, parentRequest, toDispatchByComputedRelationType, parentStream)
+}
+
+func (cl *ConcurrentLookupSubjects) lookupViaRewrite(
+	ctx context.Context,
+	req ValidatedLookupSubjectsRequest,
+	stream dispatch.LookupSubjectsStream,
+	usr *core.UsersetRewrite,
+) error {
+	switch rw := usr.RewriteOperation.(type) {
+	case *core.UsersetRewrite_Union:
+		log.Ctx(ctx).Trace().Msg("union")
+		return cl.lookupSetOperation(ctx, req, rw.Union, newLookupSubjectsUnion(stream))
+	case *core.UsersetRewrite_Intersection:
+		log.Ctx(ctx).Trace().Msg("intersection")
+		return cl.lookupSetOperation(ctx, req, rw.Intersection, newLookupSubjectsIntersection(stream))
+	case *core.UsersetRewrite_Exclusion:
+		log.Ctx(ctx).Trace().Msg("exclusion")
+		return cl.lookupSetOperation(ctx, req, rw.Exclusion, newLookupSubjectsExclusion(stream))
+	default:
+		return fmt.Errorf("unknown kind of rewrite in lookup subjects")
+	}
+}
+
+func (cl *ConcurrentLookupSubjects) lookupSetOperation(
+	ctx context.Context,
+	req ValidatedLookupSubjectsRequest,
+	so *core.SetOperation,
+	reducer lookupSubjectsReducer,
+) error {
+	cancelCtx, checkCancel := context.WithCancel(ctx)
+	defer checkCancel()
+
+	g, subCtx := errgroup.WithContext(cancelCtx)
+	g.SetLimit(int(cl.concurrencyLimit))
+
+	for index, childOneof := range so.Child {
+		stream := reducer.ForIndex(subCtx, index)
+
+		switch child := childOneof.ChildType.(type) {
+		case *core.SetOperation_Child_XThis:
+			return errors.New("use of _this is unsupported; please rewrite your schema")
+
+		case *core.SetOperation_Child_ComputedUserset:
+			g.Go(func() error {
+				return cl.lookupViaComputed(subCtx, req, stream, child.ComputedUserset)
+			})
+
+		case *core.SetOperation_Child_UsersetRewrite:
+			g.Go(func() error {
+				return cl.lookupViaRewrite(subCtx, req, stream, child.UsersetRewrite)
+			})
+
+		case *core.SetOperation_Child_TupleToUserset:
+			g.Go(func() error {
+				return cl.lookupViaTupleToUserset(subCtx, req, stream, child.TupleToUserset)
+			})
+
+		case *core.SetOperation_Child_XNil:
+			// Purposely do nothing.
+			continue
+
+		default:
+			return fmt.Errorf("unknown set operation child `%T` in expand", child)
+		}
+	}
+
+	// Wait for all dispatched operations to complete.
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	return reducer.CompletedChildOperations()
+}
+
+const dispatchChunkSize = 100
+
+func (cl *ConcurrentLookupSubjects) dispatchTo(
+	ctx context.Context,
+	parentRequest ValidatedLookupSubjectsRequest,
+	toDispatchByType *tuple.ONRByTypeSet,
+	parentStream dispatch.LookupSubjectsStream,
+) error {
+	if toDispatchByType.IsEmpty() {
+		return nil
+	}
+
+	cancelCtx, checkCancel := context.WithCancel(ctx)
+	defer checkCancel()
+
+	g, subCtx := errgroup.WithContext(cancelCtx)
+	g.SetLimit(int(cl.concurrencyLimit))
+
+	stream := &dispatch.WrappedDispatchStream[*v1.DispatchLookupSubjectsResponse]{
+		Stream: parentStream,
+		Ctx:    subCtx,
+		Processor: func(result *v1.DispatchLookupSubjectsResponse) (*v1.DispatchLookupSubjectsResponse, bool, error) {
+			return &v1.DispatchLookupSubjectsResponse{
+				FoundSubjectIds: result.FoundSubjectIds,
+				Metadata:        addCallToResponseMetadata(result.Metadata),
+			}, true, nil
+		},
+	}
+
+	toDispatchByType.ForEachType(func(resourceType *core.RelationReference, resourceIds []string) {
+		util.ForEachChunk(resourceIds, dispatchChunkSize, func(resourceIdChunk []string) {
+			g.Go(func() error {
+				return cl.d.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{
+					ResourceRelation: resourceType,
+					ResourceIds:      resourceIdChunk,
+					SubjectRelation:  parentRequest.SubjectRelation,
+					Metadata: &v1.ResolverMeta{
+						AtRevision:     parentRequest.Revision.String(),
+						DepthRemaining: parentRequest.Metadata.DepthRemaining - 1,
+					},
+				}, stream)
+			})
+		})
+	})
+
+	return g.Wait()
+}
+
+type lookupSubjectsReducer interface {
+	ForIndex(ctx context.Context, setOperationIndex int) dispatch.LookupSubjectsStream
+	CompletedChildOperations() error
+}
+
+// Union
+type lookupSubjectsUnion struct {
+	parentStream dispatch.LookupSubjectsStream
+	encountered  *util.Set[string]
+	mu           sync.Mutex
+}
+
+func newLookupSubjectsUnion(parentStream dispatch.LookupSubjectsStream) *lookupSubjectsUnion {
+	return &lookupSubjectsUnion{
+		parentStream: parentStream,
+		encountered:  util.NewSet[string](),
+		mu:           sync.Mutex{},
+	}
+}
+
+func (lsu *lookupSubjectsUnion) ForIndex(ctx context.Context, setOperationIndex int) dispatch.LookupSubjectsStream {
+	return &dispatch.WrappedDispatchStream[*v1.DispatchLookupSubjectsResponse]{
+		Stream: lsu.parentStream,
+		Ctx:    ctx,
+		Processor: func(result *v1.DispatchLookupSubjectsResponse) (*v1.DispatchLookupSubjectsResponse, bool, error) {
+			lsu.mu.Lock()
+			defer lsu.mu.Unlock()
+
+			filtered := make([]string, 0, len(result.FoundSubjectIds))
+			for _, subjectID := range result.FoundSubjectIds {
+				if lsu.encountered.Add(subjectID) {
+					filtered = append(filtered, subjectID)
+				}
+			}
+
+			if len(filtered) == 0 {
+				return nil, false, nil
+			}
+
+			return &v1.DispatchLookupSubjectsResponse{
+				FoundSubjectIds: filtered,
+				Metadata:        result.Metadata,
+			}, true, nil
+		},
+	}
+}
+
+func (lsu *lookupSubjectsUnion) CompletedChildOperations() error {
+	return nil
+}
+
+// Intersection
+type lookupSubjectsIntersection struct {
+	parentStream dispatch.LookupSubjectsStream
+	collectors   map[int]*dispatch.CollectingDispatchStream[*v1.DispatchLookupSubjectsResponse]
+}
+
+func newLookupSubjectsIntersection(parentStream dispatch.LookupSubjectsStream) *lookupSubjectsIntersection {
+	return &lookupSubjectsIntersection{
+		parentStream: parentStream,
+		collectors:   map[int]*dispatch.CollectingDispatchStream[*v1.DispatchLookupSubjectsResponse]{},
+	}
+}
+
+func (lsi *lookupSubjectsIntersection) ForIndex(ctx context.Context, setOperationIndex int) dispatch.LookupSubjectsStream {
+	collector := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupSubjectsResponse](ctx)
+	lsi.collectors[setOperationIndex] = collector
+	return collector
+}
+
+func (lsi *lookupSubjectsIntersection) CompletedChildOperations() error {
+	var foundSubjectIds *util.Set[string]
+	metadata := emptyMetadata
+
+	for index := 0; index < len(lsi.collectors); index++ {
+		collector, ok := lsi.collectors[index]
+		if !ok {
+			return fmt.Errorf("missing collector for index %d", index)
+		}
+
+		results := util.NewSet[string]()
+		for _, result := range collector.Results() {
+			metadata = combineResponseMetadata(metadata, result.Metadata)
+			results.Extend(result.FoundSubjectIds)
+		}
+
+		if index == 0 {
+			foundSubjectIds = results
+		} else {
+			foundSubjectIds.IntersectionDifference(results)
+			if foundSubjectIds.IsEmpty() {
+				return nil
+			}
+		}
+	}
+
+	return lsi.parentStream.Publish(&v1.DispatchLookupSubjectsResponse{
+		FoundSubjectIds: foundSubjectIds.AsSlice(),
+		Metadata:        metadata,
+	})
+}
+
+// Exclusion
+type lookupSubjectsExclusion struct {
+	parentStream dispatch.LookupSubjectsStream
+	collectors   map[int]*dispatch.CollectingDispatchStream[*v1.DispatchLookupSubjectsResponse]
+}
+
+func newLookupSubjectsExclusion(parentStream dispatch.LookupSubjectsStream) *lookupSubjectsExclusion {
+	return &lookupSubjectsExclusion{
+		parentStream: parentStream,
+		collectors:   map[int]*dispatch.CollectingDispatchStream[*v1.DispatchLookupSubjectsResponse]{},
+	}
+}
+
+func (lse *lookupSubjectsExclusion) ForIndex(ctx context.Context, setOperationIndex int) dispatch.LookupSubjectsStream {
+	collector := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupSubjectsResponse](ctx)
+	lse.collectors[setOperationIndex] = collector
+	return collector
+}
+
+func (lse *lookupSubjectsExclusion) CompletedChildOperations() error {
+	var foundSubjectIds *util.Set[string]
+	metadata := emptyMetadata
+
+	for index := 0; index < len(lse.collectors); index++ {
+		collector := lse.collectors[index]
+		results := util.NewSet[string]()
+		for _, result := range collector.Results() {
+			metadata = combineResponseMetadata(metadata, result.Metadata)
+			results.Extend(result.FoundSubjectIds)
+		}
+
+		if index == 0 {
+			foundSubjectIds = results
+		} else {
+			foundSubjectIds.RemoveAll(results)
+			if foundSubjectIds.IsEmpty() {
+				return nil
+			}
+		}
+	}
+
+	return lse.parentStream.Publish(&v1.DispatchLookupSubjectsResponse{
+		FoundSubjectIds: foundSubjectIds.AsSlice(),
+		Metadata:        metadata,
+	})
+}

--- a/internal/graph/reachableresources.go
+++ b/internal/graph/reachableresources.go
@@ -180,7 +180,7 @@ func (crr *ConcurrentReachableResources) lookupRelationEntrypoint(ctx context.Co
 		RelationFilter: datastore.SubjectRelationFilter{
 			NonEllipsisRelation: req.SubjectRelation.Relation,
 		},
-		SubjectIds: subjectIds,
+		OptionalSubjectIds: subjectIds,
 	}
 
 	// Fire off a query lookup in parallel.
@@ -290,9 +290,9 @@ func (crr *ConcurrentReachableResources) lookupTTUEntrypoint(ctx context.Context
 
 	// Search for the resolved subjects in the tupleset of the TTU.
 	subjectsFilter := datastore.SubjectsFilter{
-		SubjectType:    req.SubjectRelation.Namespace,
-		RelationFilter: relationFilter,
-		SubjectIds:     req.SubjectIds,
+		SubjectType:        req.SubjectRelation.Namespace,
+		RelationFilter:     relationFilter,
+		OptionalSubjectIds: req.SubjectIds,
 	}
 
 	// Fire off a query lookup in parallel.

--- a/internal/graph/reachableresources.go
+++ b/internal/graph/reachableresources.go
@@ -387,7 +387,7 @@ func (crr *ConcurrentReachableResources) redispatchOrReport(
 		stream := &dispatch.WrappedDispatchStream[*v1.DispatchReachableResourcesResponse]{
 			Stream: parentStream,
 			Ctx:    ctx,
-			Processor: func(result *v1.DispatchReachableResourcesResponse) (*v1.DispatchReachableResourcesResponse, error) {
+			Processor: func(result *v1.DispatchReachableResourcesResponse) (*v1.DispatchReachableResourcesResponse, bool, error) {
 				// If the entrypoint is not a direct result, then a check is required to determine
 				// whether the resource actually has permission.
 				status := result.Resource.ResultStatus
@@ -401,7 +401,7 @@ func (crr *ConcurrentReachableResources) redispatchOrReport(
 						ResultStatus: status,
 					},
 					Metadata: addCallToResponseMetadata(result.Metadata),
-				}, nil
+				}, true, nil
 			},
 		}
 

--- a/internal/graph/reachableresources.go
+++ b/internal/graph/reachableresources.go
@@ -18,8 +18,6 @@ import (
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
-var dispatchChunkSizes = []int{5, 10, 25, 50, 100}
-
 // NewConcurrentReachableResources creates an instance of ConcurrentReachableResources.
 func NewConcurrentReachableResources(d dispatch.ReachableResources, concurrencyLimit uint16) *ConcurrentReachableResources {
 	return &ConcurrentReachableResources{d, concurrencyLimit}
@@ -218,7 +216,7 @@ func min(a, b int) int {
 
 func (crr *ConcurrentReachableResources) chunkedRedispatch(it datastore.RelationshipIterator, handler func(resourceIdsFound []string) error) error {
 	for chunkIndex := 0; /* until done with all relationships */ true; chunkIndex++ {
-		chunkSize := dispatchChunkSizes[min(chunkIndex, len(dispatchChunkSizes)-1)]
+		chunkSize := progressiveDispatchChunkSizes[min(chunkIndex, len(progressiveDispatchChunkSizes)-1)]
 		resourceIdsFound := make([]string, 0, chunkSize)
 		for i := 0; i < chunkSize; i++ {
 			tpl := it.Next()

--- a/internal/services/shared/preconditions.go
+++ b/internal/services/shared/preconditions.go
@@ -21,7 +21,7 @@ func CheckPreconditions(
 	preconditions []*v1.Precondition,
 ) error {
 	for _, precond := range preconditions {
-		iter, err := rwt.QueryRelationships(ctx, precond.Filter, options.WithLimit(&limitOne))
+		iter, err := rwt.QueryRelationships(ctx, datastore.RelationshipsFilterFromPublicFilter(precond.Filter), options.WithLimit(&limitOne))
 		if err != nil {
 			return fmt.Errorf("error reading relationships: %w", err)
 		}

--- a/internal/services/shared/schema.go
+++ b/internal/services/shared/schema.go
@@ -3,7 +3,6 @@ package shared
 import (
 	"context"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -19,7 +18,7 @@ import (
 func EnsureNoRelationshipsExist(ctx context.Context, rwt datastore.ReadWriteTransaction, namespaceName string) error {
 	qy, qyErr := rwt.QueryRelationships(
 		ctx,
-		&v1.RelationshipFilter{ResourceType: namespaceName},
+		datastore.RelationshipsFilter{ResourceType: namespaceName},
 		options.WithLimit(options.LimitOne),
 	)
 	if err := ErrorIfTupleIteratorReturnsTuples(
@@ -66,9 +65,9 @@ func SanityCheckExistingRelationships(
 	for _, delta := range diff.Deltas() {
 		switch delta.Type {
 		case namespace.RemovedRelation:
-			qy, qyErr := rwt.QueryRelationships(ctx, &v1.RelationshipFilter{
-				ResourceType:     nsdef.Name,
-				OptionalRelation: delta.RelationName,
+			qy, qyErr := rwt.QueryRelationships(ctx, datastore.RelationshipsFilter{
+				ResourceType:             nsdef.Name,
+				OptionalResourceRelation: delta.RelationName,
 			})
 
 			err = ErrorIfTupleIteratorReturnsTuples(
@@ -100,8 +99,8 @@ func SanityCheckExistingRelationships(
 			qy, qyErr := rwt.ReverseQueryRelationships(
 				ctx,
 				datastore.SubjectsFilter{
-					SubjectType: delta.WildcardType,
-					SubjectIds:  []string{tuple.PublicWildcard},
+					SubjectType:        delta.WildcardType,
+					OptionalSubjectIds: []string{tuple.PublicWildcard},
 				},
 				options.WithResRelation(&options.ResourceRelation{
 					Namespace: nsdef.Name,

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -96,7 +96,7 @@ func (ps *permissionServer) ReadRelationships(req *v1.ReadRelationshipsRequest, 
 		DispatchCount: 1,
 	})
 
-	tupleIterator, err := ds.QueryRelationships(ctx, req.RelationshipFilter)
+	tupleIterator, err := ds.QueryRelationships(ctx, datastore.RelationshipsFilterFromPublicFilter(req.RelationshipFilter))
 	if err != nil {
 		return rewritePermissionsError(ctx, err)
 	}

--- a/internal/testfixtures/datastore.go
+++ b/internal/testfixtures/datastore.go
@@ -170,7 +170,7 @@ type TupleChecker struct {
 
 func (tc TupleChecker) ExactRelationshipIterator(ctx context.Context, tpl *core.RelationTuple, rev datastore.Revision) datastore.RelationshipIterator {
 	filter := tuple.MustToFilter(tpl)
-	iter, err := tc.DS.SnapshotReader(rev).QueryRelationships(ctx, filter)
+	iter, err := tc.DS.SnapshotReader(rev).QueryRelationships(ctx, datastore.RelationshipsFilterFromPublicFilter(filter))
 	tc.Require.NoError(err)
 	return iter
 }

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -64,13 +64,9 @@ func (vsr validatingSnapshotReader) ListNamespaces(
 }
 
 func (vsr validatingSnapshotReader) QueryRelationships(ctx context.Context,
-	filter *v1.RelationshipFilter,
+	filter datastore.RelationshipsFilter,
 	opts ...options.QueryOptionsOption,
 ) (datastore.RelationshipIterator, error) {
-	if err := filter.Validate(); err != nil {
-		return nil, err
-	}
-
 	queryOpts := options.NewQueryOptionsWithOptions(opts...)
 	for _, sub := range queryOpts.Usersets {
 		if err := sub.Validate(); err != nil {

--- a/internal/util/chunking.go
+++ b/internal/util/chunking.go
@@ -1,0 +1,16 @@
+package util
+
+// ForEachChunk executes the given handler for each chunk of items in the slice.
+func ForEachChunk[T any](data []T, chunkSize uint64, handler func(items []T)) {
+	dataLength := uint64(len(data))
+	chunkCount := (dataLength / chunkSize) + 1
+	for chunkIndex := uint64(0); chunkIndex < chunkCount; chunkIndex++ {
+		chunkStart := chunkIndex * chunkSize
+		chunkEnd := (chunkIndex + 1) * chunkSize
+		if chunkEnd > dataLength {
+			chunkEnd = dataLength
+		}
+
+		handler(data[chunkStart:chunkEnd])
+	}
+}

--- a/internal/util/chunking_test.go
+++ b/internal/util/chunking_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestForEachChunk(t *testing.T) {
+	for _, datasize := range []int{0, 1, 5, 10, 50, 100, 250} {
+		for _, chunksize := range []uint64{1, 2, 3, 5, 10, 50} {
+			t.Run(fmt.Sprintf("test-%d-%d", datasize, chunksize), func(t *testing.T) {
+				data := []int{}
+				for i := 0; i < datasize; i++ {
+					data = append(data, i)
+				}
+
+				found := []int{}
+				ForEachChunk(data, chunksize, func(items []int) {
+					found = append(found, items...)
+					require.True(t, len(items) <= int(chunksize))
+				})
+				require.Equal(t, data, found)
+			})
+		}
+	}
+}

--- a/internal/util/set.go
+++ b/internal/util/set.go
@@ -1,0 +1,79 @@
+package util
+
+// Set implements a very basic generic set.
+type Set[T comparable] struct {
+	values map[T]struct{}
+}
+
+// NewSet returns a new set.
+func NewSet[T comparable]() *Set[T] {
+	return &Set[T]{
+		values: map[T]struct{}{},
+	}
+}
+
+// Has returns true if the set contains the given value.
+func (s *Set[T]) Has(value T) bool {
+	_, exists := s.values[value]
+	return exists
+}
+
+// Add adds the given value to the set and returns true. If
+// the value is already present, returns false.
+func (s *Set[T]) Add(value T) bool {
+	if s.Has(value) {
+		return false
+	}
+
+	s.values[value] = struct{}{}
+	return true
+}
+
+// Remove removes the value from the set, returning whether
+// the element was present when the call was made.
+func (s *Set[T]) Remove(value T) bool {
+	if !s.Has(value) {
+		return false
+	}
+
+	delete(s.values, value)
+	return true
+}
+
+// Extend adds all the values to the set.
+func (s *Set[T]) Extend(values []T) {
+	for _, value := range values {
+		s.values[value] = struct{}{}
+	}
+}
+
+// IntersectionDifference removes any values from this set that
+// are not shared with the other set.
+func (s *Set[T]) IntersectionDifference(other *Set[T]) {
+	for value := range s.values {
+		if !other.Has(value) {
+			s.Remove(value)
+		}
+	}
+}
+
+// RemoveAll removes all values from this set found in the other set.
+func (s *Set[T]) RemoveAll(other *Set[T]) {
+	for value := range other.values {
+		s.Remove(value)
+	}
+}
+
+// IsEmpty returns true if the set is empty.
+func (s *Set[T]) IsEmpty() bool {
+	return len(s.values) == 0
+}
+
+// AsSlice returns the set as a slice of values.
+func (s *Set[T]) AsSlice() []T {
+	slice := make([]T, 0, len(s.values))
+	for value := range s.values {
+		slice = append(slice, value)
+	}
+	return slice
+}

--- a/internal/util/set_test.go
+++ b/internal/util/set_test.go
@@ -1,0 +1,115 @@
+package util
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetOperations(t *testing.T) {
+	// Create a set and ensure it is empty.
+	set := NewSet[string]()
+	require.True(t, set.IsEmpty())
+
+	// Add some items to the set.
+	require.True(t, set.Add("hi"))
+	require.True(t, set.Add("hello"))
+	require.False(t, set.Add("hello"))
+	require.True(t, set.Add("heyo"))
+
+	// Ensure the items are in the set.
+	require.False(t, set.IsEmpty())
+	require.True(t, set.Has("hi"))
+	require.True(t, set.Has("hello"))
+	require.True(t, set.Has("heyo"))
+
+	require.False(t, set.Has("hola"))
+	require.False(t, set.Has("hiya"))
+
+	slice := set.AsSlice()
+	sort.Strings(slice)
+	require.Equal(t, slice, []string{"hello", "heyo", "hi"})
+
+	// Remove some items.
+	require.True(t, set.Remove("hi"))
+	require.False(t, set.Remove("hi"))
+
+	require.False(t, set.Has("hi"))
+	require.True(t, set.Has("hello"))
+	require.True(t, set.Has("heyo"))
+
+	require.False(t, set.Has("hola"))
+	require.False(t, set.Has("hiya"))
+
+	slice = set.AsSlice()
+	sort.Strings(slice)
+	require.Equal(t, slice, []string{"hello", "heyo"})
+
+	// Extend the set with a slice of values
+	set.Extend([]string{"1", "2", "3"})
+
+	slice = set.AsSlice()
+	sort.Strings(slice)
+	require.Equal(t, slice, []string{"1", "2", "3", "hello", "heyo"})
+
+	// Create another set and remove its items.
+	otherSet := NewSet[string]()
+	otherSet.Extend([]string{"1", "2", "3"})
+
+	set.RemoveAll(otherSet)
+
+	slice = set.AsSlice()
+	sort.Strings(slice)
+	require.Equal(t, slice, []string{"hello", "heyo"})
+
+	// Create a third set and perform intersection difference.
+	thirdSet := NewSet[string]()
+	thirdSet.Extend([]string{"hello", "hi"})
+
+	set.IntersectionDifference(thirdSet)
+
+	slice = set.AsSlice()
+	sort.Strings(slice)
+	require.Equal(t, slice, []string{"hello"})
+}
+
+func TestSetIntersectionDifference(t *testing.T) {
+	tcs := []struct {
+		first    []int
+		second   []int
+		expected []int
+	}{
+		{
+			[]int{1, 2, 3, 4, 5},
+			[]int{1, 2, 3, 4, 5},
+			[]int{1, 2, 3, 4, 5},
+		},
+		{
+			[]int{1, 3, 5, 7, 9},
+			[]int{2, 4, 6, 8, 10},
+			[]int{},
+		},
+		{
+			[]int{1, 2, 3, 4, 5},
+			[]int{6, 5, 4, 3},
+			[]int{3, 4, 5},
+		},
+	}
+
+	for index, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", index), func(t *testing.T) {
+			firstSet := NewSet[int]()
+			firstSet.Extend(tc.first)
+
+			secondSet := NewSet[int]()
+			secondSet.Extend(tc.second)
+
+			firstSet.IntersectionDifference(secondSet)
+			slice := firstSet.AsSlice()
+			sort.Ints(slice)
+			require.Equal(t, tc.expected, slice)
+		})
+	}
+}

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -36,6 +36,10 @@ func EngineOptions() string {
 // hand side of a tuple.
 const Ellipsis = "..."
 
+// FilterMaximumIDCount is the maximum number of resource IDs or subject IDs that can be sent into
+// a filter.
+const FilterMaximumIDCount = 100
+
 // RevisionChanges represents the changes in a single transaction.
 type RevisionChanges struct {
 	Revision Revision

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -1,0 +1,97 @@
+package datastore
+
+import (
+	"testing"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelationshipsFilterFromPublicFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *v1.RelationshipFilter
+		expected RelationshipsFilter
+	}{
+		{
+			"only resource name",
+			&v1.RelationshipFilter{ResourceType: "sometype"},
+			RelationshipsFilter{ResourceType: "sometype"},
+		},
+		{
+			"resource name and id",
+			&v1.RelationshipFilter{ResourceType: "sometype", OptionalResourceId: "someid"},
+			RelationshipsFilter{ResourceType: "sometype", OptionalResourceIds: []string{"someid"}},
+		},
+		{
+			"resource name and relation",
+			&v1.RelationshipFilter{ResourceType: "sometype", OptionalRelation: "somerel"},
+			RelationshipsFilter{ResourceType: "sometype", OptionalResourceRelation: "somerel"},
+		},
+		{
+			"resource and subject",
+			&v1.RelationshipFilter{ResourceType: "sometype", OptionalSubjectFilter: &v1.SubjectFilter{SubjectType: "someothertype"}},
+			RelationshipsFilter{ResourceType: "sometype", OptionalSubjectsFilter: &SubjectsFilter{
+				SubjectType: "someothertype",
+			}},
+		},
+		{
+			"resource and subject with optional relation",
+			&v1.RelationshipFilter{
+				ResourceType: "sometype",
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					SubjectType:      "someothertype",
+					OptionalRelation: &v1.SubjectFilter_RelationFilter{Relation: "somerel"},
+				},
+			},
+			RelationshipsFilter{ResourceType: "sometype", OptionalSubjectsFilter: &SubjectsFilter{
+				SubjectType:    "someothertype",
+				RelationFilter: SubjectRelationFilter{}.WithNonEllipsisRelation("somerel"),
+			}},
+		},
+		{
+			"resource and subject with ellipsis relation",
+			&v1.RelationshipFilter{
+				ResourceType: "sometype",
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					SubjectType:      "someothertype",
+					OptionalRelation: &v1.SubjectFilter_RelationFilter{Relation: ""},
+				},
+			},
+			RelationshipsFilter{ResourceType: "sometype", OptionalSubjectsFilter: &SubjectsFilter{
+				SubjectType:    "someothertype",
+				RelationFilter: SubjectRelationFilter{}.WithEllipsisRelation(),
+			}},
+		},
+		{
+			"full",
+			&v1.RelationshipFilter{
+				ResourceType:       "sometype",
+				OptionalResourceId: "someid",
+				OptionalRelation:   "somerel",
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					SubjectType:       "someothertype",
+					OptionalSubjectId: "somesubjectid",
+					OptionalRelation:  &v1.SubjectFilter_RelationFilter{Relation: ""},
+				},
+			},
+			RelationshipsFilter{
+				ResourceType:             "sometype",
+				OptionalResourceIds:      []string{"someid"},
+				OptionalResourceRelation: "somerel",
+				OptionalSubjectsFilter: &SubjectsFilter{
+					SubjectType:        "someothertype",
+					OptionalSubjectIds: []string{"somesubjectid"},
+					RelationFilter:     SubjectRelationFilter{}.WithEllipsisRelation(),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			computed := RelationshipsFilterFromPublicFilter(test.input)
+			require.Equal(t, test.expected, computed)
+		})
+	}
+}

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -148,7 +147,7 @@ func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	deletedRevision, err := ds.HeadRevision(ctx)
 	require.NoError(err)
 
-	iter, err := ds.SnapshotReader(deletedRevision).QueryRelationships(ctx, &v1.RelationshipFilter{
+	iter, err := ds.SnapshotReader(deletedRevision).QueryRelationships(ctx, datastore.RelationshipsFilter{
 		ResourceType: testfixtures.DocumentNS.Name,
 	})
 	require.NoError(err)

--- a/pkg/datastore/test/tuples.go
+++ b/pkg/datastore/test/tuples.go
@@ -94,44 +94,44 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 				tupleSubject := tupleToFind.Subject
 
 				// Check that we can find the tuple a number of ways
-				iter, err := dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-					ResourceType:       tupleToFind.ResourceAndRelation.Namespace,
-					OptionalResourceId: tupleToFind.ResourceAndRelation.ObjectId,
+				iter, err := dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+					ResourceType:        tupleToFind.ResourceAndRelation.Namespace,
+					OptionalResourceIds: []string{tupleToFind.ResourceAndRelation.ObjectId},
 				})
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter, tupleToFind)
 
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
 					ResourceType: tupleToFind.ResourceAndRelation.Namespace,
 				}, options.WithUsersets(tupleSubject))
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter, tupleToFind)
 
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-					ResourceType:       tupleToFind.ResourceAndRelation.Namespace,
-					OptionalResourceId: tupleToFind.ResourceAndRelation.ObjectId,
-					OptionalRelation:   tupleToFind.ResourceAndRelation.Relation,
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+					ResourceType:             tupleToFind.ResourceAndRelation.Namespace,
+					OptionalResourceIds:      []string{tupleToFind.ResourceAndRelation.ObjectId},
+					OptionalResourceRelation: tupleToFind.ResourceAndRelation.Relation,
 				})
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter, tupleToFind)
 
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-					ResourceType:       tupleToFind.ResourceAndRelation.Namespace,
-					OptionalResourceId: tupleToFind.ResourceAndRelation.ObjectId,
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+					ResourceType:        tupleToFind.ResourceAndRelation.Namespace,
+					OptionalResourceIds: []string{tupleToFind.ResourceAndRelation.ObjectId},
 				}, options.WithUsersets(tupleSubject))
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter, tupleToFind)
 
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-					ResourceType:     tupleToFind.ResourceAndRelation.Namespace,
-					OptionalRelation: tupleToFind.ResourceAndRelation.Relation,
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+					ResourceType:             tupleToFind.ResourceAndRelation.Namespace,
+					OptionalResourceRelation: tupleToFind.ResourceAndRelation.Relation,
 				}, options.WithUsersets(tupleSubject))
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter, tupleToFind)
 
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-					ResourceType:     tupleToFind.ResourceAndRelation.Namespace,
-					OptionalRelation: tupleToFind.ResourceAndRelation.Relation,
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+					ResourceType:             tupleToFind.ResourceAndRelation.Namespace,
+					OptionalResourceRelation: tupleToFind.ResourceAndRelation.Relation,
 				}, options.WithUsersets(tupleSubject), options.WithLimit(options.LimitOne))
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter, tupleToFind)
@@ -160,10 +160,10 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 				tRequire.VerifyIteratorResults(iter, tupleToFind)
 
 				// Check that we fail to find the tuple with the wrong filters
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-					ResourceType:       tupleToFind.ResourceAndRelation.Namespace,
-					OptionalResourceId: tupleToFind.ResourceAndRelation.ObjectId,
-					OptionalRelation:   "fake",
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+					ResourceType:             tupleToFind.ResourceAndRelation.Namespace,
+					OptionalResourceIds:      []string{tupleToFind.ResourceAndRelation.ObjectId},
+					OptionalResourceRelation: "fake",
 				})
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter)
@@ -173,40 +173,40 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 					ObjectId:  tupleSubject.ObjectId,
 					Relation:  "fake",
 				}
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
 					ResourceType: tupleToFind.ResourceAndRelation.Namespace,
 				}, options.WithUsersets(incorrectUserset))
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter)
 
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-					ResourceType:       tupleToFind.ResourceAndRelation.Namespace,
-					OptionalResourceId: tupleToFind.ResourceAndRelation.ObjectId,
-					OptionalRelation:   tupleToFind.ResourceAndRelation.Relation,
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+					ResourceType:             tupleToFind.ResourceAndRelation.Namespace,
+					OptionalResourceIds:      []string{tupleToFind.ResourceAndRelation.ObjectId},
+					OptionalResourceRelation: tupleToFind.ResourceAndRelation.Relation,
 				}, options.WithUsersets(incorrectUserset))
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter)
 
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-					ResourceType:       tupleToFind.ResourceAndRelation.Namespace,
-					OptionalResourceId: tupleToFind.ResourceAndRelation.ObjectId,
-					OptionalRelation:   "fake",
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+					ResourceType:             tupleToFind.ResourceAndRelation.Namespace,
+					OptionalResourceIds:      []string{tupleToFind.ResourceAndRelation.ObjectId},
+					OptionalResourceRelation: "fake",
 				}, options.WithUsersets(tupleSubject))
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter)
 
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-					ResourceType:       tupleToFind.ResourceAndRelation.Namespace,
-					OptionalResourceId: "fake",
-					OptionalRelation:   tupleToFind.ResourceAndRelation.Relation,
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+					ResourceType:             tupleToFind.ResourceAndRelation.Namespace,
+					OptionalResourceIds:      []string{"fake"},
+					OptionalResourceRelation: tupleToFind.ResourceAndRelation.Relation,
 				}, options.WithUsersets(tupleSubject))
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter)
 
-				iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-					ResourceType:       tupleToFind.ResourceAndRelation.Namespace,
-					OptionalResourceId: "fake",
-					OptionalRelation:   tupleToFind.ResourceAndRelation.Relation,
+				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+					ResourceType:             tupleToFind.ResourceAndRelation.Namespace,
+					OptionalResourceIds:      []string{"fake"},
+					OptionalResourceRelation: tupleToFind.ResourceAndRelation.Relation,
 				}, options.WithUsersets(tupleSubject), options.WithLimit(options.LimitOne))
 				require.NoError(err)
 				tRequire.VerifyIteratorResults(iter)
@@ -224,18 +224,18 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 			}
 
 			// Check a query that returns a number of tuples
-			iter, err := dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
+			iter, err := dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
 				ResourceType: testResourceNamespace,
 			})
 			require.NoError(err)
 			tRequire.VerifyIteratorResults(iter, testTuples...)
 
 			// Filter it down to a single tuple with a userset
-			iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
+			iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
 				ResourceType: testResourceNamespace,
-				OptionalSubjectFilter: &v1.SubjectFilter{
-					SubjectType:       testUserNamespace,
-					OptionalSubjectId: "user0",
+				OptionalSubjectsFilter: &datastore.SubjectsFilter{
+					SubjectType:        testUserNamespace,
+					OptionalSubjectIds: []string{"user0"},
 				},
 			})
 			require.NoError(err)
@@ -259,28 +259,28 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 			}
 
 			// Check that we can find the group of tuples too
-			iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
+			iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
 				ResourceType: testTuples[0].ResourceAndRelation.Namespace,
 			})
 			require.NoError(err)
 			tRequire.VerifyIteratorResults(iter, testTuples...)
 
-			iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-				ResourceType:     testTuples[0].ResourceAndRelation.Namespace,
-				OptionalRelation: testTuples[0].ResourceAndRelation.Relation,
+			iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+				ResourceType:             testTuples[0].ResourceAndRelation.Namespace,
+				OptionalResourceRelation: testTuples[0].ResourceAndRelation.Relation,
 			})
 			require.NoError(err)
 			tRequire.VerifyIteratorResults(iter, testTuples...)
 
 			// Try some bad queries
-			iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
-				ResourceType:       testTuples[0].ResourceAndRelation.Namespace,
-				OptionalResourceId: "fakeobectid",
+			iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
+				ResourceType:        testTuples[0].ResourceAndRelation.Namespace,
+				OptionalResourceIds: []string{"fakeobectid"},
 			})
 			require.NoError(err)
 			tRequire.VerifyIteratorResults(iter)
 
-			iter, err = dsReader.QueryRelationships(ctx, &v1.RelationshipFilter{
+			iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
 				ResourceType: testTuples[0].ResourceAndRelation.Namespace,
 			}, options.WithUsersets(&core.ObjectAndRelation{
 				Namespace: "test/user",
@@ -323,7 +323,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 			tRequire.NoTupleExists(ctx, testTuples[0], deletedAt)
 			alreadyDeletedIter, err := ds.SnapshotReader(deletedAt).QueryRelationships(
 				ctx,
-				&v1.RelationshipFilter{
+				datastore.RelationshipsFilter{
 					ResourceType: testTuples[0].ResourceAndRelation.Namespace,
 				},
 			)
@@ -591,7 +591,7 @@ func UsersetsTest(t *testing.T, tester DatastoreTester) {
 				}
 
 				// Query for the tuples as a single query.
-				iter, err := ds.SnapshotReader(lastRevision).QueryRelationships(ctx, &v1.RelationshipFilter{
+				iter, err := ds.SnapshotReader(lastRevision).QueryRelationships(ctx, datastore.RelationshipsFilter{
 					ResourceType: testResourceNamespace,
 				}, options.SetUsersets(usersets))
 				require.NoError(err)
@@ -611,13 +611,13 @@ func MultipleReadsInRWTTest(t *testing.T, tester DatastoreTester) {
 	ctx := context.Background()
 
 	_, err = ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-		it, err := rwt.QueryRelationships(ctx, &v1.RelationshipFilter{
+		it, err := rwt.QueryRelationships(ctx, datastore.RelationshipsFilter{
 			ResourceType: "document",
 		})
 		require.NoError(err)
 		it.Close()
 
-		it, err = rwt.QueryRelationships(ctx, &v1.RelationshipFilter{
+		it, err = rwt.QueryRelationships(ctx, datastore.RelationshipsFilter{
 			ResourceType: "folder",
 		})
 		require.NoError(err)
@@ -650,7 +650,7 @@ func ConcurrentWriteSerializationTest(t *testing.T, tester DatastoreTester) {
 
 	g.Go(func() error {
 		_, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-			iter, err := rwt.QueryRelationships(ctx, &v1.RelationshipFilter{
+			iter, err := rwt.QueryRelationships(ctx, datastore.RelationshipsFilter{
 				ResourceType: testResourceNamespace,
 			})
 			iter.Close()
@@ -697,8 +697,8 @@ func ConcurrentWriteSerializationTest(t *testing.T, tester DatastoreTester) {
 
 func onrToSubjectsFilter(onr *core.ObjectAndRelation) datastore.SubjectsFilter {
 	return datastore.SubjectsFilter{
-		SubjectType:    onr.Namespace,
-		SubjectIds:     []string{onr.ObjectId},
-		RelationFilter: datastore.SubjectRelationFilter{}.WithNonEllipsisRelation(onr.Relation),
+		SubjectType:        onr.Namespace,
+		OptionalSubjectIds: []string{onr.ObjectId},
+		RelationFilter:     datastore.SubjectRelationFilter{}.WithNonEllipsisRelation(onr.Relation),
 	}
 }

--- a/pkg/proto/dispatch/v1/00_zerolog.go
+++ b/pkg/proto/dispatch/v1/00_zerolog.go
@@ -55,6 +55,14 @@ func (lr *DispatchReachableResourcesRequest) MarshalZerologObject(e *zerolog.Eve
 	e.Array("subject-ids", strArray(lr.SubjectIds))
 }
 
+// MarshalZerologObject implements zerolog object marshalling.
+func (ls *DispatchLookupSubjectsRequest) MarshalZerologObject(e *zerolog.Event) {
+	e.Object("metadata", ls.Metadata)
+	e.Str("resource-type", fmt.Sprintf("%s#%s", ls.ResourceRelation.Namespace, ls.ResourceRelation.Relation))
+	e.Str("subject-type", fmt.Sprintf("%s#%s", ls.SubjectRelation.Namespace, ls.SubjectRelation.Relation))
+	e.Array("resource-ids", strArray(ls.ResourceIds))
+}
+
 type strArray []string
 
 type onArray []*core.RelationReference
@@ -84,6 +92,11 @@ func (on *zerologON) MarshalZerologObject(e *zerolog.Event) {
 // MarshalZerologObject implements zerolog object marshalling.
 func (cr *DispatchLookupResponse) MarshalZerologObject(e *zerolog.Event) {
 	e.Object("metadata", cr.Metadata)
+}
+
+// MarshalZerologObject implements zerolog object marshalling.
+func (cs *DispatchLookupSubjectsResponse) MarshalZerologObject(e *zerolog.Event) {
+	e.Object("metadata", cs.Metadata)
 }
 
 // MarshalZerologObject implements zerolog object marshalling.

--- a/pkg/proto/dispatch/v1/dispatch.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch.pb.go
@@ -261,7 +261,7 @@ func (x CheckDebugTrace_RelationType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CheckDebugTrace_RelationType.Descriptor instead.
 func (CheckDebugTrace_RelationType) EnumDescriptor() ([]byte, []int) {
-	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{12, 0}
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{14, 0}
 }
 
 type DispatchCheckRequest struct {
@@ -839,6 +839,132 @@ func (x *DispatchReachableResourcesResponse) GetMetadata() *ResponseMeta {
 	return nil
 }
 
+type DispatchLookupSubjectsRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Metadata         *ResolverMeta         `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	ResourceRelation *v1.RelationReference `protobuf:"bytes,2,opt,name=resource_relation,json=resourceRelation,proto3" json:"resource_relation,omitempty"`
+	ResourceIds      []string              `protobuf:"bytes,3,rep,name=resource_ids,json=resourceIds,proto3" json:"resource_ids,omitempty"`
+	SubjectRelation  *v1.RelationReference `protobuf:"bytes,4,opt,name=subject_relation,json=subjectRelation,proto3" json:"subject_relation,omitempty"`
+}
+
+func (x *DispatchLookupSubjectsRequest) Reset() {
+	*x = DispatchLookupSubjectsRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_dispatch_v1_dispatch_proto_msgTypes[9]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *DispatchLookupSubjectsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DispatchLookupSubjectsRequest) ProtoMessage() {}
+
+func (x *DispatchLookupSubjectsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[9]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DispatchLookupSubjectsRequest.ProtoReflect.Descriptor instead.
+func (*DispatchLookupSubjectsRequest) Descriptor() ([]byte, []int) {
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *DispatchLookupSubjectsRequest) GetMetadata() *ResolverMeta {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *DispatchLookupSubjectsRequest) GetResourceRelation() *v1.RelationReference {
+	if x != nil {
+		return x.ResourceRelation
+	}
+	return nil
+}
+
+func (x *DispatchLookupSubjectsRequest) GetResourceIds() []string {
+	if x != nil {
+		return x.ResourceIds
+	}
+	return nil
+}
+
+func (x *DispatchLookupSubjectsRequest) GetSubjectRelation() *v1.RelationReference {
+	if x != nil {
+		return x.SubjectRelation
+	}
+	return nil
+}
+
+type DispatchLookupSubjectsResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	FoundSubjectIds []string      `protobuf:"bytes,1,rep,name=found_subject_ids,json=foundSubjectIds,proto3" json:"found_subject_ids,omitempty"`
+	Metadata        *ResponseMeta `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+}
+
+func (x *DispatchLookupSubjectsResponse) Reset() {
+	*x = DispatchLookupSubjectsResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_dispatch_v1_dispatch_proto_msgTypes[10]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *DispatchLookupSubjectsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DispatchLookupSubjectsResponse) ProtoMessage() {}
+
+func (x *DispatchLookupSubjectsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[10]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DispatchLookupSubjectsResponse.ProtoReflect.Descriptor instead.
+func (*DispatchLookupSubjectsResponse) Descriptor() ([]byte, []int) {
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *DispatchLookupSubjectsResponse) GetFoundSubjectIds() []string {
+	if x != nil {
+		return x.FoundSubjectIds
+	}
+	return nil
+}
+
+func (x *DispatchLookupSubjectsResponse) GetMetadata() *ResponseMeta {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ResolverMeta struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -851,7 +977,7 @@ type ResolverMeta struct {
 func (x *ResolverMeta) Reset() {
 	*x = ResolverMeta{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_dispatch_v1_dispatch_proto_msgTypes[9]
+		mi := &file_dispatch_v1_dispatch_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -864,7 +990,7 @@ func (x *ResolverMeta) String() string {
 func (*ResolverMeta) ProtoMessage() {}
 
 func (x *ResolverMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_dispatch_v1_dispatch_proto_msgTypes[9]
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -877,7 +1003,7 @@ func (x *ResolverMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolverMeta.ProtoReflect.Descriptor instead.
 func (*ResolverMeta) Descriptor() ([]byte, []int) {
-	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{9}
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ResolverMeta) GetAtRevision() string {
@@ -908,7 +1034,7 @@ type ResponseMeta struct {
 func (x *ResponseMeta) Reset() {
 	*x = ResponseMeta{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_dispatch_v1_dispatch_proto_msgTypes[10]
+		mi := &file_dispatch_v1_dispatch_proto_msgTypes[12]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -921,7 +1047,7 @@ func (x *ResponseMeta) String() string {
 func (*ResponseMeta) ProtoMessage() {}
 
 func (x *ResponseMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_dispatch_v1_dispatch_proto_msgTypes[10]
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[12]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -934,7 +1060,7 @@ func (x *ResponseMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResponseMeta.ProtoReflect.Descriptor instead.
 func (*ResponseMeta) Descriptor() ([]byte, []int) {
-	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{10}
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ResponseMeta) GetDispatchCount() uint32 {
@@ -976,7 +1102,7 @@ type DebugInformation struct {
 func (x *DebugInformation) Reset() {
 	*x = DebugInformation{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_dispatch_v1_dispatch_proto_msgTypes[11]
+		mi := &file_dispatch_v1_dispatch_proto_msgTypes[13]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -989,7 +1115,7 @@ func (x *DebugInformation) String() string {
 func (*DebugInformation) ProtoMessage() {}
 
 func (x *DebugInformation) ProtoReflect() protoreflect.Message {
-	mi := &file_dispatch_v1_dispatch_proto_msgTypes[11]
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[13]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1002,7 +1128,7 @@ func (x *DebugInformation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugInformation.ProtoReflect.Descriptor instead.
 func (*DebugInformation) Descriptor() ([]byte, []int) {
-	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{11}
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DebugInformation) GetCheck() *CheckDebugTrace {
@@ -1027,7 +1153,7 @@ type CheckDebugTrace struct {
 func (x *CheckDebugTrace) Reset() {
 	*x = CheckDebugTrace{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_dispatch_v1_dispatch_proto_msgTypes[12]
+		mi := &file_dispatch_v1_dispatch_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1040,7 +1166,7 @@ func (x *CheckDebugTrace) String() string {
 func (*CheckDebugTrace) ProtoMessage() {}
 
 func (x *CheckDebugTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_dispatch_v1_dispatch_proto_msgTypes[12]
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1053,7 +1179,7 @@ func (x *CheckDebugTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckDebugTrace.ProtoReflect.Descriptor instead.
 func (*CheckDebugTrace) Descriptor() ([]byte, []int) {
-	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{12}
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CheckDebugTrace) GetRequest() *DispatchCheckRequest {
@@ -1240,6 +1366,33 @@ var file_dispatch_v1_dispatch_proto_rawDesc = []byte{
 	0x63, 0x65, 0x12, 0x35, 0x0a, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x02,
 	0x20, 0x01, 0x28, 0x0b, 0x32, 0x19, 0x2e, 0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x2e,
 	0x76, 0x31, 0x2e, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x52,
+	0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0xa7, 0x02, 0x0a, 0x1d, 0x44, 0x69,
+	0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x4c, 0x6f, 0x6f, 0x6b, 0x75, 0x70, 0x53, 0x75, 0x62, 0x6a,
+	0x65, 0x63, 0x74, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x3f, 0x0a, 0x08, 0x6d,
+	0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x19, 0x2e,
+	0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x73, 0x6f,
+	0x6c, 0x76, 0x65, 0x72, 0x4d, 0x65, 0x74, 0x61, 0x42, 0x08, 0xfa, 0x42, 0x05, 0x8a, 0x01, 0x02,
+	0x10, 0x01, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x12, 0x51, 0x0a, 0x11,
+	0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x72, 0x65, 0x6c, 0x61, 0x74, 0x69, 0x6f,
+	0x6e, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x63, 0x6f, 0x72, 0x65, 0x2e, 0x76,
+	0x31, 0x2e, 0x52, 0x65, 0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x66, 0x65, 0x72, 0x65,
+	0x6e, 0x63, 0x65, 0x42, 0x08, 0xfa, 0x42, 0x05, 0x8a, 0x01, 0x02, 0x10, 0x01, 0x52, 0x10, 0x72,
+	0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x52, 0x65, 0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12,
+	0x21, 0x0a, 0x0c, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x69, 0x64, 0x73, 0x18,
+	0x03, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0b, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x49,
+	0x64, 0x73, 0x12, 0x4f, 0x0a, 0x10, 0x73, 0x75, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x5f, 0x72, 0x65,
+	0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x63,
+	0x6f, 0x72, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52,
+	0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x42, 0x08, 0xfa, 0x42, 0x05, 0x8a, 0x01, 0x02,
+	0x10, 0x01, 0x52, 0x0f, 0x73, 0x75, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x52, 0x65, 0x6c, 0x61, 0x74,
+	0x69, 0x6f, 0x6e, 0x22, 0x83, 0x01, 0x0a, 0x1e, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68,
+	0x4c, 0x6f, 0x6f, 0x6b, 0x75, 0x70, 0x53, 0x75, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x73, 0x52, 0x65,
+	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x2a, 0x0a, 0x11, 0x66, 0x6f, 0x75, 0x6e, 0x64, 0x5f,
+	0x73, 0x75, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x5f, 0x69, 0x64, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28,
+	0x09, 0x52, 0x0f, 0x66, 0x6f, 0x75, 0x6e, 0x64, 0x53, 0x75, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x49,
+	0x64, 0x73, 0x12, 0x35, 0x0a, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x02,
+	0x20, 0x01, 0x28, 0x0b, 0x32, 0x19, 0x2e, 0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x2e,
+	0x76, 0x31, 0x2e, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x4d, 0x65, 0x74, 0x61, 0x52,
 	0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0x7d, 0x0a, 0x0c, 0x52, 0x65, 0x73,
 	0x6f, 0x6c, 0x76, 0x65, 0x72, 0x4d, 0x65, 0x74, 0x61, 0x12, 0x3b, 0x0a, 0x0b, 0x61, 0x74, 0x5f,
 	0x72, 0x65, 0x76, 0x69, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x1a,
@@ -1290,7 +1443,7 @@ var file_dispatch_v1_dispatch_proto_rawDesc = []byte{
 	0x73, 0x22, 0x39, 0x0a, 0x0c, 0x52, 0x65, 0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x79, 0x70,
 	0x65, 0x12, 0x0b, 0x0a, 0x07, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0c,
 	0x0a, 0x08, 0x52, 0x45, 0x4c, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a,
-	0x50, 0x45, 0x52, 0x4d, 0x49, 0x53, 0x53, 0x49, 0x4f, 0x4e, 0x10, 0x02, 0x32, 0xa9, 0x03, 0x0a,
+	0x50, 0x45, 0x52, 0x4d, 0x49, 0x53, 0x53, 0x49, 0x4f, 0x4e, 0x10, 0x02, 0x32, 0xa0, 0x04, 0x0a,
 	0x0f, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
 	0x12, 0x58, 0x0a, 0x0d, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x43, 0x68, 0x65, 0x63,
 	0x6b, 0x12, 0x21, 0x2e, 0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x2e, 0x76, 0x31, 0x2e,
@@ -1317,18 +1470,26 @@ var file_dispatch_v1_dispatch_proto_rawDesc = []byte{
 	0x65, 0x73, 0x74, 0x1a, 0x2f, 0x2e, 0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x2e, 0x76,
 	0x31, 0x2e, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x52, 0x65, 0x61, 0x63, 0x68, 0x61,
 	0x62, 0x6c, 0x65, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70,
-	0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x30, 0x01, 0x42, 0xaa, 0x01, 0x0a, 0x0f, 0x63, 0x6f, 0x6d,
-	0x2e, 0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x2e, 0x76, 0x31, 0x42, 0x0d, 0x44, 0x69,
-	0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x3b, 0x67,
-	0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x75, 0x74, 0x68, 0x7a, 0x65,
-	0x64, 0x2f, 0x73, 0x70, 0x69, 0x63, 0x65, 0x64, 0x62, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x70, 0x72,
-	0x6f, 0x74, 0x6f, 0x2f, 0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x2f, 0x76, 0x31, 0x3b,
-	0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x76, 0x31, 0xa2, 0x02, 0x03, 0x44, 0x58, 0x58,
-	0xaa, 0x02, 0x0b, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x2e, 0x56, 0x31, 0xca, 0x02,
-	0x0b, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x5c, 0x56, 0x31, 0xe2, 0x02, 0x17, 0x44,
-	0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x5c, 0x56, 0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65,
-	0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02, 0x0c, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63,
-	0x68, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x30, 0x01, 0x12, 0x75, 0x0a, 0x16, 0x44, 0x69, 0x73, 0x70,
+	0x61, 0x74, 0x63, 0x68, 0x4c, 0x6f, 0x6f, 0x6b, 0x75, 0x70, 0x53, 0x75, 0x62, 0x6a, 0x65, 0x63,
+	0x74, 0x73, 0x12, 0x2a, 0x2e, 0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x2e, 0x76, 0x31,
+	0x2e, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x4c, 0x6f, 0x6f, 0x6b, 0x75, 0x70, 0x53,
+	0x75, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x2b,
+	0x2e, 0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x69, 0x73,
+	0x70, 0x61, 0x74, 0x63, 0x68, 0x4c, 0x6f, 0x6f, 0x6b, 0x75, 0x70, 0x53, 0x75, 0x62, 0x6a, 0x65,
+	0x63, 0x74, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x30, 0x01, 0x42,
+	0xaa, 0x01, 0x0a, 0x0f, 0x63, 0x6f, 0x6d, 0x2e, 0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68,
+	0x2e, 0x76, 0x31, 0x42, 0x0d, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x50, 0x72, 0x6f,
+	0x74, 0x6f, 0x50, 0x01, 0x5a, 0x3b, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d,
+	0x2f, 0x61, 0x75, 0x74, 0x68, 0x7a, 0x65, 0x64, 0x2f, 0x73, 0x70, 0x69, 0x63, 0x65, 0x64, 0x62,
+	0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x64, 0x69, 0x73, 0x70, 0x61,
+	0x74, 0x63, 0x68, 0x2f, 0x76, 0x31, 0x3b, 0x64, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x76,
+	0x31, 0xa2, 0x02, 0x03, 0x44, 0x58, 0x58, 0xaa, 0x02, 0x0b, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74,
+	0x63, 0x68, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x0b, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68,
+	0x5c, 0x56, 0x31, 0xe2, 0x02, 0x17, 0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x5c, 0x56,
+	0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02, 0x0c,
+	0x44, 0x69, 0x73, 0x70, 0x61, 0x74, 0x63, 0x68, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -1344,7 +1505,7 @@ func file_dispatch_v1_dispatch_proto_rawDescGZIP() []byte {
 }
 
 var file_dispatch_v1_dispatch_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_dispatch_v1_dispatch_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_dispatch_v1_dispatch_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_dispatch_v1_dispatch_proto_goTypes = []interface{}{
 	(DispatchCheckRequest_DebugSetting)(0),     // 0: dispatch.v1.DispatchCheckRequest.DebugSetting
 	(DispatchCheckResponse_Membership)(0),      // 1: dispatch.v1.DispatchCheckResponse.Membership
@@ -1360,57 +1521,65 @@ var file_dispatch_v1_dispatch_proto_goTypes = []interface{}{
 	(*DispatchReachableResourcesRequest)(nil),  // 11: dispatch.v1.DispatchReachableResourcesRequest
 	(*ReachableResource)(nil),                  // 12: dispatch.v1.ReachableResource
 	(*DispatchReachableResourcesResponse)(nil), // 13: dispatch.v1.DispatchReachableResourcesResponse
-	(*ResolverMeta)(nil),                       // 14: dispatch.v1.ResolverMeta
-	(*ResponseMeta)(nil),                       // 15: dispatch.v1.ResponseMeta
-	(*DebugInformation)(nil),                   // 16: dispatch.v1.DebugInformation
-	(*CheckDebugTrace)(nil),                    // 17: dispatch.v1.CheckDebugTrace
-	(*v1.ObjectAndRelation)(nil),               // 18: core.v1.ObjectAndRelation
-	(*v1.RelationTupleTreeNode)(nil),           // 19: core.v1.RelationTupleTreeNode
-	(*v1.RelationReference)(nil),               // 20: core.v1.RelationReference
+	(*DispatchLookupSubjectsRequest)(nil),      // 14: dispatch.v1.DispatchLookupSubjectsRequest
+	(*DispatchLookupSubjectsResponse)(nil),     // 15: dispatch.v1.DispatchLookupSubjectsResponse
+	(*ResolverMeta)(nil),                       // 16: dispatch.v1.ResolverMeta
+	(*ResponseMeta)(nil),                       // 17: dispatch.v1.ResponseMeta
+	(*DebugInformation)(nil),                   // 18: dispatch.v1.DebugInformation
+	(*CheckDebugTrace)(nil),                    // 19: dispatch.v1.CheckDebugTrace
+	(*v1.ObjectAndRelation)(nil),               // 20: core.v1.ObjectAndRelation
+	(*v1.RelationTupleTreeNode)(nil),           // 21: core.v1.RelationTupleTreeNode
+	(*v1.RelationReference)(nil),               // 22: core.v1.RelationReference
 }
 var file_dispatch_v1_dispatch_proto_depIdxs = []int32{
-	14, // 0: dispatch.v1.DispatchCheckRequest.metadata:type_name -> dispatch.v1.ResolverMeta
-	18, // 1: dispatch.v1.DispatchCheckRequest.resource_and_relation:type_name -> core.v1.ObjectAndRelation
-	18, // 2: dispatch.v1.DispatchCheckRequest.subject:type_name -> core.v1.ObjectAndRelation
+	16, // 0: dispatch.v1.DispatchCheckRequest.metadata:type_name -> dispatch.v1.ResolverMeta
+	20, // 1: dispatch.v1.DispatchCheckRequest.resource_and_relation:type_name -> core.v1.ObjectAndRelation
+	20, // 2: dispatch.v1.DispatchCheckRequest.subject:type_name -> core.v1.ObjectAndRelation
 	0,  // 3: dispatch.v1.DispatchCheckRequest.debug:type_name -> dispatch.v1.DispatchCheckRequest.DebugSetting
-	15, // 4: dispatch.v1.DispatchCheckResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	17, // 4: dispatch.v1.DispatchCheckResponse.metadata:type_name -> dispatch.v1.ResponseMeta
 	1,  // 5: dispatch.v1.DispatchCheckResponse.membership:type_name -> dispatch.v1.DispatchCheckResponse.Membership
-	14, // 6: dispatch.v1.DispatchExpandRequest.metadata:type_name -> dispatch.v1.ResolverMeta
-	18, // 7: dispatch.v1.DispatchExpandRequest.resource_and_relation:type_name -> core.v1.ObjectAndRelation
+	16, // 6: dispatch.v1.DispatchExpandRequest.metadata:type_name -> dispatch.v1.ResolverMeta
+	20, // 7: dispatch.v1.DispatchExpandRequest.resource_and_relation:type_name -> core.v1.ObjectAndRelation
 	2,  // 8: dispatch.v1.DispatchExpandRequest.expansion_mode:type_name -> dispatch.v1.DispatchExpandRequest.ExpansionMode
-	15, // 9: dispatch.v1.DispatchExpandResponse.metadata:type_name -> dispatch.v1.ResponseMeta
-	19, // 10: dispatch.v1.DispatchExpandResponse.tree_node:type_name -> core.v1.RelationTupleTreeNode
-	14, // 11: dispatch.v1.DispatchLookupRequest.metadata:type_name -> dispatch.v1.ResolverMeta
-	20, // 12: dispatch.v1.DispatchLookupRequest.object_relation:type_name -> core.v1.RelationReference
-	18, // 13: dispatch.v1.DispatchLookupRequest.subject:type_name -> core.v1.ObjectAndRelation
-	20, // 14: dispatch.v1.DispatchLookupRequest.direct_stack:type_name -> core.v1.RelationReference
-	20, // 15: dispatch.v1.DispatchLookupRequest.ttu_stack:type_name -> core.v1.RelationReference
-	15, // 16: dispatch.v1.DispatchLookupResponse.metadata:type_name -> dispatch.v1.ResponseMeta
-	18, // 17: dispatch.v1.DispatchLookupResponse.resolved_onrs:type_name -> core.v1.ObjectAndRelation
-	14, // 18: dispatch.v1.DispatchReachableResourcesRequest.metadata:type_name -> dispatch.v1.ResolverMeta
-	20, // 19: dispatch.v1.DispatchReachableResourcesRequest.resource_relation:type_name -> core.v1.RelationReference
-	20, // 20: dispatch.v1.DispatchReachableResourcesRequest.subject_relation:type_name -> core.v1.RelationReference
+	17, // 9: dispatch.v1.DispatchExpandResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	21, // 10: dispatch.v1.DispatchExpandResponse.tree_node:type_name -> core.v1.RelationTupleTreeNode
+	16, // 11: dispatch.v1.DispatchLookupRequest.metadata:type_name -> dispatch.v1.ResolverMeta
+	22, // 12: dispatch.v1.DispatchLookupRequest.object_relation:type_name -> core.v1.RelationReference
+	20, // 13: dispatch.v1.DispatchLookupRequest.subject:type_name -> core.v1.ObjectAndRelation
+	22, // 14: dispatch.v1.DispatchLookupRequest.direct_stack:type_name -> core.v1.RelationReference
+	22, // 15: dispatch.v1.DispatchLookupRequest.ttu_stack:type_name -> core.v1.RelationReference
+	17, // 16: dispatch.v1.DispatchLookupResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	20, // 17: dispatch.v1.DispatchLookupResponse.resolved_onrs:type_name -> core.v1.ObjectAndRelation
+	16, // 18: dispatch.v1.DispatchReachableResourcesRequest.metadata:type_name -> dispatch.v1.ResolverMeta
+	22, // 19: dispatch.v1.DispatchReachableResourcesRequest.resource_relation:type_name -> core.v1.RelationReference
+	22, // 20: dispatch.v1.DispatchReachableResourcesRequest.subject_relation:type_name -> core.v1.RelationReference
 	3,  // 21: dispatch.v1.ReachableResource.result_status:type_name -> dispatch.v1.ReachableResource.ResultStatus
 	12, // 22: dispatch.v1.DispatchReachableResourcesResponse.resource:type_name -> dispatch.v1.ReachableResource
-	15, // 23: dispatch.v1.DispatchReachableResourcesResponse.metadata:type_name -> dispatch.v1.ResponseMeta
-	16, // 24: dispatch.v1.ResponseMeta.debug_info:type_name -> dispatch.v1.DebugInformation
-	17, // 25: dispatch.v1.DebugInformation.check:type_name -> dispatch.v1.CheckDebugTrace
-	5,  // 26: dispatch.v1.CheckDebugTrace.request:type_name -> dispatch.v1.DispatchCheckRequest
-	4,  // 27: dispatch.v1.CheckDebugTrace.resource_relation_type:type_name -> dispatch.v1.CheckDebugTrace.RelationType
-	17, // 28: dispatch.v1.CheckDebugTrace.sub_problems:type_name -> dispatch.v1.CheckDebugTrace
-	5,  // 29: dispatch.v1.DispatchService.DispatchCheck:input_type -> dispatch.v1.DispatchCheckRequest
-	7,  // 30: dispatch.v1.DispatchService.DispatchExpand:input_type -> dispatch.v1.DispatchExpandRequest
-	9,  // 31: dispatch.v1.DispatchService.DispatchLookup:input_type -> dispatch.v1.DispatchLookupRequest
-	11, // 32: dispatch.v1.DispatchService.DispatchReachableResources:input_type -> dispatch.v1.DispatchReachableResourcesRequest
-	6,  // 33: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
-	8,  // 34: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
-	10, // 35: dispatch.v1.DispatchService.DispatchLookup:output_type -> dispatch.v1.DispatchLookupResponse
-	13, // 36: dispatch.v1.DispatchService.DispatchReachableResources:output_type -> dispatch.v1.DispatchReachableResourcesResponse
-	33, // [33:37] is the sub-list for method output_type
-	29, // [29:33] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	17, // 23: dispatch.v1.DispatchReachableResourcesResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	16, // 24: dispatch.v1.DispatchLookupSubjectsRequest.metadata:type_name -> dispatch.v1.ResolverMeta
+	22, // 25: dispatch.v1.DispatchLookupSubjectsRequest.resource_relation:type_name -> core.v1.RelationReference
+	22, // 26: dispatch.v1.DispatchLookupSubjectsRequest.subject_relation:type_name -> core.v1.RelationReference
+	17, // 27: dispatch.v1.DispatchLookupSubjectsResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	18, // 28: dispatch.v1.ResponseMeta.debug_info:type_name -> dispatch.v1.DebugInformation
+	19, // 29: dispatch.v1.DebugInformation.check:type_name -> dispatch.v1.CheckDebugTrace
+	5,  // 30: dispatch.v1.CheckDebugTrace.request:type_name -> dispatch.v1.DispatchCheckRequest
+	4,  // 31: dispatch.v1.CheckDebugTrace.resource_relation_type:type_name -> dispatch.v1.CheckDebugTrace.RelationType
+	19, // 32: dispatch.v1.CheckDebugTrace.sub_problems:type_name -> dispatch.v1.CheckDebugTrace
+	5,  // 33: dispatch.v1.DispatchService.DispatchCheck:input_type -> dispatch.v1.DispatchCheckRequest
+	7,  // 34: dispatch.v1.DispatchService.DispatchExpand:input_type -> dispatch.v1.DispatchExpandRequest
+	9,  // 35: dispatch.v1.DispatchService.DispatchLookup:input_type -> dispatch.v1.DispatchLookupRequest
+	11, // 36: dispatch.v1.DispatchService.DispatchReachableResources:input_type -> dispatch.v1.DispatchReachableResourcesRequest
+	14, // 37: dispatch.v1.DispatchService.DispatchLookupSubjects:input_type -> dispatch.v1.DispatchLookupSubjectsRequest
+	6,  // 38: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
+	8,  // 39: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
+	10, // 40: dispatch.v1.DispatchService.DispatchLookup:output_type -> dispatch.v1.DispatchLookupResponse
+	13, // 41: dispatch.v1.DispatchService.DispatchReachableResources:output_type -> dispatch.v1.DispatchReachableResourcesResponse
+	15, // 42: dispatch.v1.DispatchService.DispatchLookupSubjects:output_type -> dispatch.v1.DispatchLookupSubjectsResponse
+	38, // [38:43] is the sub-list for method output_type
+	33, // [33:38] is the sub-list for method input_type
+	33, // [33:33] is the sub-list for extension type_name
+	33, // [33:33] is the sub-list for extension extendee
+	0,  // [0:33] is the sub-list for field type_name
 }
 
 func init() { file_dispatch_v1_dispatch_proto_init() }
@@ -1528,7 +1697,7 @@ func file_dispatch_v1_dispatch_proto_init() {
 			}
 		}
 		file_dispatch_v1_dispatch_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ResolverMeta); i {
+			switch v := v.(*DispatchLookupSubjectsRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1540,7 +1709,7 @@ func file_dispatch_v1_dispatch_proto_init() {
 			}
 		}
 		file_dispatch_v1_dispatch_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ResponseMeta); i {
+			switch v := v.(*DispatchLookupSubjectsResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1552,7 +1721,7 @@ func file_dispatch_v1_dispatch_proto_init() {
 			}
 		}
 		file_dispatch_v1_dispatch_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*DebugInformation); i {
+			switch v := v.(*ResolverMeta); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1564,6 +1733,30 @@ func file_dispatch_v1_dispatch_proto_init() {
 			}
 		}
 		file_dispatch_v1_dispatch_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ResponseMeta); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_dispatch_v1_dispatch_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*DebugInformation); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_dispatch_v1_dispatch_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*CheckDebugTrace); i {
 			case 0:
 				return &v.state
@@ -1582,7 +1775,7 @@ func file_dispatch_v1_dispatch_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_dispatch_v1_dispatch_proto_rawDesc,
 			NumEnums:      5,
-			NumMessages:   13,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/proto/dispatch/v1/dispatch.pb.validate.go
+++ b/pkg/proto/dispatch/v1/dispatch.pb.validate.go
@@ -1687,6 +1687,361 @@ var _ interface {
 	ErrorName() string
 } = DispatchReachableResourcesResponseValidationError{}
 
+// Validate checks the field values on DispatchLookupSubjectsRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *DispatchLookupSubjectsRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on DispatchLookupSubjectsRequest with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// DispatchLookupSubjectsRequestMultiError, or nil if none found.
+func (m *DispatchLookupSubjectsRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *DispatchLookupSubjectsRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if m.GetMetadata() == nil {
+		err := DispatchLookupSubjectsRequestValidationError{
+			field:  "Metadata",
+			reason: "value is required",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, DispatchLookupSubjectsRequestValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, DispatchLookupSubjectsRequestValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return DispatchLookupSubjectsRequestValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if m.GetResourceRelation() == nil {
+		err := DispatchLookupSubjectsRequestValidationError{
+			field:  "ResourceRelation",
+			reason: "value is required",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	if all {
+		switch v := interface{}(m.GetResourceRelation()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, DispatchLookupSubjectsRequestValidationError{
+					field:  "ResourceRelation",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, DispatchLookupSubjectsRequestValidationError{
+					field:  "ResourceRelation",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetResourceRelation()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return DispatchLookupSubjectsRequestValidationError{
+				field:  "ResourceRelation",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if m.GetSubjectRelation() == nil {
+		err := DispatchLookupSubjectsRequestValidationError{
+			field:  "SubjectRelation",
+			reason: "value is required",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	if all {
+		switch v := interface{}(m.GetSubjectRelation()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, DispatchLookupSubjectsRequestValidationError{
+					field:  "SubjectRelation",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, DispatchLookupSubjectsRequestValidationError{
+					field:  "SubjectRelation",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetSubjectRelation()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return DispatchLookupSubjectsRequestValidationError{
+				field:  "SubjectRelation",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return DispatchLookupSubjectsRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// DispatchLookupSubjectsRequestMultiError is an error wrapping multiple
+// validation errors returned by DispatchLookupSubjectsRequest.ValidateAll()
+// if the designated constraints aren't met.
+type DispatchLookupSubjectsRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m DispatchLookupSubjectsRequestMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m DispatchLookupSubjectsRequestMultiError) AllErrors() []error { return m }
+
+// DispatchLookupSubjectsRequestValidationError is the validation error
+// returned by DispatchLookupSubjectsRequest.Validate if the designated
+// constraints aren't met.
+type DispatchLookupSubjectsRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e DispatchLookupSubjectsRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e DispatchLookupSubjectsRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e DispatchLookupSubjectsRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e DispatchLookupSubjectsRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e DispatchLookupSubjectsRequestValidationError) ErrorName() string {
+	return "DispatchLookupSubjectsRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e DispatchLookupSubjectsRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sDispatchLookupSubjectsRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = DispatchLookupSubjectsRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = DispatchLookupSubjectsRequestValidationError{}
+
+// Validate checks the field values on DispatchLookupSubjectsResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *DispatchLookupSubjectsResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on DispatchLookupSubjectsResponse with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// DispatchLookupSubjectsResponseMultiError, or nil if none found.
+func (m *DispatchLookupSubjectsResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *DispatchLookupSubjectsResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, DispatchLookupSubjectsResponseValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, DispatchLookupSubjectsResponseValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return DispatchLookupSubjectsResponseValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return DispatchLookupSubjectsResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// DispatchLookupSubjectsResponseMultiError is an error wrapping multiple
+// validation errors returned by DispatchLookupSubjectsResponse.ValidateAll()
+// if the designated constraints aren't met.
+type DispatchLookupSubjectsResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m DispatchLookupSubjectsResponseMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m DispatchLookupSubjectsResponseMultiError) AllErrors() []error { return m }
+
+// DispatchLookupSubjectsResponseValidationError is the validation error
+// returned by DispatchLookupSubjectsResponse.Validate if the designated
+// constraints aren't met.
+type DispatchLookupSubjectsResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e DispatchLookupSubjectsResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e DispatchLookupSubjectsResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e DispatchLookupSubjectsResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e DispatchLookupSubjectsResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e DispatchLookupSubjectsResponseValidationError) ErrorName() string {
+	return "DispatchLookupSubjectsResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e DispatchLookupSubjectsResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sDispatchLookupSubjectsResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = DispatchLookupSubjectsResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = DispatchLookupSubjectsResponseValidationError{}
+
 // Validate checks the field values on ResolverMeta with the rules defined in
 // the proto definition for this message. If any rules are violated, the first
 // error encountered is returned, or nil if there are no violations.

--- a/pkg/proto/dispatch/v1/dispatch_grpc.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_grpc.pb.go
@@ -26,6 +26,7 @@ type DispatchServiceClient interface {
 	DispatchExpand(ctx context.Context, in *DispatchExpandRequest, opts ...grpc.CallOption) (*DispatchExpandResponse, error)
 	DispatchLookup(ctx context.Context, in *DispatchLookupRequest, opts ...grpc.CallOption) (*DispatchLookupResponse, error)
 	DispatchReachableResources(ctx context.Context, in *DispatchReachableResourcesRequest, opts ...grpc.CallOption) (DispatchService_DispatchReachableResourcesClient, error)
+	DispatchLookupSubjects(ctx context.Context, in *DispatchLookupSubjectsRequest, opts ...grpc.CallOption) (DispatchService_DispatchLookupSubjectsClient, error)
 }
 
 type dispatchServiceClient struct {
@@ -95,6 +96,38 @@ func (x *dispatchServiceDispatchReachableResourcesClient) Recv() (*DispatchReach
 	return m, nil
 }
 
+func (c *dispatchServiceClient) DispatchLookupSubjects(ctx context.Context, in *DispatchLookupSubjectsRequest, opts ...grpc.CallOption) (DispatchService_DispatchLookupSubjectsClient, error) {
+	stream, err := c.cc.NewStream(ctx, &DispatchService_ServiceDesc.Streams[1], "/dispatch.v1.DispatchService/DispatchLookupSubjects", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &dispatchServiceDispatchLookupSubjectsClient{stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type DispatchService_DispatchLookupSubjectsClient interface {
+	Recv() (*DispatchLookupSubjectsResponse, error)
+	grpc.ClientStream
+}
+
+type dispatchServiceDispatchLookupSubjectsClient struct {
+	grpc.ClientStream
+}
+
+func (x *dispatchServiceDispatchLookupSubjectsClient) Recv() (*DispatchLookupSubjectsResponse, error) {
+	m := new(DispatchLookupSubjectsResponse)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // DispatchServiceServer is the server API for DispatchService service.
 // All implementations must embed UnimplementedDispatchServiceServer
 // for forward compatibility
@@ -103,6 +136,7 @@ type DispatchServiceServer interface {
 	DispatchExpand(context.Context, *DispatchExpandRequest) (*DispatchExpandResponse, error)
 	DispatchLookup(context.Context, *DispatchLookupRequest) (*DispatchLookupResponse, error)
 	DispatchReachableResources(*DispatchReachableResourcesRequest, DispatchService_DispatchReachableResourcesServer) error
+	DispatchLookupSubjects(*DispatchLookupSubjectsRequest, DispatchService_DispatchLookupSubjectsServer) error
 	mustEmbedUnimplementedDispatchServiceServer()
 }
 
@@ -121,6 +155,9 @@ func (UnimplementedDispatchServiceServer) DispatchLookup(context.Context, *Dispa
 }
 func (UnimplementedDispatchServiceServer) DispatchReachableResources(*DispatchReachableResourcesRequest, DispatchService_DispatchReachableResourcesServer) error {
 	return status.Errorf(codes.Unimplemented, "method DispatchReachableResources not implemented")
+}
+func (UnimplementedDispatchServiceServer) DispatchLookupSubjects(*DispatchLookupSubjectsRequest, DispatchService_DispatchLookupSubjectsServer) error {
+	return status.Errorf(codes.Unimplemented, "method DispatchLookupSubjects not implemented")
 }
 func (UnimplementedDispatchServiceServer) mustEmbedUnimplementedDispatchServiceServer() {}
 
@@ -210,6 +247,27 @@ func (x *dispatchServiceDispatchReachableResourcesServer) Send(m *DispatchReacha
 	return x.ServerStream.SendMsg(m)
 }
 
+func _DispatchService_DispatchLookupSubjects_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(DispatchLookupSubjectsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(DispatchServiceServer).DispatchLookupSubjects(m, &dispatchServiceDispatchLookupSubjectsServer{stream})
+}
+
+type DispatchService_DispatchLookupSubjectsServer interface {
+	Send(*DispatchLookupSubjectsResponse) error
+	grpc.ServerStream
+}
+
+type dispatchServiceDispatchLookupSubjectsServer struct {
+	grpc.ServerStream
+}
+
+func (x *dispatchServiceDispatchLookupSubjectsServer) Send(m *DispatchLookupSubjectsResponse) error {
+	return x.ServerStream.SendMsg(m)
+}
+
 // DispatchService_ServiceDesc is the grpc.ServiceDesc for DispatchService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -234,6 +292,11 @@ var DispatchService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "DispatchReachableResources",
 			Handler:       _DispatchService_DispatchReachableResources_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "DispatchLookupSubjects",
+			Handler:       _DispatchService_DispatchLookupSubjects_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/tuple/onrbytypeset.go
+++ b/pkg/tuple/onrbytypeset.go
@@ -1,0 +1,66 @@
+package tuple
+
+import (
+	"fmt"
+	"strings"
+
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+)
+
+// ONRByTypeSet is a set of ObjectAndRelation's, grouped by namespace+relation.
+type ONRByTypeSet struct {
+	byType map[string][]string
+}
+
+// NewONRByTypeSet creates and returns a new ONRByTypeSet.
+func NewONRByTypeSet() *ONRByTypeSet {
+	return &ONRByTypeSet{
+		byType: map[string][]string{},
+	}
+}
+
+// Add adds the specified ObjectAndRelation to the set.
+func (s *ONRByTypeSet) Add(onr *core.ObjectAndRelation) {
+	typeKey := fmt.Sprintf("%s#%s", onr.Namespace, onr.Relation)
+	if _, ok := s.byType[typeKey]; !ok {
+		s.byType[typeKey] = []string{}
+	}
+
+	s.byType[typeKey] = append(s.byType[typeKey], onr.ObjectId)
+}
+
+// ForEachType invokes the handler for each type of ObjectAndRelation found in the set, along
+// with all IDs of objects of that type.
+func (s *ONRByTypeSet) ForEachType(handler func(rr *core.RelationReference, objectIds []string)) {
+	for key, objectIds := range s.byType {
+		parts := strings.Split(key, "#")
+		handler(&core.RelationReference{
+			Namespace: parts[0],
+			Relation:  parts[1],
+		}, objectIds)
+	}
+}
+
+// Map runs the mapper function over each type of object in the set, returning a new ONRByTypeSet with
+// the object type replaced by that returned by the mapper function.
+func (s *ONRByTypeSet) Map(mapper func(rr *core.RelationReference) (*core.RelationReference, error)) (*ONRByTypeSet, error) {
+	mapped := NewONRByTypeSet()
+	for key, objectIds := range s.byType {
+		parts := strings.Split(key, "#")
+		updatedType, err := mapper(&core.RelationReference{
+			Namespace: parts[0],
+			Relation:  parts[1],
+		})
+		if err != nil {
+			return nil, err
+		}
+		updatedTypeKey := fmt.Sprintf("%s#%s", updatedType.Namespace, updatedType.Relation)
+		mapped.byType[updatedTypeKey] = objectIds
+	}
+	return mapped, nil
+}
+
+// IsEmpty returns true if the set is empty.
+func (s *ONRByTypeSet) IsEmpty() bool {
+	return len(s.byType) == 0
+}

--- a/pkg/tuple/onrbytypeset_test.go
+++ b/pkg/tuple/onrbytypeset_test.go
@@ -1,0 +1,61 @@
+package tuple
+
+import (
+	"sort"
+	"testing"
+
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+
+	"github.com/stretchr/testify/require"
+)
+
+func RR(namespaceName string, relationName string) *core.RelationReference {
+	return &core.RelationReference{
+		Namespace: namespaceName,
+		Relation:  relationName,
+	}
+}
+
+func TestONRByTypeSet(t *testing.T) {
+	assertHasObjectIds := func(s *ONRByTypeSet, rr *core.RelationReference, expected []string) {
+		wasFound := false
+		s.ForEachType(func(foundRR *core.RelationReference, objectIds []string) {
+			if rr.Namespace == foundRR.Namespace && rr.Relation == foundRR.Relation {
+				sort.Strings(objectIds)
+				require.Equal(t, expected, objectIds)
+				wasFound = true
+			}
+		})
+		require.True(t, wasFound)
+	}
+
+	set := NewONRByTypeSet()
+	require.True(t, set.IsEmpty())
+
+	// Add some ONRs.
+	set.Add(ParseONR("document:foo#viewer"))
+	set.Add(ParseONR("document:bar#viewer"))
+	set.Add(ParseONR("team:something#member"))
+	set.Add(ParseONR("team:other#member"))
+	set.Add(ParseONR("team:other#manager"))
+	require.False(t, set.IsEmpty())
+
+	// Run for each type over the set
+	assertHasObjectIds(set, RR("document", "viewer"), []string{"bar", "foo"})
+	assertHasObjectIds(set, RR("team", "member"), []string{"other", "something"})
+	assertHasObjectIds(set, RR("team", "manager"), []string{"other"})
+
+	// Map
+	mapped, err := set.Map(func(rr *core.RelationReference) (*core.RelationReference, error) {
+		if rr.Namespace == "document" {
+			return RR("doc", rr.Relation), nil
+		}
+
+		return rr, nil
+	})
+	require.NoError(t, err)
+
+	assertHasObjectIds(mapped, RR("doc", "viewer"), []string{"bar", "foo"})
+	assertHasObjectIds(mapped, RR("team", "member"), []string{"other", "something"})
+	assertHasObjectIds(mapped, RR("team", "manager"), []string{"other"})
+}

--- a/proto/internal/dispatch/v1/dispatch.proto
+++ b/proto/internal/dispatch/v1/dispatch.proto
@@ -11,6 +11,7 @@ service DispatchService {
   rpc DispatchExpand(DispatchExpandRequest) returns (DispatchExpandResponse) {}
   rpc DispatchLookup(DispatchLookupRequest) returns (DispatchLookupResponse) {}
   rpc DispatchReachableResources(DispatchReachableResourcesRequest) returns (stream DispatchReachableResourcesResponse) {}
+  rpc DispatchLookupSubjects(DispatchLookupSubjectsRequest) returns (stream DispatchLookupSubjectsResponse) {}
 }
 
 message DispatchCheckRequest {
@@ -108,6 +109,22 @@ message ReachableResource {
 
 message DispatchReachableResourcesResponse {
   ReachableResource resource = 1;
+  ResponseMeta metadata = 2;
+}
+
+message DispatchLookupSubjectsRequest {
+  ResolverMeta metadata = 1 [ (validate.rules).message.required = true ];
+
+  core.v1.RelationReference resource_relation = 2
+      [ (validate.rules).message.required = true ];
+  repeated string resource_ids = 3;
+
+  core.v1.RelationReference subject_relation = 4
+      [ (validate.rules).message.required = true ];
+}
+
+message DispatchLookupSubjectsResponse {
+  repeated string found_subject_ids = 1;
   ResponseMeta metadata = 2;
 }
 


### PR DESCRIPTION
This PR adds the dispatching support for LookupSubjects.

NOTE: This does not yet implement the actual API, nor does it change the dispatch for expand in any way. An open item is whether we want to change expand to share the same implementation as this code.

First step for #261
Part of #207