### PR TITLE
more follow ups to caveats in datastore

### DIFF
--- a/internal/datastore/crdb/caveat.go
+++ b/internal/datastore/crdb/caveat.go
@@ -12,7 +12,7 @@ func (cr *crdbReader) ReadCaveatByName(ctx context.Context, name string) (*core.
 	return nil, datastore.NoRevision, fmt.Errorf("unimplemented caveat support in datastore")
 }
 
-func (cr *crdbReader) ListCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (cr *crdbReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
 	return nil, fmt.Errorf("unimplemented caveat support in datastore")
 }
 

--- a/internal/datastore/mysql/caveat.go
+++ b/internal/datastore/mysql/caveat.go
@@ -12,7 +12,7 @@ func (mr *mysqlReader) ReadCaveatByName(ctx context.Context, name string) (*core
 	return nil, datastore.NoRevision, fmt.Errorf("unimplemented caveat support in datastore")
 }
 
-func (mr *mysqlReader) ListCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (mr *mysqlReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
 	return nil, fmt.Errorf("unimplemented caveat support in datastore")
 }
 

--- a/internal/datastore/postgres/migrations/zz_migration.0009_caveat.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0009_caveat.go
@@ -9,7 +9,7 @@ import (
 var caveatStatements = []string{
 	`CREATE TABLE caveat (
 		name VARCHAR NOT NULL,
-		expression BYTEA NOT NULL,
+		definition BYTEA NOT NULL,
 		created_transaction BIGINT NOT NULL,
 		deleted_transaction BIGINT NOT NULL DEFAULT '9223372036854775807',
 		CONSTRAINT pk_caveat_v1 PRIMARY KEY (name, deleted_transaction),

--- a/internal/datastore/postgres/migrations/zz_migration.0011_backfill_xid_add_indices.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0011_backfill_xid_add_indices.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
-	"github.com/rs/zerolog/log"
 
+	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/migrate"
 )
 

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -53,7 +53,7 @@ const (
 	colUsersetObjectID   = "userset_object_id"
 	colUsersetRelation   = "userset_relation"
 	colCaveatName        = "name"
-	colCaveatExpression  = "expression"
+	colCaveatDefinition  = "definition"
 	colCaveatContextName = "caveat_name"
 	colCaveatContext     = "caveat_context"
 

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -639,16 +639,19 @@ func XIDMigrationAssumptionsTest(t *testing.T, b testdatastore.RunningEngineForT
 	_, err = conn.Exec(ctx, insertRelsSQL, insertRelsArgs...)
 	require.NoError(err)
 
+	c := core.CaveatDefinition{Name: "one_caveat", SerializedExpression: []byte{0x0a, 0x0a}}
+	cMarshalled, err := c.MarshalVT()
+	require.NoError(err)
 	insertCaveatsSQL, insertCaveatsArgs, err := psql.
 		Insert(tableCaveat).
 		Columns(
 			colCaveatName,
-			colCaveatExpression,
+			colCaveatDefinition,
 			"created_transaction",
 			"deleted_transaction",
 		).
-		Values("one_caveat", []byte{0x0a, 0x0a}, oldTxIDs[0], oldTxIDs[1]).
-		Values("one_caveat", []byte{0x0a, 0x0b}, oldTxIDs[1], liveDeletedTxnID).
+		Values("one_caveat", cMarshalled, oldTxIDs[0], oldTxIDs[1]).
+		Values("one_caveat", cMarshalled, oldTxIDs[1], liveDeletedTxnID).
 		ToSql()
 	require.NoError(err)
 

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -147,7 +147,7 @@ func (dm *MockReader) ReadCaveatByName(ctx context.Context, name string) (*core.
 	panic("implement me")
 }
 
-func (dm *MockReader) ListCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (dm *MockReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
 	// TODO implement me
 	panic("implement me")
 }
@@ -245,7 +245,7 @@ func (dm *MockReadWriteTransaction) ReadCaveatByName(ctx context.Context, name s
 	panic("implement me")
 }
 
-func (dm *MockReadWriteTransaction) ListCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (dm *MockReadWriteTransaction) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
 	// TODO implement me
 	panic("implement me")
 }

--- a/internal/datastore/spanner/caveat.go
+++ b/internal/datastore/spanner/caveat.go
@@ -12,7 +12,7 @@ func (sr spannerReader) ReadCaveatByName(ctx context.Context, name string) (*cor
 	return nil, datastore.NoRevision, fmt.Errorf("unimplemented caveat support in datastore")
 }
 
-func (sr spannerReader) ListCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (sr spannerReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
 	return nil, fmt.Errorf("unimplemented caveat support in datastore")
 }
 

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -137,8 +137,8 @@ func (vsr validatingSnapshotReader) ReadCaveatByName(ctx context.Context, name s
 	return read, createdAt, err
 }
 
-func (vsr validatingSnapshotReader) ListCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
-	read, err := vsr.delegate.ListCaveats(ctx)
+func (vsr validatingSnapshotReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
+	read, err := vsr.delegate.ListCaveats(ctx, caveatNames...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datastore/caveat.go
+++ b/pkg/datastore/caveat.go
@@ -11,8 +11,9 @@ type CaveatReader interface {
 	// ReadCaveatByName returns a caveat with the provided name
 	ReadCaveatByName(ctx context.Context, name string) (*core.CaveatDefinition, Revision, error)
 
-	// ListCaveats returns all caveats stored in the system
-	ListCaveats(ctx context.Context) ([]*core.CaveatDefinition, error)
+	// ListCaveats returns all caveats stored in the system. If caveatNames are provided
+	// the result will be filtered to the provided caveat names
+	ListCaveats(ctx context.Context, caveatNamesForFiltering ...string) ([]*core.CaveatDefinition, error)
 }
 
 // CaveatStorer offers both read and write operations for Caveats

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -81,27 +81,60 @@ func WriteCaveatedRelationshipTest(t *testing.T, tester DatastoreTester) {
 
 	// Store caveat, write caveated tuple and read back same value
 	coreCaveat := createCoreCaveat(t)
+	anotherCoreCaveat := createCoreCaveat(t)
 	ctx := context.Background()
-	_, err = writeCaveat(ctx, ds, coreCaveat)
+	_, err = writeCaveats(ctx, ds, coreCaveat, anotherCoreCaveat)
 	req.NoError(err)
 
 	tpl := createTestCaveatedTuple(t, "document:companyplan#parent@folder:company#...", coreCaveat.Name)
 	rev, err := common.WriteTuples(ctx, sds, core.RelationTupleUpdate_CREATE, tpl)
 	req.NoError(err)
-	iter, err := ds.SnapshotReader(rev).QueryRelationships(ctx, datastore.RelationshipsFilter{
-		ResourceType: tpl.ResourceAndRelation.Namespace,
-	})
-	req.NoError(err)
+	assertTupleCorrectlyStored(req, ds, rev, tpl)
 
-	defer iter.Close()
-	readTpl := iter.Next()
-	foundDiff := cmp.Diff(tpl, readTpl, protocmp.Transform())
-	req.Empty(foundDiff)
+	// RelationTupleUpdate_CREATE of the same tuple and different caveat context will fail
+	_, err = common.WriteTuples(ctx, sds, core.RelationTupleUpdate_CREATE, tpl)
+	req.ErrorAs(err, &common.CreateRelationshipExistsError{})
+
+	// RelationTupleUpdate_TOUCH does update the caveat context for a caveated relationship that already exists
+	currentMap := tpl.Caveat.Context.AsMap()
+	delete(currentMap, "b")
+	st, err := structpb.NewStruct(currentMap)
+	require.NoError(t, err)
+
+	tpl.Caveat.Context = st
+	rev, err = common.WriteTuples(ctx, sds, core.RelationTupleUpdate_TOUCH, tpl)
+	req.NoError(err)
+	assertTupleCorrectlyStored(req, ds, rev, tpl)
+
+	// TOUCH can remove caveat from relationship
+	caveatContext := tpl.Caveat
+	tpl.Caveat = nil
+	rev, err = common.WriteTuples(ctx, sds, core.RelationTupleUpdate_TOUCH, tpl)
+	req.NoError(err)
+	assertTupleCorrectlyStored(req, ds, rev, tpl)
+
+	// TOUCH can store caveat in relationship with no caveat
+	tpl.Caveat = caveatContext
+	rev, err = common.WriteTuples(ctx, sds, core.RelationTupleUpdate_TOUCH, tpl)
+	req.NoError(err)
+	assertTupleCorrectlyStored(req, ds, rev, tpl)
 
 	// Caveated tuple can reference non-existing caveat - controller layer is responsible for validation
 	tpl = createTestCaveatedTuple(t, "document:rando#parent@folder:company#...", "rando")
 	_, err = common.WriteTuples(ctx, sds, core.RelationTupleUpdate_CREATE, tpl)
 	req.NoError(err)
+}
+
+func assertTupleCorrectlyStored(req *require.Assertions, ds datastore.Datastore, rev datastore.Revision, expected *core.RelationTuple) {
+	iter, err := ds.SnapshotReader(rev).QueryRelationships(context.Background(), datastore.RelationshipsFilter{
+		ResourceType: expected.ResourceAndRelation.Namespace,
+	})
+	req.NoError(err)
+
+	defer iter.Close()
+	readTpl := iter.Next()
+	foundDiff := cmp.Diff(expected, readTpl, protocmp.Transform())
+	req.Empty(foundDiff)
 }
 
 func CaveatedRelationshipFilterTest(t *testing.T, tester DatastoreTester) {


### PR DESCRIPTION
- [x] adds exhaustive testing of CREATE/TOUCH semantics
- [x] add variadic caveat list to `ListCaveats`
- [x] make `WriteCaveat` serialize the whole `CaveatDefinition` proto instead of just the serialized bytes