### PR TITLE
Add command to export migrations

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -63,6 +63,10 @@ func main() {
 	cmd.RegisterHeadFlags(headCmd)
 	rootCmd.AddCommand(headCmd)
 
+	migrationExportCmd := cmd.NewMigrationCommand(rootCmd.Use)
+	cmd.RegisterMigrationFlags(migrationExportCmd)
+	rootCmd.AddCommand(migrationExportCmd)
+
 	// Add server commands
 	var serverConfig cmdutil.Config
 	serveCmd := cmd.NewServeCommand(rootCmd.Use, &serverConfig)

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/johannesboyne/gofakes3 v0.0.0-20220314170512-33c13122505e
 	github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6
+	github.com/jzelinskie/cobrautil v0.0.12
 	github.com/jzelinskie/cobrautil/v2 v2.0.0-20221003230316-3022721fa8f0
 	github.com/jzelinskie/stringz v0.0.1
 	github.com/lib/pq v1.10.7

--- a/go.sum
+++ b/go.sum
@@ -448,6 +448,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6 h1:OzCtZaD1uI5Fc1C+4oNAp7kZ4ibh5OIgxI29moH/IbE=
 github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6/go.mod h1:CEusGbCRDFcHX9EgEhPsgJX33kpp9CfSFRBAoSGOems=
+github.com/jzelinskie/cobrautil v0.0.12 h1:NEfbvkSqvHqcH384mG4JtJb/4AmTfHYM+eV99h+t9bo=
+github.com/jzelinskie/cobrautil v0.0.12/go.mod h1:9tPpSZKwXyHMxcrIGH+u+8J3YiRlqqfpe4esM0ZYJzI=
 github.com/jzelinskie/cobrautil/v2 v2.0.0-20221003230316-3022721fa8f0 h1:PQtSXhXhIND0B9Qea303xJ/TsHFFlr+HVsU/kB8rKQo=
 github.com/jzelinskie/cobrautil/v2 v2.0.0-20221003230316-3022721fa8f0/go.mod h1:iqQf0oijpU31L1tuvD9+dKxkhdAv9IaKlnzVattaDwo=
 github.com/jzelinskie/stringz v0.0.1 h1:IahR+y8ct2nyj7B6i8UtFsGFj4ex1SX27iKFYsAheLk=

--- a/internal/datastore/crdb/migrations/zz_migration.0001_initial_schema.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0001_initial_schema.go
@@ -35,7 +35,7 @@ const (
 )
 
 func init() {
-	if err := CRDBMigrations.Register("initial", "", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
+	if err := CRDBMigrations.Register("initial", "", "", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
 		statements := []string{
 			createNamespaceConfig,
 			createRelationTuple,

--- a/internal/datastore/crdb/migrations/zz_migration.0002_add_transactions.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0002_add_transactions.go
@@ -14,7 +14,7 @@ const (
 )
 
 func init() {
-	if err := CRDBMigrations.Register("add-transactions-table", "initial", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
+	if err := CRDBMigrations.Register("add-transactions-table", "initial", "initial", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, createTransactions)
 		return err
 	}); err != nil {

--- a/internal/datastore/crdb/migrations/zz_migration.0003_add_metadata_and_counters.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0003_add_metadata_and_counters.go
@@ -21,7 +21,7 @@ const (
 )
 
 func init() {
-	if err := CRDBMigrations.Register("add-metadata-and-counters", "add-transactions-table", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
+	if err := CRDBMigrations.Register("add-metadata-and-counters", "add-transactions-table", "add-transactions-table", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, createMetadataTable); err != nil {
 			return err
 		}

--- a/internal/datastore/mysql/migrations/manager.go
+++ b/internal/datastore/mysql/migrations/manager.go
@@ -49,5 +49,5 @@ func registerMigration(version, replaces string, up migrate.MigrationFunc[Wrappe
 	}
 
 	// register the migration
-	return Manager.Register(version, replaces, up, upTx)
+	return Manager.Register(version, replaces, replaces, up, upTx)
 }

--- a/internal/datastore/postgres/migrations/driver.go
+++ b/internal/datastore/postgres/migrations/driver.go
@@ -72,21 +72,6 @@ func (apd *AlembicPostgresDriver) Close(ctx context.Context) error {
 }
 
 func (apd *AlembicPostgresDriver) WriteVersion(ctx context.Context, tx pgx.Tx, version, replaced string) error {
-	result, err := tx.Exec(
-		ctx,
-		"UPDATE alembic_version SET version_num=$1 WHERE version_num=$2",
-		version,
-		replaced,
-	)
-	if err != nil {
-		return fmt.Errorf("unable to update version row: %w", err)
-	}
-
-	updatedCount := result.RowsAffected()
-	if updatedCount != 1 {
-		return fmt.Errorf("writing version update affected %d rows, should be 1", updatedCount)
-	}
-
 	return nil
 }
 

--- a/internal/datastore/postgres/migrations/manager.go
+++ b/internal/datastore/postgres/migrations/manager.go
@@ -1,15 +1,111 @@
 package migrations
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/slices"
+
 	"github.com/authzed/spicedb/pkg/migrate"
 
 	"github.com/jackc/pgx/v4"
 )
 
-var (
-	noNonatomicMigration migrate.MigrationFunc[*pgx.Conn]
-	noTxMigration        migrate.TxMigrationFunc[pgx.Tx]
-)
-
 // DatabaseMigrations implements a migration manager for the Postgres Driver.
 var DatabaseMigrations = migrate.NewManager[*AlembicPostgresDriver, *pgx.Conn, pgx.Tx]()
+
+type PGMigrationSet []*PostgresMigration
+
+var PostgresMigrations PGMigrationSet = make([]*PostgresMigration, 0)
+
+func (p PGMigrationSet) Sort() {
+	slices.SortFunc(p, func(a *PostgresMigration, b *PostgresMigration) bool {
+		return b.replaces == a.version
+	})
+}
+
+func RegisterPGMigration(p *PostgresMigration) {
+	if p.migrationType == "" {
+		panic("migration missing type")
+	}
+	if p.migrationSafety == "" {
+		panic("migration missing safety")
+	}
+	PostgresMigrations = append(PostgresMigrations, p)
+	if err := DatabaseMigrations.Register(p.version, p.replaces, p.expected, p.Run, nil); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}
+
+type migrationType string
+
+var (
+	DDL migrationType = "DDL"
+	DML migrationType = "DML"
+)
+
+type migrationSafety string
+
+var (
+	expand   migrationSafety = "expand"
+	contract migrationSafety = "contract"
+)
+
+type PostgresMigration struct {
+	version         string
+	replaces        string
+	expected        string
+	command         strings.Builder
+	suffix          string
+	migrationType   migrationType
+	migrationSafety migrationSafety
+}
+
+func (p *PostgresMigration) Run(ctx context.Context, conn *pgx.Conn) error {
+	_, err := conn.Exec(ctx, p.command.String())
+	return err
+}
+
+func (p *PostgresMigration) Begin() {
+	p.command.WriteString("BEGIN;\n")
+}
+
+func (p *PostgresMigration) Commit() {
+	p.command.WriteString("COMMIT;")
+}
+
+func (p *PostgresMigration) WriteVersion() {
+	if p.version == "" {
+		panic("cannot write empty version")
+	}
+	p.command.WriteString(fmt.Sprintf("UPDATE alembic_version SET version_num='%[1]s' WHERE version_num='%[2]s';\n", p.version, p.replaces))
+}
+
+func (p *PostgresMigration) WriteVersionOverride(previous string) {
+	if p.version == "" {
+		panic("cannot write empty version")
+	}
+	p.command.WriteString(fmt.Sprintf("UPDATE alembic_version SET version_num='%[1]s' WHERE version_num='%[2]s';\n", p.version, previous))
+}
+
+func (p *PostgresMigration) Statement(stmt string) {
+	p.command.WriteString(stmt)
+}
+
+func (p *PostgresMigration) FileName(prefix string) string {
+	suffix := p.suffix
+	if suffix == "" {
+		suffix = ".sql"
+	}
+	return strings.Join([]string{
+		prefix,
+		string(p.migrationType),
+		string(p.migrationSafety),
+		strings.ReplaceAll(p.version, "-", "_"),
+	}, "_") + suffix
+}
+
+func (p *PostgresMigration) Bytes() []byte {
+	return []byte(p.command.String())
+}

--- a/internal/datastore/postgres/migrations/zz_migration.0001_1eaeba4b8a73_initial.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0001_1eaeba4b8a73_initial.go
@@ -1,16 +1,11 @@
 package migrations
 
-import (
-	"context"
-
-	"github.com/jackc/pgx/v4"
-)
-
 const createRelationTupleTransaction = `CREATE TABLE relation_tuple_transaction (
     id BIGSERIAL NOT NULL,
     timestamp TIMESTAMP WITHOUT TIME ZONE DEFAULT now() NOT NULL,
     CONSTRAINT pk_rttx PRIMARY KEY (id)
-);`
+);
+`
 
 const createNamespaceConfig = `CREATE TABLE namespace_config (
     namespace VARCHAR NOT NULL,
@@ -18,7 +13,8 @@ const createNamespaceConfig = `CREATE TABLE namespace_config (
     created_transaction BIGINT NOT NULL,
     deleted_transaction BIGINT NOT NULL DEFAULT '9223372036854775807',
     CONSTRAINT pk_namespace_config PRIMARY KEY (namespace, created_transaction)
-);`
+);
+`
 
 const createRelationTuple = `CREATE TABLE relation_tuple (
     id BIGSERIAL NOT NULL,
@@ -33,33 +29,40 @@ const createRelationTuple = `CREATE TABLE relation_tuple (
     CONSTRAINT pk_relation_tuple PRIMARY KEY (id),
     CONSTRAINT uq_relation_tuple_namespace UNIQUE (namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, created_transaction, deleted_transaction),
     CONSTRAINT uq_relation_tuple_living UNIQUE (namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, deleted_transaction)
-);`
+);
+`
 
-const insertFirstTransaction = "INSERT INTO relation_tuple_transaction (timestamp) VALUES (to_timestamp(0));"
+const insertFirstTransaction = "INSERT INTO relation_tuple_transaction (timestamp) VALUES (to_timestamp(0));\n"
 
 const createAlembicVersion = `CREATE TABLE alembic_version (
 	version_num VARCHAR NOT NULL
-);`
+);
+`
 
-const insertEmptyVersion = `INSERT INTO alembic_version (version_num) VALUES ('');`
+const insertEmptyVersion = `INSERT INTO alembic_version (version_num) VALUES ('');
+`
 
 func init() {
-	if err := DatabaseMigrations.Register("1eaeba4b8a73", "", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
-		statements := []string{
-			createRelationTupleTransaction,
-			createNamespaceConfig,
-			createRelationTuple,
-			insertFirstTransaction,
-			createAlembicVersion,
-			insertEmptyVersion,
-		}
-		for _, stmt := range statements {
-			if _, err := tx.Exec(ctx, stmt); err != nil {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
-		panic("failed to register migration: " + err.Error())
+	statements := []string{
+		createRelationTupleTransaction,
+		createNamespaceConfig,
+		createRelationTuple,
+		insertFirstTransaction,
+		createAlembicVersion,
+		insertEmptyVersion,
 	}
+	m := &PostgresMigration{
+		version:         "1eaeba4b8a73",
+		replaces:        "",
+		expected:        "",
+		migrationType:   DDL,
+		migrationSafety: expand,
+	}
+	m.Begin()
+	for _, stmt := range statements {
+		m.command.WriteString(stmt)
+	}
+	m.WriteVersion()
+	m.Commit()
+	RegisterPGMigration(m)
 }

--- a/internal/datastore/postgres/migrations/zz_migration.0002_add_reverse_index.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0002_add_reverse_index.go
@@ -1,28 +1,24 @@
 package migrations
 
-import (
-	"context"
-
-	"github.com/jackc/pgx/v4"
-)
-
 const (
-	createReverseQueryIndex = `CREATE INDEX ix_relation_tuple_by_subject ON relation_tuple (userset_object_id, userset_namespace, userset_relation, namespace, relation)`
-	createReverseCheckIndex = `CREATE INDEX ix_relation_tuple_by_subject_relation ON relation_tuple (userset_namespace, userset_relation, namespace, relation)`
+	createReverseQueryIndex = `CREATE INDEX ix_relation_tuple_by_subject ON relation_tuple (userset_object_id, userset_namespace, userset_relation, namespace, relation);
+`
+	createReverseCheckIndex = `CREATE INDEX ix_relation_tuple_by_subject_relation ON relation_tuple (userset_namespace, userset_relation, namespace, relation);
+`
 )
 
 func init() {
-	if err := DatabaseMigrations.Register("add-reverse-index", "1eaeba4b8a73", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
-		for _, stmt := range []string{
-			createReverseQueryIndex,
-			createReverseCheckIndex,
-		} {
-			if _, err := tx.Exec(ctx, stmt); err != nil {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
-		panic("failed to register migration: " + err.Error())
+	m := &PostgresMigration{
+		version:         "add-reverse-index",
+		replaces:        "1eaeba4b8a73",
+		expected:        "1eaeba4b8a73",
+		migrationType:   DDL,
+		migrationSafety: expand,
 	}
+	m.Begin()
+	m.Statement(createReverseQueryIndex)
+	m.Statement(createReverseCheckIndex)
+	m.WriteVersion()
+	m.Commit()
+	RegisterPGMigration(m)
 }

--- a/internal/datastore/postgres/migrations/zz_migration.0003_add_unique_living_ns.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0003_add_unique_living_ns.go
@@ -1,33 +1,39 @@
 package migrations
 
-import (
-	"context"
-
-	"github.com/jackc/pgx/v4"
-)
-
-const createUniqueLivingNamespaceConstraint = `
-	ALTER TABLE namespace_config
+const createUniqueLivingNamespaceConstraint = `ALTER TABLE namespace_config
 	ADD CONSTRAINT uq_namespace_living UNIQUE (namespace, deleted_transaction);
 `
 
-const deleteAllButNewestNamespace = `
-	DELETE FROM namespace_config WHERE namespace IN (
+const deleteAllButNewestNamespace = `DELETE FROM namespace_config WHERE namespace IN (
 		SELECT namespace FROM namespace_config WHERE deleted_transaction = 9223372036854775807 GROUP BY namespace HAVING COUNT(created_transaction) > 1
 	) AND (namespace, created_transaction) NOT IN (
-		SELECT namespace, max(created_transaction) from namespace_config where deleted_transaction = 9223372036854775807 GROUP BY namespace HAVING COUNT(created_transaction) > 1);`
+		SELECT namespace, max(created_transaction) from namespace_config where deleted_transaction = 9223372036854775807 GROUP BY namespace HAVING COUNT(created_transaction) > 1);
+`
 
 func init() {
-	if err := DatabaseMigrations.Register("add-unique-living-ns", "add-reverse-index", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
-		if _, err := tx.Exec(ctx, deleteAllButNewestNamespace); err != nil {
-			return err
-		}
-
-		if _, err := tx.Exec(ctx, createUniqueLivingNamespaceConstraint); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		panic("failed to register migration: " + err.Error())
+	m := &PostgresMigration{
+		version:         "delete-all-but-newest-ns",
+		replaces:        "add-reverse-index",
+		expected:        "add-reverse-index",
+		migrationType:   DML,
+		migrationSafety: contract,
 	}
+	m.Begin()
+	m.Statement(deleteAllButNewestNamespace)
+	m.WriteVersion()
+	m.Commit()
+	RegisterPGMigration(m)
+
+	m2 := &PostgresMigration{
+		version:         "add-unique-living-ns",
+		replaces:        "delete-all-but-newest-ns",
+		expected:        "delete-all-but-newest-ns",
+		migrationType:   DDL,
+		migrationSafety: expand,
+	}
+	m2.Begin()
+	m2.Statement(createUniqueLivingNamespaceConstraint)
+	m2.WriteVersion()
+	m2.Commit()
+	RegisterPGMigration(m2)
 }

--- a/internal/datastore/postgres/migrations/zz_migration.0004_add_transaction_timestamp_index.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0004_add_transaction_timestamp_index.go
@@ -1,20 +1,19 @@
 package migrations
 
-import (
-	"context"
-
-	"github.com/jackc/pgx/v4"
-)
-
-const createIndexOnTupleTransactionTimestamp = `
-	CREATE INDEX ix_relation_tuple_transaction_by_timestamp on relation_tuple_transaction(timestamp);
+const createIndexOnTupleTransactionTimestamp = `CREATE INDEX ix_relation_tuple_transaction_by_timestamp on relation_tuple_transaction(timestamp);
 `
 
 func init() {
-	if err := DatabaseMigrations.Register("add-transaction-timestamp-index", "add-unique-living-ns", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, createIndexOnTupleTransactionTimestamp)
-		return err
-	}); err != nil {
-		panic("failed to register migration: " + err.Error())
+	m := &PostgresMigration{
+		version:         "add-transaction-timestamp-index",
+		replaces:        "add-unique-living-ns",
+		expected:        "add-unique-living-ns",
+		migrationType:   DDL,
+		migrationSafety: expand,
 	}
+	m.Begin()
+	m.Statement(createIndexOnTupleTransactionTimestamp)
+	m.WriteVersion()
+	m.Commit()
+	RegisterPGMigration(m)
 }

--- a/internal/datastore/postgres/migrations/zz_migration.0005_change_transaction_timestamp_default.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0005_change_transaction_timestamp_default.go
@@ -1,22 +1,20 @@
 package migrations
 
-import (
-	"context"
-
-	"github.com/jackc/pgx/v4"
-)
-
-const alterTimestampDefaultValue = `
-	ALTER TABLE relation_tuple_transaction 
-		ALTER COLUMN timestamp SET DEFAULT (now() AT TIME ZONE 'UTC');`
+const alterTimestampDefaultValue = `ALTER TABLE relation_tuple_transaction 
+		ALTER COLUMN timestamp SET DEFAULT (now() AT TIME ZONE 'UTC');
+`
 
 func init() {
-	if err := DatabaseMigrations.Register("change-transaction-timestamp-default", "add-transaction-timestamp-index",
-		noNonatomicMigration,
-		func(ctx context.Context, tx pgx.Tx) error {
-			_, err := tx.Exec(ctx, alterTimestampDefaultValue)
-			return err
-		}); err != nil {
-		panic("failed to register migration: " + err.Error())
+	m := &PostgresMigration{
+		version:         "change-transaction-timestamp-default",
+		replaces:        "add-transaction-timestamp-index",
+		expected:        "add-transaction-timestamp-index",
+		migrationType:   DDL,
+		migrationSafety: contract,
 	}
+	m.Begin()
+	m.Statement(alterTimestampDefaultValue)
+	m.WriteVersion()
+	m.Commit()
+	RegisterPGMigration(m)
 }

--- a/internal/datastore/postgres/migrations/zz_migration.0008_add_ns_config_id.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0008_add_ns_config_id.go
@@ -1,32 +1,24 @@
 package migrations
 
-import (
-	"context"
-
-	"github.com/jackc/pgx/v4"
-)
-
 const (
-	dropNSConfigPK   = `ALTER TABLE namespace_config DROP CONSTRAINT IF EXISTS pk_namespace_config`
-	createNSConfigID = `ALTER TABLE namespace_config ADD COLUMN id BIGSERIAL PRIMARY KEY`
+	dropNSConfigPK = `ALTER TABLE namespace_config DROP CONSTRAINT IF EXISTS pk_namespace_config;
+`
+	createNSConfigID = `ALTER TABLE namespace_config ADD COLUMN id BIGSERIAL PRIMARY KEY;
+`
 )
 
 func init() {
-	if err := DatabaseMigrations.Register(
-		"add-ns-config-id",
-		"add-unique-datastore-id",
-		noNonatomicMigration,
-		func(ctx context.Context, tx pgx.Tx) error {
-			if _, err := tx.Exec(ctx, dropNSConfigPK); err != nil {
-				return err
-			}
-
-			if _, err := tx.Exec(ctx, createNSConfigID); err != nil {
-				return err
-			}
-
-			return nil
-		}); err != nil {
-		panic("failed to register migration: " + err.Error())
+	m := &PostgresMigration{
+		version:         "add-ns-config-id",
+		replaces:        "add-unique-datastore-id",
+		expected:        "add-unique-datastore-id",
+		migrationType:   DDL,
+		migrationSafety: expand,
 	}
+	m.Begin()
+	m.Statement(dropNSConfigPK)
+	m.Statement(createNSConfigID)
+	m.WriteVersion()
+	m.Commit()
+	RegisterPGMigration(m)
 }

--- a/internal/datastore/postgres/migrations/zz_migration.0009_add_xid8_columns.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0009_add_xid8_columns.go
@@ -1,90 +1,86 @@
 package migrations
 
-import (
-	"context"
-
-	"github.com/jackc/pgx/v4"
-)
-
 const (
-	addTransactionXIDColumns = `
-		ALTER TABLE relation_tuple_transaction
+	addTransactionXIDColumns = `ALTER TABLE relation_tuple_transaction
 			ADD COLUMN xid xid8 NOT NULL DEFAULT (pg_current_xact_id()),
-			ADD COLUMN snapshot pg_snapshot`
+			ADD COLUMN snapshot pg_snapshot;
+`
 
-	addTupleXIDColumns = `
-		ALTER TABLE relation_tuple
+	addTupleXIDColumns = `ALTER TABLE relation_tuple
 			ADD COLUMN created_xid xid8,
-			ADD COLUMN deleted_xid xid8 NOT NULL DEFAULT ('9223372036854775807');`
+			ADD COLUMN deleted_xid xid8 NOT NULL DEFAULT ('9223372036854775807');
+`
 
-	addNamespaceXIDColumns = `
-		ALTER TABLE namespace_config
+	addNamespaceXIDColumns = `ALTER TABLE namespace_config
 			ADD COLUMN created_xid xid8,
-			ADD COLUMN deleted_xid xid8 NOT NULL DEFAULT ('9223372036854775807');`
+			ADD COLUMN deleted_xid xid8 NOT NULL DEFAULT ('9223372036854775807');
+`
 
-	addTransactionDefault = `
-		ALTER TABLE relation_tuple_transaction
-			ALTER COLUMN snapshot SET DEFAULT (pg_current_snapshot());`
+	addTransactionDefault = `ALTER TABLE relation_tuple_transaction
+			ALTER COLUMN snapshot SET DEFAULT (pg_current_snapshot());
+`
 
-	addRelationTupleDefault = `
-		ALTER TABLE relation_tuple
-			ALTER COLUMN created_xid SET DEFAULT (pg_current_xact_id());`
+	addRelationTupleDefault = `ALTER TABLE relation_tuple
+			ALTER COLUMN created_xid SET DEFAULT (pg_current_xact_id());
+`
 
-	addNamepsaceDefault = `
-		ALTER TABLE namespace_config
-			ALTER COLUMN created_xid SET DEFAULT (pg_current_xact_id());`
+	addNamepsaceDefault = `ALTER TABLE namespace_config
+			ALTER COLUMN created_xid SET DEFAULT (pg_current_xact_id());
+`
 
-	backfillTransactionXids = `
-		UPDATE relation_tuple_transaction SET xid = id::text::xid8, snapshot = CONCAT(id, ':', id, ':')::pg_snapshot
-			WHERE snapshot IS NULL;`
+	backfillTransactionXids = `UPDATE relation_tuple_transaction SET xid = id::text::xid8, snapshot = CONCAT(id, ':', id, ':')::pg_snapshot
+			WHERE snapshot IS NULL;
+`
 
-	backfillTupleXIDColumns = `
-		UPDATE relation_tuple
+	backfillTupleXIDColumns = `UPDATE relation_tuple
 			SET deleted_xid = deleted_transaction::text::xid8,
 			created_xid = created_transaction::text::xid8
-			WHERE created_xid IS NULL;`
+			WHERE created_xid IS NULL;
+`
 
-	backfillNamespaceXIDColumns = `
-		UPDATE namespace_config
+	backfillNamespaceXIDColumns = `UPDATE namespace_config
 			SET deleted_xid = deleted_transaction::text::xid8,
 			created_xid = created_transaction::text::xid8
-			WHERE created_xid IS NULL;`
+			WHERE created_xid IS NULL;
+`
 
-	addTransactionSnapshotNotNull = `
-		ALTER TABLE relation_tuple_transaction ALTER COLUMN snapshot SET NOT NULL;`
+	addTransactionSnapshotNotNull = `ALTER TABLE relation_tuple_transaction ALTER COLUMN snapshot SET NOT NULL;
+`
 
-	addTupleCreatedNotNull = `
-		ALTER TABLE relation_tuple ALTER COLUMN created_xid SET NOT NULL;`
+	addTupleCreatedNotNull = `ALTER TABLE relation_tuple ALTER COLUMN created_xid SET NOT NULL;
+`
 
-	addNamespaceCreatedtNotNull = `
-		ALTER TABLE namespace_config ALTER COLUMN created_xid SET NOT NULL;`
+	addNamespaceCreatedtNotNull = `ALTER TABLE namespace_config ALTER COLUMN created_xid SET NOT NULL;
+`
 )
 
 func init() {
-	if err := DatabaseMigrations.Register("add-xid-columns", "add-ns-config-id",
-		noNonatomicMigration,
-		func(ctx context.Context, tx pgx.Tx) error {
-			for _, stmt := range []string{
-				addTransactionXIDColumns,
-				addTupleXIDColumns,
-				addNamespaceXIDColumns,
-				addTransactionDefault,
-				addRelationTupleDefault,
-				addNamepsaceDefault,
-				backfillTransactionXids,
-				backfillTupleXIDColumns,
-				backfillNamespaceXIDColumns,
-				addTransactionSnapshotNotNull,
-				addTupleCreatedNotNull,
-				addNamespaceCreatedtNotNull,
-			} {
-				if _, err := tx.Exec(ctx, stmt); err != nil {
-					return err
-				}
-			}
-
-			return nil
-		}); err != nil {
-		panic("failed to register migration: " + err.Error())
+	m := &PostgresMigration{
+		version:         "add-xid-columns",
+		replaces:        "add-ns-config-id",
+		expected:        "add-ns-config-id",
+		migrationType:   DDL,
+		migrationSafety: expand,
 	}
+	m.Begin()
+
+	for _, stmt := range []string{
+		addTransactionXIDColumns,
+		addTupleXIDColumns,
+		addNamespaceXIDColumns,
+		addTransactionDefault,
+		addRelationTupleDefault,
+		addNamepsaceDefault,
+		backfillTransactionXids,
+		backfillTupleXIDColumns,
+		backfillNamespaceXIDColumns,
+		addTransactionSnapshotNotNull,
+		addTupleCreatedNotNull,
+		addNamespaceCreatedtNotNull,
+	} {
+		m.Statement(stmt)
+	}
+	m.WriteVersion()
+	m.Commit()
+	RegisterPGMigration(m)
 }

--- a/internal/datastore/postgres/migrations/zz_migration.0012_drop_bigserial_ids.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0012_drop_bigserial_ids.go
@@ -1,36 +1,34 @@
 package migrations
 
-import (
-	"context"
-
-	"github.com/jackc/pgx/v4"
-)
-
 var dropIDStmts = []string{
 	`ALTER TABLE relation_tuple_transaction
-		DROP COLUMN id;`,
+		DROP COLUMN id;
+`,
 	`ALTER TABLE namespace_config
 		DROP COLUMN id,
 		DROP COLUMN created_transaction,
-		DROP COLUMN deleted_transaction;`,
+		DROP COLUMN deleted_transaction;
+`,
 	`ALTER TABLE relation_tuple
 		DROP COLUMN id,
 		DROP COLUMN created_transaction,
-		DROP COLUMN deleted_transaction;`,
+		DROP COLUMN deleted_transaction;
+`,
 }
 
 func init() {
-	if err := DatabaseMigrations.Register("drop-bigserial-ids", "add-xid-constraints",
-		noNonatomicMigration,
-		func(ctx context.Context, tx pgx.Tx) error {
-			for _, stmt := range dropIDStmts {
-				if _, err := tx.Exec(ctx, stmt); err != nil {
-					return err
-				}
-			}
-
-			return nil
-		}); err != nil {
-		panic("failed to register migration: " + err.Error())
+	m := &PostgresMigration{
+		version:         "drop-bigserial-ids",
+		replaces:        "add-xid-constraints",
+		expected:        "add-xid-constraints",
+		migrationType:   DDL,
+		migrationSafety: contract,
 	}
+	m.Begin()
+	for _, stmt := range dropIDStmts {
+		m.Statement(stmt)
+	}
+	m.WriteVersion()
+	m.Commit()
+	RegisterPGMigration(m)
 }

--- a/internal/datastore/spanner/migrations/zz_migration.0001_initial_schema.go
+++ b/internal/datastore/spanner/migrations/zz_migration.0001_initial_schema.go
@@ -48,7 +48,7 @@ const (
 )
 
 func init() {
-	if err := SpannerMigrations.Register("initial", "", func(ctx context.Context, w Wrapper) error {
+	if err := SpannerMigrations.Register("initial", "", "", func(ctx context.Context, w Wrapper) error {
 		updateOp, err := w.adminClient.UpdateDatabaseDdl(ctx, &database.UpdateDatabaseDdlRequest{
 			Database: w.client.DatabaseName(),
 			Statements: []string{

--- a/internal/datastore/spanner/migrations/zz_migration.0002_add_metadata_and_counters.go
+++ b/internal/datastore/spanner/migrations/zz_migration.0002_add_metadata_and_counters.go
@@ -20,7 +20,7 @@ const (
 )
 
 func init() {
-	if err := SpannerMigrations.Register("add-metadata-and-counters", "initial", func(ctx context.Context, w Wrapper) error {
+	if err := SpannerMigrations.Register("add-metadata-and-counters", "initial", "initial", func(ctx context.Context, w Wrapper) error {
 		updateOp, err := w.adminClient.UpdateDatabaseDdl(ctx, &database.UpdateDatabaseDdlRequest{
 			Database: w.client.DatabaseName(),
 			Statements: []string{

--- a/pkg/cmd/migrations.go
+++ b/pkg/cmd/migrations.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jzelinskie/cobrautil"
+	"github.com/spf13/cobra"
+
+	"github.com/authzed/spicedb/internal/datastore/postgres"
+	"github.com/authzed/spicedb/internal/datastore/postgres/migrations"
+	"github.com/authzed/spicedb/pkg/cmd/server"
+)
+
+func RegisterMigrationFlags(cmd *cobra.Command) {
+	cmd.Flags().String("datastore-engine", "postgres", fmt.Sprintf(`type of migrations to export (%s)`, "postgres"))
+	cmd.Flags().String("dir", "migrations", "directory to write migration files")
+}
+
+func NewMigrationCommand(programName string) *cobra.Command {
+	return &cobra.Command{
+		Use:     "migrations",
+		Short:   "Inspect, compute, and export datastore migrations.",
+		Long:    "Computes and exports datastore migrations for auditing or integration with external tools. Most users should use \"spicedb migrate\" instead.",
+		PreRunE: server.DefaultPreRunE(programName),
+		RunE:    migrationRun,
+		Args:    cobra.MaximumNArgs(1),
+	}
+}
+
+func migrationRun(cmd *cobra.Command, args []string) error {
+	datastoreEngine := cobrautil.MustGetStringExpanded(cmd, "datastore-engine")
+	directory := cobrautil.MustGetStringExpanded(cmd, "dir")
+
+	if err := os.MkdirAll(directory, 0o600); err != nil {
+		return err
+	}
+
+	switch datastoreEngine {
+	case postgres.Engine:
+		migs := migrations.PostgresMigrations
+		migs.Sort()
+		epoch := time.Now().Unix()
+		for i, m := range migs {
+			file := filepath.Join(directory, m.FileName(fmt.Sprintf("%d", epoch+int64(i))))
+			if err := os.WriteFile(file, m.Bytes(), 0o600); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("migration export not supported for engine: %s", datastoreEngine)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds a new command, `spicedb migrations`, that will export a representation of the migrations for a given datastore.

Initially, only Postgres is supported, and for now only SQL files are output.

```sh
$ spicedb migrations --datastore-engine=postgres
$ tree migrations
migrations
├── 1664918821_DDL_expand_1eaeba4b8a73.sql
├── 1664918822_DDL_expand_add_reverse_index.sql
├── 1664918823_DML_contract_delete_all_but_newest_ns.sql
├── 1664918824_DDL_expand_add_unique_living_ns.sql
├── 1664918825_DDL_expand_add_transaction_timestamp_index.sql
├── 1664918826_DDL_contract_change_transaction_timestamp_default.sql
├── 1664918827_DDL_expand_add_gc_index_internal.sql
├── 1664918828_DML_expand_add_gc_index.sql
├── 1664918829_DDL_expand_add_unique_datastore_id.sql
├── 1664918830_DDL_expand_add_ns_config_id.sql
├── 1664918831_DDL_expand_add_xid_columns.sql
├── 1664918832_DDL_contract_add_xid_indices_0.sql
├── 1664918833_DDL_contract_add_xid_indices_1.sql
├── 1664918834_DDL_contract_add_xid_indices_2.sql
├── 1664918835_DDL_contract_add_xid_indices_3.sql
├── 1664918836_DDL_contract_add_xid_indices_4.sql
├── 1664918837_DDL_contract_add_xid_indices_5.sql
├── 1664918838_DDL_contract_add_xid_indices_6.sql
├── 1664918839_DML_expand_add_xid_indices.sql
├── 1664918840_DDL_contract_drop_ns_config_pk_2.sql
├── 1664918841_DDL_contract_add_xid_constraints_0.sql
├── 1664918842_DDL_contract_add_xid_constraints_1.sql
├── 1664918843_DDL_contract_add_xid_constraints_2.sql
├── 1664918844_DML_expand_add_xid_constraints.sql
└── 1664918845_DDL_contract_drop_bigserial_ids.sql
```

The filenames ensure ordering via epoch prefixes, and indicate at a glance what affect the migration will have (DDL/DML, expand/contract). Note that the epoch prefixes are not stable between runs of `spicedb migrations` - looking for feedback for whether that should be changed.

The existing `spicedb migrate` commands work exactly as they did before for users that aren't using external migration tools.