### PR TITLE
adds tests to demonstrate various caveat use-cases

### DIFF
--- a/pkg/caveats/customtypes/ipaddress.go
+++ b/pkg/caveats/customtypes/ipaddress.go
@@ -18,6 +18,15 @@ func ParseIPAddress(ip string) (IPAddress, error) {
 	return IPAddress{parsed}, err
 }
 
+// MustParseIPAddress parses the string form of an IP Address into an IPAddress object type.
+func MustParseIPAddress(ip string) IPAddress {
+	ipAddress, err := ParseIPAddress(ip)
+	if err != nil {
+		panic(err)
+	}
+	return ipAddress
+}
+
 var ipaddressCelType = types.NewTypeValue("IPAddress", traits.ReceiverType)
 
 // IPAddress defines a custom type for representing an IP Address in caveats.

--- a/pkg/caveats/customtypes/ipaddress.go
+++ b/pkg/caveats/customtypes/ipaddress.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 
 	"github.com/google/cel-go/cel"
-
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"

--- a/pkg/caveats/customtypes/now.go
+++ b/pkg/caveats/customtypes/now.go
@@ -1,0 +1,19 @@
+package customtypes
+
+import (
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+func init() {
+	registerCustomType("now",
+		cel.Function("now",
+			cel.Overload("now_timestamp", []*cel.Type{}, cel.TimestampType,
+				cel.FunctionBinding(func(arg ...ref.Val) ref.Val {
+					return types.Timestamp{Time: time.Now()}
+				}))),
+	)
+}


### PR DESCRIPTION
Implements various use-cases described in https://github.com/authzed/spicedb/issues/386

# What

implements various caveat use-cases to demonstrate viability of the design

# How

- IP Allowlists
- application attributes ([source](https://github.com/authzed/spicedb/issues/386#issuecomment-1163747750))
- subject created after resource ([source](https://github.com/authzed/spicedb/issues/386#issuecomment-1034278567))
- time-bound permission
- legal-guardian ([source](https://github.com/authzed/spicedb/issues/386#issuecomment-1252776047))