### PR TITLE
don't generate nsswitch.conf (base images have it now)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@ FROM golang:1.19-alpine3.16 AS spicedb-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 COPY . .
-RUN echo 'hosts: files dns' > /tmp/nsswitch.conf
 RUN CGO_ENABLED=0 go build -v ./cmd/spicedb/
 
 FROM distroless.dev/static
-COPY --from=spicedb-builder /tmp/nsswitch.conf /etc/nsswitch.conf
 COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.12 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY --from=spicedb-builder /go/src/app/spicedb /usr/local/bin/spicedb
 ENTRYPOINT ["spicedb"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,7 +3,6 @@
 ARG BASE=distroless.dev/static
 FROM $BASE
 
-COPY --from=gcr.io/distroless/static-debian11 /etc/nsswitch.conf /etc/nsswitch.conf
 COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.12 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY spicedb /usr/local/bin/spicedb
 ENTRYPOINT ["spicedb"]


### PR DESCRIPTION
The base images have `nsswitch.conf` now - checked using https://github.com/exdx/dcp 

```sh
$ dcp distroless.dev/static -c /etc/nsswitch.conf
 DEBUG dcp::image > 📦 Searching for image distroless.dev/static locally
 DEBUG dcp        > 🔧 PullStatus { status: "Pulling from static", id: Some("latest"), progress: None, progress_detail: None }
 DEBUG dcp        > 🔧 PullStatus { status: "Digest: sha256:477c99033800e7d30a02e3a293b58eb731f19a48f63d195bf6a06e07a6b00e1a", id: None, progress: None, progress_detail: None }
 DEBUG dcp        > 🔧 PullStatus { status: "Status: Image is up to date for distroless.dev/static:latest", id: None, progress: None, progress_detail: None }
 DEBUG dcp        > 📦 Created container with id: "e68bcd494296ee4ec0dcbb69f65da8fd269da504c1ce0643d6c257a611b92316"
 INFO  dcp        > ✅ Copied content to . successfully
 DEBUG dcp        > 📦 Cleaned up container "e68bcd494296ee4ec0dcbb69f65da8fd269da504c1ce0643d6c257a611b92316" successfully
$ cat nsswitch.conf
# musl itself does not support NSS, however some third-party DNS
# implementations use the nsswitch.conf file to determine what
# policy to follow.
# Editing this file is not recommended.
hosts: files dns
```