### PR TITLE
Handle duplicate writes in a nicer way

### DIFF
--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -453,6 +453,16 @@ func TestInvalidWriteRelationshipArgs(t *testing.T) {
 			codes.InvalidArgument,
 			"wildcard",
 		},
+		{
+			"duplicate relationship",
+			nil,
+			[]*v1.Relationship{
+				rel("document", "somedoc", "parent", "user", "tom", ""),
+				rel("document", "somedoc", "parent", "user", "tom", ""),
+			},
+			codes.InvalidArgument,
+			"duplicate",
+		},
 	}
 
 	for _, delta := range testTimedeltas {

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -8,6 +8,7 @@ import (
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
 	"github.com/authzed/spicedb/internal/datastore/options"
+	"github.com/authzed/spicedb/internal/util"
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -129,9 +130,16 @@ func (vrwt validatingReadWriteTransaction) WriteRelationships(mutations []*core.
 	if err := validateUpdatesToWrite(mutations...); err != nil {
 		return err
 	}
+
+	// Ensure there are no duplicate mutations.
+	tupleSet := util.NewSet[string]()
 	for _, mutation := range mutations {
 		if err := mutation.Validate(); err != nil {
 			return err
+		}
+
+		if !tupleSet.Add(tuple.String(mutation.Tuple)) {
+			return fmt.Errorf("found duplicate update for relationship %s", tuple.String(mutation.Tuple))
 		}
 	}
 

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -40,6 +40,8 @@ func All(t *testing.T, tester DatastoreTester) {
 	t.Run("TestSimple", func(t *testing.T) { SimpleTest(t, tester) })
 	t.Run("TestDeleteRelationships", func(t *testing.T) { DeleteRelationshipsTest(t, tester) })
 	t.Run("TestInvalidReads", func(t *testing.T) { InvalidReadsTest(t, tester) })
+	t.Run("TestDeleteNonExistant", func(t *testing.T) { DeleteNotExistantTest(t, tester) })
+	t.Run("TestDeleteAlreadyDeleted", func(t *testing.T) { DeleteAlreadyDeletedTest(t, tester) })
 	t.Run("TestUsersets", func(t *testing.T) { UsersetsTest(t, tester) })
 	t.Run("TestMultipleReadsInRWT", func(t *testing.T) { MultipleReadsInRWTTest(t, tester) })
 	t.Run("TestConcurrentWriteSerialization", func(t *testing.T) { ConcurrentWriteSerializationTest(t, tester) })


### PR DESCRIPTION
SpiceDB will now raise an error if a `WriteRelationships` call contains the same relationship more than once. This PR also validates that this cannot occur during testing, and adds some additional datastore tests around delete and write operations