### PR TITLE
Ensure that internal errors are returned before dev errors

### DIFF
--- a/pkg/development/development_test.go
+++ b/pkg/development/development_test.go
@@ -41,3 +41,31 @@ definition document {
 	require.NoError(t, err)
 	require.Nil(t, adErrs)
 }
+
+func TestDevelopmentInvalidRelationship(t *testing.T) {
+	_, _, err := NewDevContext(context.Background(), &devinterface.RequestContext{
+		Schema: `definition user {}
+
+definition document {
+	relation viewer: user
+}
+`,
+		Relationships: []*core.RelationTuple{
+			{
+				ResourceAndRelation: &core.ObjectAndRelation{
+					Namespace: "document",
+					ObjectId:  "*",
+					Relation:  "view",
+				},
+				Subject: &core.ObjectAndRelation{
+					Namespace: "user",
+					ObjectId:  "tom",
+					Relation:  "...",
+				},
+			},
+		},
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid resource id")
+}

--- a/pkg/development/wasm/main.go
+++ b/pkg/development/wasm/main.go
@@ -62,12 +62,12 @@ func runDevelopmentOperations(this js.Value, args []js.Value) interface{} {
 	}
 
 	devContext, devErrors, err := newDevContextFromJSON(args[0].String())
-	if devErrors != nil {
-		return derr(devErrors)
-	}
-
 	if err != nil {
 		return rerr(err.Error())
+	}
+
+	if devErrors != nil && (len(devErrors.InputErrors) > 0 || len(devErrors.ValidationErrors) > 0) {
+		return derr(devErrors)
 	}
 
 	for index := 0; index < args[1].Length(); index++ {


### PR DESCRIPTION
Fixes an issue with invalid relationships not showing an error in the playground