### PR TITLE
Fix chunking util to never call for an empty chunk

### DIFF
--- a/internal/util/chunking.go
+++ b/internal/util/chunking.go
@@ -11,6 +11,9 @@ func ForEachChunk[T any](data []T, chunkSize uint64, handler func(items []T)) {
 			chunkEnd = dataLength
 		}
 
-		handler(data[chunkStart:chunkEnd])
+		chunk := data[chunkStart:chunkEnd]
+		if len(chunk) > 0 {
+			handler(chunk)
+		}
 	}
 }

--- a/internal/util/chunking_test.go
+++ b/internal/util/chunking_test.go
@@ -20,6 +20,7 @@ func TestForEachChunk(t *testing.T) {
 				ForEachChunk(data, chunksize, func(items []int) {
 					found = append(found, items...)
 					require.True(t, len(items) <= int(chunksize))
+					require.True(t, len(items) > 0)
 				})
 				require.Equal(t, data, found)
 			})


### PR DESCRIPTION
An empty chunk was being returned when the chunk size and overall size hit the same border. This could hit a panic in the new chunked check dispatch code