### PR TITLE
pkg/cmd: support cache sizes in percentages of free memory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/mostynb/go-grpc-compression v1.1.17
 	github.com/ngrok/sqlmw v0.0.0-20211220175533-9d16fdc47b31
 	github.com/ory/dockertest/v3 v3.9.1
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/planetscale/vtprotobuf v0.3.1-0.20220817155510-0ae748fd2007
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -591,6 +591,8 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/ory/dockertest/v3 v3.9.1 h1:v4dkG+dlu76goxMiTT2j8zV7s4oPPEppKT8K8p2f1kY=
 github.com/ory/dockertest/v3 v3.9.1/go.mod h1:42Ir9hmvaAPm0Mgibk6mBPi7SFvTXxEcnztDYOJ//uM=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=

--- a/internal/datastore/proxy/caching.go
+++ b/internal/datastore/proxy/caching.go
@@ -24,9 +24,9 @@ func NewCachingDatastoreProxy(
 ) (datastore.Datastore, error) {
 	if cacheConfig == nil {
 		cacheConfig = &cache.Config{
-			NumCounters: 1e4,     // number of keys to track frequency of (10k).
-			MaxCost:     1 << 24, // maximum cost of cache (16MB).
-			BufferItems: 64,      // number of keys per Get buffer.
+			NumCounters: 10_000,               // number of samples to track frequency
+			MaxCost:     16 * humanize.MiByte, // upper bound for the cache size
+			BufferItems: 64,                   // constant recommended by ristretto
 		}
 	} else {
 		log.Info().Int64("numCounters", cacheConfig.NumCounters).Str("maxCost", humanize.Bytes(uint64(cacheConfig.MaxCost))).Msg("configured caching namespace manager")

--- a/internal/datastore/proxy/caching.go
+++ b/internal/datastore/proxy/caching.go
@@ -4,14 +4,27 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"testing"
 
+	"github.com/dustin/go-humanize"
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/authzed/spicedb/pkg/cache"
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
+
+// DatastoreProxyTestCache returns a cache used for testing.
+func DatastoreProxyTestCache(t testing.TB) cache.Cache {
+	cache, err := cache.NewCache(&cache.Config{
+		NumCounters: 1000,
+		MaxCost:     1 * humanize.MiByte,
+	})
+	require.Nil(t, err)
+	return cache
+}
 
 // NewCachingDatastoreProxy creates a new datastore proxy which caches namespace definitions that
 // are loaded at specific datastore revisions.

--- a/internal/datastore/proxy/caching_test.go
+++ b/internal/datastore/proxy/caching_test.go
@@ -5,13 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/authzed/spicedb/internal/datastore/proxy/proxy_test"
-	"github.com/authzed/spicedb/pkg/cache"
 	"github.com/authzed/spicedb/pkg/datastore"
 )
 
@@ -43,13 +41,7 @@ func TestSnapshotNamespaceCaching(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 
-	cache, err := cache.NewCache(&cache.Config{
-		NumCounters: 1000,
-		MaxCost:     1 * humanize.MiByte,
-	})
-	require.Nil(err)
-
-	ds := NewCachingDatastoreProxy(dsMock, cache)
+	ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
 
 	_, updatedOneA, err := ds.SnapshotReader(one).ReadNamespace(ctx, nsA)
 	require.NoError(err)

--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"testing"
 
+	"github.com/dustin/go-humanize"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
 
 	"github.com/authzed/spicedb/internal/dispatch"
 	"github.com/authzed/spicedb/internal/dispatch/keys"
@@ -55,6 +58,16 @@ type reachableResourcesResultEntry struct {
 
 type lookupSubjectsResultEntry struct {
 	responses []*v1.DispatchLookupSubjectsResponse
+}
+
+func DispatchTestCache(t testing.TB) cache.Cache {
+	cache, err := cache.NewCache(&cache.Config{
+		NumCounters: 1000,
+		MaxCost:     1 * humanize.MiByte,
+		Metrics:     true,
+	})
+	require.Nil(t, err)
+	return cache
 }
 
 // NewCachingDispatcher creates a new dispatch.Dispatcher which delegates

--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/dustin/go-humanize"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 
@@ -58,33 +57,11 @@ type lookupSubjectsResultEntry struct {
 	responses []*v1.DispatchLookupSubjectsResponse
 }
 
-// NewCachingDispatcher creates a new dispatch.Dispatcher which delegates dispatch requests
-// and caches the responses when possible and desirable.
-func NewCachingDispatcher(
-	cacheConfig *cache.Config,
-	prometheusSubsystem string,
-	keyHandler keys.Handler,
-) (*Dispatcher, error) {
-	if cacheConfig == nil {
-		cacheConfig = &cache.Config{
-			NumCounters: 1e4,     // number of keys to track frequency of (10k).
-			MaxCost:     1 << 24, // maximum cost of cache (16MB).
-			BufferItems: 64,      // number of keys per Get buffer.
-			Metrics:     true,    // collect metrics.
-		}
-	} else {
-		log.Info().Int64("numCounters", cacheConfig.NumCounters).Str("maxCost", humanize.Bytes(uint64(cacheConfig.MaxCost))).Msg("configured caching dispatcher")
-	}
-
-	var cacheInst cache.Cache
-	if cacheConfig.Disabled {
+// NewCachingDispatcher creates a new dispatch.Dispatcher which delegates
+// dispatch requests and caches the responses when possible and desirable.
+func NewCachingDispatcher(cacheInst cache.Cache, prometheusSubsystem string, keyHandler keys.Handler) (*Dispatcher, error) {
+	if cacheInst == nil {
 		cacheInst = cache.NoopCache()
-	} else {
-		c, err := cache.NewCache(cacheConfig)
-		if err != nil {
-			return nil, fmt.Errorf(errCachingInitialization, err)
-		}
-		cacheInst = c
 	}
 
 	checkTotalCounter := prometheus.NewCounter(prometheus.CounterOpts{

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -116,7 +116,7 @@ func TestMaxDepthCaching(t *testing.T) {
 				}
 			}
 
-			dispatch, err := NewCachingDispatcher(nil, "", nil)
+			dispatch, err := NewCachingDispatcher(DispatchTestCache(t), "", nil)
 			dispatch.SetDelegate(delegate)
 			require.NoError(err)
 			defer dispatch.Close()

--- a/internal/dispatch/cluster/cluster.go
+++ b/internal/dispatch/cluster/cluster.go
@@ -15,7 +15,7 @@ type Option func(*optionState)
 
 type optionState struct {
 	prometheusSubsystem string
-	cacheConfig         *cache.Config
+	cache               cache.Cache
 	concurrencyLimit    uint16
 }
 
@@ -26,10 +26,10 @@ func PrometheusSubsystem(name string) Option {
 	}
 }
 
-// CacheConfig sets the configuration for the local dispatcher's cache.
-func CacheConfig(config *cache.Config) Option {
+// Cache sets the cache for the remote dispatcher.
+func Cache(c cache.Cache) Option {
 	return func(state *optionState) {
-		state.cacheConfig = config
+		state.cache = c
 	}
 }
 
@@ -60,7 +60,7 @@ func NewClusterDispatcher(dispatch dispatch.Dispatcher, options ...Option) (disp
 		opts.prometheusSubsystem = "dispatch"
 	}
 
-	cachingClusterDispatch, err := caching.NewCachingDispatcher(opts.cacheConfig, opts.prometheusSubsystem, &keys.CanonicalKeyHandler{})
+	cachingClusterDispatch, err := caching.NewCachingDispatcher(opts.cache, opts.prometheusSubsystem, &keys.CanonicalKeyHandler{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dispatch/combined/combined.go
+++ b/internal/dispatch/combined/combined.go
@@ -30,7 +30,7 @@ type optionState struct {
 	upstreamCAPath      string
 	grpcPresharedKey    string
 	grpcDialOpts        []grpc.DialOption
-	cacheConfig         *cache.Config
+	cache               cache.Cache
 	concurrencyLimit    uint16
 }
 
@@ -72,10 +72,10 @@ func GrpcDialOpts(opts ...grpc.DialOption) Option {
 	}
 }
 
-// CacheConfig sets the configuration for the local dispatcher's cache.
-func CacheConfig(config *cache.Config) Option {
+// Cache sets the cache for the dispatcher.
+func Cache(c cache.Cache) Option {
 	return func(state *optionState) {
-		state.cacheConfig = config
+		state.cache = c
 	}
 }
 
@@ -99,7 +99,7 @@ func NewDispatcher(options ...Option) (dispatch.Dispatcher, error) {
 		opts.prometheusSubsystem = "dispatch_client"
 	}
 
-	cachingRedispatch, err := caching.NewCachingDispatcher(opts.cacheConfig, opts.prometheusSubsystem, &keys.CanonicalKeyHandler{})
+	cachingRedispatch, err := caching.NewCachingDispatcher(opts.cache, opts.prometheusSubsystem, &keys.CanonicalKeyHandler{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -120,7 +120,7 @@ func TestSimpleCheck(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					require := require.New(t)
 
-					ctx, dispatch, revision := newLocalDispatcher(require)
+					ctx, dispatch, revision := newLocalDispatcher(t)
 
 					checkResult, err := dispatch.DispatchCheck(ctx, &v1.DispatchCheckRequest{
 						ResourceRelation: RR(tc.namespace, expected.relation),
@@ -254,7 +254,7 @@ func TestCheckMetadata(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					require := require.New(t)
 
-					ctx, dispatch, revision := newLocalDispatcher(require)
+					ctx, dispatch, revision := newLocalDispatcher(t)
 
 					checkResult, err := dispatch.DispatchCheck(ctx, &v1.DispatchCheckRequest{
 						ResourceRelation: RR(tc.namespace, expected.relation),
@@ -283,20 +283,20 @@ func TestCheckMetadata(t *testing.T) {
 	}
 }
 
-func newLocalDispatcher(require *require.Assertions) (context.Context, dispatch.Dispatcher, decimal.Decimal) {
+func newLocalDispatcher(t testing.TB) (context.Context, dispatch.Dispatcher, decimal.Decimal) {
 	rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
-	require.NoError(err)
+	require.NoError(t, err)
 
-	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
+	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
 
 	dispatch := NewLocalOnlyDispatcher(10)
 
-	cachingDispatcher, err := caching.NewCachingDispatcher(nil, "", &keys.CanonicalKeyHandler{})
+	cachingDispatcher, err := caching.NewCachingDispatcher(caching.DispatchTestCache(t), "", &keys.CanonicalKeyHandler{})
 	cachingDispatcher.SetDelegate(dispatch)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	ctx := log.Logger.WithContext(datastoremw.ContextWithHandle(context.Background()))
-	require.NoError(datastoremw.SetInContext(ctx, ds))
+	require.NoError(t, datastoremw.SetInContext(ctx, ds))
 
 	return ctx, cachingDispatcher, revision
 }

--- a/internal/dispatch/graph/expand_test.go
+++ b/internal/dispatch/graph/expand_test.go
@@ -156,7 +156,7 @@ func TestExpand(t *testing.T) {
 		t.Run(fmt.Sprintf("%s-%s", tuple.StringONR(tc.start), tc.expansionMode), func(t *testing.T) {
 			require := require.New(t)
 
-			ctx, dispatch, revision := newLocalDispatcher(require)
+			ctx, dispatch, revision := newLocalDispatcher(t)
 
 			expandResult, err := dispatch.DispatchExpand(ctx, &v1.DispatchExpandRequest{
 				ResourceAndRelation: tc.start,

--- a/internal/dispatch/graph/lookup_test.go
+++ b/internal/dispatch/graph/lookup_test.go
@@ -110,7 +110,7 @@ func TestSimpleLookup(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 
-			ctx, dispatch, revision := newLocalDispatcher(require)
+			ctx, dispatch, revision := newLocalDispatcher(t)
 
 			lookupResult, err := dispatch.DispatchLookup(ctx, &v1.DispatchLookupRequest{
 				ObjectRelation: tc.start,

--- a/internal/dispatch/graph/lookupsubjects_test.go
+++ b/internal/dispatch/graph/lookupsubjects_test.go
@@ -123,7 +123,7 @@ func TestSimpleLookupSubjects(t *testing.T) {
 		t.Run(fmt.Sprintf("simple-lookup-subjects:%s:%s:%s:%s:%s", tc.resourceType, tc.resourceID, tc.permission, tc.subjectType, tc.subjectRelation), func(t *testing.T) {
 			require := require.New(t)
 
-			ctx, dis, revision := newLocalDispatcher(require)
+			ctx, dis, revision := newLocalDispatcher(t)
 			stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupSubjectsResponse](ctx)
 
 			err := dis.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{
@@ -235,7 +235,7 @@ func TestLookupSubjectsDispatchCount(t *testing.T) {
 		t.Run(fmt.Sprintf("dispatch-count-lookup-subjects:%s:%s:%s:%s:%s", tc.resourceType, tc.resourceID, tc.permission, tc.subjectType, tc.subjectRelation), func(t *testing.T) {
 			require := require.New(t)
 
-			ctx, dis, revision := newLocalDispatcher(require)
+			ctx, dis, revision := newLocalDispatcher(t)
 			stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupSubjectsResponse](ctx)
 
 			err := dis.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{

--- a/internal/dispatch/graph/reachableresources_test.go
+++ b/internal/dispatch/graph/reachableresources_test.go
@@ -141,7 +141,7 @@ func TestSimpleReachableResources(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 
-			ctx, dispatcher, revision := newLocalDispatcher(require)
+			ctx, dispatcher, revision := newLocalDispatcher(t)
 
 			stream := dispatch.NewCollectingDispatchStream[*v1.DispatchReachableResourcesResponse](ctx)
 			err := dispatcher.DispatchReachableResources(&v1.DispatchReachableResourcesRequest{
@@ -182,7 +182,7 @@ func TestSimpleReachableResources(t *testing.T) {
 func TestMaxDepthreachableResources(t *testing.T) {
 	require := require.New(t)
 
-	ctx, dispatcher, revision := newLocalDispatcher(require)
+	ctx, dispatcher, revision := newLocalDispatcher(t)
 
 	stream := dispatch.NewCollectingDispatchStream[*v1.DispatchReachableResourcesResponse](ctx)
 	err := dispatcher.DispatchReachableResources(&v1.DispatchReachableResourcesRequest{

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -17,7 +17,6 @@ import (
 
 	combineddispatch "github.com/authzed/spicedb/internal/dispatch/combined"
 	hashbalancer "github.com/authzed/spicedb/pkg/balancer"
-	"github.com/authzed/spicedb/pkg/cache"
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/util"
 	"github.com/authzed/spicedb/pkg/datastore"
@@ -180,15 +179,8 @@ func TestClusterWithDispatchAndCacheConfig(t testing.TB, size uint, ds datastore
 				}),
 			),
 		}
-		if !cacheEnabled {
-			dispatcherOptions = append(dispatcherOptions, combineddispatch.CacheConfig(&cache.Config{
-				Disabled: true,
-			}))
-		}
 
-		dispatcher, err := combineddispatch.NewDispatcher(
-			dispatcherOptions...,
-		)
+		dispatcher, err := combineddispatch.NewDispatcher(dispatcherOptions...)
 		require.NoError(t, err)
 
 		serverOptions := []server.ConfigOption{
@@ -214,19 +206,8 @@ func TestClusterWithDispatchAndCacheConfig(t testing.TB, size uint, ds datastore
 			}),
 			server.WithDispatchClusterMetricsPrefix(fmt.Sprintf("%s_%d_dispatch", prefix, i)),
 		}
-		if !cacheEnabled {
-			serverOptions = append(serverOptions, server.WithDispatchCacheConfig(server.CacheConfig{
-				Disabled: true,
-			}))
 
-			serverOptions = append(serverOptions, server.WithClusterDispatchCacheConfig(server.CacheConfig{
-				Disabled: true,
-			}))
-		}
-
-		srv, err := server.NewConfigWithOptions(
-			serverOptions...,
-		).Complete()
+		srv, err := server.NewConfigWithOptions(serverOptions...).Complete()
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,5 +1,10 @@
 package cache
 
+import (
+	"github.com/dustin/go-humanize"
+	"github.com/rs/zerolog"
+)
+
 // Config for caching.
 // See: https://github.com/dgraph-io/ristretto#Config
 type Config struct {
@@ -26,20 +31,18 @@ type Config struct {
 	// overflowing the MaxCost value.
 	MaxCost int64
 
-	// BufferItems determines the size of Get buffers.
-	//
-	// Unless you have a rare use case, using `64` as the BufferItems value
-	// results in good performance.
-	BufferItems int64
-
 	// Metrics determines whether cache statistics are kept during the cache's
 	// lifetime. There *is* some overhead to keeping statistics, so you should
 	// only set this flag to true when testing or throughput performance isn't a
 	// major factor.
 	Metrics bool
+}
 
-	// Disabled, if specified, completely disables the cache.
-	Disabled bool
+func (c *Config) MarshalZerologObject(e *zerolog.Event) {
+	e.
+		Str("maxCost", humanize.IBytes(uint64(c.MaxCost))).
+		Int64("numCounters", c.NumCounters).
+		Bool("metrics", c.Metrics)
 }
 
 // Cache defines an interface for a generic cache.
@@ -58,6 +61,8 @@ type Cache interface {
 
 	// GetMetrics returns the metrics block for the cache.
 	GetMetrics() Metrics
+
+	zerolog.LogObjectMarshaler
 }
 
 // Metrics defines metrics exported by the cache.
@@ -75,27 +80,18 @@ type Metrics interface {
 	CostEvicted() uint64
 }
 
-// NoopCache returns an implementation of the cache interface that does nothing.
+// NoopCache returns a cache that does nothing.
 func NoopCache() Cache {
 	return &noopCache{}
 }
 
 type noopCache struct{}
 
-func (no *noopCache) Get(key interface{}) (interface{}, bool) {
-	return nil, false
-}
-
-func (no *noopCache) Set(key interface{}, entry interface{}, cost int64) bool {
-	return false
-}
-
-func (no *noopCache) Wait() {
-}
-
-func (no *noopCache) Close() {
-}
-
-func (no *noopCache) GetMetrics() Metrics {
-	return nil
+func (no *noopCache) Get(key interface{}) (interface{}, bool)                 { return nil, false }
+func (no *noopCache) Set(key interface{}, entry interface{}, cost int64) bool { return false }
+func (no *noopCache) Wait()                                                   {}
+func (no *noopCache) Close()                                                  {}
+func (no *noopCache) GetMetrics() Metrics                                     { return nil }
+func (no *noopCache) MarshalZerologObject(e *zerolog.Event) {
+	e.Bool("enabled", false)
 }

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -14,6 +14,29 @@ import (
 
 const PresharedKeyFlag = "grpc-preshared-key"
 
+var (
+	namespaceCacheDefaults = &server.CacheConfig{
+		Enabled:     true,
+		Metrics:     false,
+		NumCounters: 1_000,
+		MaxCost:     "16MiB",
+	}
+
+	dispatchCacheDefaults = &server.CacheConfig{
+		Enabled:     true,
+		Metrics:     false,
+		NumCounters: 10_000,
+		MaxCost:     "30%",
+	}
+
+	dispatchClusterCacheDefaults = &server.CacheConfig{
+		Enabled:     true,
+		Metrics:     false,
+		NumCounters: 100_000,
+		MaxCost:     "70%",
+	}
+)
+
 func RegisterServeFlags(cmd *cobra.Command, config *server.Config) {
 	// Flags for the gRPC API server
 	util.RegisterGRPCServerFlags(cmd.Flags(), &config.GRPCServer, "grpc", "gRPC", ":50051", true)
@@ -31,12 +54,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) {
 	if err := cmd.Flags().MarkHidden("ns-cache-expiration"); err != nil {
 		panic("failed to mark flag hidden: " + err.Error())
 	}
-	server.RegisterCacheFlags(cmd.Flags(), "ns-cache", &config.NamespaceCacheConfig, &server.CacheConfig{
-		Enabled:     true,
-		Metrics:     false,
-		NumCounters: 1_000,
-		MaxCost:     "16MiB",
-	})
+	server.RegisterCacheFlags(cmd.Flags(), "ns-cache", &config.NamespaceCacheConfig, namespaceCacheDefaults)
 
 	// Flags for parsing and validating schemas.
 	cmd.Flags().BoolVar(&config.SchemaPrefixesRequired, "schema-prefixes-required", false, "require prefixes on all object definitions in schemas")
@@ -62,18 +80,8 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) {
 
 	// Flags for configuring the dispatch server
 	util.RegisterGRPCServerFlags(cmd.Flags(), &config.DispatchServer, "dispatch-cluster", "dispatch", ":50053", false)
-	server.RegisterCacheFlags(cmd.Flags(), "dispatch-cache", &config.DispatchCacheConfig, &server.CacheConfig{
-		Enabled:     true,
-		Metrics:     false,
-		NumCounters: 10_000,
-		MaxCost:     "30%",
-	})
-	server.RegisterCacheFlags(cmd.Flags(), "dispatch-cluster-cache", &config.ClusterDispatchCacheConfig, &server.CacheConfig{
-		Enabled:     true,
-		Metrics:     false,
-		NumCounters: 100_000,
-		MaxCost:     "70%",
-	})
+	server.RegisterCacheFlags(cmd.Flags(), "dispatch-cache", &config.DispatchCacheConfig, dispatchCacheDefaults)
+	server.RegisterCacheFlags(cmd.Flags(), "dispatch-cluster-cache", &config.ClusterDispatchCacheConfig, dispatchClusterCacheDefaults)
 
 	// Flags for configuring dispatch requests
 	cmd.Flags().Uint32Var(&config.DispatchMaxDepth, "dispatch-max-depth", 50, "maximum recursion depth for nested calls")

--- a/pkg/cmd/server/cacheconfig.go
+++ b/pkg/cmd/server/cacheconfig.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -13,42 +14,29 @@ import (
 	"github.com/authzed/spicedb/pkg/cache"
 )
 
-// At startup, measure 75% of available free memory.
-var freeMemory uint64
+var (
+	// At startup, measure 75% of available free memory.
+	freeMemory uint64
+
+	errOverHundredPercent = errors.New("percentage greater than 100")
+)
 
 func init() {
 	freeMemory = memory.FreeMemory() / 100 * 75
 }
 
-// CacheConfig defines configuration for a ristretto cache.
-// See: https://github.com/dgraph-io/ristretto#Config
+// CacheConfig defines the configuration various SpiceDB caches.
 type CacheConfig struct {
 	MaxCost     string
 	NumCounters int64
 	Metrics     bool
-	Disabled    bool
+	Enabled     bool
 }
 
-const (
-	defaultMaxCost     = "16MB"
-	defaultNumCounters = 1e4 // number of keys to track frequency of (10k).
-	defaultBufferItems = 64
-)
-
 // Complete translates the CLI cache config into a cache config.
-func (cc *CacheConfig) Complete() (*cache.Config, error) {
-	if cc.Disabled {
-		return &cache.Config{
-			MaxCost:     1,
-			NumCounters: cc.NumCounters,
-			Metrics:     cc.Metrics,
-			BufferItems: defaultBufferItems,
-			Disabled:    true,
-		}, nil
-	}
-
-	if cc.MaxCost == "" || cc.NumCounters == 0 {
-		return nil, nil
+func (cc *CacheConfig) Complete() (cache.Cache, error) {
+	if !cc.Enabled || cc.MaxCost == "" || cc.MaxCost == "0%" || cc.NumCounters == 0 {
+		return cache.NoopCache(), nil
 	}
 
 	var (
@@ -57,7 +45,7 @@ func (cc *CacheConfig) Complete() (*cache.Config, error) {
 	)
 
 	if strings.HasSuffix(cc.MaxCost, "%") {
-		maxCost, err = parsePercent(cc.MaxCost)
+		maxCost, err = parsePercent(cc.MaxCost, freeMemory)
 	} else {
 		maxCost, err = humanize.ParseBytes(cc.MaxCost)
 	}
@@ -65,16 +53,14 @@ func (cc *CacheConfig) Complete() (*cache.Config, error) {
 		return nil, fmt.Errorf("error parsing cache max memory: `%s`: %w", cc.MaxCost, err)
 	}
 
-	return &cache.Config{
+	return cache.NewCache(&cache.Config{
 		MaxCost:     int64(maxCost),
 		NumCounters: cc.NumCounters,
 		Metrics:     cc.Metrics,
-		BufferItems: defaultBufferItems,
-		Disabled:    false,
-	}, nil
+	})
 }
 
-func parsePercent(str string) (uint64, error) {
+func parsePercent(str string, freeMem uint64) (uint64, error) {
 	percent := strings.TrimSuffix(str, "%")
 	parsedPercent, err := strconv.ParseUint(percent, 10, 64)
 	if err != nil {
@@ -82,17 +68,18 @@ func parsePercent(str string) (uint64, error) {
 	}
 
 	if parsedPercent > 100 {
-		return 0, fmt.Errorf("percentage greater than 100")
+		return 0, errOverHundredPercent
 	}
 
-	return parsedPercent, nil
+	return freeMem / 100 * parsedPercent, nil
 }
 
-// RegisterCacheConfigFlags registers flags for a ristretto-based cache.
-func RegisterCacheConfigFlags(flags *pflag.FlagSet, config *CacheConfig, flagPrefix string) {
+// RegisterCacheFlags registers flags used to configure SpiceDB's various
+// caches.
+func RegisterCacheFlags(flags *pflag.FlagSet, flagPrefix string, config, defaults *CacheConfig) {
 	flagPrefix = stringz.DefaultEmpty(flagPrefix, "cache")
-	flags.StringVar(&config.MaxCost, flagPrefix+"-max-cost", defaultMaxCost, "the maximum cost to be stored in the cache, in bytes")
-	flags.Int64Var(&config.NumCounters, flagPrefix+"-num-counters", defaultNumCounters, "the number of keys to track")
-	flags.BoolVar(&config.Metrics, flagPrefix+"-metrics", false, "whether metrics should be maintained for the cache. WARNING: Incurs a performance penality.")
-	flags.BoolVar(&config.Disabled, flagPrefix+"-disabled", false, "if true, fully disables the cache. WARNING: Incurs a performance penality.")
+	flags.StringVar(&config.MaxCost, flagPrefix+"-max-cost", defaults.MaxCost, "upper bound cache size in bytes or percent of available memory")
+	flags.Int64Var(&config.NumCounters, flagPrefix+"-num-counters", defaults.NumCounters, "number of TinyLFU samples to track")
+	flags.BoolVar(&config.Metrics, flagPrefix+"-metrics", defaults.Metrics, "enable cache metrics")
+	flags.BoolVar(&config.Enabled, flagPrefix+"-enabled", defaults.Enabled, "enable caching")
 }

--- a/pkg/cmd/server/cacheconfig_test.go
+++ b/pkg/cmd/server/cacheconfig_test.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePercent(t *testing.T) {
+	table := []struct {
+		percent     string
+		freeMem     uint64
+		expected    uint64
+		expectedErr error
+	}{
+		{"100%", 1000, 1000, nil},
+		{"0%", 1000, 0, nil},
+		{"50%", 1000, 500, nil},
+		{"100%", 0, 0, nil},
+		{"1000%", 1000, 0, errOverHundredPercent},
+	}
+
+	for _, tt := range table {
+		v, err := parsePercent(tt.percent, tt.freeMem)
+		if tt.expectedErr == nil {
+			require.Nil(t, err)
+		} else {
+			require.Equal(t, tt.expectedErr, err)
+		}
+		require.Equal(t, tt.expected, v)
+	}
+}

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -135,11 +135,9 @@ func (c *Config) Complete() (RunnableServer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create namespace cache: %w", err)
 	}
+	log.Info().EmbedObject(nscc).Msg("configured namespace cache")
 
-	ds, err = proxy.NewCachingDatastoreProxy(ds, nscc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create namespace caching datastore proxy: %w", err)
-	}
+	ds = proxy.NewCachingDatastoreProxy(ds, nscc)
 
 	enableGRPCHistogram()
 
@@ -150,6 +148,7 @@ func (c *Config) Complete() (RunnableServer, error) {
 		if cerr != nil {
 			return nil, fmt.Errorf("failed to create dispatcher: %w", cerr)
 		}
+		log.Info().EmbedObject(cc).Msg("configured dispatch cache")
 
 		dispatchPresharedKey := ""
 		if len(c.PresharedKey) > 0 {
@@ -165,7 +164,7 @@ func (c *Config) Complete() (RunnableServer, error) {
 				grpc.WithDefaultServiceConfig(balancer.BalancerServiceConfig),
 			),
 			combineddispatch.PrometheusSubsystem(c.DispatchClientMetricsPrefix),
-			combineddispatch.CacheConfig(cc),
+			combineddispatch.Cache(cc),
 			combineddispatch.ConcurrencyLimit(c.DispatchConcurrencyLimit),
 		)
 		if err != nil {
@@ -187,12 +186,13 @@ func (c *Config) Complete() (RunnableServer, error) {
 		if cerr != nil {
 			return nil, fmt.Errorf("failed to configure cluster dispatch: %w", cerr)
 		}
+		log.Info().EmbedObject(cdcc).Msg("configured cluster dispatch cache")
 
 		var err error
 		cachingClusterDispatch, err = clusterdispatch.NewClusterDispatcher(
 			dispatcher,
 			clusterdispatch.PrometheusSubsystem(c.DispatchClusterMetricsPrefix),
-			clusterdispatch.CacheConfig(cdcc),
+			clusterdispatch.Cache(cdcc),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to configure cluster dispatch: %w", err)


### PR DESCRIPTION
This PR has been reworked a bunch, but now adds support for cache max cost flags to use percentages of free memory in addition to bytes.

Lots of other cleanup was done in the process.