### PR TITLE
fix panic on cached optimized revisions

### DIFF
--- a/internal/datastore/common/revisions/optimized.go
+++ b/internal/datastore/common/revisions/optimized.go
@@ -68,7 +68,9 @@ func (cor *CachedOptimizedRevisions) OptimizedRevision(ctx context.Context) (dat
 
 		return optimized, nil
 	})
-
+	if err != nil {
+		return datastore.NoRevision, err
+	}
 	return lastQuantizedRevision.(decimal.Decimal), err
 }
 

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -419,9 +419,9 @@ func (mds *Datastore) Close() error {
 // the necessary tables.
 //
 // fundamentally different from PSQL implementation:
-// - checking if the current migration version is compatible is implemented with IsHeadCompatible
-// - Database seeding is handled here, so that we can decouple schema migration from data migration
-//   and support skeema-based migrations.
+//   - checking if the current migration version is compatible is implemented with IsHeadCompatible
+//   - Database seeding is handled here, so that we can decouple schema migration from data migration
+//     and support skeema-based migrations.
 func (mds *Datastore) IsReady(ctx context.Context) (bool, error) {
 	if err := mds.db.PingContext(ctx); err != nil {
 		return false, err

--- a/internal/namespace/canonicalization.go
+++ b/internal/namespace/canonicalization.go
@@ -22,28 +22,31 @@ const computedKeyPrefix = "%"
 // and the operations (+, -, &) are converted into binary operations.
 //
 // For example, for the namespace:
-//   definition somenamespace {
-//      relation first: ...
-//      relation second: ...
-//      relation third: ...
-//      permission someperm = second + (first - third->something)
-//   }
+//
+//	definition somenamespace {
+//	   relation first: ...
+//	   relation second: ...
+//	   relation third: ...
+//	   permission someperm = second + (first - third->something)
+//	}
 //
 // We begin by assigning a unique integer index to each relation and arrow found for all
 // expressions in the namespace:
-//   definition somenamespace {
-//	    relation first: ...
-//               ^ index 0
-//      relation second: ...
-//               ^ index 1
-//      relation third: ...
-//               ^ index 2
-//      permission someperm = second + (first - third->something)
-//                            ^ 1       ^ 0     ^ index 3
-//   }
+//
+//	  definition somenamespace {
+//		    relation first: ...
+//	              ^ index 0
+//	     relation second: ...
+//	              ^ index 1
+//	     relation third: ...
+//	              ^ index 2
+//	     permission someperm = second + (first - third->something)
+//	                           ^ 1       ^ 0     ^ index 3
+//	  }
 //
 // These indexes are then used with the rudd library to build the expression:
-//    someperm => `bdd.Or(bdd.Ithvar(1), bdd.And(bdd.Ithvar(0), bdd.NIthvar(2)))`
+//
+//	someperm => `bdd.Or(bdd.Ithvar(1), bdd.And(bdd.Ithvar(0), bdd.NIthvar(2)))`
 //
 // The `rudd` library automatically handles associativity, and produces a hash representing the
 // canonical representation of the binary expression. These hashes can then be used for caching,

--- a/internal/telemetry/reporter.go
+++ b/internal/telemetry/reporter.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -74,7 +74,7 @@ func writeTimeSeries(ctx context.Context, client *http.Client, endpoint string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode/100 != 2 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf(
 			"unexpected Prometheus remote write response: %d: %s",
 			resp.StatusCode,

--- a/pkg/development/wasm/main.go
+++ b/pkg/development/wasm/main.go
@@ -33,25 +33,26 @@ func derr(derrs *development.DeveloperErrors) interface{} {
 // one or more development operations.
 //
 // The arguments are:
-//   1) JSON-string form of the development context:
-//      {
-//	        "schema": "definition user {}"
-//          "relationships": [
-//             {
-//								"resource_and_relation": {"namespace": "ns", "object_id": "oid", "relation": "viewer"},
-//								"subject": {... same fields as resource_and_relation ...}
-//						 }
-//				  ]
-//      }
 //
-//   2) An array (*not* JSON encoded) of operations to be run by the package:
-//			[
-//				{
-//					"operation": "check",
-// 					"parameters": "(json string with parameters for operation)",
-//					"callback": callback: (result, err) => { ... },
-//				}
-//      ]
+//  1. JSON-string form of the development context:
+//     {
+//     "schema": "definition user {}"
+//     "relationships": [
+//     {
+//     "resource_and_relation": {"namespace": "ns", "object_id": "oid", "relation": "viewer"},
+//     "subject": {... same fields as resource_and_relation ...}
+//     }
+//     ]
+//     }
+//
+//  2. An array (*not* JSON encoded) of operations to be run by the package:
+//     [
+//     {
+//     "operation": "check",
+//     "parameters": "(json string with parameters for operation)",
+//     "callback": callback: (result, err) => { ... },
+//     }
+//     ]
 //
 // See example/wasm.html for an example and the individual operations for their parameters
 // and callback arguments.

--- a/pkg/schemadsl/input/sourcepositionmapper_test.go
+++ b/pkg/schemadsl/input/sourcepositionmapper_test.go
@@ -1,14 +1,14 @@
 package input
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPositionMapping(t *testing.T) {
-	mappingText, err := ioutil.ReadFile("tests/mapping.txt")
+	mappingText, err := os.ReadFile("tests/mapping.txt")
 	if !assert.Nil(t, err, "Got error reading mapping file") {
 		return
 	}

--- a/pkg/schemadsl/parser/parser.go
+++ b/pkg/schemadsl/parser/parser.go
@@ -329,7 +329,7 @@ func (p *sourceParser) tryConsumeBaseExpression() (AstNode, bool) {
 // tryConsumeIdentifierLiteral attempts to consume an identifier as a literal
 // expression.
 //
-/// ```foo```
+// ```foo```
 func (p *sourceParser) tryConsumeIdentifierLiteral() (AstNode, bool) {
 	if !p.isToken(lexer.TokenTypeIdentifier) {
 		return nil, false

--- a/pkg/schemadsl/parser/parser_test.go
+++ b/pkg/schemadsl/parser/parser_test.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"container/list"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -27,7 +26,7 @@ type parserTest struct {
 }
 
 func (pt *parserTest) input() string {
-	b, err := ioutil.ReadFile(fmt.Sprintf("tests/%s.zed", pt.filename))
+	b, err := os.ReadFile(fmt.Sprintf("tests/%s.zed", pt.filename))
 	if err != nil {
 		panic(err)
 	}
@@ -36,7 +35,7 @@ func (pt *parserTest) input() string {
 }
 
 func (pt *parserTest) tree() string {
-	b, err := ioutil.ReadFile(fmt.Sprintf("tests/%s.zed.expected", pt.filename))
+	b, err := os.ReadFile(fmt.Sprintf("tests/%s.zed.expected", pt.filename))
 	if err != nil {
 		panic(err)
 	}
@@ -45,7 +44,7 @@ func (pt *parserTest) tree() string {
 }
 
 func (pt *parserTest) writeTree(value string) {
-	err := ioutil.WriteFile(fmt.Sprintf("tests/%s.zed.expected", pt.filename), []byte(value), 0o600)
+	err := os.WriteFile(fmt.Sprintf("tests/%s.zed.expected", pt.filename), []byte(value), 0o600)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# What

This PR fixes a panic that sometimes triggered when database connection errors happened during the computation of optimized revisions through the singleflight wrapper.

# Why

Any error happening in the optimized revision function executed through the singleflight group was unhandled, which led `lastQuantizedRevision.(decimal.Decimal)` type assertion to panic:

https://github.com/authzed/spicedb/blob/ae4552ed89f0561f71893da2feeb7feb1e767e71/internal/datastore/common/revisions/optimized.go#L72

```
panic: interface conversion: interface {} is nil, not decimal.Decimal
```

# How

By adding good old `if err != nil ...` 😄 

# Notes

There are some `gofumpt` lint errors caused with go 1.19, so had to fix then here 🙏🏻 