### PR TITLE
Add a test for writing and reading back a serialized namespace in the datastores

### DIFF
--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -36,6 +36,7 @@ func All(t *testing.T, tester DatastoreTester) {
 	t.Run("TestNamespaceWrite", func(t *testing.T) { NamespaceWriteTest(t, tester) })
 	t.Run("TestNamespaceDelete", func(t *testing.T) { NamespaceDeleteTest(t, tester) })
 	t.Run("TestEmptyNamespaceDelete", func(t *testing.T) { EmptyNamespaceDeleteTest(t, tester) })
+	t.Run("TestStableNamespaceReadWrite", func(t *testing.T) { StableNamespaceReadWriteTest(t, tester) })
 
 	t.Run("TestSimple", func(t *testing.T) { SimpleTest(t, tester) })
 	t.Run("TestDeleteRelationships", func(t *testing.T) { DeleteRelationshipsTest(t, tester) })


### PR DESCRIPTION
This test ensures that the marshal and unmarshal code work together properly for namespaces across all datastores

This is important because we store the namespaces as serialized proto bytes in the datastore namespace tables