### PR TITLE
Add configurable limits for write and delete relationship APIs

### DIFF
--- a/internal/services/cert_test.go
+++ b/internal/services/cert_test.go
@@ -114,6 +114,8 @@ func TestCertRotation(t *testing.T) {
 		server.WithDatastore(ds),
 		server.WithDispatcher(graph.NewLocalOnlyDispatcher(1)),
 		server.WithDispatchMaxDepth(50),
+		server.WithMaximumPreconditionCount(1000),
+		server.WithMaximumUpdatesPerWrite(1000),
 		server.WithGRPCServer(util.GRPCServerConfig{
 			Network:      util.BufferedNetwork,
 			Enabled:      true,

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -44,17 +44,17 @@ func RegisterGrpcServices(
 	srv *grpc.Server,
 	healthManager health.Manager,
 	dispatch dispatch.Dispatcher,
-	maxDepth uint32,
 	prefixRequired v1alpha1svc.PrefixRequiredOption,
 	schemaServiceOption SchemaServiceOption,
 	watchServiceOption WatchServiceOption,
+	permSysConfig v1svc.PermissionsServerConfig,
 ) {
 	healthManager.RegisterReportedService(OverallServerHealthCheckKey)
 
 	v1alpha1.RegisterSchemaServiceServer(srv, v1alpha1svc.NewSchemaServer(prefixRequired))
 	healthManager.RegisterReportedService(v1alpha1.SchemaService_ServiceDesc.ServiceName)
 
-	v1.RegisterPermissionsServiceServer(srv, v1svc.NewPermissionsServer(dispatch, maxDepth))
+	v1.RegisterPermissionsServiceServer(srv, v1svc.NewPermissionsServer(dispatch, permSysConfig))
 	healthManager.RegisterReportedService(v1.PermissionsService_ServiceDesc.ServiceName)
 
 	if watchServiceOption == WatchServiceEnabled {

--- a/internal/services/v1/permissions.go
+++ b/internal/services/v1/permissions.go
@@ -63,7 +63,7 @@ func (ps *permissionServer) CheckPermission(ctx context.Context, req *v1.CheckPe
 	cr, err := ps.dispatch.DispatchCheck(ctx, &dispatch.DispatchCheckRequest{
 		Metadata: &dispatch.ResolverMeta{
 			AtRevision:     atRevision.String(),
-			DepthRemaining: ps.defaultDepth,
+			DepthRemaining: ps.config.MaximumAPIDepth,
 		},
 		ResourceAndRelation: &core.ObjectAndRelation{
 			Namespace: req.Resource.ObjectType,
@@ -132,7 +132,7 @@ func (ps *permissionServer) ExpandPermissionTree(ctx context.Context, req *v1.Ex
 	resp, err := ps.dispatch.DispatchExpand(ctx, &dispatch.DispatchExpandRequest{
 		Metadata: &dispatch.ResolverMeta{
 			AtRevision:     atRevision.String(),
-			DepthRemaining: ps.defaultDepth,
+			DepthRemaining: ps.config.MaximumAPIDepth,
 		},
 		ResourceAndRelation: &core.ObjectAndRelation{
 			Namespace: req.Resource.ObjectType,
@@ -331,7 +331,7 @@ func (ps *permissionServer) LookupResources(req *v1.LookupResourcesRequest, resp
 	lookupResp, err := ps.dispatch.DispatchLookup(ctx, &dispatch.DispatchLookupRequest{
 		Metadata: &dispatch.ResolverMeta{
 			AtRevision:     atRevision.String(),
-			DepthRemaining: ps.defaultDepth,
+			DepthRemaining: ps.config.MaximumAPIDepth,
 		},
 		ObjectRelation: &core.RelationReference{
 			Namespace: req.ResourceObjectType,
@@ -428,7 +428,7 @@ func (ps *permissionServer) LookupSubjects(req *v1.LookupSubjectsRequest, resp v
 		&dispatch.DispatchLookupSubjectsRequest{
 			Metadata: &dispatch.ResolverMeta{
 				AtRevision:     atRevision.String(),
-				DepthRemaining: ps.defaultDepth,
+				DepthRemaining: ps.config.MaximumAPIDepth,
 			},
 			ResourceRelation: &core.RelationReference{
 				Namespace: req.Resource.ObjectType,

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -28,14 +28,35 @@ import (
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
 
+// PermissionsServerConfig is configuration for the permissions server.
+type PermissionsServerConfig struct {
+	// MaxUpdatesPerWrite holds the maximum number of updates allowed per
+	// WriteRelationships call.
+	MaxUpdatesPerWrite uint16
+
+	// MaxPreconditionsCount holds the maximum number of preconditions allowed
+	// on a WriteRelationships or DeleteRelationships call.
+	MaxPreconditionsCount uint16
+
+	// MaximumAPIDepth is the default/starting depth remaining for API calls made
+	// to the permissions server.
+	MaximumAPIDepth uint32
+}
+
 // NewPermissionsServer creates a PermissionsServiceServer instance.
 func NewPermissionsServer(
 	dispatch dispatch.Dispatcher,
-	defaultDepth uint32,
+	config PermissionsServerConfig,
 ) v1.PermissionsServiceServer {
+	configWithDefaults := PermissionsServerConfig{
+		MaxPreconditionsCount: defaultIfZero(config.MaxPreconditionsCount, 1000),
+		MaxUpdatesPerWrite:    defaultIfZero(config.MaxUpdatesPerWrite, 1000),
+		MaximumAPIDepth:       defaultIfZero(config.MaximumAPIDepth, 50),
+	}
+
 	return &permissionServer{
-		dispatch:     dispatch,
-		defaultDepth: defaultDepth,
+		dispatch: dispatch,
+		config:   configWithDefaults,
 		WithServiceSpecificInterceptors: shared.WithServiceSpecificInterceptors{
 			Unary: grpcmw.ChainUnaryServer(
 				grpcvalidate.UnaryServerInterceptor(),
@@ -55,8 +76,8 @@ type permissionServer struct {
 	v1.UnimplementedPermissionsServiceServer
 	shared.WithServiceSpecificInterceptors
 
-	dispatch     dispatch.Dispatcher
-	defaultDepth uint32
+	dispatch dispatch.Dispatcher
+	config   PermissionsServerConfig
 }
 
 func (ps *permissionServer) checkFilterComponent(ctx context.Context, objectType, optionalRelation string, ds datastore.Reader) error {
@@ -140,6 +161,30 @@ func (ps *permissionServer) ReadRelationships(req *v1.ReadRelationshipsRequest, 
 
 func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.WriteRelationshipsRequest) (*v1.WriteRelationshipsResponse, error) {
 	ds := datastoremw.MustFromContext(ctx)
+
+	if len(req.Updates) > int(ps.config.MaxUpdatesPerWrite) {
+		return nil, rewritePermissionsError(
+			ctx,
+			status.Errorf(
+				codes.InvalidArgument,
+				"update count of %d is greater than maximum allowed of %d",
+				len(req.Updates),
+				ps.config.MaxUpdatesPerWrite,
+			),
+		)
+	}
+
+	if len(req.OptionalPreconditions) > int(ps.config.MaxPreconditionsCount) {
+		return nil, rewritePermissionsError(
+			ctx,
+			status.Errorf(
+				codes.InvalidArgument,
+				"precondition count of %d is greater than maximum allowed of %d",
+				len(req.OptionalPreconditions),
+				ps.config.MaxPreconditionsCount,
+			),
+		)
+	}
 
 	revision, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 		for _, precond := range req.OptionalPreconditions {
@@ -251,6 +296,18 @@ func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.Writ
 }
 
 func (ps *permissionServer) DeleteRelationships(ctx context.Context, req *v1.DeleteRelationshipsRequest) (*v1.DeleteRelationshipsResponse, error) {
+	if len(req.OptionalPreconditions) > int(ps.config.MaxPreconditionsCount) {
+		return nil, rewritePermissionsError(
+			ctx,
+			status.Errorf(
+				codes.InvalidArgument,
+				"precondition count of %d is greater than maximum allowed of %d",
+				len(req.OptionalPreconditions),
+				ps.config.MaxPreconditionsCount,
+			),
+		)
+	}
+
 	ds := datastoremw.MustFromContext(ctx)
 
 	revision, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
@@ -313,4 +370,15 @@ func rewritePermissionsError(ctx context.Context, err error) error {
 		log.Ctx(ctx).Err(err).Msg("received unexpected error")
 		return err
 	}
+}
+
+type uinteger interface {
+	uint32 | uint16
+}
+
+func defaultIfZero[T uinteger](value T, defaultValue T) T {
+	if value == 0 {
+		return defaultValue
+	}
+	return value
 }

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -195,6 +195,8 @@ func TestClusterWithDispatchAndCacheConfig(t testing.TB, size uint, ds datastore
 			server.WithDatastore(ds),
 			server.WithDispatcher(dispatcher),
 			server.WithDispatchMaxDepth(50),
+			server.WithMaximumPreconditionCount(1000),
+			server.WithMaximumUpdatesPerWrite(1000),
 			server.WithGRPCServer(util.GRPCServerConfig{
 				Network: util.BufferedNetwork,
 				Enabled: true,

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -69,6 +69,8 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) {
 	// Flags for configuring API behavior
 	cmd.Flags().BoolVar(&config.DisableV1SchemaAPI, "disable-v1-schema-api", false, "disables the V1 schema API")
 	cmd.Flags().BoolVar(&config.DisableVersionResponse, "disable-version-response", false, "disables version response support in the API")
+	cmd.Flags().Uint16Var(&config.MaximumUpdatesPerWrite, "write-relationships-max-updates-per-call", 1000, "maximum number of updates allowed for WriteRelationships calls")
+	cmd.Flags().Uint16Var(&config.MaximumPreconditionCount, "update-relationships-max-preconditions-per-call", 1000, "maximum number of preconditions allowed for WriteRelationships and DeleteRelationships calls")
 
 	// Flags for misc services
 	util.RegisterHTTPServerFlags(cmd.Flags(), &config.DashboardAPI, "dashboard", "dashboard", ":8080", true)

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/authzed/spicedb/internal/services"
 	dispatchSvc "github.com/authzed/spicedb/internal/services/dispatch"
 	"github.com/authzed/spicedb/internal/services/health"
+	v1svc "github.com/authzed/spicedb/internal/services/v1"
 	v1alpha1svc "github.com/authzed/spicedb/internal/services/v1alpha1"
 	"github.com/authzed/spicedb/internal/telemetry"
 	"github.com/authzed/spicedb/pkg/balancer"
@@ -75,7 +76,9 @@ type Config struct {
 	ClusterDispatchCacheConfig CacheConfig
 
 	// API Behavior
-	DisableV1SchemaAPI bool
+	DisableV1SchemaAPI       bool
+	MaximumUpdatesPerWrite   uint16
+	MaximumPreconditionCount uint16
 
 	// Additional Services
 	DashboardAPI util.HTTPServerConfig
@@ -235,6 +238,20 @@ func (c *Config) Complete() (RunnableServer, error) {
 		c.UnaryMiddleware, c.StreamingMiddleware = DefaultMiddleware(log.Logger, c.GRPCAuthFunc, !c.DisableVersionResponse, dispatcher, ds)
 	}
 
+	if c.MaximumPreconditionCount == 0 {
+		return nil, fmt.Errorf("maximum preconditions allowed must be greater than zero")
+	}
+
+	if c.MaximumUpdatesPerWrite == 0 {
+		return nil, fmt.Errorf("maximum updates per write allowed must be greater than zero")
+	}
+
+	permSysConfig := v1svc.PermissionsServerConfig{
+		MaxPreconditionsCount: c.MaximumPreconditionCount,
+		MaxUpdatesPerWrite:    c.MaximumUpdatesPerWrite,
+		MaximumAPIDepth:       c.DispatchMaxDepth,
+	}
+
 	healthManager := health.NewHealthManager(dispatcher, ds)
 	grpcServer, err := c.GRPCServer.Complete(zerolog.InfoLevel,
 		func(server *grpc.Server) {
@@ -242,10 +259,10 @@ func (c *Config) Complete() (RunnableServer, error) {
 				server,
 				healthManager,
 				dispatcher,
-				c.DispatchMaxDepth,
 				prefixRequiredOption,
 				v1SchemaServiceOption,
 				watchServiceOption,
+				permSysConfig,
 			)
 		},
 	)

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -50,6 +50,8 @@ func (c *Config) ToOption() ConfigOption {
 		to.DispatchCacheConfig = c.DispatchCacheConfig
 		to.ClusterDispatchCacheConfig = c.ClusterDispatchCacheConfig
 		to.DisableV1SchemaAPI = c.DisableV1SchemaAPI
+		to.MaximumUpdatesPerWrite = c.MaximumUpdatesPerWrite
+		to.MaximumPreconditionCount = c.MaximumPreconditionCount
 		to.DashboardAPI = c.DashboardAPI
 		to.MetricsAPI = c.MetricsAPI
 		to.UnaryMiddleware = c.UnaryMiddleware
@@ -257,6 +259,20 @@ func WithClusterDispatchCacheConfig(clusterDispatchCacheConfig CacheConfig) Conf
 func WithDisableV1SchemaAPI(disableV1SchemaAPI bool) ConfigOption {
 	return func(c *Config) {
 		c.DisableV1SchemaAPI = disableV1SchemaAPI
+	}
+}
+
+// WithMaximumUpdatesPerWrite returns an option that can set MaximumUpdatesPerWrite on a Config
+func WithMaximumUpdatesPerWrite(maximumUpdatesPerWrite uint16) ConfigOption {
+	return func(c *Config) {
+		c.MaximumUpdatesPerWrite = maximumUpdatesPerWrite
+	}
+}
+
+// WithMaximumPreconditionCount returns an option that can set MaximumPreconditionCount on a Config
+func WithMaximumPreconditionCount(maximumPreconditionCount uint16) ConfigOption {
+	return func(c *Config) {
+		c.MaximumPreconditionCount = maximumPreconditionCount
 	}
 }
 

--- a/pkg/cmd/testing.go
+++ b/pkg/cmd/testing.go
@@ -18,6 +18,10 @@ func RegisterTestingFlags(cmd *cobra.Command, config *testserver.Config) {
 	util.RegisterHTTPServerFlags(cmd.Flags(), &config.ReadOnlyHTTPGateway, "readonly-http", "read-only HTTP", ":8082", false)
 
 	cmd.Flags().StringSliceVar(&config.LoadConfigs, "load-configs", []string{}, "configuration yaml files to load")
+
+	// Flags for API behavior
+	cmd.Flags().Uint16Var(&config.MaximumUpdatesPerWrite, "write-relationships-max-updates-per-call", 1000, "maximum number of updates allowed for WriteRelationships calls")
+	cmd.Flags().Uint16Var(&config.MaximumPreconditionCount, "update-relationships-max-preconditions-per-call", 1000, "maximum number of preconditions allowed for WriteRelationships and DeleteRelationships calls")
 }
 
 func NewTestingCommand(programName string, config *testserver.Config) *cobra.Command {

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/authzed/spicedb/internal/middleware/servicespecific"
 	"github.com/authzed/spicedb/internal/services"
 	"github.com/authzed/spicedb/internal/services/health"
+	v1svc "github.com/authzed/spicedb/internal/services/v1"
 	v1alpha1svc "github.com/authzed/spicedb/internal/services/v1alpha1"
 	"github.com/authzed/spicedb/pkg/cmd/util"
 )
@@ -26,11 +27,13 @@ const maxDepth = 50
 
 //go:generate go run github.com/ecordell/optgen -output zz_generated.options.go . Config
 type Config struct {
-	GRPCServer          util.GRPCServerConfig
-	ReadOnlyGRPCServer  util.GRPCServerConfig
-	HTTPGateway         util.HTTPServerConfig
-	ReadOnlyHTTPGateway util.HTTPServerConfig
-	LoadConfigs         []string
+	GRPCServer               util.GRPCServerConfig
+	ReadOnlyGRPCServer       util.GRPCServerConfig
+	HTTPGateway              util.HTTPServerConfig
+	ReadOnlyHTTPGateway      util.HTTPServerConfig
+	LoadConfigs              []string
+	MaximumUpdatesPerWrite   uint16
+	MaximumPreconditionCount uint16
 }
 
 type RunnableTestServer interface {
@@ -57,10 +60,14 @@ func (c *Config) Complete() (RunnableTestServer, error) {
 			srv,
 			healthManager,
 			dispatcher,
-			maxDepth,
 			v1alpha1svc.PrefixNotRequired,
 			services.V1SchemaServiceEnabled,
 			services.WatchServiceEnabled,
+			v1svc.PermissionsServerConfig{
+				MaxPreconditionsCount: c.MaximumPreconditionCount,
+				MaxUpdatesPerWrite:    c.MaximumUpdatesPerWrite,
+				MaximumAPIDepth:       maxDepth,
+			},
 		)
 	}
 	gRPCSrv, err := c.GRPCServer.Complete(zerolog.InfoLevel, registerServices,

--- a/pkg/cmd/testserver/zz_generated.options.go
+++ b/pkg/cmd/testserver/zz_generated.options.go
@@ -22,6 +22,8 @@ func (c *Config) ToOption() ConfigOption {
 		to.HTTPGateway = c.HTTPGateway
 		to.ReadOnlyHTTPGateway = c.ReadOnlyHTTPGateway
 		to.LoadConfigs = c.LoadConfigs
+		to.MaximumUpdatesPerWrite = c.MaximumUpdatesPerWrite
+		to.MaximumPreconditionCount = c.MaximumPreconditionCount
 	}
 }
 
@@ -72,5 +74,19 @@ func WithLoadConfigs(loadConfigs string) ConfigOption {
 func SetLoadConfigs(loadConfigs []string) ConfigOption {
 	return func(c *Config) {
 		c.LoadConfigs = loadConfigs
+	}
+}
+
+// WithMaximumUpdatesPerWrite returns an option that can set MaximumUpdatesPerWrite on a Config
+func WithMaximumUpdatesPerWrite(maximumUpdatesPerWrite uint16) ConfigOption {
+	return func(c *Config) {
+		c.MaximumUpdatesPerWrite = maximumUpdatesPerWrite
+	}
+}
+
+// WithMaximumPreconditionCount returns an option that can set MaximumPreconditionCount on a Config
+func WithMaximumPreconditionCount(maximumPreconditionCount uint16) ConfigOption {
+	return func(c *Config) {
+		c.MaximumPreconditionCount = maximumPreconditionCount
 	}
 }


### PR DESCRIPTION
This sets a new (configurable) limit of 1000 updates and preconditions for WriteRelationships and DeleteRelationships