### PR TITLE
Add building of WASM developer binary to releases

### DIFF
--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -1,0 +1,27 @@
+---
+name: "Build WASM"
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - "main"
+    paths:
+      - "pkg/development/wasm/**"
+      - ".github/workflows/wasm.yaml"
+jobs:
+  build:
+    name: "Build WASM"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-go@v3"
+        with:
+          go-version: "~1.19.1"
+      - run: |
+          echo "Building WASM..."
+          GOOS=js GOARCH=wasm go build  -o dist/main.wasm ./pkg/development/wasm/...
+          echo "Build complete"
+      - uses: "EndBug/add-and-commit@v9"
+        with:
+          add: "dist/*"
+          default_author: "github_actor"
+          message: "Automated WASM build"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -1,27 +1,26 @@
 ---
 name: "Build WASM"
 on: # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - "main"
-    paths:
-      - "pkg/development/wasm/**"
-      - ".github/workflows/wasm.yaml"
+  release:
+    types: ["created"]
+permissions:
+  contents: "write"
 jobs:
   build:
     name: "Build WASM"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
+        with:
+          ref: "${{ env.GITHUB_SHA }}"
       - uses: "actions/setup-go@v3"
         with:
           go-version: "~1.19.1"
       - run: |
           echo "Building WASM..."
-          GOOS=js GOARCH=wasm go build  -o dist/main.wasm ./pkg/development/wasm/...
+          GOOS=js GOARCH=wasm go build  -o dist/development.wasm ./pkg/development/wasm/...
           echo "Build complete"
-      - uses: "EndBug/add-and-commit@v9"
+      - uses: "shogo82148/actions-upload-release-asset@v1"
         with:
-          add: "dist/*"
-          default_author: "github_actor"
-          message: "Automated WASM build"
+          upload_url: "${{ github.event.release.upload_url }}"
+          asset_path: "dist/*"


### PR DESCRIPTION
Add a workflow that builds SpiceDB as wasm and commits it to `dist`