### PR TITLE
map pgx info logging level to debug

### DIFF
--- a/internal/datastore/crdb/migrations/driver.go
+++ b/internal/datastore/crdb/migrations/driver.go
@@ -7,9 +7,8 @@ import (
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/log/zerologadapter"
-	"github.com/rs/zerolog/log"
 
+	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
 	"github.com/authzed/spicedb/pkg/migrate"
 )
 
@@ -35,8 +34,7 @@ func NewCRDBDriver(url string) (*CRDBDriver, error) {
 	if err != nil {
 		return nil, fmt.Errorf(errUnableToInstantiate, err)
 	}
-
-	connConfig.Logger = zerologadapter.NewLogger(log.Logger)
+	pgxcommon.ConfigurePGXLogger(connConfig)
 
 	db, err := pgx.ConnectConfig(context.Background(), connConfig)
 	if err != nil {


### PR DESCRIPTION
This PR reduces noise in SpiceDB's logs for PostgreSQL / CRDB datastores, and reduces performance overhead caused by the logging of very large statements, like for example `WriteRelationships` of thousands of elements. We observed the server would sometimes fail with `context deadline exceeded` when PGX statement logging was enabled.

It does it by turning every pgx `info` event into a `debug` event.

<img width="1503" alt="Screenshot 2022-09-05 at 18 03 04" src="https://user-images.githubusercontent.com/6774726/188499786-2d37b51e-fac1-4afc-9835-723e223ad40e.png">
<img width="1505" alt="Screenshot 2022-09-05 at 18 03 17" src="https://user-images.githubusercontent.com/6774726/188499857-b7f223cc-5999-4322-bd0b-7cac091d3f8b.png">