### PR TITLE
more resilient CRDB datastore on connection draining

### DIFF
--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -87,6 +87,10 @@ func NewCRDBDatastore(url string, options ...Option) (datastore.Datastore, error
 		poolConfig.MaxConnLifetime = *config.connMaxLifetime
 	}
 
+	if config.connHealthCheckInterval != nil {
+		poolConfig.HealthCheckPeriod = *config.connHealthCheckInterval
+	}
+
 	poolConfig.ConnConfig.Logger = zerologadapter.NewLogger(log.Logger)
 
 	pool, err := pgxpool.ConnectConfig(context.Background(), poolConfig)

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -299,14 +299,16 @@ func (cds *crdbDatastore) HeadRevision(ctx context.Context) (datastore.Revision,
 	defer span.End()
 
 	var hlcNow datastore.Revision
-	err := cds.pool.BeginTxFunc(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly}, func(tx pgx.Tx) error {
-		var fnErr error
-		hlcNow, fnErr = readCRDBNow(ctx, tx)
-		if fnErr != nil {
-			hlcNow = datastore.NoRevision
-			return fmt.Errorf(errRevision, fnErr)
-		}
-		return nil
+	err := cds.execute(ctx, func(ctx context.Context) error {
+		return cds.pool.BeginTxFunc(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly}, func(tx pgx.Tx) error {
+			var fnErr error
+			hlcNow, fnErr = readCRDBNow(ctx, tx)
+			if fnErr != nil {
+				hlcNow = datastore.NoRevision
+				return fmt.Errorf(errRevision, fnErr)
+			}
+			return nil
+		})
 	})
 
 	return hlcNow, err

--- a/internal/datastore/crdb/options.go
+++ b/internal/datastore/crdb/options.go
@@ -6,10 +6,11 @@ import (
 )
 
 type crdbOptions struct {
-	connMaxIdleTime *time.Duration
-	connMaxLifetime *time.Duration
-	minOpenConns    *int
-	maxOpenConns    *int
+	connMaxIdleTime         *time.Duration
+	connMaxLifetime         *time.Duration
+	connHealthCheckInterval *time.Duration
+	minOpenConns            *int
+	maxOpenConns            *int
 
 	watchBufferLength           uint16
 	revisionQuantization        time.Duration
@@ -82,6 +83,24 @@ func generateConfig(options []Option) (crdbOptions, error) {
 func SplitAtUsersetCount(splitAtUsersetCount uint16) Option {
 	return func(po *crdbOptions) {
 		po.splitAtUsersetCount = splitAtUsersetCount
+	}
+}
+
+// ConnHealthCheckInterval is the frequency at which both idle and max lifetime connections
+// are checked, and also the frequency at which minimum number of connections is
+// checked. This happens asynchronously.
+//
+// This is not the only approach to evaluate those: connection idle/max lifetime
+// is also checked when connections are released to the pool.
+//
+// There is no guarantee connections won't last longer than their specified idle/max lifetime. It's largely
+// dependent on the health-check goroutine being able to pull them from the connection pool. The health-check
+// may not be able to clean up those connections is they are held by the application very frequently.
+//
+// This value defaults to 30s.
+func ConnHealthCheckInterval(interval time.Duration) Option {
+	return func(po *crdbOptions) {
+		po.connHealthCheckInterval = &interval
 	}
 }
 

--- a/internal/datastore/crdb/options.go
+++ b/internal/datastore/crdb/options.go
@@ -90,7 +90,7 @@ func SplitAtUsersetCount(splitAtUsersetCount uint16) Option {
 // are checked, and also the frequency at which the minimum number of connections is
 // checked. This happens asynchronously.
 //
-// This is not the only approach to evaluate those counts: connection idle/max lifetime
+// This is not the only approach to evaluate these counts: connection idle/max lifetime
 // is also checked when connections are released to the pool.
 //
 // There is no guarantee connections won't last longer than their specified idle/max lifetime. It's largely

--- a/internal/datastore/crdb/options.go
+++ b/internal/datastore/crdb/options.go
@@ -87,15 +87,15 @@ func SplitAtUsersetCount(splitAtUsersetCount uint16) Option {
 }
 
 // ConnHealthCheckInterval is the frequency at which both idle and max lifetime connections
-// are checked, and also the frequency at which minimum number of connections is
+// are checked, and also the frequency at which the minimum number of connections is
 // checked. This happens asynchronously.
 //
-// This is not the only approach to evaluate those: connection idle/max lifetime
+// This is not the only approach to evaluate those counts: connection idle/max lifetime
 // is also checked when connections are released to the pool.
 //
 // There is no guarantee connections won't last longer than their specified idle/max lifetime. It's largely
 // dependent on the health-check goroutine being able to pull them from the connection pool. The health-check
-// may not be able to clean up those connections is they are held by the application very frequently.
+// may not be able to clean up those connections if they are held by the application very frequently.
 //
 // This value defaults to 30s.
 func ConnHealthCheckInterval(interval time.Duration) Option {

--- a/internal/datastore/crdb/tx.go
+++ b/internal/datastore/crdb/tx.go
@@ -16,12 +16,14 @@ const (
 	crdbRetryErrCode = "40001"
 	// https://www.cockroachlabs.com/docs/stable/common-errors.html#result-is-ambiguous
 	crdbAmbiguousErrorCode = "40003"
+	// https://www.cockroachlabs.com/docs/stable/node-shutdown.html#connection-retry-loop
+	crdbServerNotAcceptingClients = "57P01"
 	// Error when SqlState is unknown
 	crdbUnknownSQLState = "XXUUU"
 	// Error message encountered when crdb nodes have large clock skew
 	crdbClockSkewMessage = "cannot specify timestamp in the future"
 
-	errReachedMaxAttempts = "maximum attempts reached (%d/%d): %w"
+	errReachedMaxRetries = "maximum retries reached (%d/%d): %w"
 )
 
 var resetHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
@@ -67,7 +69,7 @@ func executeWithResets(ctx context.Context, fn innerFunc, maxRetries uint8) (err
 	}
 
 	// The last error was resettable but we're out of retries
-	return fmt.Errorf(errReachedMaxAttempts, retries, maxRetries+1, err)
+	return fmt.Errorf(errReachedMaxRetries, retries, maxRetries+1, err)
 }
 
 func resettable(ctx context.Context, err error) bool {
@@ -78,12 +80,18 @@ func resettable(ctx context.Context, err error) bool {
 	if strings.Contains(err.Error(), "broken pipe") {
 		return true
 	}
+	// detect when cockroach closed a connection
+	if strings.Contains(err.Error(), "unexpected EOF") {
+		return true
+	}
 	sqlState := sqlErrorCode(ctx, err)
 	// Ambiguous result error includes connection closed errors
 	// https://www.cockroachlabs.com/docs/stable/common-errors.html#result-is-ambiguous
 	return sqlState == crdbAmbiguousErrorCode ||
 		// Reset for retriable errors
 		sqlState == crdbRetryErrCode ||
+		// Retry on node draining
+		sqlState == crdbServerNotAcceptingClients ||
 		// Error encountered when crdb nodes have large clock skew
 		(sqlState == crdbUnknownSQLState && strings.Contains(err.Error(), crdbClockSkewMessage))
 }

--- a/internal/datastore/crdb/tx.go
+++ b/internal/datastore/crdb/tx.go
@@ -58,6 +58,7 @@ func executeWithResets(ctx context.Context, fn innerFunc, maxRetries uint8) (err
 	for retries = 0; retries <= maxRetries; retries++ {
 		err = fn(ctx)
 		if resettable(ctx, err) {
+			log.Ctx(ctx).Warn().Err(err).Msg("retrying resetteable database error")
 			continue
 		}
 
@@ -91,7 +92,7 @@ func resettable(ctx context.Context, err error) bool {
 func sqlErrorCode(ctx context.Context, err error) string {
 	var pgerr *pgconn.PgError
 	if !errors.As(err, &pgerr) {
-		log.Debug().Err(err).Msg("couldn't determine a sqlstate error code")
+		log.Ctx(ctx).Debug().Err(err).Msg("couldn't determine a sqlstate error code")
 		return ""
 	}
 

--- a/internal/datastore/crdb/tx_test.go
+++ b/internal/datastore/crdb/tx_test.go
@@ -5,6 +5,7 @@ package crdb
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -64,7 +65,7 @@ func TestTxReset(t *testing.T) {
 			errors: []error{
 				&pgconn.PgError{Code: crdbAmbiguousErrorCode},
 				&pgconn.PgError{Code: crdbAmbiguousErrorCode},
-				&pgconn.PgError{Code: crdbAmbiguousErrorCode},
+				&pgconn.PgError{Code: crdbServerNotAcceptingClients},
 			},
 			expectError: false,
 		},
@@ -92,6 +93,15 @@ func TestTxReset(t *testing.T) {
 				&pgconn.PgError{Code: crdbAmbiguousErrorCode},
 			},
 			expectError: true,
+		},
+		{
+			name:       "stale connections",
+			maxRetries: 3,
+			errors: []error{
+				errors.New("unexpected EOF"),
+				errors.New("broken pipe"),
+			},
+			expectError: false,
 		},
 		{
 			name:       "clockSkew",

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -111,7 +111,7 @@ func RegisterDatastoreFlags(cmd *cobra.Command, opts *Config) {
 	// See crdb doc for info about follower reads and how it is configured: https://www.cockroachlabs.com/docs/stable/follower-reads.html
 	cmd.Flags().DurationVar(&opts.FollowerReadDelay, "datastore-follower-read-delay-duration", 4_800*time.Millisecond, "amount of time to subtract from non-sync revision timestamps to ensure they are sufficiently in the past to enable follower reads (cockroach driver only)")
 	cmd.Flags().Uint16Var(&opts.SplitQueryCount, "datastore-query-userset-batch-size", 1024, "number of usersets after which a relationship query will be split into multiple queries")
-	cmd.Flags().IntVar(&opts.MaxRetries, "datastore-max-tx-retries", 3, "number of times a retriable transaction should be retried")
+	cmd.Flags().IntVar(&opts.MaxRetries, "datastore-max-tx-retries", 10, "number of times a retriable transaction should be retried")
 	cmd.Flags().StringVar(&opts.OverlapStrategy, "datastore-tx-overlap-strategy", "static", `strategy to generate transaction overlap keys ("prefix", "static", "insecure") (cockroach driver only)`)
 	cmd.Flags().StringVar(&opts.OverlapKey, "datastore-tx-overlap-key", "key", "static key to touch when writing to ensure transactions overlap (only used if --datastore-tx-overlap-strategy=static is set; cockroach driver only)")
 	cmd.Flags().StringVar(&opts.SpannerCredentialsFile, "datastore-spanner-credentials", "", "path to service account key credentials file with access to the cloud spanner instance (omit to use application default credentials)")

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -223,6 +223,7 @@ func newCRDBDatastore(opts Config) (datastore.Datastore, error) {
 		crdb.RevisionQuantization(opts.RevisionQuantization),
 		crdb.ConnMaxIdleTime(opts.MaxIdleTime),
 		crdb.ConnMaxLifetime(opts.MaxLifetime),
+		crdb.ConnHealthCheckInterval(opts.HealthCheckPeriod),
 		crdb.MaxOpenConns(opts.MaxOpenConns),
 		crdb.MinOpenConns(opts.MinOpenConns),
 		crdb.SplitAtUsersetCount(opts.SplitQueryCount),

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -111,7 +111,7 @@ func RegisterDatastoreFlags(cmd *cobra.Command, opts *Config) {
 	// See crdb doc for info about follower reads and how it is configured: https://www.cockroachlabs.com/docs/stable/follower-reads.html
 	cmd.Flags().DurationVar(&opts.FollowerReadDelay, "datastore-follower-read-delay-duration", 4_800*time.Millisecond, "amount of time to subtract from non-sync revision timestamps to ensure they are sufficiently in the past to enable follower reads (cockroach driver only)")
 	cmd.Flags().Uint16Var(&opts.SplitQueryCount, "datastore-query-userset-batch-size", 1024, "number of usersets after which a relationship query will be split into multiple queries")
-	cmd.Flags().IntVar(&opts.MaxRetries, "datastore-max-tx-retries", 10, "number of times a retriable transaction should be retried")
+	cmd.Flags().IntVar(&opts.MaxRetries, "datastore-max-tx-retries", 3, "number of times a retriable transaction should be retried")
 	cmd.Flags().StringVar(&opts.OverlapStrategy, "datastore-tx-overlap-strategy", "static", `strategy to generate transaction overlap keys ("prefix", "static", "insecure") (cockroach driver only)`)
 	cmd.Flags().StringVar(&opts.OverlapKey, "datastore-tx-overlap-key", "key", "static key to touch when writing to ensure transactions overlap (only used if --datastore-tx-overlap-strategy=static is set; cockroach driver only)")
 	cmd.Flags().StringVar(&opts.SpannerCredentialsFile, "datastore-spanner-credentials", "", "path to service account key credentials file with access to the cloud spanner instance (omit to use application default credentials)")


### PR DESCRIPTION
I introduced some changes to help with connection draining:

- Log when datastore detect errors and retries
- Retry on `unexpected EOF` - all operations are idempotent
- Retry when CRDB is draining and does not accept connections
- Propagate spicedb CLI value for health-check-interval parameter.
- Do retry on errors in `Datastore.HeadRevision`

# A look at connection draining with the pgx driver

In order to drain connections properly we need to understand how that's handled by the PGX driver.

- connections that are committed or rolledback are released back to the pool. The `Release()` function will check for idle and max lifetime, so it will close any connections that have exceeded those values.
- the other way to get connections closed is via the health-check. This is a goroutine that is executed on a regular interval. PGX **tries** to get available connections from the pool to check if they have exceeded those parameters. This is important, because if a connection is always locked by the application, it means the goroutine will never be able to check max lifetime, and therefore can exceed that value until it's returned back to the pool

The TLDR is:

- make sure to always end statements with commit/rollback connections, or they will never be released to the pool, and never closed even if they have exceeded max lifetime
- the health-check should be set to a value close the the max lifetime, or less, in order to increase the odds the deadline is honored
- depending on the workload, it's entirely possible connections may exceed significantly their lifetime if they are held very often by the application.
- the health-check may put pressure on the connection pool. The more frequent, the more those connections will spend doing unproductive health checks outside of the pool.