### PR TITLE
internal: add docker build tag to transitives

### DIFF
--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -1,5 +1,5 @@
-//go:build ci
-// +build ci
+//go:build ci && docker
+// +build ci,docker
 
 package crdb
 

--- a/internal/datastore/crdb/tx_test.go
+++ b/internal/datastore/crdb/tx_test.go
@@ -1,5 +1,5 @@
-//go:build ci
-// +build ci
+//go:build ci && docker
+// +build ci,docker
 
 package crdb
 

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -1,5 +1,5 @@
-//go:build ci
-// +build ci
+//go:build ci && docker
+// +build ci,docker
 
 package mysql
 

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -1,5 +1,5 @@
-//go:build ci
-// +build ci
+//go:build ci && docker
+// +build ci,docker
 
 package postgres
 

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -1,5 +1,5 @@
-//go:build ci
-// +build ci
+//go:build ci && docker
+// +build ci,docker
 
 package spanner
 

--- a/internal/services/benchmark_test.go
+++ b/internal/services/benchmark_test.go
@@ -1,3 +1,6 @@
+//go:build docker
+// +build docker
+
 package services_test
 
 import (

--- a/internal/services/dispatch_test.go
+++ b/internal/services/dispatch_test.go
@@ -1,5 +1,5 @@
-//go:build ci
-// +build ci
+//go:build ci && docker
+// +build ci,docker
 
 package services_test
 

--- a/internal/services/healthcheck_test.go
+++ b/internal/services/healthcheck_test.go
@@ -1,5 +1,5 @@
-//go:build ci
-// +build ci
+//go:build ci && docker
+// +build ci,docker
 
 package services_test
 

--- a/internal/services/perf_test.go
+++ b/internal/services/perf_test.go
@@ -1,5 +1,5 @@
-//go:build ci
-// +build ci
+//go:build ci && docker
+// +build ci,docker
 
 package services_test
 

--- a/internal/testserver/datastore/config/config.go
+++ b/internal/testserver/datastore/config/config.go
@@ -1,3 +1,6 @@
+//go:build docker
+// +build docker
+
 package config
 
 import (

--- a/internal/testserver/datastore/crdb.go
+++ b/internal/testserver/datastore/crdb.go
@@ -1,3 +1,6 @@
+//go:build docker
+// +build docker
+
 package datastore
 
 import (

--- a/internal/testserver/datastore/datastore.go
+++ b/internal/testserver/datastore/datastore.go
@@ -1,3 +1,6 @@
+//go:build docker
+// +build docker
+
 package datastore
 
 import (

--- a/internal/testserver/datastore/memory.go
+++ b/internal/testserver/datastore/memory.go
@@ -1,3 +1,6 @@
+//go:build docker
+// +build docker
+
 package datastore
 
 import (

--- a/internal/testserver/datastore/mysql.go
+++ b/internal/testserver/datastore/mysql.go
@@ -1,3 +1,6 @@
+//go:build docker
+// +build docker
+
 package datastore
 
 import (

--- a/internal/testserver/datastore/postgres.go
+++ b/internal/testserver/datastore/postgres.go
@@ -1,3 +1,6 @@
+//go:build docker
+// +build docker
+
 package datastore
 
 import (

--- a/internal/testserver/datastore/spanner.go
+++ b/internal/testserver/datastore/spanner.go
@@ -1,3 +1,6 @@
+//go:build docker
+// +build docker
+
 package datastore
 
 import (


### PR DESCRIPTION
This fixes running benchmarks in environments without docker.