### PR TITLE
disable async logging

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
+          go-version: "~1.19.2"
       - uses: "authzed/actions/go-build@main"
 
   image-build:
@@ -49,7 +49,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
+          go-version: "~1.19.2"
       - uses: "authzed/actions/docker-build@main"
         with:
           push: false
@@ -68,7 +68,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
+          go-version: "~1.19.2"
       - uses: "authzed/actions/go-test@main"
         with:
           tags: "ci"
@@ -80,7 +80,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
+          go-version: "~1.19.2"
       - name: "Cache Binaries"
         id: "cache-binaries"
         uses: "actions/cache@v2"
@@ -128,7 +128,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
+          go-version: "~1.19.2"
       - name: "Install wasmbrowsertest"
         run: "go install github.com/agnivade/wasmbrowsertest@latest"
       - name: "Run WASM Tests"
@@ -141,7 +141,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
+          go-version: "~1.19.2"
       - name: "Install Go Tools"
         run: "./hack/install-tools.sh"
       - uses: "authzed/actions/buf-generate@main"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
+          go-version: "~1.19.2"
       - uses: "authzed/actions/go-test@main"
         with:
           working_directory: "tools/analyzers"
@@ -27,7 +27,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
+          go-version: "~1.19.2"
       - uses: "authzed/actions/gofumpt@main"
       - uses: "authzed/actions/gofumpt@main"
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
+          go-version: "~1.19.2"
       - uses: "authzed/actions/docker-login@main"
         with:
           quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -15,7 +15,7 @@ jobs:
           ref: "${{ env.GITHUB_SHA }}"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
+          go-version: "~1.19.2"
       - run: |
           echo "Building WASM..."
           GOOS=js GOARCH=wasm go build  -o dist/development.wasm ./pkg/development/wasm/...

--- a/pkg/cmd/server/defaults.go
+++ b/pkg/cmd/server/defaults.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
-	"time"
 
 	"github.com/fatih/color"
 	"github.com/go-logr/zerologr"
@@ -57,7 +56,6 @@ func DefaultPreRunE(programName string) cobrautil.CobraRunFunc {
 	return cobrautil.CommandStack(
 		cobrautil.SyncViperPreRunE(programName),
 		cobrazerolog.New(
-			cobrazerolog.WithAsync(1000, 10*time.Millisecond),
 			cobrazerolog.WithTarget(func(logger zerolog.Logger) {
 				logging.SetGlobalLogger(logger)
 			}),


### PR DESCRIPTION
async logging was recently introduced in https://github.com/authzed/spicedb/pull/844

unfortunately nothing is calling `Close()` on `diode.Writer`, which means buffer is not being flushed on process termination and causes log messages to get lost.

I propose disabling this until we come up with a solution that guarantees no log messages are lost on process termination.

Note: I also upgraded to go 1.19.2 to fix some vulns detected by `govulncheck`