### PR TITLE
remove dupe validation in WriteRelationships

### DIFF
--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -192,7 +192,7 @@ func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.Writ
 	// Check for duplicate updates.
 	updateRelationshipSet := util.NewSet[string]()
 	for _, update := range req.Updates {
-		tupleStr := tuple.MustRelString(update.Relationship)
+		tupleStr := tuple.StringRelationship(update.Relationship)
 		if !updateRelationshipSet.Add(tupleStr) {
 			return nil, rewritePermissionsError(
 				ctx,

--- a/pkg/tuple/onr.go
+++ b/pkg/tuple/onr.go
@@ -3,9 +3,7 @@ package tuple
 import (
 	"fmt"
 	"sort"
-	"strings"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/jzelinskie/stringz"
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -95,19 +93,4 @@ func StringsONRs(onrs []*core.ObjectAndRelation) []string {
 
 	sort.Strings(onrstrings)
 	return onrstrings
-}
-
-// StringObjectRef marshals a *v1.ObjectReference into a string.
-func StringObjectRef(ref *v1.ObjectReference) string {
-	return ref.ObjectType + ":" + ref.ObjectId
-}
-
-// StringSubjectRef marshals a *v1.SubjectReference into a string.
-func StringSubjectRef(ref *v1.SubjectReference) string {
-	var b strings.Builder
-	b.WriteString(ref.Object.ObjectType + ":" + ref.Object.ObjectId)
-	if ref.OptionalRelation != "" {
-		b.WriteString("#" + ref.OptionalRelation)
-	}
-	return b.String()
 }

--- a/pkg/tuple/relationship.go
+++ b/pkg/tuple/relationship.go
@@ -1,0 +1,26 @@
+package tuple
+
+import (
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+)
+
+// StringObjectRef marshals a *v1.ObjectReference into a string.
+func StringObjectRef(ref *v1.ObjectReference) string {
+	return ref.ObjectType + ":" + ref.ObjectId
+}
+
+// StringSubjectRef marshals a *v1.SubjectReference into a string.
+func StringSubjectRef(ref *v1.SubjectReference) string {
+	if ref.OptionalRelation != "" {
+		return ref.Object.ObjectType + ":" + ref.Object.ObjectId + "#" + ref.OptionalRelation
+	}
+	return ref.Object.ObjectType + ":" + ref.Object.ObjectId
+}
+
+// StringRelationship converts a v1.Relationship to a string.
+func StringRelationship(rel *v1.Relationship) string {
+	if rel == nil || rel.Resource == nil || rel.Subject == nil {
+		return ""
+	}
+	return StringObjectRef(rel.Resource) + "#" + rel.Relation + "@" + StringSubjectRef(rel.Subject)
+}

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -84,8 +84,11 @@ func String(tpl *core.RelationTuple) string {
 
 // MustRelString converts a relationship into a string.  Will panic if
 // the Relationship does not validate.
-func MustRelString(tpl *v1.Relationship) string {
-	return String(MustFromRelationship(tpl))
+func MustRelString(rel *v1.Relationship) string {
+	if err := rel.Validate(); err != nil {
+		panic(fmt.Sprintf("invalid relationship: %#v %s", rel, err))
+	}
+	return StringRelationship(rel)
 }
 
 // MustParse wraps Parse such that any failures panic rather than returning


### PR DESCRIPTION
I noticed in flamegraphs that validation was taking a chunk of the request time on large WriteRelationshipsRequest payloads, and that it was happening two times:
- one through the validation middleware
- one in `permissionServer.WriteRelationships` to detect dupes

<img width="1486" alt="Screenshot 2022-09-05 at 17 56 10" src="https://user-images.githubusercontent.com/6774726/188628170-d1011580-113b-43fc-b09a-c23a54476cb7.png">

This was a regression from https://github.com/authzed/spicedb/pull/796

The commit improves the performance in various ways:
- removes the duplicated validation
- reduces CPU time to generate a v1.Relationship string in 85%
- reduces allocations to generate a v1.Relationship string in 100% (no allocations)

Output from `benchstat` from the new `StringRelationship` function. FWIW this is not going to have a dramatic impact on the request path, but given I was removing the duped validation, I decided to have a closer look for any low hanging fruit.

```
name                   old time/op    new time/op    delta
StringRelationship-16     516ns ± 2%      77ns ± 2%   -85.08%  (p=0.008 n=5+5)

name                   old alloc/op   new alloc/op   delta
StringRelationship-16      192B ± 0%        0B       -100.00%  (p=0.008 n=5+5)

name                   old allocs/op  new allocs/op  delta
StringRelationship-16      11.0 ± 0%       0.0       -100.00%  (p=0.008 n=5+5)
```

## Bonus: disable server logging during test

I also disabled server logs during tests in  https://github.com/authzed/spicedb/commit/62f1401a0075db3beceffcf3f4337916a986b643
Makes tests slightly faster with `-json` and with a less cluttered output