### PR TITLE
Change caching to sort order resource and subject IDs

### DIFF
--- a/internal/dispatch/keys/computed_test.go
+++ b/internal/dispatch/keys/computed_test.go
@@ -47,7 +47,21 @@ func TestStableCacheKeys(t *testing.T) {
 					},
 				}, computeBothHashes)
 			},
-			"d6a999a7a0a4d39c9f01",
+			"e09cbca18290f7afae01",
+		},
+		{
+			"basic check with canonical ordering",
+			func() DispatchCacheKey {
+				return checkRequestToKey(&v1.DispatchCheckRequest{
+					ResourceRelation: RR("document", "view"),
+					ResourceIds:      []string{"bar", "foo"},
+					Subject:          ONR("user", "tom", "..."),
+					Metadata: &v1.ResolverMeta{
+						AtRevision: "1234",
+					},
+				}, computeBothHashes)
+			},
+			"e09cbca18290f7afae01",
 		},
 		{
 			"different check",
@@ -75,7 +89,7 @@ func TestStableCacheKeys(t *testing.T) {
 					},
 				}, "view")
 			},
-			"be9fff86aa9aebdba801",
+			"a1ebd1d6a7a8b18fff01",
 		},
 		{
 			"expand",

--- a/internal/dispatch/keys/hasher_common.go
+++ b/internal/dispatch/keys/hasher_common.go
@@ -1,6 +1,8 @@
 package keys
 
 import (
+	"sort"
+
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 )
@@ -32,7 +34,13 @@ func (hrs hashableResultSetting) AppendToHash(hasher hasherInterface) {
 type hashableIds []string
 
 func (hid hashableIds) AppendToHash(hasher hasherInterface) {
-	for _, id := range hid {
+	// Sort the IDs to canonicalize them. We have to clone to ensure that this does cause issues
+	// with others accessing the slice.
+	c := make([]string, len(hid))
+	copy(c, hid)
+	sort.Strings(c)
+
+	for _, id := range c {
 		hasher.WriteString(id)
 		hasher.WriteString(",")
 	}


### PR DESCRIPTION
Ensures more chances of cache entries being reused