### PR TITLE
fix datastore integration tests not running

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -59,7 +59,7 @@ jobs:
       - uses: "authzed/actions/go-test@main"
         with:
           working_directory: "cmd/spicedb"
-          tags: "docker"
+          tags: "docker,image"
 
   unit:
     name: "Unit"
@@ -71,7 +71,7 @@ jobs:
           go-version: "~1.19.2"
       - uses: "authzed/actions/go-test@main"
         with:
-          tags: "ci"
+          tags: "ci,docker"
           timeout: "30m"
   e2e:
     name: "E2E"

--- a/cmd/spicedb/migrate_integration_test.go
+++ b/cmd/spicedb/migrate_integration_test.go
@@ -1,5 +1,5 @@
-//go:build docker
-// +build docker
+//go:build docker && image
+// +build docker,image
 
 package main
 

--- a/cmd/spicedb/restgateway_integration_test.go
+++ b/cmd/spicedb/restgateway_integration_test.go
@@ -1,5 +1,5 @@
-//go:build docker
-// +build docker
+//go:build docker && image
+// +build docker,image
 
 package main
 

--- a/cmd/spicedb/serve_integration_test.go
+++ b/cmd/spicedb/serve_integration_test.go
@@ -1,5 +1,5 @@
-//go:build docker
-// +build docker
+//go:build docker && image
+// +build docker,image
 
 package main
 

--- a/cmd/spicedb/servetesting_integration_test.go
+++ b/cmd/spicedb/servetesting_integration_test.go
@@ -1,5 +1,5 @@
-//go:build docker
-// +build docker
+//go:build docker && image
+// +build docker,image
 
 package main
 


### PR DESCRIPTION
regressed in https://github.com/authzed/spicedb/pull/854

A new `docker` tag was added to identify tests that require docker daemon running. The GitHub Action configured to run our test was not updated to include the newly added tag, and caused datastore integration tests to be skipped.

In order to fix this I added the missing `tag`. This in turn meant the integration tests under `cmd` started to run, so I added a new tag `image` to clarify that specify that not only `docker` is required, but also a built image of spicedb.