### PR TITLE
Add a nightly build for spicedb

### DIFF
--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -1,0 +1,32 @@
+---
+name: "Nightly Release"
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - "main"
+jobs:
+  goreleaser:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 0
+      - uses: "actions/setup-go@v3"
+        with:
+          go-version: "~1.18"
+      - uses: "authzed/actions/docker-login@main"
+        with:
+          quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          dockerhub_token: "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}"
+      - uses: "docker/setup-qemu-action@v1"
+      - uses: "docker/setup-buildx-action@v1"
+      - uses: "goreleaser/goreleaser-action@v2"
+        with:
+          distribution: "goreleaser-pro"
+          version: "latest"
+          args: "release --rm-dist --nightly"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          HOMEBREW_TAP_GITHUB_TOKEN: "${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}"
+          GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -149,3 +149,5 @@ release:
   footer: |
     ## Docker Images
     This release is available at `authzed/spicedb:v{{ .Version }}`, `quay.io/authzed/spicedb:v{{ .Version }}`, `ghcr.io/authzed/spicedb:v{{ .Version }}`
+nightly:
+  name_template: "devel"


### PR DESCRIPTION
I find myself often building images from head of main, I thought it might be nice to publish devel / nightly images somewhere so that they can be pulled instead.