### PR TITLE
Improves Postgres write performance

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
-	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
+	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -325,8 +325,9 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be h1:fmw3UbQh+nxngCAHrDCCztao/kbYFnWjoqop8dHx05A=
+golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/hashicorp/go-memdb v1.3.3
 	github.com/influxdata/tdigest v0.0.1
 	github.com/jackc/pgconn v1.13.0
+	github.com/jackc/pgio v1.0.0
 	github.com/jackc/pgtype v1.12.0
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/johannesboyne/gofakes3 v0.0.0-20220314170512-33c13122505e
@@ -119,7 +120,6 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.1 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect

--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
+	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,9 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be h1:fmw3UbQh+nxngCAHrDCCztao/kbYFnWjoqop8dHx05A=
+golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/internal/datastore/common/gc.go
+++ b/internal/datastore/common/gc.go
@@ -84,7 +84,7 @@ func (g DeletionCounts) MarshalZerologObject(e *zerolog.Event) {
 // StartGarbageCollector loops forever until the context is canceled and
 // performs garbage collection on the provided interval.
 func StartGarbageCollector(ctx context.Context, gc GarbageCollector, interval, window, timeout time.Duration) error {
-	log.Ctx(ctx).Info().
+	log.Info().
 		Dur("interval", interval).
 		Msg("datastore garbage collection worker started")
 

--- a/internal/datastore/common/revisions/remoteclock.go
+++ b/internal/datastore/common/revisions/remoteclock.go
@@ -85,10 +85,10 @@ func (rcr *RemoteClockRevisions) CheckRevision(ctx context.Context, revision dat
 		return datastore.NewInvalidRevisionErr(revision, datastore.RevisionStale)
 	}
 
-	isFuture := revisionNanos > nowNanos
-	if isFuture {
-		log.Debug().Stringer("now", now).Stringer("revision", revision).Msg("future revision")
-		return datastore.NewInvalidRevisionErr(revision, datastore.RevisionInFuture)
+	isUnknown := revisionNanos > nowNanos
+	if isUnknown {
+		log.Debug().Stringer("now", now).Stringer("revision", revision).Msg("unknown revision")
+		return datastore.NewInvalidRevisionErr(revision, datastore.CouldNotDetermineRevision)
 	}
 
 	return nil

--- a/internal/datastore/memdb/revisions.go
+++ b/internal/datastore/memdb/revisions.go
@@ -34,7 +34,7 @@ func (mdb *memdbDatastore) checkRevisionLocal(revision datastore.Revision) error
 	now := revisionFromTimestamp(time.Now().UTC())
 
 	if revision.GreaterThan(now) {
-		return datastore.NewInvalidRevisionErr(revision, datastore.RevisionInFuture)
+		return datastore.NewInvalidRevisionErr(revision, datastore.CouldNotDetermineRevision)
 	}
 
 	oldest := now.Add(mdb.negativeGCWindow)

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -166,7 +166,7 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	// Run GC at the transaction and ensure no relationships are removed.
 	mds := ds.(*Datastore)
 
-	removed, err := mds.DeleteBeforeTx(ctx, uint64(writtenAt.IntPart()))
+	removed, err := mds.DeleteBeforeTx(ctx, writtenAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Zero(removed.Namespaces)
@@ -185,7 +185,7 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	req.NoError(err)
 
 	// Run GC to remove the old namespace
-	removed, err = mds.DeleteBeforeTx(ctx, uint64(writtenAt.IntPart()))
+	removed, err = mds.DeleteBeforeTx(ctx, writtenAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Equal(int64(1), removed.Transactions)
@@ -198,14 +198,14 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	req.NoError(err)
 
 	// Run GC at the transaction and ensure no relationships are removed, but 1 transaction (the previous write namespace) is.
-	removed, err = mds.DeleteBeforeTx(ctx, uint64(relWrittenAt.IntPart()))
+	removed, err = mds.DeleteBeforeTx(ctx, relWrittenAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Equal(int64(1), removed.Transactions)
 	req.Zero(removed.Namespaces)
 
 	// Run GC again and ensure there are no changes.
-	removed, err = mds.DeleteBeforeTx(ctx, uint64(relWrittenAt.IntPart()))
+	removed, err = mds.DeleteBeforeTx(ctx, relWrittenAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Zero(removed.Transactions)
@@ -220,14 +220,14 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	req.NoError(err)
 
 	// Run GC at the transaction and ensure the (older copy of the) relationship is removed, as well as 1 transaction (the write).
-	removed, err = mds.DeleteBeforeTx(ctx, uint64(relOverwrittenAt.IntPart()))
+	removed, err = mds.DeleteBeforeTx(ctx, relOverwrittenAt)
 	req.NoError(err)
 	req.Equal(int64(1), removed.Relationships)
 	req.Equal(int64(1), removed.Transactions)
 	req.Zero(removed.Namespaces)
 
 	// Run GC again and ensure there are no changes.
-	removed, err = mds.DeleteBeforeTx(ctx, uint64(relOverwrittenAt.IntPart()))
+	removed, err = mds.DeleteBeforeTx(ctx, relOverwrittenAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Zero(removed.Transactions)
@@ -244,14 +244,14 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	tRequire.NoTupleExists(ctx, tpl, relDeletedAt)
 
 	// Run GC at the transaction and ensure the relationship is removed, as well as 1 transaction (the overwrite).
-	removed, err = mds.DeleteBeforeTx(ctx, uint64(relDeletedAt.IntPart()))
+	removed, err = mds.DeleteBeforeTx(ctx, relDeletedAt)
 	req.NoError(err)
 	req.Equal(int64(1), removed.Relationships)
 	req.Equal(int64(1), removed.Transactions)
 	req.Zero(removed.Namespaces)
 
 	// Run GC again and ensure there are no changes.
-	removed, err = mds.DeleteBeforeTx(ctx, uint64(relDeletedAt.IntPart()))
+	removed, err = mds.DeleteBeforeTx(ctx, relDeletedAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Zero(removed.Transactions)
@@ -269,7 +269,7 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 
 	// Run GC at the transaction and ensure the older copies of the relationships are removed,
 	// as well as the 2 older write transactions and the older delete transaction.
-	removed, err = mds.DeleteBeforeTx(ctx, uint64(relLastWriteAt.IntPart()))
+	removed, err = mds.DeleteBeforeTx(ctx, relLastWriteAt)
 	req.NoError(err)
 	req.Equal(int64(2), removed.Relationships)
 	req.Equal(int64(3), removed.Transactions)

--- a/internal/datastore/postgres/README.md
+++ b/internal/datastore/postgres/README.md
@@ -6,6 +6,10 @@ PostgreSQL is a traditional relational database management system that is very p
 This datastore implementation allows you to use a PostgreSQL database as the backing durable storage for SpiceDB.
 Recommended usage: when you are comfortable with having all permissions data stored in a single region.
 
+## Configuration
+
+`track_commit_timestamp` must be set to `on` for the Watch API to be enabled.
+
 ## Implementation Caveats
 
 While PostgreSQL uses MVCC to implement its ACID properties, it doesn't offer users the ability to read dirty data without adding an extension.

--- a/internal/datastore/postgres/README.md
+++ b/internal/datastore/postgres/README.md
@@ -1,5 +1,7 @@
 # PostgreSQL Datastore
 
+**Minimum required version**: `13.0`
+
 PostgreSQL is a traditional relational database management system that is very popular.
 This datastore implementation allows you to use a PostgreSQL database as the backing durable storage for SpiceDB.
 Recommended usage: when you are comfortable with having all permissions data stored in a single region.

--- a/internal/datastore/postgres/gc.go
+++ b/internal/datastore/postgres/gc.go
@@ -58,7 +58,7 @@ func (pgd *pgDatastore) TxIDBefore(ctx context.Context, before time.Time) (datas
 		return datastore.NoRevision, err
 	}
 
-	value := XID8{}
+	value := xid8{}
 	err = pgd.dbpool.QueryRow(
 		datastore.SeparateContextWithTracing(ctx), sql, args...,
 	).Scan(&value)

--- a/internal/datastore/postgres/migrations/zz_migration.0009_add_xid8_columns.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0009_add_xid8_columns.go
@@ -1,0 +1,90 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+)
+
+const (
+	addTransactionXIDColumns = `
+		ALTER TABLE relation_tuple_transaction
+			ADD COLUMN xid xid8 NOT NULL DEFAULT (pg_current_xact_id()),
+			ADD COLUMN snapshot pg_snapshot`
+
+	addTupleXIDColumns = `
+		ALTER TABLE relation_tuple
+			ADD COLUMN created_xid xid8,
+			ADD COLUMN deleted_xid xid8 NOT NULL DEFAULT ('9223372036854775807');`
+
+	addNamespaceXIDColumns = `
+		ALTER TABLE namespace_config
+			ADD COLUMN created_xid xid8,
+			ADD COLUMN deleted_xid xid8 NOT NULL DEFAULT ('9223372036854775807');`
+
+	addTransactionDefault = `
+		ALTER TABLE relation_tuple_transaction
+			ALTER COLUMN snapshot SET DEFAULT (pg_current_snapshot());`
+
+	addRelationTupleDefault = `
+		ALTER TABLE relation_tuple
+			ALTER COLUMN created_xid SET DEFAULT (pg_current_xact_id());`
+
+	addNamepsaceDefault = `
+		ALTER TABLE namespace_config
+			ALTER COLUMN created_xid SET DEFAULT (pg_current_xact_id());`
+
+	backfillTransactionXids = `
+		UPDATE relation_tuple_transaction SET xid = id::text::xid8, snapshot = CONCAT(id, ':', id, ':')::pg_snapshot
+			WHERE snapshot IS NULL;`
+
+	backfillTupleXIDColumns = `
+		UPDATE relation_tuple
+			SET deleted_xid = deleted_transaction::text::xid8,
+			created_xid = created_transaction::text::xid8
+			WHERE created_xid IS NULL;`
+
+	backfillNamespaceXIDColumns = `
+		UPDATE namespace_config
+			SET deleted_xid = deleted_transaction::text::xid8,
+			created_xid = created_transaction::text::xid8
+			WHERE created_xid IS NULL;`
+
+	addTransactionSnapshotNotNull = `
+		ALTER TABLE relation_tuple_transaction ALTER COLUMN snapshot SET NOT NULL;`
+
+	addTupleCreatedNotNull = `
+		ALTER TABLE relation_tuple ALTER COLUMN created_xid SET NOT NULL;`
+
+	addNamespaceCreatedtNotNull = `
+		ALTER TABLE namespace_config ALTER COLUMN created_xid SET NOT NULL;`
+)
+
+func init() {
+	if err := DatabaseMigrations.Register("add-xid-columns", "add-ns-config-id",
+		noNonatomicMigration,
+		func(ctx context.Context, tx pgx.Tx) error {
+			for _, stmt := range []string{
+				addTransactionXIDColumns,
+				addTupleXIDColumns,
+				addNamespaceXIDColumns,
+				addTransactionDefault,
+				addRelationTupleDefault,
+				addNamepsaceDefault,
+				backfillTransactionXids,
+				backfillTupleXIDColumns,
+				backfillNamespaceXIDColumns,
+				addTransactionSnapshotNotNull,
+				addTupleCreatedNotNull,
+				addNamespaceCreatedtNotNull,
+			} {
+				if _, err := tx.Exec(ctx, stmt); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}

--- a/internal/datastore/postgres/migrations/zz_migration.0010_add_xid_indices.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0010_add_xid_indices.go
@@ -1,0 +1,43 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+)
+
+var addXIDIndices = []string{
+	// Replace the indices that are inherent from having a primary key constraint
+	"CREATE UNIQUE INDEX CONCURRENTLY ix_rttx_oldpk ON relation_tuple_transaction (id)",
+	"CREATE UNIQUE INDEX CONCURRENTLY ix_namespace_config_oldpk ON namespace_config (id)",
+
+	// Add indices that will eventually back our new constraints
+	"CREATE UNIQUE INDEX CONCURRENTLY ix_rttx_pk ON relation_tuple_transaction (xid);",
+	`CREATE UNIQUE INDEX CONCURRENTLY ix_namespace_config_pk
+		ON namespace_config (namespace, created_xid, deleted_xid);`,
+	`CREATE UNIQUE INDEX CONCURRENTLY ix_namespace_config_living
+		ON namespace_config (namespace, deleted_xid);`,
+	`CREATE UNIQUE INDEX CONCURRENTLY ix_relation_tuple_pk
+		ON relation_tuple (namespace, object_id, relation, userset_namespace, userset_object_id,
+						   userset_relation, created_xid, deleted_xid);`,
+	`CREATE UNIQUE INDEX CONCURRENTLY ix_relation_tuple_living
+		ON relation_tuple (namespace, object_id, relation, userset_namespace, userset_object_id,
+						   userset_relation, deleted_xid);`,
+}
+
+func init() {
+	if err := DatabaseMigrations.Register("add-xid-indices", "add-xid-columns",
+		func(ctx context.Context, conn *pgx.Conn) error {
+			for _, stmt := range addXIDIndices {
+				if _, err := conn.Exec(ctx, stmt); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+		noTxMigration,
+	); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}

--- a/internal/datastore/postgres/migrations/zz_migration.0011_add_xid_constraints.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0011_add_xid_constraints.go
@@ -1,0 +1,56 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v4"
+)
+
+const (
+	getNSConfigPkeyName = `
+	SELECT constraint_name FROM information_schema.table_constraints
+		WHERE table_schema = 'public'
+      	AND table_name = 'namespace_config'
+      	AND constraint_type = 'PRIMARY KEY';`
+
+	dropNSConfigIDPkey = "ALTER TABLE namespace_config DROP CONSTRAINT %s;"
+)
+
+var addXIDConstraints = []string{
+	`ALTER TABLE relation_tuple_transaction
+		DROP CONSTRAINT pk_rttx,
+		ADD CONSTRAINT pk_rttx PRIMARY KEY USING INDEX ix_rttx_pk;`,
+	`ALTER TABLE namespace_config
+		ADD CONSTRAINT pk_namespace_config PRIMARY KEY USING INDEX ix_namespace_config_pk,
+		ADD CONSTRAINT uq_namespace_living_xid UNIQUE USING INDEX ix_namespace_config_living;`,
+	`ALTER TABLE relation_tuple
+		DROP CONSTRAINT pk_relation_tuple,
+		ADD CONSTRAINT pk_relation_tuple PRIMARY KEY USING INDEX ix_relation_tuple_pk,
+		ADD CONSTRAINT uq_relation_tuple_living_xid UNIQUE USING INDEX ix_relation_tuple_living;`,
+}
+
+func init() {
+	if err := DatabaseMigrations.Register("add-xid-constraints", "add-xid-indices",
+		noNonatomicMigration,
+		func(ctx context.Context, tx pgx.Tx) error {
+			var constraintName string
+			if err := tx.QueryRow(ctx, getNSConfigPkeyName).Scan(&constraintName); err != nil {
+				return err
+			}
+
+			if _, err := tx.Exec(ctx, fmt.Sprintf(dropNSConfigIDPkey, constraintName)); err != nil {
+				return err
+			}
+
+			for _, stmt := range addXIDConstraints {
+				if _, err := tx.Exec(ctx, stmt); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}

--- a/internal/datastore/postgres/migrations/zz_migration.0012_drop_bigserial_ids.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0012_drop_bigserial_ids.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+)
+
+var dropIDStmts = []string{
+	`ALTER TABLE relation_tuple_transaction
+		DROP COLUMN id;`,
+	`ALTER TABLE namespace_config
+		DROP COLUMN id,
+		DROP COLUMN created_transaction,
+		DROP COLUMN deleted_transaction;`,
+	`ALTER TABLE relation_tuple
+		DROP COLUMN id,
+		DROP COLUMN created_transaction,
+		DROP COLUMN deleted_transaction;`,
+}
+
+func init() {
+	if err := DatabaseMigrations.Register("drop-bigserial-ids", "add-xid-constraints",
+		noNonatomicMigration,
+		func(ctx context.Context, tx pgx.Tx) error {
+			for _, stmt := range dropIDStmts {
+				if _, err := tx.Exec(ctx, stmt); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -291,7 +291,7 @@ func (pgd *pgDatastore) ReadWriteTx(
 ) (datastore.Revision, error) {
 	var err error
 	for i := uint8(0); i <= pgd.maxRetries; i++ {
-		var newXID XID8
+		var newXID xid8
 		err = pgd.dbpool.BeginTxFunc(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
 			var err error
 			newXID, err = createNewTransaction(ctx, tx)

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -132,7 +132,7 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	// Run GC at the transaction and ensure no relationships are removed.
 	pds := ds.(*pgDatastore)
 
-	removed, err := pds.DeleteBeforeTx(ctx, uint64(writtenAt.IntPart()))
+	removed, err := pds.DeleteBeforeTx(ctx, writtenAt)
 	require.NoError(err)
 	require.Zero(removed.Relationships)
 	require.Zero(removed.Namespaces)
@@ -151,7 +151,7 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Run GC to remove the old namespace
-	removed, err = pds.DeleteBeforeTx(ctx, uint64(writtenAt.IntPart()))
+	removed, err = pds.DeleteBeforeTx(ctx, writtenAt)
 	require.NoError(err)
 	require.Zero(removed.Relationships)
 	require.Equal(int64(1), removed.Transactions)
@@ -164,14 +164,14 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Run GC at the transaction and ensure no relationships are removed, but 1 transaction (the previous write namespace) is.
-	removed, err = pds.DeleteBeforeTx(ctx, uint64(relWrittenAt.IntPart()))
+	removed, err = pds.DeleteBeforeTx(ctx, relWrittenAt)
 	require.NoError(err)
 	require.Zero(removed.Relationships)
 	require.Equal(int64(1), removed.Transactions)
 	require.Zero(removed.Namespaces)
 
 	// Run GC again and ensure there are no changes.
-	removed, err = pds.DeleteBeforeTx(ctx, uint64(relWrittenAt.IntPart()))
+	removed, err = pds.DeleteBeforeTx(ctx, relWrittenAt)
 	require.NoError(err)
 	require.Zero(removed.Relationships)
 	require.Zero(removed.Transactions)
@@ -186,14 +186,14 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Run GC at the transaction and ensure the (older copy of the) relationship is removed, as well as 1 transaction (the write).
-	removed, err = pds.DeleteBeforeTx(ctx, uint64(relOverwrittenAt.IntPart()))
+	removed, err = pds.DeleteBeforeTx(ctx, relOverwrittenAt)
 	require.NoError(err)
 	require.Equal(int64(1), removed.Relationships)
 	require.Equal(int64(1), removed.Transactions)
 	require.Zero(removed.Namespaces)
 
 	// Run GC again and ensure there are no changes.
-	removed, err = pds.DeleteBeforeTx(ctx, uint64(relOverwrittenAt.IntPart()))
+	removed, err = pds.DeleteBeforeTx(ctx, relOverwrittenAt)
 	require.NoError(err)
 	require.Zero(removed.Relationships)
 	require.Zero(removed.Transactions)
@@ -210,14 +210,14 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	tRequire.NoTupleExists(ctx, tpl, relDeletedAt)
 
 	// Run GC at the transaction and ensure the relationship is removed, as well as 1 transaction (the overwrite).
-	removed, err = pds.DeleteBeforeTx(ctx, uint64(relDeletedAt.IntPart()))
+	removed, err = pds.DeleteBeforeTx(ctx, relDeletedAt)
 	require.NoError(err)
 	require.Equal(int64(1), removed.Relationships)
 	require.Equal(int64(1), removed.Transactions)
 	require.Zero(removed.Namespaces)
 
 	// Run GC again and ensure there are no changes.
-	removed, err = pds.DeleteBeforeTx(ctx, uint64(relDeletedAt.IntPart()))
+	removed, err = pds.DeleteBeforeTx(ctx, relDeletedAt)
 	require.NoError(err)
 	require.Zero(removed.Relationships)
 	require.Zero(removed.Transactions)
@@ -233,7 +233,7 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 
 	// Run GC at the transaction and ensure the older copies of the relationships are removed,
 	// as well as the 2 older write transactions and the older delete transaction.
-	removed, err = pds.DeleteBeforeTx(ctx, uint64(relLastWriteAt.IntPart()))
+	removed, err = pds.DeleteBeforeTx(ctx, relLastWriteAt)
 	require.NoError(err)
 	require.Equal(int64(2), removed.Relationships)
 	require.Equal(int64(3), removed.Transactions)

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -531,7 +531,7 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 				tc.quantization.Nanoseconds(),
 			)
 
-			var revision XID8
+			var revision xid8
 			var validFor time.Duration
 			err = conn.QueryRow(ctx, queryRevision).Scan(&revision, &validFor)
 			require.NoError(err)

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -264,7 +264,7 @@ func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
 	tx, err := pgd.dbpool.Begin(ctx)
 	require.NoError(err)
 
-	txID, err := createNewTransaction(ctx, tx)
+	txID, _, err := createNewTransaction(ctx, tx)
 	require.NoError(err)
 
 	err = tx.Commit(ctx)

--- a/internal/datastore/postgres/reader.go
+++ b/internal/datastore/postgres/reader.go
@@ -45,7 +45,7 @@ var (
 		ColUsersetRelation:  colUsersetRelation,
 	}
 
-	readNamespace = psql.Select(colConfig, colCreatedTxn).From(tableNamespace)
+	readNamespace = psql.Select(colConfig, colCreatedXid).From(tableNamespace)
 )
 
 const (
@@ -117,7 +117,7 @@ func loadNamespace(ctx context.Context, namespace string, tx pgx.Tx, baseQuery s
 	}
 
 	var config []byte
-	var version datastore.Revision
+	var version XID8
 	err = tx.QueryRow(ctx, sql, args...).Scan(&config, &version)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -131,7 +131,7 @@ func loadNamespace(ctx context.Context, namespace string, tx pgx.Tx, baseQuery s
 		return nil, datastore.NoRevision, err
 	}
 
-	return loaded, version, nil
+	return loaded, revisionFromTransaction(version), nil
 }
 
 func (r *pgReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {

--- a/internal/datastore/postgres/reader.go
+++ b/internal/datastore/postgres/reader.go
@@ -117,7 +117,7 @@ func loadNamespace(ctx context.Context, namespace string, tx pgx.Tx, baseQuery s
 	}
 
 	var config []byte
-	var version XID8
+	var version xid8
 	err = tx.QueryRow(ctx, sql, args...).Scan(&config, &version)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/datastore/postgres/readwrite.go
+++ b/internal/datastore/postgres/readwrite.go
@@ -51,7 +51,7 @@ type pgReadWriteTXN struct {
 	*pgReader
 	ctx    context.Context
 	tx     pgx.Tx
-	newXID XID8
+	newXID xid8
 }
 
 func (rwt *pgReadWriteTXN) WriteRelationships(mutations []*core.RelationTupleUpdate) error {

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -130,10 +130,10 @@ func transactionFromRevision(revision datastore.Revision) XID8 {
 	}
 }
 
-func createNewTransaction(ctx context.Context, tx pgx.Tx) (newTxnID uint64, newXID XID8, err error) {
+func createNewTransaction(ctx context.Context, tx pgx.Tx) (newXID XID8, err error) {
 	ctx, span := tracer.Start(ctx, "createNewTransaction")
 	defer span.End()
 
-	err = tx.QueryRow(ctx, createTxn).Scan(&newTxnID, &newXID)
+	err = tx.QueryRow(ctx, createTxn).Scan(&newXID)
 	return
 }

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -52,7 +52,7 @@ const (
 )
 
 func (pgd *pgDatastore) optimizedRevisionFunc(ctx context.Context) (datastore.Revision, time.Duration, error) {
-	var revision XID8
+	var revision xid8
 	var validForNanos time.Duration
 	if err := pgd.dbpool.QueryRow(
 		datastore.SeparateContextWithTracing(ctx), pgd.optimizedRevisionQuery,
@@ -98,39 +98,39 @@ func (pgd *pgDatastore) CheckRevision(ctx context.Context, revision datastore.Re
 	return nil
 }
 
-func (pgd *pgDatastore) loadRevision(ctx context.Context) (XID8, error) {
+func (pgd *pgDatastore) loadRevision(ctx context.Context) (xid8, error) {
 	ctx, span := tracer.Start(ctx, "loadRevision")
 	defer span.End()
 
 	sql, args, err := getRevision.ToSql()
 	if err != nil {
-		return XID8{}, fmt.Errorf(errRevision, err)
+		return xid8{}, fmt.Errorf(errRevision, err)
 	}
 
-	var revision XID8
+	var revision xid8
 	err = pgd.dbpool.QueryRow(datastore.SeparateContextWithTracing(ctx), sql, args...).Scan(&revision)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return XID8{}, nil
+			return xid8{}, nil
 		}
-		return XID8{}, fmt.Errorf(errRevision, err)
+		return xid8{}, fmt.Errorf(errRevision, err)
 	}
 
 	return revision, nil
 }
 
-func revisionFromTransaction(txID XID8) datastore.Revision {
+func revisionFromTransaction(txID xid8) datastore.Revision {
 	return decimal.NewFromInt(int64(txID.Uint))
 }
 
-func transactionFromRevision(revision datastore.Revision) XID8 {
-	return XID8{
+func transactionFromRevision(revision datastore.Revision) xid8 {
+	return xid8{
 		Uint:   uint64(revision.IntPart()),
 		Status: pgtype.Present,
 	}
 }
 
-func createNewTransaction(ctx context.Context, tx pgx.Tx) (newXID XID8, err error) {
+func createNewTransaction(ctx context.Context, tx pgx.Tx) (newXID xid8, err error) {
 	ctx, span := tracer.Start(ctx, "createNewTransaction")
 	defer span.End()
 

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -126,10 +126,10 @@ func transactionFromRevision(revision datastore.Revision) uint64 {
 	return uint64(revision.IntPart())
 }
 
-func createNewTransaction(ctx context.Context, tx pgx.Tx) (newTxnID uint64, err error) {
+func createNewTransaction(ctx context.Context, tx pgx.Tx) (newTxnID uint64, newXID XID8, err error) {
 	ctx, span := tracer.Start(ctx, "createNewTransaction")
 	defer span.End()
 
-	err = tx.QueryRow(ctx, createTxn).Scan(&newTxnID)
+	err = tx.QueryRow(ctx, createTxn).Scan(&newTxnID, &newXID)
 	return
 }

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/shopspring/decimal"
 
@@ -22,14 +23,14 @@ const (
 	// transaction. It will also return the amount of nanoseconds until the next
 	// optimized revision would be selected server-side, for use with caching.
 	//
-	//   %[1] Name of id column
+	//   %[1] Name of xid column
 	//   %[2] Relationship tuple transaction table
 	//   %[3] Name of timestamp column
 	//   %[4] Quantization period (in nanoseconds)
 	querySelectRevision = `
 	SELECT COALESCE(
-		(SELECT MIN(%[1]s) FROM %[2]s WHERE %[3]s >= TO_TIMESTAMP(FLOOR(EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'utc') * 1000000000 / %[4]d) * %[4]d / 1000000000) AT TIME ZONE 'utc'),
-		(SELECT MAX(%[1]s) FROM %[2]s)
+		(SELECT MIN(%[1]s::text::bigint) FROM %[2]s WHERE %[3]s >= TO_TIMESTAMP(FLOOR(EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'utc') * 1000000000 / %[4]d) * %[4]d / 1000000000) AT TIME ZONE 'utc'),
+		(SELECT MAX(%[1]s::text::bigint) FROM %[2]s)
 	),
 	%[4]d - CAST(EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'utc') * 1000000000 as bigint) %% %[4]d;`
 
@@ -38,20 +39,20 @@ const (
 	// window, and one boolean for whether the transaction ID represents a transaction
 	// that will occur in the future.
 	//
-	//   %[1] Name of id column
+	//   %[1] Name of xid column
 	//   %[2] Relationship tuple transaction table
 	//   %[3] Name of timestamp column
 	//   %[4] Inverse of GC window (in seconds)
 	queryValidTransaction = `
 	SELECT $1 >= (
-		SELECT MIN(%[1]s) FROM %[2]s WHERE %[3]s >= NOW() - INTERVAL '%[4]f seconds'
+		SELECT MIN(%[1]s::text::bigint) FROM %[2]s WHERE %[3]s >= NOW() - INTERVAL '%[4]f seconds'
 	) as fresh, $1 > (
-		SELECT MAX(%[1]s) FROM %[2]s
+		SELECT MAX(%[1]s::text::bigint) FROM %[2]s
 	) as unknown;`
 )
 
 func (pgd *pgDatastore) optimizedRevisionFunc(ctx context.Context) (datastore.Revision, time.Duration, error) {
-	var revision uint64
+	var revision XID8
 	var validForNanos time.Duration
 	if err := pgd.dbpool.QueryRow(
 		datastore.SeparateContextWithTracing(ctx), pgd.optimizedRevisionQuery,
@@ -97,33 +98,36 @@ func (pgd *pgDatastore) CheckRevision(ctx context.Context, revision datastore.Re
 	return nil
 }
 
-func (pgd *pgDatastore) loadRevision(ctx context.Context) (uint64, error) {
+func (pgd *pgDatastore) loadRevision(ctx context.Context) (XID8, error) {
 	ctx, span := tracer.Start(ctx, "loadRevision")
 	defer span.End()
 
 	sql, args, err := getRevision.ToSql()
 	if err != nil {
-		return 0, fmt.Errorf(errRevision, err)
+		return XID8{}, fmt.Errorf(errRevision, err)
 	}
 
-	var revision uint64
+	var revision XID8
 	err = pgd.dbpool.QueryRow(datastore.SeparateContextWithTracing(ctx), sql, args...).Scan(&revision)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return 0, nil
+			return XID8{}, nil
 		}
-		return 0, fmt.Errorf(errRevision, err)
+		return XID8{}, fmt.Errorf(errRevision, err)
 	}
 
 	return revision, nil
 }
 
-func revisionFromTransaction(txID uint64) datastore.Revision {
-	return decimal.NewFromInt(int64(txID))
+func revisionFromTransaction(txID XID8) datastore.Revision {
+	return decimal.NewFromInt(int64(txID.Uint))
 }
 
-func transactionFromRevision(revision datastore.Revision) uint64 {
-	return uint64(revision.IntPart())
+func transactionFromRevision(revision datastore.Revision) XID8 {
+	return XID8{
+		Uint:   uint64(revision.IntPart()),
+		Status: pgtype.Present,
+	}
 }
 
 func createNewTransaction(ctx context.Context, tx pgx.Tx) (newTxnID uint64, newXID XID8, err error) {

--- a/internal/datastore/postgres/stats.go
+++ b/internal/datastore/postgres/stats.go
@@ -39,7 +39,7 @@ func (pgd *pgDatastore) Statistics(ctx context.Context) (datastore.Stats, error)
 		return datastore.Stats{}, fmt.Errorf("unable to prepare row count sql: %w", err)
 	}
 
-	nsQuery := readNamespace.Where(sq.Eq{colDeletedTxn: liveDeletedTxnID})
+	nsQuery := readNamespace.Where(sq.Eq{colDeletedXid: liveDeletedTxnID})
 
 	var uniqueID string
 	var nsDefs []*corev1.NamespaceDefinition

--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -3,32 +3,48 @@ package postgres
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
 
-	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-
 	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/pkg/datastore"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
 const (
 	watchSleep = 100 * time.Millisecond
 )
 
-var queryChanged = psql.Select(
-	colNamespace,
-	colObjectID,
-	colRelation,
-	colUsersetNamespace,
-	colUsersetObjectID,
-	colUsersetRelation,
-	colCreatedTxn,
-	colDeletedTxn,
-).From(tableTuple)
+var (
+	// This query must cast an xid8 to xid, which is a safe operation as long as the
+	// xid8 is one of the last ~2 billion transaction IDs generated. We should be garbage
+	// collecting these transactions long before we get to that point.
+	newRevisionsQuery = fmt.Sprintf(`
+	SELECT %[1]s from %[2]s
+	WHERE pg_xact_commit_timestamp(%[1]s::xid) > (
+		SELECT pg_xact_commit_timestamp(%[1]s::xid) FROM relation_tuple_transaction where %[1]s = $1
+	) AND %[1]s < pg_snapshot_xmin(pg_current_snapshot())
+	ORDER BY pg_xact_commit_timestamp(%[1]s::xid);
+`, colXID, tableTransaction)
 
-func (pgd *pgDatastore) Watch(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
+	queryChanged = psql.Select(
+		colNamespace,
+		colObjectID,
+		colRelation,
+		colUsersetNamespace,
+		colUsersetObjectID,
+		colUsersetRelation,
+		colCreatedXid,
+		colDeletedXid,
+	).From(tableTuple)
+)
+
+func (pgd *pgDatastore) Watch(
+	ctx context.Context,
+	afterRevision datastore.Revision,
+) (<-chan *datastore.RevisionChanges, <-chan error) {
 	updates := make(chan *datastore.RevisionChanges, pgd.watchBufferLength)
 	errs := make(chan error, 1)
 
@@ -39,9 +55,7 @@ func (pgd *pgDatastore) Watch(ctx context.Context, afterRevision datastore.Revis
 		currentTxn := transactionFromRevision(afterRevision)
 
 		for {
-			var stagedUpdates []*datastore.RevisionChanges
-			var err error
-			stagedUpdates, currentTxn, err = pgd.loadChanges(ctx, currentTxn)
+			newTxns, err := pgd.getNewRevisions(ctx, currentTxn)
 			if err != nil {
 				if errors.Is(ctx.Err(), context.Canceled) {
 					errs <- datastore.NewWatchCanceledErr()
@@ -51,18 +65,28 @@ func (pgd *pgDatastore) Watch(ctx context.Context, afterRevision datastore.Revis
 				return
 			}
 
-			// Write the staged updates to the channel
-			for _, changeToWrite := range stagedUpdates {
+			for _, revision := range newTxns {
+				changeToWrite, err := pgd.loadChanges(ctx, revision)
+				if err != nil {
+					if errors.Is(ctx.Err(), context.Canceled) {
+						errs <- datastore.NewWatchCanceledErr()
+					} else {
+						errs <- err
+					}
+					return
+				}
+
 				select {
 				case updates <- changeToWrite:
 				default:
 					errs <- datastore.NewWatchDisconnectedErr()
 					return
 				}
+
+				currentTxn = revision
 			}
 
-			// If there were no changes, sleep a bit
-			if len(stagedUpdates) == 0 {
+			if len(newTxns) == 0 {
 				sleep := time.NewTimer(watchSleep)
 
 				select {
@@ -79,79 +103,82 @@ func (pgd *pgDatastore) Watch(ctx context.Context, afterRevision datastore.Revis
 	return updates, errs
 }
 
-func (pgd *pgDatastore) loadChanges(
+func (pgd *pgDatastore) getNewRevisions(
 	ctx context.Context,
-	afterRevision uint64,
-) (changes []*datastore.RevisionChanges, newRevision uint64, err error) {
-	newRevision, err = pgd.loadRevision(ctx)
+	afterTX XID8,
+) ([]XID8, error) {
+	rows, err := pgd.dbpool.Query(context.Background(), newRevisionsQuery, afterTX)
 	if err != nil {
-		return
-	}
-
-	if newRevision == afterRevision {
-		return
-	}
-
-	sql, args, err := queryChanged.Where(sq.Or{
-		sq.And{
-			sq.Gt{colCreatedTxn: afterRevision},
-			sq.LtOrEq{colCreatedTxn: newRevision},
-		},
-		sq.And{
-			sq.Gt{colDeletedTxn: afterRevision},
-			sq.LtOrEq{colDeletedTxn: newRevision},
-		},
-	}).ToSql()
-	if err != nil {
-		return
-	}
-
-	rows, err := pgd.dbpool.Query(ctx, sql, args...)
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			err = datastore.NewWatchCanceledErr()
-		}
-		return
+		return nil, fmt.Errorf("unable to load new revisions: %w", err)
 	}
 	defer rows.Close()
 
-	stagedChanges := common.NewChanges()
-
+	var ids []XID8
 	for rows.Next() {
+		var nextXID XID8
+		if err := rows.Scan(&nextXID); err != nil {
+			return nil, fmt.Errorf("unable to decode new revision: %w", err)
+		}
+
+		ids = append(ids, nextXID)
+	}
+	if rows.Err() != nil {
+		return nil, fmt.Errorf("unable to load new revisions: %w", err)
+	}
+
+	return ids, nil
+}
+
+func (pgd *pgDatastore) loadChanges(ctx context.Context, revision XID8) (*datastore.RevisionChanges, error) {
+	sql, args, err := queryChanged.Where(sq.Or{
+		sq.Eq{colCreatedXid: revision},
+		sq.Eq{colDeletedXid: revision},
+	}).ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("unable to prepare changes SQL: %w", err)
+	}
+
+	changes, err := pgd.dbpool.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load changes for XID: %w", err)
+	}
+
+	tracked := common.NewChanges()
+	for changes.Next() {
 		nextTuple := &core.RelationTuple{
 			ResourceAndRelation: &core.ObjectAndRelation{},
 			Subject:             &core.ObjectAndRelation{},
 		}
 
-		var createdTxn uint64
-		var deletedTxn uint64
-		err = rows.Scan(
+		var createdXID, deletedXID XID8
+		if err := changes.Scan(
 			&nextTuple.ResourceAndRelation.Namespace,
 			&nextTuple.ResourceAndRelation.ObjectId,
 			&nextTuple.ResourceAndRelation.Relation,
 			&nextTuple.Subject.Namespace,
 			&nextTuple.Subject.ObjectId,
 			&nextTuple.Subject.Relation,
-			&createdTxn,
-			&deletedTxn,
-		)
-		if err != nil {
-			return
+			&createdXID,
+			&deletedXID,
+		); err != nil {
+			return nil, fmt.Errorf("unable to parse changed tuple: %w", err)
 		}
 
-		if createdTxn > afterRevision && createdTxn <= newRevision {
-			stagedChanges.AddChange(ctx, revisionFromTransaction(createdTxn), nextTuple, core.RelationTupleUpdate_TOUCH)
-		}
-
-		if deletedTxn > afterRevision && deletedTxn <= newRevision {
-			stagedChanges.AddChange(ctx, revisionFromTransaction(deletedTxn), nextTuple, core.RelationTupleUpdate_DELETE)
+		if createdXID.Uint == revision.Uint {
+			tracked.AddChange(ctx, revisionFromTransaction(revision), nextTuple, core.RelationTupleUpdate_TOUCH)
+		} else if deletedXID.Uint == revision.Uint {
+			tracked.AddChange(ctx, revisionFromTransaction(revision), nextTuple, core.RelationTupleUpdate_DELETE)
 		}
 	}
-	if err = rows.Err(); err != nil {
-		return
+	if changes.Err() != nil {
+		return nil, fmt.Errorf("unable to load changes for XID: %w", err)
 	}
 
-	changes = stagedChanges.AsRevisionChanges()
-
-	return
+	reconciledChanges := tracked.AsRevisionChanges()
+	if len(reconciledChanges) == 0 {
+		return &datastore.RevisionChanges{
+			Revision: revisionFromTransaction(revision),
+		}, nil
+	}
+	return reconciledChanges[0], nil
 }

--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -105,17 +105,17 @@ func (pgd *pgDatastore) Watch(
 
 func (pgd *pgDatastore) getNewRevisions(
 	ctx context.Context,
-	afterTX XID8,
-) ([]XID8, error) {
+	afterTX xid8,
+) ([]xid8, error) {
 	rows, err := pgd.dbpool.Query(context.Background(), newRevisionsQuery, afterTX)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load new revisions: %w", err)
 	}
 	defer rows.Close()
 
-	var ids []XID8
+	var ids []xid8
 	for rows.Next() {
-		var nextXID XID8
+		var nextXID xid8
 		if err := rows.Scan(&nextXID); err != nil {
 			return nil, fmt.Errorf("unable to decode new revision: %w", err)
 		}
@@ -129,7 +129,7 @@ func (pgd *pgDatastore) getNewRevisions(
 	return ids, nil
 }
 
-func (pgd *pgDatastore) loadChanges(ctx context.Context, revision XID8) (*datastore.RevisionChanges, error) {
+func (pgd *pgDatastore) loadChanges(ctx context.Context, revision xid8) (*datastore.RevisionChanges, error) {
 	sql, args, err := queryChanged.Where(sq.Or{
 		sq.Eq{colCreatedXid: revision},
 		sq.Eq{colDeletedXid: revision},
@@ -150,7 +150,7 @@ func (pgd *pgDatastore) loadChanges(ctx context.Context, revision XID8) (*datast
 			Subject:             &core.ObjectAndRelation{},
 		}
 
-		var createdXID, deletedXID XID8
+		var createdXID, deletedXID xid8
 		if err := changes.Scan(
 			&nextTuple.ResourceAndRelation.Namespace,
 			&nextTuple.ResourceAndRelation.ObjectId,

--- a/internal/datastore/postgres/xid8.go
+++ b/internal/datastore/postgres/xid8.go
@@ -1,0 +1,207 @@
+// Adapted from https://github.com/jackc/pgtype/blob/f59f1408937ef0bed249f2bfbafb77222bb48f65/xid.go
+
+package postgres
+
+import (
+	"database/sql/driver"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/jackc/pgio"
+	"github.com/jackc/pgtype"
+)
+
+type pguint64 struct {
+	Uint   uint64
+	Status pgtype.Status
+}
+
+var errUndefined = errors.New("cannot encode status undefined")
+
+// xid8 represents the xid8 postgres type, which is a 64-bit transaction ID that is *NOT*
+// subject to transaction wraparound limitations.
+// https://www.postgresql.org/docs/current/datatype-oid.html
+type XID8 pguint64
+
+func (txid *XID8) Set(src interface{}) error {
+	return (*pguint64)(txid).Set(src)
+}
+
+func (txid XID8) Get() interface{} {
+	return (pguint64)(txid).Get()
+}
+
+func (txid *XID8) AssignTo(dst interface{}) error {
+	return (*pguint64)(txid).AssignTo(dst)
+}
+
+func (txid *XID8) DecodeText(ci *pgtype.ConnInfo, src []byte) error {
+	return (*pguint64)(txid).DecodeText(ci, src)
+}
+
+func (txid *XID8) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
+	return (*pguint64)(txid).DecodeBinary(ci, src)
+}
+
+func (txid XID8) EncodeText(ci *pgtype.ConnInfo, buf []byte) ([]byte, error) {
+	return (pguint64)(txid).EncodeText(ci, buf)
+}
+
+func (txid XID8) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) ([]byte, error) {
+	return (pguint64)(txid).EncodeBinary(ci, buf)
+}
+
+func (txid *XID8) Scan(src interface{}) error {
+	return (*pguint64)(txid).Scan(src)
+}
+
+func (txid XID8) Value() (driver.Value, error) {
+	return (pguint64)(txid).Value()
+}
+
+func (pui *pguint64) Set(src interface{}) error {
+	switch value := src.(type) {
+	case int64:
+		if value < 0 {
+			return fmt.Errorf("%d is less than minimum value for pguint64", value)
+		}
+		*pui = pguint64{Uint: uint64(value), Status: pgtype.Present}
+	case int32:
+		if value < 0 {
+			return fmt.Errorf("%d is less than minimum value for pguint64", value)
+		}
+		*pui = pguint64{Uint: uint64(value), Status: pgtype.Present}
+	case uint32:
+		*pui = pguint64{Uint: uint64(value), Status: pgtype.Present}
+	case uint64:
+		*pui = pguint64{Uint: value, Status: pgtype.Present}
+	default:
+		return fmt.Errorf("cannot convert %v to pguint64", value)
+	}
+
+	return nil
+}
+
+func (pui pguint64) Get() interface{} {
+	switch pui.Status {
+	case pgtype.Present:
+		return pui.Uint
+	case pgtype.Null:
+		return nil
+	default:
+		return pui.Status
+	}
+}
+
+func (pui *pguint64) AssignTo(dst interface{}) error {
+	switch v := dst.(type) {
+	case *uint64:
+		if pui.Status == pgtype.Present {
+			*v = pui.Uint
+		} else {
+			return fmt.Errorf("cannot assign %v into %T", pui, dst)
+		}
+	case **uint64:
+		if pui.Status == pgtype.Present {
+			n := pui.Uint
+			*v = &n
+		} else {
+			*v = nil
+		}
+	}
+
+	return nil
+}
+
+func (pui *pguint64) DecodeText(ci *pgtype.ConnInfo, src []byte) error {
+	if src == nil {
+		*pui = pguint64{Status: pgtype.Null}
+		return nil
+	}
+
+	n, err := strconv.ParseUint(string(src), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*pui = pguint64{Uint: n, Status: pgtype.Present}
+	return nil
+}
+
+func (pui *pguint64) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
+	if src == nil {
+		*pui = pguint64{Status: pgtype.Null}
+		return nil
+	}
+
+	if len(src) != 8 {
+		return fmt.Errorf("invalid length: %v", len(src))
+	}
+
+	n := binary.BigEndian.Uint64(src)
+
+	*pui = pguint64{Uint: n, Status: pgtype.Present}
+	return nil
+}
+
+func (pui pguint64) EncodeText(ci *pgtype.ConnInfo, buf []byte) ([]byte, error) {
+	switch pui.Status {
+	case pgtype.Null:
+		return nil, nil
+	case pgtype.Undefined:
+		return nil, errUndefined
+	}
+
+	return append(buf, strconv.FormatUint(pui.Uint, 10)...), nil
+}
+
+func (pui pguint64) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) ([]byte, error) {
+	switch pui.Status {
+	case pgtype.Null:
+		return nil, nil
+	case pgtype.Undefined:
+		return nil, errUndefined
+	}
+
+	return pgio.AppendUint64(buf, pui.Uint), nil
+}
+
+func (pui *pguint64) Scan(src interface{}) error {
+	if src == nil {
+		*pui = pguint64{Status: pgtype.Null}
+		return nil
+	}
+
+	switch src := src.(type) {
+	case uint32:
+		*pui = pguint64{Uint: uint64(src), Status: pgtype.Present}
+		return nil
+	case int64:
+		*pui = pguint64{Uint: uint64(src), Status: pgtype.Present}
+		return nil
+	case uint64:
+		*pui = pguint64{Uint: src, Status: pgtype.Present}
+		return nil
+	case string:
+		return pui.DecodeText(nil, []byte(src))
+	case []byte:
+		srcCopy := make([]byte, len(src))
+		copy(srcCopy, src)
+		return pui.DecodeText(nil, srcCopy)
+	}
+
+	return fmt.Errorf("cannot scan %T", src)
+}
+
+func (pui pguint64) Value() (driver.Value, error) {
+	switch pui.Status {
+	case pgtype.Present:
+		return int64(pui.Uint), nil
+	case pgtype.Null:
+		return nil, nil
+	default:
+		return nil, errUndefined
+	}
+}

--- a/internal/datastore/postgres/xid8.go
+++ b/internal/datastore/postgres/xid8.go
@@ -23,41 +23,41 @@ var errUndefined = errors.New("cannot encode status undefined")
 // xid8 represents the xid8 postgres type, which is a 64-bit transaction ID that is *NOT*
 // subject to transaction wraparound limitations.
 // https://www.postgresql.org/docs/current/datatype-oid.html
-type XID8 pguint64
+type xid8 pguint64
 
-func (txid *XID8) Set(src interface{}) error {
+func (txid *xid8) Set(src interface{}) error {
 	return (*pguint64)(txid).Set(src)
 }
 
-func (txid XID8) Get() interface{} {
+func (txid xid8) Get() interface{} {
 	return (pguint64)(txid).Get()
 }
 
-func (txid *XID8) AssignTo(dst interface{}) error {
+func (txid *xid8) AssignTo(dst interface{}) error {
 	return (*pguint64)(txid).AssignTo(dst)
 }
 
-func (txid *XID8) DecodeText(ci *pgtype.ConnInfo, src []byte) error {
+func (txid *xid8) DecodeText(ci *pgtype.ConnInfo, src []byte) error {
 	return (*pguint64)(txid).DecodeText(ci, src)
 }
 
-func (txid *XID8) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
+func (txid *xid8) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
 	return (*pguint64)(txid).DecodeBinary(ci, src)
 }
 
-func (txid XID8) EncodeText(ci *pgtype.ConnInfo, buf []byte) ([]byte, error) {
+func (txid xid8) EncodeText(ci *pgtype.ConnInfo, buf []byte) ([]byte, error) {
 	return (pguint64)(txid).EncodeText(ci, buf)
 }
 
-func (txid XID8) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) ([]byte, error) {
+func (txid xid8) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) ([]byte, error) {
 	return (pguint64)(txid).EncodeBinary(ci, buf)
 }
 
-func (txid *XID8) Scan(src interface{}) error {
+func (txid *xid8) Scan(src interface{}) error {
 	return (*pguint64)(txid).Scan(src)
 }
 
-func (txid XID8) Value() (driver.Value, error) {
+func (txid xid8) Value() (driver.Value, error) {
 	return (pguint64)(txid).Value()
 }
 

--- a/internal/testserver/datastore/postgres.go
+++ b/internal/testserver/datastore/postgres.go
@@ -39,6 +39,7 @@ func RunPostgresForTesting(t testing.TB, bridgeNetworkName string) RunningEngine
 		Env:          []string{"POSTGRES_PASSWORD=secret", "POSTGRES_DB=defaultdb"},
 		ExposedPorts: []string{"5432/tcp"},
 		NetworkID:    bridgeNetworkName,
+		Cmd:          []string{"-c", "track_commit_timestamp=1"},
 	})
 	require.NoError(t, err)
 

--- a/internal/testserver/datastore/postgres.go
+++ b/internal/testserver/datastore/postgres.go
@@ -35,7 +35,7 @@ func RunPostgresForTesting(t testing.TB, bridgeNetworkName string) RunningEngine
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Name:         name,
 		Repository:   "postgres",
-		Tag:          "10.20",
+		Tag:          "13.8",
 		Env:          []string{"POSTGRES_PASSWORD=secret", "POSTGRES_DB=defaultdb"},
 		ExposedPorts: []string{"5432/tcp"},
 		NetworkID:    bridgeNetworkName,

--- a/pkg/datastore/errors.go
+++ b/pkg/datastore/errors.go
@@ -41,10 +41,6 @@ const (
 	// validity by being too old.
 	RevisionStale InvalidRevisionReason = iota
 
-	// RevisionInFuture is the reason returned when a revision is outside the window of
-	// validity by being too new.
-	RevisionInFuture
-
 	// CouldNotDetermineRevision is the reason returned when a revision for a
 	// request could not be determined.
 	CouldNotDetermineRevision
@@ -72,8 +68,6 @@ func (eri ErrInvalidRevision) MarshalZerologObject(e *zerolog.Event) {
 	switch eri.reason {
 	case RevisionStale:
 		e.Str("error", eri.Error()).Str("reason", "stale")
-	case RevisionInFuture:
-		e.Str("error", eri.Error()).Str("reason", "future")
 	case CouldNotDetermineRevision:
 		e.Str("error", eri.Error()).Str("reason", "indeterminate")
 	default:
@@ -117,13 +111,6 @@ func NewInvalidRevisionErr(revision Revision, reason InvalidRevisionReason) erro
 	case RevisionStale:
 		return ErrInvalidRevision{
 			error:    fmt.Errorf("revision has expired"),
-			revision: revision,
-			reason:   reason,
-		}
-
-	case RevisionInFuture:
-		return ErrInvalidRevision{
-			error:    fmt.Errorf("revision is for a future time"),
 			revision: revision,
 			reason:   reason,
 		}

--- a/pkg/datastore/test/tuples.go
+++ b/pkg/datastore/test/tuples.go
@@ -477,7 +477,7 @@ func InvalidReadsTest(t *testing.T, tester DatastoreTester) {
 		// Check that we can't read a revision that's ahead of the latest
 		err = ds.CheckRevision(ctx, nextWrite.Add(decimal.NewFromInt(1_000_000_000)))
 		require.True(errors.As(err, &revisionErr))
-		require.Equal(datastore.RevisionInFuture, revisionErr.Reason())
+		require.Equal(datastore.CouldNotDetermineRevision, revisionErr.Reason())
 	})
 }
 

--- a/pkg/datastore/test/watch.go
+++ b/pkg/datastore/test/watch.go
@@ -126,7 +126,7 @@ func verifyUpdates(
 		select {
 		case change, ok := <-changes:
 			if !ok {
-				require.True(expectDisconnect)
+				require.True(expectDisconnect, "unexpected disconnect")
 				errWait := time.NewTimer(2 * time.Second)
 				select {
 				case err := <-errchan:
@@ -146,12 +146,14 @@ func verifyUpdates(
 
 			require.True(missingExpected.IsEmpty(), "expected changes missing: %s", missingExpected)
 			require.True(unexpected.IsEmpty(), "unexpected changes: %s", unexpected)
+
+			time.Sleep(1 * time.Millisecond)
 		case <-changeWait.C:
 			require.Fail("Timed out", "waiting for changes: %s", expected)
 		}
 	}
 
-	require.False(expectDisconnect)
+	require.False(expectDisconnect, "all changes verified without expected disconnect")
 }
 
 func setOfChanges(changes []*core.RelationTupleUpdate) *strset.Set {


### PR DESCRIPTION
Previously Postgres was limited to 1 concurrent write request globally. With this change we leverage some of the transaction isolation primitives introduced in Postgres 13 to extend the effective repeatable read lifetime beyond the transaction's lifetime. With this we can leverage internal Postgres transaction IDs and snapshots to greatly improve the performance of our MVCC implementation.

**Contains a 4-phase migration!**