### PR TITLE
Add an error case for redefining a type in schema

### DIFF
--- a/internal/services/v1/schema_test.go
+++ b/internal/services/v1/schema_test.go
@@ -379,3 +379,17 @@ func TestSchemaEmpty(t *testing.T) {
 	_, err = client.ReadSchema(context.Background(), &v1.ReadSchemaRequest{})
 	grpcutil.RequireStatus(t, codes.NotFound, err)
 }
+
+func TestSchemaTypeRedefined(t *testing.T) {
+	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
+	t.Cleanup(cleanup)
+	client := v1.NewSchemaServiceClient(conn)
+
+	// Write a schema that redefines the same type.
+	_, err := client.WriteSchema(context.Background(), &v1.WriteSchemaRequest{
+		Schema: `definition example/user {}
+	
+		definition example/user {}`,
+	})
+	grpcutil.RequireStatus(t, codes.InvalidArgument, err)
+}

--- a/internal/services/v1alpha1/schema_test.go
+++ b/internal/services/v1alpha1/schema_test.go
@@ -284,3 +284,17 @@ func TestSchemaReadDeleteAndFailWrite(t *testing.T) {
 	})
 	grpcutil.RequireStatus(t, codes.NotFound, err)
 }
+
+func TestSchemaTypeRedefined(t *testing.T) {
+	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, false, testfixtures.EmptyDatastore)
+	t.Cleanup(cleanup)
+	client := v1alpha1.NewSchemaServiceClient(conn)
+
+	// Write a schema that redefines the same type.
+	_, err := client.WriteSchema(context.Background(), &v1alpha1.WriteSchemaRequest{
+		Schema: `definition example/user {}
+	
+		definition example/user {}`,
+	})
+	grpcutil.RequireStatus(t, codes.InvalidArgument, err)
+}

--- a/pkg/schemadsl/compiler/compiler_test.go
+++ b/pkg/schemadsl/compiler/compiler_test.go
@@ -505,6 +505,14 @@ func TestCompile(t *testing.T) {
 				),
 			},
 		},
+		{
+			"duplicate definition",
+			&someTenant,
+			`definition foo {}
+			definition foo {}`,
+			"parse error in `duplicate definition`, line 2, column 4: duplicate definition: sometenant/foo",
+			[]*core.NamespaceDefinition{},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/schemadsl/compiler/translator.go
+++ b/pkg/schemadsl/compiler/translator.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/authzed/spicedb/internal/util"
+
 	"github.com/jzelinskie/stringz"
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -40,10 +42,16 @@ const Ellipsis = "..."
 
 func translate(tctx translationContext, root *dslNode) ([]*core.NamespaceDefinition, error) {
 	definitions := []*core.NamespaceDefinition{}
+	names := util.NewSet[string]()
+
 	for _, definitionNode := range root.GetChildren() {
 		definition, err := translateDefinition(tctx, definitionNode)
 		if err != nil {
 			return []*core.NamespaceDefinition{}, err
+		}
+
+		if !names.Add(definition.Name) {
+			return nil, definitionNode.Errorf("duplicate definition: %s", definition.Name)
 		}
 
 		definitions = append(definitions, definition)


### PR DESCRIPTION
This will now be raised as an error, and schema prevented from writing