### PR TITLE
Fix performance for large schema writes in V1Alpha1

### DIFF
--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -137,6 +137,11 @@ func (dm *MockReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefi
 	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
 }
 
+func (dm *MockReader) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+	args := dm.Called()
+	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
+}
+
 type MockReadWriteTransaction struct {
 	mock.Mock
 }
@@ -196,6 +201,11 @@ func (dm *MockReadWriteTransaction) ReverseQueryRelationships(
 }
 
 func (dm *MockReadWriteTransaction) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+	args := dm.Called()
+	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
+}
+
+func (dm *MockReadWriteTransaction) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
 	args := dm.Called()
 	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
 }

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -64,6 +64,25 @@ func (vsr validatingSnapshotReader) ListNamespaces(
 	return read, err
 }
 
+func (vsr validatingSnapshotReader) LookupNamespaces(
+	ctx context.Context,
+	nsNames []string,
+) ([]*core.NamespaceDefinition, error) {
+	read, err := vsr.delegate.LookupNamespaces(ctx, nsNames)
+	if err != nil {
+		return read, err
+	}
+
+	for _, nsDef := range read {
+		err := nsDef.Validate()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return read, err
+}
+
 func (vsr validatingSnapshotReader) QueryRelationships(ctx context.Context,
 	filter datastore.RelationshipsFilter,
 	opts ...options.QueryOptionsOption,

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -165,6 +165,9 @@ type Reader interface {
 
 	// ListNamespaces lists all namespaces defined.
 	ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error)
+
+	// LookupNamespaces finds all namespaces with the matching names.
+	LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error)
 }
 
 type ReadWriteTransaction interface {

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -107,6 +107,20 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	require.Equal(1, len(checkOldList))
 	require.Equal(testUserNS.Name, checkOldList[0].Name)
 	require.Empty(cmp.Diff(testUserNS, checkOldList[0], protocmp.Transform()))
+
+	checkLookup, err := ds.SnapshotReader(secondWritten).LookupNamespaces(ctx, []string{testNamespace.Name})
+	require.NoError(err)
+	require.Equal(1, len(checkLookup))
+	require.Equal(testNamespace.Name, checkLookup[0].Name)
+	require.Empty(cmp.Diff(testNamespace, checkLookup[0], protocmp.Transform()))
+
+	checkLookupMultiple, err := ds.SnapshotReader(secondWritten).LookupNamespaces(ctx, []string{testNamespace.Name, testUserNS.Name})
+	require.NoError(err)
+	require.Equal(2, len(checkLookupMultiple))
+
+	emptyLookup, err := ds.SnapshotReader(secondWritten).LookupNamespaces(ctx, []string{"anothername"})
+	require.NoError(err)
+	require.Equal(0, len(emptyLookup))
 }
 
 // NamespaceDeleteTest tests whether or not the requirements for deleting


### PR DESCRIPTION
This will hopefully reduce the flakiness of the E2E test suite, which writes large batches of definitions via the V1Alpha1 WriteSchema call