### PR TITLE
Disable GC in datastore drivers when in read-only mode

### DIFF
--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -204,7 +204,7 @@ func NewMySQLDatastore(uri string, options ...Option) (*Datastore, error) {
 	}
 
 	// Start a goroutine for garbage collection.
-	if store.gcInterval > 0*time.Minute {
+	if store.gcInterval > 0*time.Minute && config.gcEnabled {
 		store.gcGroup, store.gcCtx = errgroup.WithContext(store.gcCtx)
 		store.gcGroup.Go(func() error {
 			return common.StartGarbageCollector(

--- a/internal/datastore/mysql/options.go
+++ b/internal/datastore/mysql/options.go
@@ -20,6 +20,7 @@ const (
 	defaultMaxRevisionStalenessPercent       = 0.1
 	defaultEnablePrometheusStats             = false
 	defaultMaxRetries                        = 8
+	defaultGCEnabled                         = true
 )
 
 type mysqlOptions struct {
@@ -38,6 +39,7 @@ type mysqlOptions struct {
 	analyzeBeforeStats          bool
 	maxRetries                  uint8
 	lockWaitTimeoutSeconds      *uint8
+	gcEnabled                   bool
 }
 
 // Option provides the facility to configure how clients within the
@@ -58,6 +60,7 @@ func generateConfig(options []Option) (mysqlOptions, error) {
 		maxRevisionStalenessPercent: defaultMaxRevisionStalenessPercent,
 		enablePrometheusStats:       defaultEnablePrometheusStats,
 		maxRetries:                  defaultMaxRetries,
+		gcEnabled:                   defaultGCEnabled,
 	}
 
 	for _, option := range options {
@@ -205,5 +208,14 @@ func DebugAnalyzeBeforeStatistics() Option {
 func OverrideLockWaitTimeout(seconds uint8) Option {
 	return func(po *mysqlOptions) {
 		po.lockWaitTimeoutSeconds = &seconds
+	}
+}
+
+// GCEnabled indicates whether garbage collection is enabled.
+//
+// GC is enabled by default.
+func GCEnabled(isGCEnabled bool) Option {
+	return func(po *mysqlOptions) {
+		po.gcEnabled = isGCEnabled
 	}
 }

--- a/internal/datastore/postgres/options.go
+++ b/internal/datastore/postgres/options.go
@@ -23,6 +23,7 @@ type postgresOptions struct {
 
 	enablePrometheusStats   bool
 	analyzeBeforeStatistics bool
+	gcEnabled               bool
 
 	logger *tracingLogger
 }
@@ -39,6 +40,7 @@ const (
 	defaultMaxRevisionStalenessPercent       = 0.1
 	defaultEnablePrometheusStats             = false
 	defaultMaxRetries                        = 10
+	defaultGCEnabled                         = true
 )
 
 // Option provides the facility to configure how clients within the
@@ -56,6 +58,7 @@ func generateConfig(options []Option) (postgresOptions, error) {
 		maxRevisionStalenessPercent: defaultMaxRevisionStalenessPercent,
 		enablePrometheusStats:       defaultEnablePrometheusStats,
 		maxRetries:                  defaultMaxRetries,
+		gcEnabled:                   defaultGCEnabled,
 	}
 
 	for _, option := range options {
@@ -218,6 +221,15 @@ func WithEnablePrometheusStats(enablePrometheusStats bool) Option {
 func EnableTracing() Option {
 	return func(po *postgresOptions) {
 		po.logger = &tracingLogger{}
+	}
+}
+
+// GCEnabled indicates whether garbage collection is enabled.
+//
+// GC is enabled by default.
+func GCEnabled(isGCEnabled bool) Option {
+	return func(po *postgresOptions) {
+		po.gcEnabled = isGCEnabled
 	}
 }
 

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -167,7 +167,7 @@ func NewPostgresDatastore(
 	datastore.SetOptimizedRevisionFunc(datastore.optimizedRevisionFunc)
 
 	// Start a goroutine for garbage collection.
-	if datastore.gcInterval > 0*time.Minute {
+	if datastore.gcInterval > 0*time.Minute && config.gcEnabled {
 		datastore.gcGroup, datastore.gcCtx = errgroup.WithContext(datastore.gcCtx)
 		datastore.gcGroup.Go(func() error {
 			return common.StartGarbageCollector(

--- a/internal/datastore/spanner/options.go
+++ b/internal/datastore/spanner/options.go
@@ -12,6 +12,7 @@ type spannerOptions struct {
 	maxRevisionStalenessPercent float64
 	gcWindow                    time.Duration
 	gcInterval                  time.Duration
+	gcEnabled                   bool
 	credentialsFilePath         string
 	emulatorHost                string
 }
@@ -25,6 +26,7 @@ const (
 	defaultWatchBufferLength           = 128
 	defaultGCWindow                    = 60 * time.Minute
 	defaultGCInterval                  = 3 * time.Minute
+	defaultGCEnabled                   = true
 )
 
 // Option provides the facility to configure how clients within the Spanner
@@ -35,6 +37,7 @@ func generateConfig(options []Option) (spannerOptions, error) {
 	computed := spannerOptions{
 		gcWindow:                    defaultGCWindow,
 		gcInterval:                  defaultGCInterval,
+		gcEnabled:                   defaultGCEnabled,
 		watchBufferLength:           defaultWatchBufferLength,
 		revisionQuantization:        defaultRevisionQuantization,
 		followerReadDelay:           defaultFollowerReadDelay,
@@ -129,5 +132,14 @@ func CredentialsFile(path string) Option {
 func EmulatorHost(uri string) Option {
 	return func(so *spannerOptions) {
 		so.emulatorHost = uri
+	}
+}
+
+// GCEnabled indicates whether garbage collection is enabled.
+//
+// GC is enabled by default.
+func GCEnabled(isGCEnabled bool) Option {
+	return func(so *spannerOptions) {
+		so.gcEnabled = isGCEnabled
 	}
 }

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -240,6 +240,7 @@ func newCRDBDatastore(opts Config) (datastore.Datastore, error) {
 func newPostgresDatastore(opts Config) (datastore.Datastore, error) {
 	pgOpts := []postgres.Option{
 		postgres.GCWindow(opts.GCWindow),
+		postgres.GCEnabled(!opts.ReadOnly),
 		postgres.RevisionQuantization(opts.RevisionQuantization),
 		postgres.ConnMaxIdleTime(opts.MaxIdleTime),
 		postgres.ConnMaxLifetime(opts.MaxLifetime),
@@ -263,6 +264,7 @@ func newSpannerDatastore(opts Config) (datastore.Datastore, error) {
 		spanner.FollowerReadDelay(opts.FollowerReadDelay),
 		spanner.GCInterval(opts.GCInterval),
 		spanner.GCWindow(opts.GCWindow),
+		spanner.GCEnabled(!opts.ReadOnly),
 		spanner.CredentialsFile(opts.SpannerCredentialsFile),
 		spanner.WatchBufferLength(opts.WatchBufferLength),
 		spanner.EmulatorHost(opts.SpannerEmulatorHost),
@@ -274,6 +276,7 @@ func newMySQLDatastore(opts Config) (datastore.Datastore, error) {
 		mysql.GCInterval(opts.GCInterval),
 		mysql.GCWindow(opts.GCWindow),
 		mysql.GCInterval(opts.GCInterval),
+		mysql.GCEnabled(!opts.ReadOnly),
 		mysql.ConnMaxIdleTime(opts.MaxIdleTime),
 		mysql.ConnMaxLifetime(opts.MaxLifetime),
 		mysql.MaxOpenConns(opts.MaxOpenConns),


### PR DESCRIPTION
Fixes #738