### PR TITLE
newly added lookup subject metrics weren't being unregistered

### DIFF
--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -462,6 +462,8 @@ func (cd *Dispatcher) Close() error {
 	prometheus.Unregister(cd.lookupFromCacheCounter)
 	prometheus.Unregister(cd.checkFromCacheCounter)
 	prometheus.Unregister(cd.reachableResourcesFromCacheCounter)
+	prometheus.Unregister(cd.lookupSubjectsFromCacheCounter)
+	prometheus.Unregister(cd.lookupSubjectsTotalCounter)
 	prometheus.Unregister(cd.cacheHits)
 	prometheus.Unregister(cd.cacheMisses)
 	prometheus.Unregister(cd.costAddedBytes)


### PR DESCRIPTION
fixes bug introduced in https://github.com/authzed/spicedb/pull/736

This makes the caching dispatcher to unregister newly added metrics. It caused some of our internal tests to fail with duplicate metrics being registered