### PR TITLE
fix calls to logger that are not being sent

### DIFF
--- a/internal/datastore/mysql/migrations/driver.go
+++ b/internal/datastore/mysql/migrations/driver.go
@@ -159,7 +159,7 @@ func (driver *MySQLDriver) Close(_ context.Context) error {
 // Useful to avoid silently ignoring errors in defer statements
 func LogOnError(ctx context.Context, f func() error) {
 	if err := f(); err != nil {
-		log.Ctx(ctx).Error().Err(err)
+		log.Ctx(ctx).Error().Err(err).Msg("mysql error")
 	}
 }
 

--- a/internal/middleware/consistency/consistency.go
+++ b/internal/middleware/consistency/consistency.go
@@ -242,7 +242,7 @@ func rewriteDatastoreError(ctx context.Context, err error) error {
 		return shared.ErrServiceReadOnly
 
 	default:
-		log.Ctx(ctx).Err(err)
+		log.Ctx(ctx).Err(err).Msg("unexpected consistency middleware error")
 		return err
 	}
 }

--- a/internal/services/dispatch/v1/acl.go
+++ b/internal/services/dispatch/v1/acl.go
@@ -79,7 +79,7 @@ func rewriteGraphError(ctx context.Context, err error) error {
 	case errors.As(err, &graph.ErrAlwaysFail{}):
 		fallthrough
 	default:
-		log.Err(err)
+		log.Err(err).Msg("unexpected graph error")
 		return err
 	}
 }

--- a/internal/services/v1/errors.go
+++ b/internal/services/v1/errors.go
@@ -229,7 +229,7 @@ func rewriteError(ctx context.Context, err error) error {
 	case errors.As(err, &graph.ErrRelationMissingTypeInfo{}):
 		return status.Errorf(codes.FailedPrecondition, "failed precondition: %s", err)
 	case errors.As(err, &graph.ErrAlwaysFail{}):
-		log.Ctx(ctx).Err(err)
+		log.Ctx(ctx).Err(err).Msg("received internal error")
 		return status.Errorf(codes.Internal, "internal error: %s", err)
 
 	default:

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -298,7 +298,7 @@ func rewriteACLError(ctx context.Context, err error) error {
 		return status.Errorf(codes.FailedPrecondition, "failed precondition: %s", err)
 
 	case errors.As(err, &maingraph.ErrAlwaysFail{}):
-		log.Ctx(ctx).Err(err)
+		log.Ctx(ctx).Err(err).Msg("internal graph error in devcontext")
 		return status.Errorf(codes.Internal, "internal error: %s", err)
 
 	default:
@@ -306,7 +306,7 @@ func rewriteACLError(ctx context.Context, err error) error {
 			return status.Errorf(codes.InvalidArgument, "%s", err)
 		}
 
-		log.Ctx(ctx).Err(err)
+		log.Ctx(ctx).Err(err).Msg("unexpected graph error in devcontext")
 		return err
 	}
 }


### PR DESCRIPTION
Part of https://github.com/authzed/spicedb/issues/753

# What

Fixes logger calls that aren't actually being logged

# How

These calls to are not being actually sent (which is usually usually done with `Msg()` or `Send()`)