### PR TITLE
internal/datastore: use proto.Marshal

### DIFF
--- a/internal/datastore/crdb/readwrite.go
+++ b/internal/datastore/crdb/readwrite.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/attribute"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/authzed/spicedb/internal/datastore/common"
 	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
@@ -228,7 +229,7 @@ func (rwt *crdbReadWriteTXN) WriteNamespaces(newConfigs ...*core.NamespaceDefini
 	for _, newConfig := range newConfigs {
 		rwt.addOverlapKey(newConfig.Name)
 
-		serialized, err := newConfig.MarshalVT()
+		serialized, err := proto.Marshal(newConfig)
 		if err != nil {
 			return fmt.Errorf(errUnableToWriteConfig, err)
 		}

--- a/internal/datastore/memdb/readwrite.go
+++ b/internal/datastore/memdb/readwrite.go
@@ -6,6 +6,7 @@ import (
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/hashicorp/go-memdb"
 	"github.com/jzelinskie/stringz"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/pkg/datastore"
@@ -126,7 +127,7 @@ func (rwt *memdbReadWriteTx) WriteNamespaces(newConfigs ...*core.NamespaceDefini
 	}
 
 	for _, newConfig := range newConfigs {
-		serialized, err := newConfig.MarshalVT()
+		serialized, err := proto.Marshal(newConfig)
 		if err != nil {
 			return err
 		}

--- a/internal/datastore/mysql/readwrite.go
+++ b/internal/datastore/mysql/readwrite.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jzelinskie/stringz"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/internal/datastore/mysql/migrations"
@@ -194,7 +195,7 @@ func (rwt *mysqlReadWriteTXN) WriteNamespaces(newNamespaces ...*core.NamespaceDe
 
 	writtenNamespaceNames := make([]string, 0, len(newNamespaces))
 	for _, newNamespace := range newNamespaces {
-		serialized, err := newNamespace.MarshalVT()
+		serialized, err := proto.Marshal(newNamespace)
 		if err != nil {
 			return fmt.Errorf(errUnableToWriteConfig, err)
 		}

--- a/internal/datastore/postgres/readwrite.go
+++ b/internal/datastore/postgres/readwrite.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/jzelinskie/stringz"
 	"go.opentelemetry.io/otel/attribute"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/authzed/spicedb/internal/datastore/common"
 	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
@@ -172,7 +173,7 @@ func (rwt *pgReadWriteTXN) WriteNamespaces(newConfigs ...*core.NamespaceDefiniti
 
 	writtenNamespaceNames := make([]string, 0, len(newConfigs))
 	for _, newNamespace := range newConfigs {
-		serialized, err := newNamespace.MarshalVT()
+		serialized, err := proto.Marshal(newNamespace)
 		if err != nil {
 			return fmt.Errorf(errUnableToWriteConfig, err)
 		}

--- a/internal/datastore/spanner/readwrite.go
+++ b/internal/datastore/spanner/readwrite.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -207,7 +208,7 @@ func (rwt spannerReadWriteTXN) WriteNamespaces(newConfigs ...*core.NamespaceDefi
 
 	mutations := make([]*spanner.Mutation, 0, len(newConfigs))
 	for _, newConfig := range newConfigs {
-		serialized, err := newConfig.MarshalVT()
+		serialized, err := proto.Marshal(newConfig)
 		if err != nil {
 			return fmt.Errorf(errUnableToWriteConfig, err)
 		}


### PR DESCRIPTION
MarshalVT does not handle empty fields the same.

The following marshals two different ways:

&pb.AllowedRelation{
  RelationOrWildcard: &pb.AllowedRelation_PublicWildcard_{},
}

protobuf: []byte{0x22, 0x0}
vtprotobuf: []byte{}