### PR TITLE
hack: mv install-tools into hack dir

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -130,7 +130,7 @@ jobs:
         with:
           go-version: "~1.18"
       - name: "Install Go Tools"
-        run: "./install-tools.sh"
+        run: "./hack/install-tools.sh"
       - uses: "authzed/actions/buf-generate@main"
       - uses: "bufbuild/buf-breaking-action@v0.4.0"
         if: "github.event_name == 'pull_request'"

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -xeuo pipefail
+
+read -ra TOOLS < <(go list -f "{{range .Imports}}{{.}} {{end}}" tools.go)
+go install "${TOOLS[@]}"

--- a/hack/update-all-deps.sh
+++ b/hack/update-all-deps.sh
@@ -1,11 +1,12 @@
-#! /bin/bash
+#!/bin/bash
+set -xeuo pipefail
 
-set -x 
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR/.." || exit
 go get -u -t -tags ci,tools ./...
 go mod tidy
+
 cd "$SCRIPT_DIR/../e2e" || exit
 go get -u -t -u -t -tags tools ./...
 go mod tidy

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -1,2 +1,0 @@
-tools=$(go list -f '{{range .Imports}}{{.}} {{end}}' tools.go)
-go install $tools


### PR DESCRIPTION
This is a really simple PR to move the `install-tools.sh` script into the hack directory.

I also ran shfmt, shellcheck, and checkbashisms on the scripts.