### PR TITLE
update spanner emulator logs

### DIFF
--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -63,8 +63,10 @@ func NewSpannerDatastore(database string, opts ...Option) (datastore.Datastore, 
 		return nil, fmt.Errorf(errUnableToInstantiate, err)
 	}
 
-	if len(config.emulatorHost) > 0 || len(os.Getenv("SPANNER_EMULATOR_HOST")) > 0 {
+	if len(config.emulatorHost) > 0 {
 		os.Setenv("SPANNER_EMULATOR_HOST", config.emulatorHost)
+	}
+	if len(os.Getenv("SPANNER_EMULATOR_HOST")) > 0 {
 		log.Info().Str("spanner-emulator-host", os.Getenv("SPANNER_EMULATOR_HOST")).Msg("running against spanner emulator")
 	}
 

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -63,13 +63,13 @@ func NewSpannerDatastore(database string, opts ...Option) (datastore.Datastore, 
 		return nil, fmt.Errorf(errUnableToInstantiate, err)
 	}
 
-	if len(config.emulatorHost) > 0 {
+	if len(config.emulatorHost) > 0 || len(os.Getenv("SPANNER_EMULATOR_HOST")) > 0 {
 		os.Setenv("SPANNER_EMULATOR_HOST", config.emulatorHost)
+		log.Info().Str("spanner-emulator-host", os.Getenv("SPANNER_EMULATOR_HOST")).Msg("running against spanner emulator")
 	}
 
 	config.gcInterval = common.WithJitter(0.2, config.gcInterval)
 	log.Info().Float64("factor", 0.2).Msg("gc configured with jitter")
-	log.Info().Str("spanner-emulator-host", os.Getenv("SPANNER_EMULATOR_HOST")).Msg("spanner emulator")
 
 	client, err := spanner.NewClient(context.Background(), database, option.WithCredentialsFile(config.credentialsFilePath))
 	if err != nil {


### PR DESCRIPTION
This was always printing the log even when the emulator was not used