### PR TITLE
Use distroless.dev/static base, add debug variants

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,6 +67,18 @@ dockers:
     use: "buildx"
     build_flag_templates:
       - "--platform=linux/amd64"
+  # AMD64 (debug)
+  - image_templates:
+      - &amd_debug_image_quay "quay.io/authzed/spicedb:v{{ .Version }}-amd64-debug"
+      - &amd_debug_image_gh "ghcr.io/authzed/spicedb:v{{ .Version }}-amd64-debug"
+      - &amd_debug_image_dh "authzed/spicedb:v{{ .Version }}-amd64-debug"
+    dockerfile: &dockerfile "Dockerfile.release"
+    goos: "linux"
+    goarch: "amd64"
+    use: "buildx"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=BASE=distroless.dev/busybox"
   # ARM64
   - image_templates:
       - &arm_image_quay "quay.io/authzed/spicedb:v{{ .Version }}-arm64"
@@ -78,6 +90,18 @@ dockers:
     use: "buildx"
     build_flag_templates:
       - "--platform=linux/arm64"
+  # ARM64 (debug)
+  - image_templates:
+      - &arm_debug_image_quay "quay.io/authzed/spicedb:v{{ .Version }}-arm64-debug"
+      - &arm_debug_image_gh "ghcr.io/authzed/spicedb:v{{ .Version }}-arm64-debug"
+      - &arm_debug_image_dh "authzed/spicedb:v{{ .Version }}-arm64-debug"
+    dockerfile: *dockerfile
+    goos: "linux"
+    goarch: "arm64"
+    use: "buildx"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=BASE=distroless.dev/busybox"
 docker_manifests:
   # Quay
   - name_template: "quay.io/authzed/spicedb:v{{ .Version }}"
@@ -94,6 +118,24 @@ docker_manifests:
     image_templates: [*amd_image_dh, *arm_image_dh]
   - name_template: "authzed/spicedb:latest"
     image_templates: [*amd_image_dh, *arm_image_dh]
+
+  # Debug Images:
+
+  # Quay (debug)
+  - name_template: "quay.io/authzed/spicedb:v{{ .Version }}-debug"
+    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
+  - name_template: "quay.io/authzed/spicedb:debug"
+    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
+  # GitHub Registry
+  - name_template: "ghcr.io/authzed/spicedb:v{{ .Version }}-debug"
+    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
+  - name_template: "ghcr.io/authzed/spicedb:debug"
+    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
+  # Docker Hub
+  - name_template: "authzed/spicedb:v{{ .Version }}-debug"
+    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
+  - name_template: "authzed/spicedb:debug"
+    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -124,17 +124,17 @@ docker_manifests:
   # Quay (debug)
   - name_template: "quay.io/authzed/spicedb:v{{ .Version }}-debug"
     image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
-  - name_template: "quay.io/authzed/spicedb:debug"
+  - name_template: "quay.io/authzed/spicedb:latest-debug"
     image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
   # GitHub Registry
   - name_template: "ghcr.io/authzed/spicedb:v{{ .Version }}-debug"
     image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
-  - name_template: "ghcr.io/authzed/spicedb:debug"
+  - name_template: "ghcr.io/authzed/spicedb:latest-debug"
     image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
   # Docker Hub
   - name_template: "authzed/spicedb:v{{ .Version }}-debug"
     image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
-  - name_template: "authzed/spicedb:debug"
+  - name_template: "authzed/spicedb:latest-debug"
     image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
 checksum:
   name_template: "checksums.txt"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,8 @@
 # vim: syntax=dockerfile
-FROM gcr.io/distroless/base
+
+ARG BASE=distroless.dev/static
+FROM $BASE
+
 COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.6 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY spicedb /usr/local/bin/spicedb
 ENTRYPOINT ["spicedb"]


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

Fixes https://github.com/authzed/spicedb/issues/749

This updates the release image to be built on `distroless.dev/static` instead of `gcr.io/distroless/base` -- this image is smaller, and includes even less than the bazel-distroless base image. Trivy reports 11 vulnerabilities in the current base image, and zero in `distroless.dev/static`.

This adds release workflows to build, e.g., `authzed/spicedb:debug`, `authzed/spicedb:vX.Y.Z-debug`, `authzed/spicedb:vX.Y.Z-arm64-debug` images, based on `distroless.dev/busybox`