### PR TITLE
reduce differences between release and dev dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@ FROM golang:1.19-alpine3.16 AS spicedb-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 COPY . .
-RUN go build -v ./cmd/spicedb/
+RUN echo 'hosts: files dns' > /tmp/nsswitch.conf
+RUN CGO_ENABLED=0 go build -v ./cmd/spicedb/
 
-FROM alpine:3.16.2
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.6 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
+FROM distroless.dev/static
+COPY --from=spicedb-builder /tmp/nsswitch.conf /etc/nsswitch.conf
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.12 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY --from=spicedb-builder /go/src/app/spicedb /usr/local/bin/spicedb
 ENTRYPOINT ["spicedb"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,6 +3,6 @@
 ARG BASE=distroless.dev/static
 FROM $BASE
 
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.6 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.12 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY spicedb /usr/local/bin/spicedb
 ENTRYPOINT ["spicedb"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,6 +3,7 @@
 ARG BASE=distroless.dev/static
 FROM $BASE
 
+COPY --from=gcr.io/distroless/static-debian11 /etc/nsswitch.conf /etc/nsswitch.conf
 COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.12 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY spicedb /usr/local/bin/spicedb
 ENTRYPOINT ["spicedb"]


### PR DESCRIPTION
use `distroless.dev/static` like `Dockerfile.release`, to reduce differences between release and dev

- `CGO_ENABLED=0` is added as it's how the binary that ends up in `Dockerfile.release` ends up, but also needed for `distroless.dev/static` as it does not include musl/glibc
- also updates health probe to latest version
- `nsswitch.conf` is not included in the base image, so it's kept it needs to be built outside as there is not shell in static

Dive reports `Image efficiency score: 100 %` 