### PR TITLE
introduce feature flags middleware

### DIFF
--- a/internal/middleware/featureflag/featureflag.go
+++ b/internal/middleware/featureflag/featureflag.go
@@ -10,33 +10,39 @@ import (
 
 var key = struct{}{}
 
-type Flags map[string]struct{}
+type flags map[string]struct{}
 
+// WithFlag injects in the context the name of an enabled feature flag
 func WithFlag(ctx context.Context, flag string) context.Context {
-	flags := injector.FromContext[Flags](ctx, key)
-	if flags == nil {
-		flags = map[string]struct{}{flag: {}}
-		return injector.ContextWithValue(ctx, key, flags)
+	f := injector.FromContext[flags](ctx, key)
+	if f == nil {
+		f = map[string]struct{}{flag: {}}
+		return injector.ContextWithValue(ctx, key, f)
 	}
-	flags[flag] = struct{}{}
+	f[flag] = struct{}{}
 	return ctx
 }
 
+// FromContext returns a value of a feature flag specified by its name.
 func FromContext(ctx context.Context, flag string) bool {
-	flags := injector.FromContext[Flags](ctx, key)
-	_, ok := flags[flag]
+	f := injector.FromContext[flags](ctx, key)
+	_, ok := f[flag]
 	return ok
 }
 
+// UnaryServerInterceptor returns a new unary server interceptor that injects
+// the state of the applications feature flags in the context
 func UnaryServerInterceptor(flags []string) grpc.UnaryServerInterceptor {
-	return injector.UnaryServerInterceptor(key, FromStringSlice(flags))
+	return injector.UnaryServerInterceptor(key, fromStringSlice(flags))
 }
 
+// StreamServerInterceptor returns a new stream server interceptor that injects
+// the state of the applications feature flags in the context
 func StreamServerInterceptor(flags []string) grpc.StreamServerInterceptor {
-	return injector.StreamServerInterceptor(key, FromStringSlice(flags))
+	return injector.StreamServerInterceptor(key, fromStringSlice(flags))
 }
 
-func FromStringSlice(flags []string) Flags {
+func fromStringSlice(flags []string) flags {
 	flagMap := make(map[string]struct{}, len(flags))
 	for _, flag := range flags {
 		flagMap[flag] = struct{}{}

--- a/internal/middleware/featureflag/featureflag.go
+++ b/internal/middleware/featureflag/featureflag.go
@@ -1,0 +1,36 @@
+package featureflag
+
+import (
+	"context"
+
+	"github.com/authzed/spicedb/internal/middleware/injector"
+
+	"google.golang.org/grpc"
+)
+
+var key = struct{}{}
+
+type Flags map[string]bool
+
+func WithFlag(ctx context.Context, flag string, enabled bool) context.Context {
+	flags := injector.FromContext[Flags](ctx, key)
+	if flags == nil {
+		flags = map[string]bool{flag: enabled}
+		return injector.ContextWithValue(ctx, key, flags)
+	}
+	flags[flag] = enabled
+	return ctx
+}
+
+func FromContext(ctx context.Context, flag string) bool {
+	flags := injector.FromContext[Flags](ctx, key)
+	return flags[flag]
+}
+
+func UnaryServerInterceptor(value Flags) grpc.UnaryServerInterceptor {
+	return injector.UnaryServerInterceptor(key, value)
+}
+
+func StreamServerInterceptor(flags Flags) grpc.StreamServerInterceptor {
+	return injector.StreamServerInterceptor(key, flags)
+}

--- a/internal/middleware/featureflag/featureflag_test.go
+++ b/internal/middleware/featureflag/featureflag_test.go
@@ -10,6 +10,6 @@ import (
 func TestFeatureFlags(t *testing.T) {
 	ctx := context.Background()
 	require.False(t, FromContext(ctx, "foo"))
-	ctx = WithFlag(ctx, "foo", true)
+	ctx = WithFlag(ctx, "foo")
 	require.True(t, FromContext(ctx, "foo"))
 }

--- a/internal/middleware/featureflag/featureflag_test.go
+++ b/internal/middleware/featureflag/featureflag_test.go
@@ -1,0 +1,15 @@
+package featureflag
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeatureFlags(t *testing.T) {
+	ctx := context.Background()
+	require.False(t, FromContext(ctx, "foo"))
+	ctx = WithFlag(ctx, "foo", true)
+	require.True(t, FromContext(ctx, "foo"))
+}

--- a/internal/middleware/injector/injector.go
+++ b/internal/middleware/injector/injector.go
@@ -1,0 +1,36 @@
+package injector
+
+import (
+	"context"
+
+	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
+	"google.golang.org/grpc"
+)
+
+type Key any
+
+func ContextWithValue[T any](ctx context.Context, key Key, value T) context.Context {
+	return context.WithValue(ctx, key, value)
+}
+
+func FromContext[T any](ctx context.Context, key Key) T {
+	var value T
+	if v := ctx.Value(key); v != nil {
+		value = v.(T)
+	}
+	return value
+}
+
+func UnaryServerInterceptor[T any](key Key, value T) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		return handler(ContextWithValue[T](ctx, key, value), req)
+	}
+}
+
+func StreamServerInterceptor[T any](key Key, value T) grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		wrapped := middleware.WrapServerStream(stream)
+		wrapped.WrappedContext = ContextWithValue[T](wrapped.WrappedContext, key, value)
+		return handler(srv, wrapped)
+	}
+}

--- a/internal/middleware/injector/injector.go
+++ b/internal/middleware/injector/injector.go
@@ -9,10 +9,12 @@ import (
 
 type Key any
 
+// ContextWithValue injects a value in the context identified by the provided key
 func ContextWithValue[T any](ctx context.Context, key Key, value T) context.Context {
 	return context.WithValue(ctx, key, value)
 }
 
+// FromContext returns a value in the context specified by the provided key.
 func FromContext[T any](ctx context.Context, key Key) T {
 	var value T
 	if v := ctx.Value(key); v != nil {
@@ -21,12 +23,16 @@ func FromContext[T any](ctx context.Context, key Key) T {
 	return value
 }
 
+// UnaryServerInterceptor returns a new unary server interceptor that injects
+// state in the context identified by a specific key
 func UnaryServerInterceptor[T any](key Key, value T) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		return handler(ContextWithValue[T](ctx, key, value), req)
 	}
 }
 
+// StreamServerInterceptor returns a new stream server interceptor that injects
+// state in the context identified by a specific key
 func StreamServerInterceptor[T any](key Key, value T) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		wrapped := middleware.WrapServerStream(stream)

--- a/internal/middleware/injector/injector_test.go
+++ b/internal/middleware/injector/injector_test.go
@@ -1,0 +1,35 @@
+package injector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjector(t *testing.T) {
+	ctx := ContextWithValue[bool](context.Background(), "exists", true)
+	ctx = ContextWithValue[bool](ctx, "exists-too", true)
+	require.True(t, FromContext[bool](ctx, "exists"))
+	require.True(t, FromContext[bool](ctx, "exists-too"))
+	require.False(t, FromContext[bool](ctx, "does-not-exist"))
+}
+
+type handler[T any] struct {
+	t     *testing.T
+	key   string
+	value T
+}
+
+func (h handler[T]) handle(ctx context.Context, req interface{}) (interface{}, error) {
+	value := FromContext[T](ctx, h.key)
+	require.Equal(h.t, h.value, value)
+	return nil, nil
+}
+
+func TestUnaryServerInterceptor(t *testing.T) {
+	interceptor := UnaryServerInterceptor("test", 1234)
+	h := handler[int]{t: t, key: "test", value: 1234}
+	_, err := interceptor(context.Background(), 123, nil, h.handle)
+	require.NoError(t, err)
+}

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -78,6 +78,9 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) {
 	cmd.Flags().StringVar(&config.TelemetryEndpoint, "telemetry-endpoint", telemetry.DefaultEndpoint, "endpoint to which telemetry is reported, empty string to disable")
 	cmd.Flags().StringVar(&config.TelemetryCAOverridePath, "telemetry-ca-override-path", "", "TODO")
 	cmd.Flags().DurationVar(&config.TelemetryInterval, "telemetry-interval", telemetry.DefaultInterval, "approximate period between telemetry reports, minimum 1 minute")
+
+	// Feature Flags
+	cmd.Flags().StringSliceVar(&config.FeatureFlags, "feature-flags", []string{}, "feature flags enabled")
 }
 
 func NewServeCommand(programName string, config *server.Config) *cobra.Command {

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -94,6 +94,9 @@ type Config struct {
 	TelemetryCAOverridePath  string
 	TelemetryEndpoint        string
 	TelemetryInterval        time.Duration
+
+	// Feature Flag
+	FeatureFlags []string
 }
 
 // Complete validates the config and fills out defaults.
@@ -172,9 +175,9 @@ func (c *Config) Complete() (RunnableServer, error) {
 
 	if len(c.DispatchUnaryMiddleware) == 0 && len(c.DispatchStreamingMiddleware) == 0 {
 		if c.GRPCAuthFunc == nil {
-			c.DispatchUnaryMiddleware, c.DispatchStreamingMiddleware = DefaultDispatchMiddleware(log.Logger, auth.RequirePresharedKey(c.PresharedKey), ds)
+			c.DispatchUnaryMiddleware, c.DispatchStreamingMiddleware = DefaultDispatchMiddleware(log.Logger, auth.RequirePresharedKey(c.PresharedKey), ds, c.FeatureFlags)
 		} else {
-			c.DispatchUnaryMiddleware, c.DispatchStreamingMiddleware = DefaultDispatchMiddleware(log.Logger, c.GRPCAuthFunc, ds)
+			c.DispatchUnaryMiddleware, c.DispatchStreamingMiddleware = DefaultDispatchMiddleware(log.Logger, c.GRPCAuthFunc, ds, c.FeatureFlags)
 		}
 	}
 
@@ -232,7 +235,7 @@ func (c *Config) Complete() (RunnableServer, error) {
 	}
 
 	if len(c.UnaryMiddleware) == 0 && len(c.StreamingMiddleware) == 0 {
-		c.UnaryMiddleware, c.StreamingMiddleware = DefaultMiddleware(log.Logger, c.GRPCAuthFunc, !c.DisableVersionResponse, dispatcher, ds)
+		c.UnaryMiddleware, c.StreamingMiddleware = DefaultMiddleware(log.Logger, c.GRPCAuthFunc, !c.DisableVersionResponse, dispatcher, ds, c.FeatureFlags)
 	}
 
 	healthManager := health.NewHealthManager(dispatcher, ds)

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -60,6 +60,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.TelemetryCAOverridePath = c.TelemetryCAOverridePath
 		to.TelemetryEndpoint = c.TelemetryEndpoint
 		to.TelemetryInterval = c.TelemetryInterval
+		to.FeatureFlags = c.FeatureFlags
 	}
 }
 
@@ -355,5 +356,19 @@ func WithTelemetryEndpoint(telemetryEndpoint string) ConfigOption {
 func WithTelemetryInterval(telemetryInterval time.Duration) ConfigOption {
 	return func(c *Config) {
 		c.TelemetryInterval = telemetryInterval
+	}
+}
+
+// WithFeatureFlags returns an option that can append FeatureFlagss to Config.FeatureFlags
+func WithFeatureFlags(featureFlags string) ConfigOption {
+	return func(c *Config) {
+		c.FeatureFlags = append(c.FeatureFlags, featureFlags)
+	}
+}
+
+// SetFeatureFlags returns an option that can set FeatureFlags on a Config
+func SetFeatureFlags(featureFlags []string) ConfigOption {
+	return func(c *Config) {
+		c.FeatureFlags = featureFlags
 	}
 }

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -129,7 +129,7 @@ type TxUserFunc func(context.Context, ReadWriteTransaction) error
 
 // Datastore represents tuple access for a single namespace.
 type Datastore interface {
-	// SnapshotRead creates a read-only handle that reads the datastore at the specified revision.
+	// SnapshotReader creates a read-only handle that reads the datastore at the specified revision.
 	// Any errors establishing the reader will be returned by subsequent calls.
 	SnapshotReader(Revision) Reader
 
@@ -198,7 +198,7 @@ type Stats struct {
 	UniqueID string
 
 	// EstimatedRelationshipCount is a best-guess estimate of the number of relationships
-	// in the datstore. Computing it should use a lightweight method such as reading
+	// in the datastore. Computing it should use a lightweight method such as reading
 	// table statistics.
 	EstimatedRelationshipCount uint64
 
@@ -212,14 +212,14 @@ type RelationshipIterator interface {
 	// Next returns the next tuple in the result set.
 	Next() *core.RelationTuple
 
-	// After receiving a nil response, the caller must check for an error.
+	// Err after receiving a nil response, the caller must check for an error.
 	Err() error
 
 	// Close cancels the query and closes any open connections.
 	Close()
 }
 
-// Revision is a type alias to make changing the revision type a little bit
+// Revision is a type alias to make changing the revision type a bit
 // easier if we need to do it in the future. Implementations should code
 // directly against decimal.Decimal when creating or parsing.
 type Revision = decimal.Decimal

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -13,7 +13,7 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
-var Engines = []string{}
+var Engines []string
 
 // SortedEngineIDs returns the full set of engine IDs, sorted.
 func SortedEngineIDs() []string {


### PR DESCRIPTION
part of https://github.com/authzed/spicedb/issues/757

introduces a `--feature-flag` argument to `spicedb serve` that allows specifying a number of enabled feature flags.
Those values will then get injected into the gRPC server context via a middleware that will make it available to the request path, so that any component can guard new logic behind a feature flag for a safer rollout of new functionality.