### PR TITLE
make all tests parallel and enable linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,7 @@ linters:
     - 'importas'
     - 'ineffassign'
     - 'makezero'
+    - 'paralleltest'
     - 'prealloc'
     - 'predeclared'
     - 'promlinter'

--- a/e2e/newenemy/newenemy_test.go
+++ b/e2e/newenemy/newenemy_test.go
@@ -122,6 +122,7 @@ func initializeTestCRDBCluster(ctx context.Context, t testing.TB) cockroach.Clus
 }
 
 func TestNoNewEnemy(t *testing.T) {
+	t.Parallel()
 	rand.Seed(time.Now().UnixNano())
 	ctx, cancel := context.WithCancel(testCtx)
 	t.Cleanup(cancel)
@@ -204,7 +205,9 @@ func TestNoNewEnemy(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			vulnerableFn, protectedFn := attemptFnsForProbeFns(tt.vulnerableMax, tt.vulnerableProbe, tt.protectedProbe)
 			statTest(t, tt.sampleSize, vulnerableFn, protectedFn)
 		})

--- a/internal/auth/presharedkey_test.go
+++ b/internal/auth/presharedkey_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestPresharedKeys(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name           string
 		presharedkeys  []string
@@ -28,7 +29,9 @@ func TestPresharedKeys(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
+		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
 			f := RequirePresharedKey(testcase.presharedkeys)
 			ctx := context.Background()
 			if testcase.withMetadata {

--- a/internal/caveats/builder_test.go
+++ b/internal/caveats/builder_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestShortcircuitedOr(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		first    *v1.CaveatExpression
 		second   *v1.CaveatExpression
@@ -36,7 +37,7 @@ func TestShortcircuitedOr(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%v-%v", tc.first, tc.second), func(t *testing.T) {
 			testutil.RequireProtoEqual(t, tc.expected, ShortcircuitedOr(tc.first, tc.second), "mismatch")
 		})
@@ -44,6 +45,7 @@ func TestShortcircuitedOr(t *testing.T) {
 }
 
 func TestOr(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		first    *v1.CaveatExpression
 		second   *v1.CaveatExpression
@@ -83,7 +85,7 @@ func TestOr(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%v-%v", tc.first, tc.second), func(t *testing.T) {
 			testutil.RequireProtoEqual(t, tc.expected, Or(tc.first, tc.second), "mismatch")
 		})
@@ -91,6 +93,7 @@ func TestOr(t *testing.T) {
 }
 
 func TestAnd(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		first    *v1.CaveatExpression
 		second   *v1.CaveatExpression
@@ -130,7 +133,7 @@ func TestAnd(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%v-%v", tc.first, tc.second), func(t *testing.T) {
 			testutil.RequireProtoEqual(t, tc.expected, And(tc.first, tc.second), "mismatch")
 		})
@@ -138,6 +141,7 @@ func TestAnd(t *testing.T) {
 }
 
 func TestInvert(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		first    *v1.CaveatExpression
 		expected *v1.CaveatExpression
@@ -159,7 +163,7 @@ func TestInvert(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%v", tc.first), func(t *testing.T) {
 			testutil.RequireProtoEqual(t, tc.expected, Invert(tc.first), "mismatch")
 		})

--- a/internal/caveats/diff_test.go
+++ b/internal/caveats/diff_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestCaveatDiff(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name           string
 		existing       *core.CaveatDefinition
@@ -152,7 +153,9 @@ func TestCaveatDiff(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			diff, err := DiffCaveats(tc.existing, tc.updated)
 			require.Nil(err)

--- a/internal/caveats/run_test.go
+++ b/internal/caveats/run_test.go
@@ -21,6 +21,7 @@ var (
 )
 
 func TestRunCaveatExpressions(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name          string
 		expression    *v1.CaveatExpression
@@ -162,7 +163,9 @@ func TestRunCaveatExpressions(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			req := require.New(t)
 
 			rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)

--- a/internal/datasets/subjectset_test.go
+++ b/internal/datasets/subjectset_test.go
@@ -22,6 +22,7 @@ var (
 )
 
 func TestSubjectSetAdd(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name        string
 		existing    []*v1.FoundSubject
@@ -227,7 +228,7 @@ func TestSubjectSetAdd(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(tc.name, func(t *testing.T) {
 			existingSet := NewSubjectSet()
 			for _, existing := range tc.existing {
@@ -244,6 +245,7 @@ func TestSubjectSetAdd(t *testing.T) {
 }
 
 func TestSubjectSetSubtract(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name        string
 		existing    []*v1.FoundSubject
@@ -592,7 +594,7 @@ func TestSubjectSetSubtract(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(tc.name, func(t *testing.T) {
 			existingSet := NewSubjectSet()
 			for _, existing := range tc.existing {
@@ -609,6 +611,7 @@ func TestSubjectSetSubtract(t *testing.T) {
 }
 
 func TestSubjectSetIntersection(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name                string
 		existing            []*v1.FoundSubject
@@ -926,7 +929,7 @@ func TestSubjectSetIntersection(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(tc.name, func(t *testing.T) {
 			existingSet := NewSubjectSet()
 			for _, existing := range tc.existing {
@@ -973,6 +976,7 @@ func TestSubjectSetIntersection(t *testing.T) {
 }
 
 func TestMultipleOperations(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name        string
 		runOps      func(set SubjectSet)
@@ -1299,7 +1303,7 @@ func TestMultipleOperations(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(tc.name, func(t *testing.T) {
 			set := NewSubjectSet()
 			tc.runOps(set)
@@ -1312,6 +1316,7 @@ func TestMultipleOperations(t *testing.T) {
 }
 
 func TestSubtractAll(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name             string
 		startingSubjects []*v1.FoundSubject
@@ -1344,7 +1349,7 @@ func TestSubtractAll(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(tc.name, func(t *testing.T) {
 			set := NewSubjectSet()
 
@@ -1367,6 +1372,7 @@ func TestSubtractAll(t *testing.T) {
 }
 
 func TestSubjectSetClone(t *testing.T) {
+	t.Parallel()
 	ss := NewSubjectSet()
 	require.True(t, ss.IsEmpty())
 
@@ -1397,6 +1403,7 @@ func TestSubjectSetClone(t *testing.T) {
 }
 
 func TestSubjectSetGet(t *testing.T) {
+	t.Parallel()
 	ss := NewSubjectSet()
 	require.True(t, ss.IsEmpty())
 
@@ -1451,7 +1458,8 @@ var testSets = [][]*v1.FoundSubject{
 }
 
 func TestUnionCommutativity(t *testing.T) {
-	for _, pair := range allSubsets(testSets, 2) {
+	t.Parallel()
+	for _, pair := range allSubsets(testSets, 2) { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%v", pair), func(t *testing.T) {
 			left1, left2 := NewSubjectSet(), NewSubjectSet()
 			for _, l := range pair[0] {
@@ -1476,7 +1484,8 @@ func TestUnionCommutativity(t *testing.T) {
 }
 
 func TestUnionAssociativity(t *testing.T) {
-	for _, triple := range allSubsets(testSets, 3) {
+	t.Parallel()
+	for _, triple := range allSubsets(testSets, 3) { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s U %s U %s", testutil.FormatSubjects(triple[0]), testutil.FormatSubjects(triple[1]), testutil.FormatSubjects(triple[2])), func(t *testing.T) {
 			// A U (B U C) == (A U B) U C
 
@@ -1512,7 +1521,8 @@ func TestUnionAssociativity(t *testing.T) {
 }
 
 func TestIntersectionCommutativity(t *testing.T) {
-	for _, pair := range allSubsets(testSets, 2) {
+	t.Parallel()
+	for _, pair := range allSubsets(testSets, 2) { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%v", pair), func(t *testing.T) {
 			left1, left2 := NewSubjectSet(), NewSubjectSet()
 			for _, l := range pair[0] {
@@ -1537,7 +1547,8 @@ func TestIntersectionCommutativity(t *testing.T) {
 }
 
 func TestIntersectionAssociativity(t *testing.T) {
-	for _, triple := range allSubsets(testSets, 3) {
+	t.Parallel()
+	for _, triple := range allSubsets(testSets, 3) { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s ∩ %s ∩ %s", testutil.FormatSubjects(triple[0]), testutil.FormatSubjects(triple[1]), testutil.FormatSubjects(triple[2])), func(t *testing.T) {
 			// A ∩ (B ∩ C) == (A ∩ B) ∩ C
 
@@ -1573,7 +1584,8 @@ func TestIntersectionAssociativity(t *testing.T) {
 }
 
 func TestIdempotentUnion(t *testing.T) {
-	for _, set := range testSets {
+	t.Parallel()
+	for _, set := range testSets { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%v", set), func(t *testing.T) {
 			// A U A == A
 			A1, A2 := NewSubjectSet(), NewSubjectSet()
@@ -1591,7 +1603,8 @@ func TestIdempotentUnion(t *testing.T) {
 }
 
 func TestIdempotentIntersection(t *testing.T) {
-	for _, set := range testSets {
+	t.Parallel()
+	for _, set := range testSets { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%v", set), func(t *testing.T) {
 			// A ∩ A == A
 			A1, A2 := NewSubjectSet(), NewSubjectSet()
@@ -1609,6 +1622,7 @@ func TestIdempotentIntersection(t *testing.T) {
 }
 
 func TestUnionWildcardWithWildcard(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		existing        *v1.FoundSubject
 		toUnion         *v1.FoundSubject
@@ -1705,7 +1719,7 @@ func TestUnionWildcardWithWildcard(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s U %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toUnion)), func(t *testing.T) {
 			existing := wrap(tc.existing)
 			produced := unionWildcardWithWildcard[*v1.FoundSubject](existing, tc.toUnion, subjectSetConstructor)
@@ -1719,6 +1733,7 @@ func TestUnionWildcardWithWildcard(t *testing.T) {
 }
 
 func TestUnionWildcardWithConcrete(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		existing *v1.FoundSubject
 		toUnion  *v1.FoundSubject
@@ -1821,7 +1836,7 @@ func TestUnionWildcardWithConcrete(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s U %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toUnion)), func(t *testing.T) {
 			existing := wrap(tc.existing)
 			produced := unionWildcardWithConcrete[*v1.FoundSubject](existing, tc.toUnion, subjectSetConstructor)
@@ -1831,6 +1846,7 @@ func TestUnionWildcardWithConcrete(t *testing.T) {
 }
 
 func TestUnionConcreteWithConcrete(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		existing         *v1.FoundSubject
 		toUnion          *v1.FoundSubject
@@ -1879,7 +1895,7 @@ func TestUnionConcreteWithConcrete(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s U %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toUnion)), func(t *testing.T) {
 			existing := wrap(tc.existing)
 			toUnion := wrap(tc.toUnion)
@@ -1894,6 +1910,7 @@ func TestUnionConcreteWithConcrete(t *testing.T) {
 }
 
 func TestSubtractWildcardFromWildcard(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		existing          *v1.FoundSubject
 		toSubtract        *v1.FoundSubject
@@ -2020,7 +2037,7 @@ func TestSubtractWildcardFromWildcard(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s - %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toSubtract)), func(t *testing.T) {
 			existing := wrap(tc.existing)
 
@@ -2032,6 +2049,7 @@ func TestSubtractWildcardFromWildcard(t *testing.T) {
 }
 
 func TestSubtractWildcardFromConcrete(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		existing   *v1.FoundSubject
 		toSubtract *v1.FoundSubject
@@ -2127,7 +2145,7 @@ func TestSubtractWildcardFromConcrete(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%v - %v", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toSubtract)), func(t *testing.T) {
 			produced := subtractWildcardFromConcrete[*v1.FoundSubject](tc.existing, tc.toSubtract, subjectSetConstructor)
 			testutil.RequireExpectedSubject(t, tc.expected, produced)
@@ -2136,6 +2154,7 @@ func TestSubtractWildcardFromConcrete(t *testing.T) {
 }
 
 func TestSubtractConcreteFromConcrete(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		existing   *v1.FoundSubject
 		toSubtract *v1.FoundSubject
@@ -2176,7 +2195,7 @@ func TestSubtractConcreteFromConcrete(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s - %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toSubtract)), func(t *testing.T) {
 			produced := subtractConcreteFromConcrete[*v1.FoundSubject](tc.existing, tc.toSubtract, subjectSetConstructor)
 			testutil.RequireExpectedSubject(t, tc.expected, produced)
@@ -2185,6 +2204,7 @@ func TestSubtractConcreteFromConcrete(t *testing.T) {
 }
 
 func TestSubtractConcreteFromWildcard(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		existing   *v1.FoundSubject
 		toSubtract *v1.FoundSubject
@@ -2249,7 +2269,7 @@ func TestSubtractConcreteFromWildcard(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s - %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toSubtract)), func(t *testing.T) {
 			produced := subtractConcreteFromWildcard[*v1.FoundSubject](tc.existing, tc.toSubtract, subjectSetConstructor)
 			testutil.RequireExpectedSubject(t, tc.expected, produced)
@@ -2258,6 +2278,7 @@ func TestSubtractConcreteFromWildcard(t *testing.T) {
 }
 
 func TestIntersectConcreteWithConcrete(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		first    *v1.FoundSubject
 		second   *v1.FoundSubject
@@ -2305,7 +2326,7 @@ func TestIntersectConcreteWithConcrete(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s ∩ %s", testutil.FormatSubject(tc.first), testutil.FormatSubject(tc.second)), func(t *testing.T) {
 			second := wrap(tc.second)
 
@@ -2316,6 +2337,7 @@ func TestIntersectConcreteWithConcrete(t *testing.T) {
 }
 
 func TestIntersectWildcardWithWildcard(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		first  *v1.FoundSubject
 		second *v1.FoundSubject
@@ -2415,7 +2437,7 @@ func TestIntersectWildcardWithWildcard(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s ∩ %s", testutil.FormatSubject(tc.first), testutil.FormatSubject(tc.second)), func(t *testing.T) {
 			first := wrap(tc.first)
 			second := wrap(tc.second)
@@ -2430,6 +2452,7 @@ func TestIntersectWildcardWithWildcard(t *testing.T) {
 }
 
 func TestIntersectConcreteWithWildcard(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		concrete *v1.FoundSubject
 		wildcard *v1.FoundSubject
@@ -2540,7 +2563,7 @@ func TestIntersectConcreteWithWildcard(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s ∩ %s", testutil.FormatSubject(tc.concrete), testutil.FormatSubject(tc.wildcard)), func(t *testing.T) {
 			wildcard := wrap(tc.wildcard)
 

--- a/internal/datasets/subjectsetbyresourceid_test.go
+++ b/internal/datasets/subjectsetbyresourceid_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestSubjectSetByResourceIDBasicOperations(t *testing.T) {
+	t.Parallel()
 	ssr := NewSubjectSetByResourceID()
 	require.True(t, ssr.IsEmpty())
 
@@ -46,6 +47,7 @@ func TestSubjectSetByResourceIDBasicOperations(t *testing.T) {
 }
 
 func TestSubjectSetByResourceIDUnionWith(t *testing.T) {
+	t.Parallel()
 	ssr := NewSubjectSetByResourceID()
 	ssr.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:tom#..."))
 	ssr.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:sarah#..."))
@@ -98,6 +100,7 @@ func (a sortFoundSubjects) Less(i, j int) bool {
 }
 
 func TestSubjectSetByResourceIDIntersectionDifference(t *testing.T) {
+	t.Parallel()
 	first := NewSubjectSetByResourceID()
 	first.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:tom#..."))
 	first.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:sarah#..."))
@@ -120,6 +123,7 @@ func TestSubjectSetByResourceIDIntersectionDifference(t *testing.T) {
 }
 
 func TestSubjectSetByResourceIDIntersectionDifferenceMissingKey(t *testing.T) {
+	t.Parallel()
 	first := NewSubjectSetByResourceID()
 	first.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:tom#..."))
 	first.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:sarah#..."))
@@ -141,6 +145,7 @@ func TestSubjectSetByResourceIDIntersectionDifferenceMissingKey(t *testing.T) {
 }
 
 func TestSubjectSetByResourceIDIntersectionDifferenceItemInSecondSet(t *testing.T) {
+	t.Parallel()
 	first := NewSubjectSetByResourceID()
 	first.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:tom#..."))
 	first.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:sarah#..."))
@@ -162,6 +167,7 @@ func TestSubjectSetByResourceIDIntersectionDifferenceItemInSecondSet(t *testing.
 }
 
 func TestSubjectSetByResourceIDSubtractAll(t *testing.T) {
+	t.Parallel()
 	first := NewSubjectSetByResourceID()
 	first.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:tom#..."))
 	first.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:sarah#..."))
@@ -189,6 +195,7 @@ func TestSubjectSetByResourceIDSubtractAll(t *testing.T) {
 }
 
 func TestSubjectSetByResourceIDSubtractAllEmpty(t *testing.T) {
+	t.Parallel()
 	first := NewSubjectSetByResourceID()
 	first.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:tom#..."))
 	first.AddFromRelationship(tuple.MustParse("document:firstdoc#viewer@user:mi#..."))
@@ -202,6 +209,7 @@ func TestSubjectSetByResourceIDSubtractAllEmpty(t *testing.T) {
 }
 
 func TestSubjectSetByResourceIDBasicCaveatedOperations(t *testing.T) {
+	t.Parallel()
 	ssr := NewSubjectSetByResourceID()
 	require.True(t, ssr.IsEmpty())
 

--- a/internal/datasets/subjectsetbytype_test.go
+++ b/internal/datasets/subjectsetbytype_test.go
@@ -18,6 +18,7 @@ func RR(namespaceName string, relationName string) *core.RelationReference {
 }
 
 func TestSubjectByTypeSet(t *testing.T) {
+	t.Parallel()
 	assertHasObjectIds := func(s *SubjectByTypeSet, rr *core.RelationReference, expected []string) {
 		wasFound := false
 		s.ForEachType(func(foundRR *core.RelationReference, subjects SubjectSet) {
@@ -74,6 +75,7 @@ func TestSubjectByTypeSet(t *testing.T) {
 }
 
 func TestSubjectSetByTypeWithCaveats(t *testing.T) {
+	t.Parallel()
 	set := NewSubjectByTypeSet()
 	require.True(t, set.IsEmpty())
 

--- a/internal/datastore/common/changes_test.go
+++ b/internal/datastore/common/changes_test.go
@@ -32,6 +32,7 @@ func revisionFromTransactionID(txID uint64) datastore.Revision {
 }
 
 func TestChanges(t *testing.T) {
+	t.Parallel()
 	type changeEntry struct {
 		revision     uint64
 		relationship string
@@ -176,7 +177,9 @@ func TestChanges(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ctx := context.Background()
@@ -195,6 +198,7 @@ func TestChanges(t *testing.T) {
 }
 
 func TestCanonicalize(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name            string
 		input, expected []*datastore.RevisionChanges
@@ -269,7 +273,9 @@ func TestCanonicalize(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			require.Equal(tc.expected, canonicalize(tc.input))
 		})

--- a/internal/datastore/common/revisions/optimized_test.go
+++ b/internal/datastore/common/revisions/optimized_test.go
@@ -32,6 +32,7 @@ var (
 )
 
 func TestOptimizedRevisionCache(t *testing.T) {
+	t.Parallel()
 	type revisionResponse struct {
 		rev      datastore.Revision
 		validFor time.Duration
@@ -101,7 +102,9 @@ func TestOptimizedRevisionCache(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			or := NewCachedOptimizedRevisions(tc.maxStaleness)
@@ -131,6 +134,7 @@ func TestOptimizedRevisionCache(t *testing.T) {
 }
 
 func TestOptimizedRevisionCacheSingleFlight(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	or := NewCachedOptimizedRevisions(0)
@@ -166,6 +170,7 @@ func TestOptimizedRevisionCacheSingleFlight(t *testing.T) {
 }
 
 func TestSingleFlightError(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 
 	or := NewCachedOptimizedRevisions(0)

--- a/internal/datastore/common/revisions/remoteclock_test.go
+++ b/internal/datastore/common/revisions/remoteclock_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestRemoteClockOptimizedRevisions(t *testing.T) {
+	t.Parallel()
 	type timeAndExpectedRevision struct {
 		unixTime int64
 		expected int64
@@ -72,7 +73,9 @@ func TestRemoteClockOptimizedRevisions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			rcr := NewRemoteClockRevisions(1*time.Hour, 0, tc.followerReadDelay, tc.quantization)
@@ -107,6 +110,7 @@ func TestRemoteClockOptimizedRevisions(t *testing.T) {
 }
 
 func TestRemoteClockCheckRevisions(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name                string
 		gcWindow            time.Duration
@@ -123,7 +127,9 @@ func TestRemoteClockCheckRevisions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			rcr := NewRemoteClockRevisions(tc.gcWindow, 0, 0, 0)

--- a/internal/datastore/common/sql_test.go
+++ b/internal/datastore/common/sql_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestSchemaQueryFilterer(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		run          func(filterer SchemaQueryFilterer) SchemaQueryFilterer
@@ -290,7 +291,9 @@ func TestSchemaQueryFilterer(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			base := sq.Select("*")
 			filterer := NewSchemaQueryFilterer(SchemaInformation{
 				TableTuple:          "tuple",

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestCRDBDatastore(t *testing.T) {
+	t.Parallel()
 	b := testdatastore.RunCRDBForTesting(t, "")
 	test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
@@ -52,6 +53,7 @@ func TestCRDBDatastore(t *testing.T) {
 }
 
 func TestCRDBDatastoreWithFollowerReads(t *testing.T) {
+	t.Parallel()
 	followerReadDelay := time.Duration(4.8 * float64(time.Second))
 	gcWindow := 100 * time.Second
 
@@ -61,6 +63,7 @@ func TestCRDBDatastoreWithFollowerReads(t *testing.T) {
 	}
 	for _, quantization := range quantizationDurations {
 		t.Run(fmt.Sprintf("Quantization%s", quantization), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ds := testdatastore.RunCRDBForTesting(t, "").NewDatastore(t, func(engine, uri string) datastore.Datastore {
@@ -96,6 +99,7 @@ func TestCRDBDatastoreWithFollowerReads(t *testing.T) {
 }
 
 func TestWatchFeatureDetection(t *testing.T) {
+	t.Parallel()
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 	cases := []struct {
@@ -136,6 +140,7 @@ func TestWatchFeatureDetection(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
 			adminConn, nonAdminConnURI := newCRDBWithUser(t, pool)

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -62,6 +62,7 @@ func TestCRDBDatastoreWithFollowerReads(t *testing.T) {
 		100 * time.Millisecond,
 	}
 	for _, quantization := range quantizationDurations {
+		quantization := quantization
 		t.Run(fmt.Sprintf("Quantization%s", quantization), func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)
@@ -139,6 +140,7 @@ func TestWatchFeatureDetection(t *testing.T) {
 		},
 	}
 	for _, tt := range cases {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())

--- a/internal/datastore/crdb/keys_test.go
+++ b/internal/datastore/crdb/keys_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestOverlapKeyAddition(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name       string
 		keyer      overlapKeyer
@@ -44,7 +45,9 @@ func TestOverlapKeyAddition(t *testing.T) {
 		},
 	}
 	for _, tt := range cases {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			set := newKeySet()
 			for _, n := range tt.namespaces {
 				tt.keyer.addKey(set, n)

--- a/internal/datastore/memdb/memdb_test.go
+++ b/internal/datastore/memdb/memdb_test.go
@@ -24,10 +24,12 @@ func (mdbt memDBTest) New(revisionQuantization, gcWindow time.Duration, watchBuf
 }
 
 func TestMemdbDatastore(t *testing.T) {
+	t.Parallel()
 	test.All(t, memDBTest{})
 }
 
 func TestConcurrentWritePanic(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds, err := NewMemdbDatastore(0, 1*time.Hour, 1*time.Hour)

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -70,6 +70,7 @@ type datastoreTestFunc func(t *testing.T, ds datastore.Datastore)
 
 func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestFunc, options ...Option) func(*testing.T) {
 	return func(t *testing.T) {
+		t.Parallel()
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 			ds, err := newMySQLDatastore(uri, options...)
 			require.NoError(t, err)
@@ -82,6 +83,7 @@ func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestF
 }
 
 func TestMySQLDatastore(t *testing.T) {
+	t.Parallel()
 	b := testdatastore.RunMySQLForTesting(t, "")
 	dst := datastoreTester{b: b, t: t}
 	test.All(t, test.DatastoreTesterFunc(dst.createDatastore))
@@ -102,12 +104,14 @@ func TestMySQLDatastore(t *testing.T) {
 }
 
 func TestMySQLDatastoreWithTablePrefix(t *testing.T) {
+	t.Parallel()
 	b := testdatastore.RunMySQLForTestingWithOptions(t, testdatastore.MySQLTesterOptions{MigrateForNewDatastore: true, Prefix: "spicedb_"}, "")
 	dst := datastoreTester{b: b, t: t, prefix: "spicedb_"}
 	test.All(t, test.DatastoreTesterFunc(dst.createDatastore))
 }
 
 func DatabaseSeedingTest(t *testing.T, ds datastore.Datastore) {
+	// t.Parallel() already invoked in createDatastoreTest
 	req := require.New(t)
 
 	// ensure datastore is seeded right after initialization
@@ -122,6 +126,7 @@ func DatabaseSeedingTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func PrometheusCollectorTest(t *testing.T, ds datastore.Datastore) {
+	// t.Parallel() already invoked in createDatastoreTest
 	req := require.New(t)
 
 	// cause some use of the SQL connection pool to generate metrics
@@ -144,6 +149,7 @@ func PrometheusCollectorTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
+	// t.Parallel() already invoked in createDatastoreTest
 	req := require.New(t)
 
 	ctx := context.Background()
@@ -282,6 +288,7 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func GarbageCollectionByTimeTest(t *testing.T, ds datastore.Datastore) {
+	// t.Parallel() already invoked in createDatastoreTest
 	req := require.New(t)
 
 	ctx := context.Background()
@@ -355,6 +362,7 @@ func GarbageCollectionByTimeTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func ChunkedGarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
+	// t.Parallel() already invoked in createDatastoreTest
 	req := require.New(t)
 
 	ctx := context.Background()
@@ -438,6 +446,7 @@ func ChunkedGarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
+	// t.Parallel() already invoked in createDatastoreTest
 	testCases := []struct {
 		testName         string
 		quantization     time.Duration
@@ -478,6 +487,7 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -537,6 +547,7 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 // By default, the current time zone for each connection is the server's time.
 // The time zone can be set on a per-connection basis.
 func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
+	// t.Parallel() already invoked in createDatastoreTest
 	req := require.New(t)
 
 	// Setting db default time zone to before UTC
@@ -576,6 +587,7 @@ func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func TestMySQLMigrations(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 
 	db := datastoreDB(t, false)
@@ -597,6 +609,7 @@ func TestMySQLMigrations(t *testing.T) {
 }
 
 func TestMySQLMigrationsWithPrefix(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 
 	prefix := "spicedb_"

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -486,6 +486,7 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)

--- a/internal/datastore/mysql/revisions_test.go
+++ b/internal/datastore/mysql/revisions_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func Test_revisionFromTransaction(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		txID uint64
@@ -23,7 +24,9 @@ func Test_revisionFromTransaction(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			got := revisionFromTransaction(tt.txID)
 			require.True(tt.want.Equal(got))
@@ -32,6 +35,7 @@ func Test_revisionFromTransaction(t *testing.T) {
 }
 
 func Test_transactionFromRevision(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		revision revision.Decimal
@@ -42,7 +46,9 @@ func Test_transactionFromRevision(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			got := transactionFromRevision(tt.revision)
 			require.Equal(tt.want, got)

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -535,6 +535,7 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestPostgresDatastore(t *testing.T) {
+	t.Parallel()
 	for _, config := range []struct {
 		targetMigration string
 		migrationPhase  string
@@ -54,6 +55,7 @@ func TestPostgresDatastore(t *testing.T) {
 			}))
 
 			t.Run("WithSplit", func(t *testing.T) {
+				t.Parallel()
 				// Set the split at a VERY small size, to ensure any WithUsersets queries are split.
 				test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 					ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
@@ -131,6 +133,7 @@ type datastoreTestFunc func(t *testing.T, ds datastore.Datastore)
 
 func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestFunc, options ...Option) func(*testing.T) {
 	return func(t *testing.T) {
+		t.Parallel()
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 			ds, err := newPostgresDatastore(uri, options...)
 			require.NoError(t, err)
@@ -143,6 +146,7 @@ func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestF
 }
 
 func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
+	// t.Parallel() already called in createDatastoreTest
 	require := require.New(t)
 
 	ctx := context.Background()
@@ -289,6 +293,7 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
+	// t.Parallel() already called in createDatastoreTest
 	require := require.New(t)
 
 	ctx := context.Background()
@@ -327,6 +332,7 @@ func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func GarbageCollectionByTimeTest(t *testing.T, ds datastore.Datastore) {
+	// t.Parallel() already called in createDatastoreTest
 	require := require.New(t)
 
 	ctx := context.Background()
@@ -403,6 +409,7 @@ func GarbageCollectionByTimeTest(t *testing.T, ds datastore.Datastore) {
 const chunkRelationshipCount = 2000
 
 func ChunkedGarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
+	// t.Parallel() already called in createDatastoreTest
 	require := require.New(t)
 
 	ctx := context.Background()
@@ -487,6 +494,7 @@ func ChunkedGarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
+	// t.Parallel() already called in createDatastoreTest
 	testCases := []struct {
 		testName      string
 		quantization  time.Duration
@@ -528,6 +536,7 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()

--- a/internal/datastore/postgres/revisions_test.go
+++ b/internal/datastore/postgres/revisions_test.go
@@ -22,6 +22,7 @@ const (
 )
 
 func TestRevisionOrdering(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		lhsTx        uint64
 		lhsXmin      int64
@@ -62,7 +63,9 @@ func TestRevisionOrdering(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(fmt.Sprintf("%d.%d:%d.%d", tc.lhsTx, tc.lhsXmin, tc.rhsTx, tc.rhsXmin), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			lhs := testRevision(tc.lhsTx, tc.lhsXmin)
@@ -80,6 +83,7 @@ func TestRevisionOrdering(t *testing.T) {
 }
 
 func TestRevisionSerDe(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		tx          uint64
 		xmin        int64
@@ -95,7 +99,9 @@ func TestRevisionSerDe(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(fmt.Sprintf("%d.%d", tc.tx, tc.xmin), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			rev := testRevision(tc.tx, tc.xmin)
 			serialized := rev.String()
@@ -109,6 +115,7 @@ func TestRevisionSerDe(t *testing.T) {
 }
 
 func TestRevisionDeserializationErrors(t *testing.T) {
+	t.Parallel()
 	testCases := []string{
 		"1:0",
 		"-1.0",
@@ -121,7 +128,7 @@ func TestRevisionDeserializationErrors(t *testing.T) {
 		"0.abc",
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range testCases { // nolint: paralleltest
 		t.Run(tc, func(t *testing.T) {
 			_, err := parseRevision(tc)
 			require.Error(t, err)

--- a/internal/datastore/proxy/caching_test.go
+++ b/internal/datastore/proxy/caching_test.go
@@ -138,6 +138,7 @@ func TestRWTNamespaceCaching(t *testing.T) {
 }
 
 func TestRWTNamespaceCacheWithWrites(t *testing.T) {
+	t.Parallel()
 	dsMock := &proxy_test.MockDatastore{}
 	rwtMock := &proxy_test.MockReadWriteTransaction{}
 
@@ -288,6 +289,7 @@ func (r *reader) ReadNamespace(ctx context.Context, namespace string) (ns *core.
 }
 
 func TestSingleFlightCancelled(t *testing.T) {
+	t.Parallel()
 	dsMock := &proxy_test.MockDatastore{}
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	ctx2, cancel2 := context.WithCancel(context.Background())

--- a/internal/datastore/proxy/caching_test.go
+++ b/internal/datastore/proxy/caching_test.go
@@ -37,6 +37,7 @@ const (
 // datastore implementation, the process of inserting it into the cache and
 // back does not break anything.
 func TestNilUnmarshal(t *testing.T) {
+	t.Parallel()
 	nsDef := (*core.NamespaceDefinition)(nil)
 	marshalled, err := nsDef.MarshalVT()
 	require.Nil(t, err)
@@ -48,6 +49,7 @@ func TestNilUnmarshal(t *testing.T) {
 }
 
 func TestSnapshotNamespaceCaching(t *testing.T) {
+	t.Parallel()
 	dsMock := &proxy_test.MockDatastore{}
 
 	oneReader := &proxy_test.MockReader{}
@@ -103,6 +105,7 @@ func TestSnapshotNamespaceCaching(t *testing.T) {
 }
 
 func TestRWTNamespaceCaching(t *testing.T) {
+	t.Parallel()
 	dsMock := &proxy_test.MockDatastore{}
 	rwtMock := &proxy_test.MockReadWriteTransaction{}
 
@@ -180,6 +183,7 @@ func TestRWTNamespaceCacheWithWrites(t *testing.T) {
 }
 
 func TestSingleFlight(t *testing.T) {
+	t.Parallel()
 	dsMock := &proxy_test.MockDatastore{}
 
 	ctx := context.Background()
@@ -213,6 +217,7 @@ func TestSingleFlight(t *testing.T) {
 }
 
 func TestSnapshotNamespaceCachingRealDatastore(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name          string
 		nsDef         *core.NamespaceDefinition
@@ -241,7 +246,9 @@ func TestSnapshotNamespaceCachingRealDatastore(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 			require.NoError(t, err)
 

--- a/internal/datastore/proxy/hedging_test.go
+++ b/internal/datastore/proxy/hedging_test.go
@@ -35,7 +35,7 @@ var (
 
 type testFunc func(t *testing.T, proxy datastore.Datastore, expectFirst bool)
 
-func TestDatastoreRequestHedging(t *testing.T) {
+func TestDatastoreRequestHedging(t *testing.T) { // nolint: paralleltest
 	testCases := []struct {
 		methodName        string
 		useSnapshotReader bool
@@ -133,7 +133,7 @@ func TestDatastoreRequestHedging(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range testCases { // nolint: paralleltest
 		t.Run(tc.methodName, func(t *testing.T) {
 			defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/authzed/spicedb/internal/datastore/proxy.autoAdvance.func1"), goleak.IgnoreCurrent())
 			mockTime := clock.NewMock()
@@ -195,6 +195,7 @@ func TestDatastoreRequestHedging(t *testing.T) {
 }
 
 func TestDigestRollover(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	delegate := &proxy_test.MockDatastore{}
@@ -258,6 +259,7 @@ func TestDigestRollover(t *testing.T) {
 }
 
 func TestBadArgs(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	delegate := &proxy_test.MockDatastore{}
 
@@ -283,6 +285,7 @@ func TestBadArgs(t *testing.T) {
 }
 
 func TestDatastoreE2E(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	delegateDatastore := &proxy_test.MockDatastore{}
@@ -340,6 +343,7 @@ func TestDatastoreE2E(t *testing.T) {
 }
 
 func TestContextCancellation(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	delegate := &proxy_test.MockDatastore{}

--- a/internal/datastore/proxy/readonly_test.go
+++ b/internal/datastore/proxy/readonly_test.go
@@ -27,6 +27,7 @@ func newReadOnlyMock() (*proxy_test.MockDatastore, *proxy_test.MockReader) {
 }
 
 func TestRWOperationErrors(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	delegate, _ := newReadOnlyMock()
@@ -54,6 +55,7 @@ func TestRWOperationErrors(t *testing.T) {
 var expectedRevision = revision.NewFromDecimal(decimal.NewFromInt(123))
 
 func TestIsReadyPassthrough(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	delegate, _ := newReadOnlyMock()
@@ -69,6 +71,7 @@ func TestIsReadyPassthrough(t *testing.T) {
 }
 
 func TestOptimizedRevisionPassthrough(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	delegate, _ := newReadOnlyMock()
@@ -84,6 +87,7 @@ func TestOptimizedRevisionPassthrough(t *testing.T) {
 }
 
 func TestHeadRevisionPassthrough(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	delegate, _ := newReadOnlyMock()
@@ -99,6 +103,7 @@ func TestHeadRevisionPassthrough(t *testing.T) {
 }
 
 func TestCheckRevisionPassthrough(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	delegate, _ := newReadOnlyMock()
@@ -113,6 +118,7 @@ func TestCheckRevisionPassthrough(t *testing.T) {
 }
 
 func TestWatchPassthrough(t *testing.T) {
+	t.Parallel()
 	delegate, _ := newReadOnlyMock()
 	ds := NewReadonlyDatastore(delegate)
 	ctx := context.Background()
@@ -127,6 +133,7 @@ func TestWatchPassthrough(t *testing.T) {
 }
 
 func TestSnapshotReaderPassthrough(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	delegate, reader := newReadOnlyMock()

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestSpannerDatastore(t *testing.T) {
+	t.Parallel()
 	b := testdatastore.RunSpannerForTesting(t, "")
 	test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {

--- a/internal/developmentmembership/foundsubject_test.go
+++ b/internal/developmentmembership/foundsubject_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestToValidationString(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name     string
 		fs       FoundSubject
@@ -42,7 +43,9 @@ func TestToValidationString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			require.Equal(tc.expected, tc.fs.ToValidationString())
 

--- a/internal/developmentmembership/membership_test.go
+++ b/internal/developmentmembership/membership_test.go
@@ -58,6 +58,7 @@ var (
 )
 
 func TestMembershipSetBasic(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -79,6 +80,7 @@ func TestMembershipSetBasic(t *testing.T) {
 }
 
 func TestMembershipSetIntersectionBasic(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -99,6 +101,7 @@ func TestMembershipSetIntersectionBasic(t *testing.T) {
 }
 
 func TestMembershipSetIntersectionWithDifferentTypesOneMissingLeft(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -120,6 +123,7 @@ func TestMembershipSetIntersectionWithDifferentTypesOneMissingLeft(t *testing.T)
 }
 
 func TestMembershipSetIntersectionWithDifferentTypesOneMissingRight(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -141,6 +145,7 @@ func TestMembershipSetIntersectionWithDifferentTypesOneMissingRight(t *testing.T
 }
 
 func TestMembershipSetIntersectionWithDifferentTypes(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -164,6 +169,7 @@ func TestMembershipSetIntersectionWithDifferentTypes(t *testing.T) {
 }
 
 func TestMembershipSetExclusion(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -184,6 +190,7 @@ func TestMembershipSetExclusion(t *testing.T) {
 }
 
 func TestMembershipSetExclusionMultiple(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -208,6 +215,7 @@ func TestMembershipSetExclusionMultiple(t *testing.T) {
 }
 
 func TestMembershipSetExclusionMultipleWithWildcard(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -231,6 +239,7 @@ func TestMembershipSetExclusionMultipleWithWildcard(t *testing.T) {
 }
 
 func TestMembershipSetExclusionMultipleMiddle(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -255,6 +264,7 @@ func TestMembershipSetExclusionMultipleMiddle(t *testing.T) {
 }
 
 func TestMembershipSetIntersectionWithOneWildcard(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -275,6 +285,7 @@ func TestMembershipSetIntersectionWithOneWildcard(t *testing.T) {
 }
 
 func TestMembershipSetIntersectionWithAllWildcardLeft(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -295,6 +306,7 @@ func TestMembershipSetIntersectionWithAllWildcardLeft(t *testing.T) {
 }
 
 func TestMembershipSetIntersectionWithAllWildcardRight(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -315,6 +327,7 @@ func TestMembershipSetIntersectionWithAllWildcardRight(t *testing.T) {
 }
 
 func TestMembershipSetExclusionWithLeftWildcard(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -335,6 +348,7 @@ func TestMembershipSetExclusionWithLeftWildcard(t *testing.T) {
 }
 
 func TestMembershipSetExclusionWithRightWildcard(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -355,6 +369,7 @@ func TestMembershipSetExclusionWithRightWildcard(t *testing.T) {
 }
 
 func TestMembershipSetIntersectionWithThreeWildcards(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -378,6 +393,7 @@ func TestMembershipSetIntersectionWithThreeWildcards(t *testing.T) {
 }
 
 func TestMembershipSetIntersectionWithOneBranchMissingWildcards(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 
@@ -402,6 +418,7 @@ func TestMembershipSetIntersectionWithOneBranchMissingWildcards(t *testing.T) {
 }
 
 func TestMembershipSetIntersectionWithTwoBranchesMissingWildcards(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	ms := NewMembershipSet()
 

--- a/internal/developmentmembership/trackingsubjectset_test.go
+++ b/internal/developmentmembership/trackingsubjectset_test.go
@@ -58,6 +58,7 @@ func fs(subjectType string, subjectID string, subjectRel string, excludedSubject
 }
 
 func TestTrackingSubjectSet(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name     string
 		set      *TrackingSubjectSet
@@ -327,7 +328,9 @@ func TestTrackingSubjectSet(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			for _, fs := range tc.expected {
 				_, isWildcard := fs.WildcardType()
@@ -351,6 +354,7 @@ func TestTrackingSubjectSet(t *testing.T) {
 }
 
 func TestTrackingSubjectSetResourceTracking(t *testing.T) {
+	t.Parallel()
 	tss := NewTrackingSubjectSet()
 	tss.Add(NewFoundSubject(ONR("user", "tom", "..."), ONR("resource", "foo", "viewer")))
 	tss.Add(NewFoundSubject(ONR("user", "tom", "..."), ONR("resource", "bar", "viewer")))
@@ -369,6 +373,7 @@ func TestTrackingSubjectSetResourceTracking(t *testing.T) {
 }
 
 func TestTrackingSubjectSetResourceTrackingWithWildcard(t *testing.T) {
+	t.Parallel()
 	tss := NewTrackingSubjectSet()
 	tss.Add(NewFoundSubject(ONR("user", "tom", "..."), ONR("resource", "foo", "viewer")))
 

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -32,6 +32,7 @@ func RR(namespaceName string, relationName string) *core.RelationReference {
 }
 
 func TestMaxDepthCaching(t *testing.T) {
+	t.Parallel()
 	start1 := "document:doc1#read"
 	start2 := "document:doc2#read"
 	user1 := "user:user1#..."
@@ -86,7 +87,9 @@ func TestMaxDepthCaching(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			delegate := delegateDispatchMock{&mock.Mock{}}

--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -34,6 +34,7 @@ var goleakIgnores = []goleak.Option{
 
 func TestSimpleCheck(t *testing.T) {
 	defer goleak.VerifyNone(t, goleakIgnores...)
+	t.Parallel()
 
 	type expected struct {
 		relation string
@@ -105,8 +106,11 @@ func TestSimpleCheck(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		for _, userset := range tc.usersets {
+			userset := userset
 			for _, expected := range userset.expected {
+				expected := expected
 				name := fmt.Sprintf(
 					"simple::%s:%s#%s@%s:%s#%s=>%t",
 					tc.namespace,
@@ -119,6 +123,7 @@ func TestSimpleCheck(t *testing.T) {
 				)
 
 				t.Run(name, func(t *testing.T) {
+					t.Parallel()
 					require := require.New(t)
 
 					ctx, dispatch, revision := newLocalDispatcher(t)
@@ -150,6 +155,7 @@ func TestSimpleCheck(t *testing.T) {
 }
 
 func TestMaxDepth(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
@@ -183,6 +189,7 @@ func TestMaxDepth(t *testing.T) {
 }
 
 func TestCheckMetadata(t *testing.T) {
+	t.Parallel()
 	type expected struct {
 		relation              string
 		isMember              bool
@@ -239,8 +246,11 @@ func TestCheckMetadata(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		for _, userset := range tc.usersets {
+			userset := userset
 			for _, expected := range userset.expected {
+				expected := expected
 				name := fmt.Sprintf(
 					"metadata:%s:%s#%s@%s:%s#%s=>%t",
 					tc.namespace,
@@ -253,6 +263,7 @@ func TestCheckMetadata(t *testing.T) {
 				)
 
 				t.Run(name, func(t *testing.T) {
+					t.Parallel()
 					require := require.New(t)
 
 					ctx, dispatch, revision := newLocalDispatcher(t)

--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -32,9 +32,8 @@ var goleakIgnores = []goleak.Option{
 	goleak.IgnoreCurrent(),
 }
 
-func TestSimpleCheck(t *testing.T) {
+func TestSimpleCheck(t *testing.T) { // nolint: paralleltest
 	defer goleak.VerifyNone(t, goleakIgnores...)
-	t.Parallel()
 
 	type expected struct {
 		relation string

--- a/internal/dispatch/graph/expand_test.go
+++ b/internal/dispatch/graph/expand_test.go
@@ -129,9 +129,8 @@ var (
 	)
 )
 
-func TestExpand(t *testing.T) {
+func TestExpand(t *testing.T) { // nolint: paralleltest
 	defer goleak.VerifyNone(t, goleakIgnores...)
-	t.Parallel()
 
 	testCases := []struct {
 		start                 *core.ObjectAndRelation
@@ -269,9 +268,8 @@ func onrExpr(onr *core.ObjectAndRelation) ast.Expr {
 	}
 }
 
-func TestMaxDepthExpand(t *testing.T) {
+func TestMaxDepthExpand(t *testing.T) { // nolint: paralleltest
 	defer goleak.VerifyNone(t, goleakIgnores...)
-	t.Parallel()
 
 	require := require.New(t)
 

--- a/internal/dispatch/graph/expand_test.go
+++ b/internal/dispatch/graph/expand_test.go
@@ -131,6 +131,7 @@ var (
 
 func TestExpand(t *testing.T) {
 	defer goleak.VerifyNone(t, goleakIgnores...)
+	t.Parallel()
 
 	testCases := []struct {
 		start                 *core.ObjectAndRelation
@@ -156,7 +157,9 @@ func TestExpand(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(fmt.Sprintf("%s-%s", tuple.StringONR(tc.start), tc.expansionMode), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ctx, dispatch, revision := newLocalDispatcher(t)
@@ -268,6 +271,7 @@ func onrExpr(onr *core.ObjectAndRelation) ast.Expr {
 
 func TestMaxDepthExpand(t *testing.T) {
 	defer goleak.VerifyNone(t, goleakIgnores...)
+	t.Parallel()
 
 	require := require.New(t)
 

--- a/internal/dispatch/graph/lookup_test.go
+++ b/internal/dispatch/graph/lookup_test.go
@@ -34,6 +34,7 @@ func resolvedRes(resourceID string) *v1.ResolvedResource {
 
 func TestSimpleLookup(t *testing.T) {
 	defer goleak.VerifyNone(t, goleakIgnores...)
+	t.Parallel()
 
 	testCases := []struct {
 		start                 *core.RelationReference
@@ -99,6 +100,7 @@ func TestSimpleLookup(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		name := fmt.Sprintf(
 			"%s#%s->%s",
 			tc.start.Namespace,
@@ -107,6 +109,7 @@ func TestSimpleLookup(t *testing.T) {
 		)
 
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			ctx, dispatch, revision := newLocalDispatcher(t)
 
@@ -153,6 +156,7 @@ func TestSimpleLookup(t *testing.T) {
 }
 
 func TestMaxDepthLookup(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)

--- a/internal/dispatch/graph/lookup_test.go
+++ b/internal/dispatch/graph/lookup_test.go
@@ -32,9 +32,8 @@ func resolvedRes(resourceID string) *v1.ResolvedResource {
 	}
 }
 
-func TestSimpleLookup(t *testing.T) {
+func TestSimpleLookup(t *testing.T) { // nolint: paralleltest
 	defer goleak.VerifyNone(t, goleakIgnores...)
-	t.Parallel()
 
 	testCases := []struct {
 		start                 *core.RelationReference

--- a/internal/dispatch/graph/lookupsubjects_test.go
+++ b/internal/dispatch/graph/lookupsubjects_test.go
@@ -31,6 +31,7 @@ var (
 
 func TestSimpleLookupSubjects(t *testing.T) {
 	defer goleak.VerifyNone(t, goleakIgnores...)
+	t.Parallel()
 
 	testCases := []struct {
 		resourceType     string
@@ -131,7 +132,9 @@ func TestSimpleLookupSubjects(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(fmt.Sprintf("simple-lookup-subjects:%s:%s:%s:%s:%s", tc.resourceType, tc.resourceID, tc.permission, tc.subjectType, tc.subjectRelation), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ctx, dis, revision := newLocalDispatcher(t)
@@ -188,6 +191,7 @@ func TestSimpleLookupSubjects(t *testing.T) {
 }
 
 func TestLookupSubjectsMaxDepth(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
@@ -219,6 +223,7 @@ func TestLookupSubjectsMaxDepth(t *testing.T) {
 }
 
 func TestLookupSubjectsDispatchCount(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		resourceType          string
 		resourceID            string
@@ -246,7 +251,9 @@ func TestLookupSubjectsDispatchCount(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(fmt.Sprintf("dispatch-count-lookup-subjects:%s:%s:%s:%s:%s", tc.resourceType, tc.resourceID, tc.permission, tc.subjectType, tc.subjectRelation), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ctx, dis, revision := newLocalDispatcher(t)

--- a/internal/dispatch/graph/lookupsubjects_test.go
+++ b/internal/dispatch/graph/lookupsubjects_test.go
@@ -29,9 +29,8 @@ var (
 	caveatInvert = caveats.Invert
 )
 
-func TestSimpleLookupSubjects(t *testing.T) {
+func TestSimpleLookupSubjects(t *testing.T) { // nolint: paralleltest
 	defer goleak.VerifyNone(t, goleakIgnores...)
-	t.Parallel()
 
 	testCases := []struct {
 		resourceType     string
@@ -278,6 +277,7 @@ func TestLookupSubjectsDispatchCount(t *testing.T) {
 }
 
 func TestCaveatedLookupSubjects(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name          string
 		schema        string
@@ -645,7 +645,9 @@ func TestCaveatedLookupSubjects(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			dispatcher := NewLocalOnlyDispatcher(10)

--- a/internal/dispatch/graph/reachableresources_test.go
+++ b/internal/dispatch/graph/reachableresources_test.go
@@ -30,9 +30,8 @@ func reachable(onr *core.ObjectAndRelation, hasPermission bool) reachableResourc
 	}
 }
 
-func TestSimpleReachableResources(t *testing.T) {
+func TestSimpleReachableResources(t *testing.T) { // nolint: paralleltest
 	defer goleak.VerifyNone(t, goleakIgnores...)
-	t.Parallel()
 
 	testCases := []struct {
 		start     *core.RelationReference
@@ -295,6 +294,7 @@ func BenchmarkReachableResources(b *testing.B) {
 }
 
 func TestCaveatedReachableResources(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name          string
 		schema        string
@@ -559,7 +559,9 @@ func TestCaveatedReachableResources(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			dispatcher := NewLocalOnlyDispatcher(10)

--- a/internal/dispatch/graph/reachableresources_test.go
+++ b/internal/dispatch/graph/reachableresources_test.go
@@ -32,6 +32,7 @@ func reachable(onr *core.ObjectAndRelation, hasPermission bool) reachableResourc
 
 func TestSimpleReachableResources(t *testing.T) {
 	defer goleak.VerifyNone(t, goleakIgnores...)
+	t.Parallel()
 
 	testCases := []struct {
 		start     *core.RelationReference
@@ -133,6 +134,7 @@ func TestSimpleReachableResources(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		name := fmt.Sprintf(
 			"%s#%s->%s",
 			tc.start.Namespace,
@@ -141,6 +143,7 @@ func TestSimpleReachableResources(t *testing.T) {
 		)
 
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ctx, dispatcher, revision := newLocalDispatcher(t)
@@ -182,6 +185,7 @@ func TestSimpleReachableResources(t *testing.T) {
 }
 
 func TestMaxDepthreachableResources(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ctx, dispatcher, revision := newLocalDispatcher(t)

--- a/internal/dispatch/keys/computed_test.go
+++ b/internal/dispatch/keys/computed_test.go
@@ -504,6 +504,7 @@ func TestComputeOnlyStableHash(t *testing.T) {
 }
 
 func TestComputeContextHash(t *testing.T) {
+	t.Parallel()
 	result := lookupRequestToKey(&v1.DispatchLookupRequest{
 		ObjectRelation: RR("document", "view"),
 		Subject:        ONR("user", "mariah", "..."),

--- a/internal/dispatch/keys/computed_test.go
+++ b/internal/dispatch/keys/computed_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestKeyPrefixOverlap(t *testing.T) {
+	t.Parallel()
 	encountered := map[string]struct{}{}
 	for _, prefix := range cachePrefixes {
 		_, ok := encountered[string(prefix)]
@@ -32,6 +33,7 @@ var (
 )
 
 func TestStableCacheKeys(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name      string
 		createKey func() DispatchCacheKey
@@ -269,7 +271,9 @@ func TestStableCacheKeys(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			key := tc.createKey()
 			require.Equal(t, tc.expected, hex.EncodeToString(key.StableSumAsBytes()))
 		})
@@ -412,6 +416,7 @@ var generatorFuncs = map[string]generatorFunc{
 }
 
 func TestCacheKeyNoOverlap(t *testing.T) {
+	t.Parallel()
 	allResourceIds := [][]string{
 		{"1"},
 		{"1", "2"},
@@ -448,7 +453,7 @@ func TestCacheKeyNoOverlap(t *testing.T) {
 	// Ensure all key functions are generated.
 	require.Equal(t, len(generatorFuncs), len(cachePrefixes))
 
-	for _, resourceIds := range allResourceIds {
+	for _, resourceIds := range allResourceIds { // nolint: paralleltest
 		t.Run(strings.Join(resourceIds, ","), func(t *testing.T) {
 			for _, subjectIds := range allSubjectIds {
 				t.Run(strings.Join(subjectIds, ","), func(t *testing.T) {
@@ -485,6 +490,7 @@ func TestCacheKeyNoOverlap(t *testing.T) {
 }
 
 func TestComputeOnlyStableHash(t *testing.T) {
+	t.Parallel()
 	result := checkRequestToKey(&v1.DispatchCheckRequest{
 		ResourceRelation: RR("document", "view"),
 		ResourceIds:      []string{"foo", "bar"},

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -44,7 +44,7 @@ func NewHandler(ctx context.Context, upstreamAddr, upstreamTLSCertPath string) (
 		opts = append(opts, grpcutil.WithCustomCerts(upstreamTLSCertPath, grpcutil.SkipVerifyCA))
 	}
 
-	healthConn, err := grpc.Dial(upstreamAddr, opts...)
+	healthConn, err := grpc.DialContext(ctx, upstreamAddr, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestOtelForwarding(t *testing.T) {
+	t.Parallel()
 	// Set the global propagator
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAsyncDispatch(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		numRequests      uint16
 		concurrencyLimit uint16
@@ -23,7 +24,9 @@ func TestAsyncDispatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(fmt.Sprintf("%d/%d", tc.numRequests, tc.concurrencyLimit), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ctx := context.Background()

--- a/internal/graph/computed/computecheck_test.go
+++ b/internal/graph/computed/computecheck_test.go
@@ -30,6 +30,7 @@ type caveatedUpdate struct {
 }
 
 func TestComputeCheckWithCaveats(t *testing.T) {
+	t.Parallel()
 	type check struct {
 		check                 string
 		context               map[string]any
@@ -801,7 +802,9 @@ func TestComputeCheckWithCaveats(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 			require.NoError(t, err)
 
@@ -849,6 +852,7 @@ func TestComputeCheckWithCaveats(t *testing.T) {
 }
 
 func TestComputeCheckError(t *testing.T) {
+	t.Parallel()
 	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 	require.NoError(t, err)
 

--- a/internal/graph/computed/computecheck_test.go
+++ b/internal/graph/computed/computecheck_test.go
@@ -878,6 +878,7 @@ func TestComputeCheckError(t *testing.T) {
 }
 
 func TestComputeBulkCheck(t *testing.T) {
+	t.Parallel()
 	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 	require.NoError(t, err)
 

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestChunkSizes(t *testing.T) {
+	t.Parallel()
 	for index, cs := range progressiveDispatchChunkSizes {
 		require.LessOrEqual(t, cs, datastore.FilterMaximumIDCount)
 		if index > 0 {
@@ -18,5 +19,6 @@ func TestChunkSizes(t *testing.T) {
 }
 
 func TestMaxDispatchChunkSize(t *testing.T) {
+	t.Parallel()
 	require.LessOrEqual(t, maxDispatchChunkSize, datastore.FilterMaximumIDCount)
 }

--- a/internal/graph/membershipset_test.go
+++ b/internal/graph/membershipset_test.go
@@ -24,6 +24,7 @@ func caveat(name string, context map[string]any) *v1.CaveatExpression {
 }
 
 func TestMembershipSetAddDirectMember(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name                string
 		existingMembers     map[string]*v1.CaveatExpression
@@ -126,7 +127,9 @@ func TestMembershipSetAddDirectMember(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ms := membershipSetFromMap(tc.existingMembers)
 			ms.AddDirectMember(tc.directMemberID, unwrapCaveat(tc.directMemberCaveat))
 			require.Equal(t, tc.expectedMembers, ms.membersByID)
@@ -137,6 +140,7 @@ func TestMembershipSetAddDirectMember(t *testing.T) {
 }
 
 func TestMembershipSetAddMemberViaRelationship(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name                     string
 		existingMembers          map[string]*v1.CaveatExpression
@@ -228,7 +232,9 @@ func TestMembershipSetAddMemberViaRelationship(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ms := membershipSetFromMap(tc.existingMembers)
 			ms.AddMemberViaRelationship(tc.resourceID, tc.resourceCaveatExpression, tc.parentRelationship)
 			require.Equal(t, tc.expectedMembers, ms.membersByID)
@@ -238,6 +244,7 @@ func TestMembershipSetAddMemberViaRelationship(t *testing.T) {
 }
 
 func TestMembershipSetUnionWith(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name                string
 		set1                map[string]*v1.CaveatExpression
@@ -369,7 +376,9 @@ func TestMembershipSetUnionWith(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ms1 := membershipSetFromMap(tc.set1)
 			ms2 := membershipSetFromMap(tc.set2)
 			ms1.UnionWith(ms2.AsCheckResultsMap())
@@ -381,6 +390,7 @@ func TestMembershipSetUnionWith(t *testing.T) {
 }
 
 func TestMembershipSetIntersectWith(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name                string
 		set1                map[string]*v1.CaveatExpression
@@ -545,7 +555,9 @@ func TestMembershipSetIntersectWith(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ms1 := membershipSetFromMap(tc.set1)
 			ms2 := membershipSetFromMap(tc.set2)
 			ms1.IntersectWith(ms2.AsCheckResultsMap())
@@ -557,6 +569,7 @@ func TestMembershipSetIntersectWith(t *testing.T) {
 }
 
 func TestMembershipSetSubtract(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name                string
 		set1                map[string]*v1.CaveatExpression
@@ -705,7 +718,9 @@ func TestMembershipSetSubtract(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ms1 := membershipSetFromMap(tc.set1)
 			ms2 := membershipSetFromMap(tc.set2)
 			ms1.Subtract(ms2.AsCheckResultsMap())

--- a/internal/graph/parallelchecker_test.go
+++ b/internal/graph/parallelchecker_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestParallelCheckerDirectOverload(t *testing.T) {
+	t.Parallel()
 	pc := newParallelChecker(context.Background(), func() {}, nil, ValidatedLookupRequest{
 		DispatchLookupRequest: &v1.DispatchLookupRequest{
 			Limit: 50,
@@ -42,6 +43,7 @@ func TestParallelCheckerDirectOverload(t *testing.T) {
 }
 
 func TestQueueToCheckLimit(t *testing.T) {
+	t.Parallel()
 	pc := newParallelChecker(context.Background(), func() {}, nil, ValidatedLookupRequest{
 		DispatchLookupRequest: &v1.DispatchLookupRequest{
 			Limit: 1,

--- a/internal/middleware/consistency/consistency_test.go
+++ b/internal/middleware/consistency/consistency_test.go
@@ -28,6 +28,7 @@ var (
 )
 
 func TestAddRevisionToContextNoneSupplied(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds := &proxy_test.MockDatastore{}
@@ -41,6 +42,7 @@ func TestAddRevisionToContextNoneSupplied(t *testing.T) {
 }
 
 func TestAddRevisionToContextMinimizeLatency(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds := &proxy_test.MockDatastore{}
@@ -60,6 +62,7 @@ func TestAddRevisionToContextMinimizeLatency(t *testing.T) {
 }
 
 func TestAddRevisionToContextFullyConsistent(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds := &proxy_test.MockDatastore{}
@@ -79,6 +82,7 @@ func TestAddRevisionToContextFullyConsistent(t *testing.T) {
 }
 
 func TestAddRevisionToContextAtLeastAsFresh(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds := &proxy_test.MockDatastore{}
@@ -99,6 +103,7 @@ func TestAddRevisionToContextAtLeastAsFresh(t *testing.T) {
 }
 
 func TestAddRevisionToContextAtValidExactSnapshot(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds := &proxy_test.MockDatastore{}
@@ -119,6 +124,7 @@ func TestAddRevisionToContextAtValidExactSnapshot(t *testing.T) {
 }
 
 func TestAddRevisionToContextAtInvalidExactSnapshot(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds := &proxy_test.MockDatastore{}
@@ -138,6 +144,7 @@ func TestAddRevisionToContextAtInvalidExactSnapshot(t *testing.T) {
 }
 
 func TestAddRevisionToContextAPIAlwaysFullyConsistent(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds := &proxy_test.MockDatastore{}
@@ -151,6 +158,7 @@ func TestAddRevisionToContextAPIAlwaysFullyConsistent(t *testing.T) {
 }
 
 func TestMiddlewareConsistencyTestSuite(t *testing.T) {
+	t.Parallel()
 	ds := &proxy_test.MockDatastore{}
 	ds.On("HeadRevision").Return(head, nil)
 

--- a/internal/middleware/usagemetrics/usagemetrics_test.go
+++ b/internal/middleware/usagemetrics/usagemetrics_test.go
@@ -74,6 +74,7 @@ type metricsMiddlewareTestSuite struct {
 }
 
 func TestMetricsMiddleware(t *testing.T) {
+	t.Parallel()
 	s := &metricsMiddlewareTestSuite{
 		InterceptorTestSuite: &testpb.InterceptorTestSuite{
 			TestService: &testServer{},

--- a/internal/namespace/aliasing_test.go
+++ b/internal/namespace/aliasing_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAliasing(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name             string
 		toCheck          *core.NamespaceDefinition
@@ -190,7 +191,9 @@ func TestAliasing(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)

--- a/internal/namespace/annotate_test.go
+++ b/internal/namespace/annotate_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAnnotateNamespace(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)

--- a/internal/namespace/canonicalization_test.go
+++ b/internal/namespace/canonicalization_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestCanonicalization(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name             string
 		toCheck          *core.NamespaceDefinition
@@ -377,7 +378,9 @@ func TestCanonicalization(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
@@ -416,6 +419,7 @@ definition document {
 `
 
 func TestCanonicalizationComparison(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name         string
 		first        string
@@ -503,7 +507,9 @@ func TestCanonicalizationComparison(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)

--- a/internal/namespace/caveats_test.go
+++ b/internal/namespace/caveats_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestValidateCaveatDefinition(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		caveat        *core.CaveatDefinition
 		expectedError string
@@ -47,7 +48,9 @@ func TestValidateCaveatDefinition(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.caveat.Name, func(t *testing.T) {
+			t.Parallel()
 			err := ValidateCaveatDefinition(tc.caveat)
 			if tc.expectedError != "" {
 				require.NotNil(t, err)

--- a/internal/namespace/diff_test.go
+++ b/internal/namespace/diff_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestNamespaceDiff(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name           string
 		existing       *core.NamespaceDefinition
@@ -465,7 +466,9 @@ func TestNamespaceDiff(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			diff, err := DiffNamespaces(tc.existing, tc.updated)
 			require.Nil(err)

--- a/internal/namespace/reachabilitygraph_test.go
+++ b/internal/namespace/reachabilitygraph_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestReachabilityGraph(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name                                 string
 		schema                               string
@@ -476,7 +477,9 @@ func TestReachabilityGraph(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)

--- a/internal/namespace/typesystem_test.go
+++ b/internal/namespace/typesystem_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestTypeSystem(t *testing.T) {
+	t.Parallel()
 	emptyEnv := caveats.NewEnvironment()
 
 	testCases := []struct {
@@ -347,7 +348,9 @@ func TestTypeSystem(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)

--- a/internal/namespace/util_test.go
+++ b/internal/namespace/util_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestListReferencedNamespaces(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name          string
 		toCheck       []*core.NamespaceDefinition
@@ -55,7 +56,9 @@ func TestListReferencedNamespaces(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			found := ListReferencedNamespaces(tc.toCheck)

--- a/internal/services/integrationtesting/cert_test.go
+++ b/internal/services/integrationtesting/cert_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestCertRotation(t *testing.T) {
+	t.Parallel()
 	const (
 		// length of time the initial cert is valid
 		initialValidDuration = 1 * time.Second

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -43,6 +43,7 @@ import (
 var testTimedeltas = []time.Duration{1 * time.Second}
 
 func TestConsistency(t *testing.T) {
+	t.Parallel()
 	_, filename, _, _ := runtime.Caller(0)
 	consistencyTestFiles := []string{}
 	err := filepath.Walk(path.Join(path.Dir(filename), "testconfigs"), func(path string, info os.FileInfo, err error) error {
@@ -61,7 +62,9 @@ func TestConsistency(t *testing.T) {
 	rrequire.NoError(err)
 
 	for _, delta := range testTimedeltas {
+		delta := delta
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
+			t.Parallel()
 			for _, filePath := range consistencyTestFiles {
 				t.Run(path.Base(filePath), func(t *testing.T) {
 					for _, dispatcherKind := range []string{"local", "caching"} {

--- a/internal/services/integrationtesting/healthcheck_test.go
+++ b/internal/services/integrationtesting/healthcheck_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestHealthCheck(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	for _, engine := range datastore.Engines {

--- a/internal/services/integrationtesting/ops_test.go
+++ b/internal/services/integrationtesting/ops_test.go
@@ -120,6 +120,7 @@ func (dr deleteCaveatedRelationship) Execute(tester opsTester) error {
 }
 
 func TestSchemaAndRelationshipsOperations(t *testing.T) {
+	t.Parallel()
 	tcs := []schemaTestCase{
 		// Test: write a basic, valid schema.
 		{
@@ -749,7 +750,9 @@ func TestSchemaAndRelationshipsOperations(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			for _, testerName := range []string{"v1"} {
 				t.Run(testerName, func(t *testing.T) {
 					conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, false, tf.EmptyDatastore)

--- a/internal/services/integrationtesting/perf_test.go
+++ b/internal/services/integrationtesting/perf_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestBurst(t *testing.T) {
+	t.Parallel()
 	blacklist := []string{
 		spanner.Engine, // spanner emulator doesn't support parallel transactions
 	}

--- a/internal/services/shared/schema_test.go
+++ b/internal/services/shared/schema_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestApplySchemaChanges(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 	require.NoError(err)

--- a/internal/services/v0/developer_test.go
+++ b/internal/services/v0/developer_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDeveloperSharing(t *testing.T) {
+	t.Parallel()
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"), goleak.IgnoreCurrent())
 
 	require := require.New(t)
@@ -44,6 +45,7 @@ func TestDeveloperSharing(t *testing.T) {
 }
 
 func TestDeveloperSharingConverted(t *testing.T) {
+	t.Parallel()
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"), goleak.IgnoreCurrent())
 
 	require := require.New(t)

--- a/internal/services/v0/download_test.go
+++ b/internal/services/v0/download_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestDeveloperDownload(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	store := NewInMemoryShareStore("flavored")
@@ -70,7 +71,9 @@ assertions: ay
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			url := downloadPath + test.ref
 			require.HTTPStatusCode(handler, test.method, url, nil, test.expectedCode)
 			if len(test.expectedBody) > 0 {

--- a/internal/services/v0/sharestore_test.go
+++ b/internal/services/v0/sharestore_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestS3ShareStore(t *testing.T) {
+	t.Parallel()
 	backend := s3mem.New()
 	faker := gofakes3.New(backend)
 	ts := httptest.NewServer(faker.Server())

--- a/internal/services/v1/errors_test.go
+++ b/internal/services/v1/errors_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestRewriteCanceledError(t *testing.T) {
+	t.Parallel()
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	cancelFunc()
 	errorRewritten := rewriteError(ctx, ctx.Err())
@@ -17,6 +18,7 @@ func TestRewriteCanceledError(t *testing.T) {
 }
 
 func TestRewriteDeadlineExceededError(t *testing.T) {
+	t.Parallel()
 	ctx, cancelFunc := context.WithDeadline(context.Background(), time.Now())
 	defer cancelFunc()
 	errorRewritten := rewriteError(ctx, ctx.Err())

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -54,6 +54,7 @@ func sub(subType string, subID string, subRel string) *v1.SubjectReference {
 }
 
 func TestCheckPermissions(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		resource       *v1.ObjectReference
 		permission     string
@@ -226,10 +227,15 @@ func TestCheckPermissions(t *testing.T) {
 	}
 
 	for _, delta := range testTimedeltas {
+		delta := delta
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
+			t.Parallel()
 			for _, debug := range []bool{false, true} {
+				debug := debug
 				t.Run(fmt.Sprintf("debug%v", debug), func(t *testing.T) {
+					t.Parallel()
 					for _, tc := range testCases {
+						tc := tc
 						t.Run(fmt.Sprintf(
 							"%s:%s#%s@%s:%s#%s",
 							tc.resource.ObjectType,
@@ -239,6 +245,7 @@ func TestCheckPermissions(t *testing.T) {
 							tc.subject.Object.ObjectId,
 							tc.subject.OptionalRelation,
 						), func(t *testing.T) {
+							t.Parallel()
 							require := require.New(t)
 							conn, cleanup, _, revision := testserver.NewTestServer(require, delta, memdb.DisableGC, true, tf.StandardDatastoreWithData)
 							client := v1.NewPermissionsServiceClient(conn)
@@ -297,6 +304,7 @@ func TestCheckPermissions(t *testing.T) {
 }
 
 func TestCheckPermissionWithDebugInfo(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	conn, cleanup, _, revision := testserver.NewTestServer(require, testTimedeltas[0], memdb.DisableGC, true, tf.StandardDatastoreWithData)
 	client := v1.NewPermissionsServiceClient(conn)
@@ -342,7 +350,7 @@ func TestCheckPermissionWithDebugInfo(t *testing.T) {
 	require.Equal(3, len(compiled.OrderedDefinitions))
 }
 
-func TestLookupResources(t *testing.T) {
+func TestLookupResources(t *testing.T) { // nolint: paralleltest
 	testCases := []struct {
 		objectType        string
 		permission        string
@@ -455,7 +463,7 @@ func TestLookupResources(t *testing.T) {
 		},
 	}
 
-	for _, delta := range testTimedeltas {
+	for _, delta := range testTimedeltas { // nolint: paralleltest
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(fmt.Sprintf("%s::%s from %s:%s#%s", tc.objectType, tc.permission, tc.subject.Object.ObjectType, tc.subject.Object.ObjectId, tc.subject.OptionalRelation), func(t *testing.T) {
@@ -511,7 +519,7 @@ func TestLookupResources(t *testing.T) {
 	}
 }
 
-func TestExpand(t *testing.T) {
+func TestExpand(t *testing.T) { // nolint: paralleltest
 	testCases := []struct {
 		startObjectType    string
 		startObjectID      string
@@ -526,7 +534,7 @@ func TestExpand(t *testing.T) {
 		{"document", "", "owner", 1, codes.InvalidArgument},
 	}
 
-	for _, delta := range testTimedeltas {
+	for _, delta := range testTimedeltas { // nolint: paralleltest
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(fmt.Sprintf("%s:%s#%s", tc.startObjectType, tc.startObjectID, tc.startPermission), func(t *testing.T) {
@@ -582,6 +590,7 @@ func countLeafs(node *v1.PermissionRelationshipTree) int {
 }
 
 func TestTranslateExpansionTree(t *testing.T) {
+	t.Parallel()
 	ONR := tuple.ObjectAndRelation
 
 	table := []struct {
@@ -652,14 +661,16 @@ func TestTranslateExpansionTree(t *testing.T) {
 	}
 
 	for _, tt := range table {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			out := v1svc.TranslateRelationshipTree(v1svc.TranslateExpansionTree(tt.input))
 			require.Equal(t, tt.input, out)
 		})
 	}
 }
 
-func TestLookupSubjects(t *testing.T) {
+func TestLookupSubjects(t *testing.T) { // nolint: paralleltest
 	testCases := []struct {
 		resource        *v1.ObjectReference
 		permission      string
@@ -751,7 +762,7 @@ func TestLookupSubjects(t *testing.T) {
 		},
 	}
 
-	for _, delta := range testTimedeltas {
+	for _, delta := range testTimedeltas { // nolint: paralleltest
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(fmt.Sprintf("%s:%s#%s for %s#%s", tc.resource.ObjectType, tc.resource.ObjectId, tc.permission, tc.subjectType, tc.subjectRelation), func(t *testing.T) {
@@ -809,6 +820,7 @@ func TestLookupSubjects(t *testing.T) {
 }
 
 func TestCheckWithCaveats(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 	conn, cleanup, _, revision := testserver.NewTestServer(req, testTimedeltas[0], memdb.DisableGC, true, tf.StandardDatastoreWithCaveatedData)
 	client := v1.NewPermissionsServiceClient(conn)
@@ -860,6 +872,7 @@ func TestCheckWithCaveats(t *testing.T) {
 }
 
 func TestLookupResourcesWithCaveats(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 	conn, cleanup, _, revision := testserver.NewTestServer(req, testTimedeltas[0], memdb.DisableGC, true,
 		func(ds datastore.Datastore, require *require.Assertions) (datastore.Datastore, datastore.Revision) {
@@ -981,6 +994,7 @@ func (a byIDAndPermission) Less(i, j int) bool {
 func (a byIDAndPermission) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 
 func TestLookupSubjectsWithCaveats(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 	conn, cleanup, _, revision := testserver.NewTestServer(req, testTimedeltas[0], memdb.DisableGC, true,
 		func(ds datastore.Datastore, require *require.Assertions) (datastore.Datastore, datastore.Revision) {

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -1154,6 +1154,7 @@ func TestLookupSubjectsWithCaveats(t *testing.T) {
 }
 
 func TestLookupSubjectsWithCaveatedWildcards(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 	conn, cleanup, _, revision := testserver.NewTestServer(req, testTimedeltas[0], memdb.DisableGC, true,
 		func(ds datastore.Datastore, require *require.Assertions) (datastore.Datastore, datastore.Revision) {

--- a/internal/services/v1/preconditions_test.go
+++ b/internal/services/v1/preconditions_test.go
@@ -23,6 +23,7 @@ var companyPlanFolder = &v1.RelationshipFilter{
 }
 
 func TestPreconditions(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	uninitialized, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 	require.NoError(err)

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -350,6 +350,7 @@ func TestWriteRelationships(t *testing.T) {
 }
 
 func TestWriteCaveatedRelationships(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 
 	conn, cleanup, _, _ := testserver.NewTestServer(req, 0, memdb.DisableGC, true, tf.StandardDatastoreWithData)

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestReadRelationships(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name         string
 		filter       *v1.RelationshipFilter
@@ -200,9 +201,13 @@ func TestReadRelationships(t *testing.T) {
 	}
 
 	for _, delta := range testTimedeltas {
+		delta := delta
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
+			t.Parallel()
 			for _, tc := range testCases {
+				tc := tc
 				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
 					require := require.New(t)
 					conn, cleanup, _, revision := testserver.NewTestServer(require, delta, memdb.DisableGC, true, tf.StandardDatastoreWithData)
 					client := v1.NewPermissionsServiceClient(conn)
@@ -255,6 +260,7 @@ func TestReadRelationships(t *testing.T) {
 }
 
 func TestWriteRelationships(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	conn, cleanup, _, _ := testserver.NewTestServer(require, 0, memdb.DisableGC, true, tf.StandardDatastoreWithData)
@@ -458,6 +464,7 @@ func relWithCaveat(resType, resID, relation, subType, subID, subRel, caveatName 
 }
 
 func TestInvalidWriteRelationship(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name          string
 		preconditions []*v1.RelationshipFilter
@@ -576,9 +583,12 @@ func TestInvalidWriteRelationship(t *testing.T) {
 	}
 
 	for _, delta := range testTimedeltas {
+		delta := delta
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 			for _, tc := range testCases {
+				tc := tc
 				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
 					require := require.New(t)
 					conn, cleanup, _, _ := testserver.NewTestServer(require, 0, memdb.DisableGC, true, tf.StandardDatastoreWithData)
 					client := v1.NewPermissionsServiceClient(conn)
@@ -617,6 +627,7 @@ func TestInvalidWriteRelationship(t *testing.T) {
 }
 
 func TestDeleteRelationships(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name          string
 		req           *v1.DeleteRelationshipsRequest
@@ -898,8 +909,11 @@ func TestDeleteRelationships(t *testing.T) {
 		},
 	}
 	for _, delta := range testTimedeltas {
+		delta := delta
 		for _, tc := range testCases {
+			tc := tc
 			t.Run(fmt.Sprintf("fuzz%d/%s", delta/time.Millisecond, tc.name), func(t *testing.T) {
+				t.Parallel()
 				require := require.New(t)
 				conn, cleanup, ds, revision := testserver.NewTestServer(require, delta, memdb.DisableGC, true, tf.StandardDatastoreWithData)
 				client := v1.NewPermissionsServiceClient(conn)
@@ -926,6 +940,7 @@ func TestDeleteRelationships(t *testing.T) {
 }
 
 func TestDeleteRelationshipsPreconditionsOverLimit(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	conn, cleanup, _, _ := testserver.NewTestServerWithConfig(
 		require,
@@ -984,6 +999,7 @@ func TestDeleteRelationshipsPreconditionsOverLimit(t *testing.T) {
 }
 
 func TestWriteRelationshipsPreconditionsOverLimit(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	conn, cleanup, _, _ := testserver.NewTestServerWithConfig(
 		require,
@@ -1033,6 +1049,7 @@ func TestWriteRelationshipsPreconditionsOverLimit(t *testing.T) {
 }
 
 func TestWriteRelationshipsUpdatesOverLimit(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 	conn, cleanup, _, _ := testserver.NewTestServerWithConfig(
 		require,

--- a/internal/services/v1/schema_test.go
+++ b/internal/services/v1/schema_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestSchemaWriteNoPrefix(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -30,6 +31,7 @@ func TestSchemaWriteNoPrefix(t *testing.T) {
 }
 
 func TestSchemaWriteInvalidSchema(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -44,6 +46,7 @@ func TestSchemaWriteInvalidSchema(t *testing.T) {
 }
 
 func TestSchemaWriteInvalidNamespace(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -60,6 +63,7 @@ func TestSchemaWriteInvalidNamespace(t *testing.T) {
 }
 
 func TestSchemaWriteAndReadBack(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -80,6 +84,7 @@ func TestSchemaWriteAndReadBack(t *testing.T) {
 }
 
 func TestSchemaDeleteRelation(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -142,6 +147,7 @@ func TestSchemaDeleteRelation(t *testing.T) {
 }
 
 func TestSchemaDeletePermission(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -180,6 +186,7 @@ func TestSchemaDeletePermission(t *testing.T) {
 }
 
 func TestSchemaChangeRelationToPermission(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -239,6 +246,7 @@ func TestSchemaChangeRelationToPermission(t *testing.T) {
 }
 
 func TestSchemaDeleteDefinition(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -290,6 +298,7 @@ func TestSchemaDeleteDefinition(t *testing.T) {
 }
 
 func TestSchemaRemoveWildcard(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -351,6 +360,7 @@ definition example/user {}`
 }
 
 func TestSchemaEmpty(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -401,6 +411,7 @@ func TestSchemaEmpty(t *testing.T) {
 }
 
 func TestSchemaTypeRedefined(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -422,6 +433,7 @@ func TestSchemaTypeRedefined(t *testing.T) {
 }
 
 func TestSchemaTypeInvalid(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, false, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)

--- a/internal/services/v1/schema_test.go
+++ b/internal/services/v1/schema_test.go
@@ -451,6 +451,7 @@ func TestSchemaTypeInvalid(t *testing.T) {
 }
 
 func TestSchemaRemoveCaveat(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 	client := v1.NewSchemaServiceClient(conn)
@@ -521,6 +522,7 @@ definition user {}`
 }
 
 func TestSchemaUnchangedNamespaces(t *testing.T) {
+	t.Parallel()
 	conn, cleanup, ds, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 	t.Cleanup(cleanup)
 

--- a/internal/services/v1/watch_test.go
+++ b/internal/services/v1/watch_test.go
@@ -50,6 +50,7 @@ func update(
 }
 
 func TestWatch(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name              string
 		objectTypesFilter []string
@@ -99,7 +100,9 @@ func TestWatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			conn, cleanup, _, revision := testserver.NewTestServer(require, 0, memdb.DisableGC, true, testfixtures.StandardDatastoreWithData)

--- a/internal/testserver/datastore/crdb.go
+++ b/internal/testserver/datastore/crdb.go
@@ -6,6 +6,7 @@ package datastore
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -23,6 +24,7 @@ const enableRangefeeds = `SET CLUSTER SETTING kv.rangefeed.enabled = true;`
 
 type crdbTester struct {
 	conn     *pgx.Conn
+	mutex    sync.Mutex
 	hostname string
 	creds    string
 	port     string
@@ -82,7 +84,8 @@ func (r *crdbTester) NewDatabase(t testing.TB) string {
 	require.NoError(t, err)
 
 	newDBName := "db" + uniquePortion
-
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	_, err = r.conn.Exec(context.Background(), "CREATE DATABASE "+newDBName)
 	require.NoError(t, err)
 

--- a/internal/testutil/subjects_test.go
+++ b/internal/testutil/subjects_test.go
@@ -21,6 +21,7 @@ var (
 )
 
 func TestCompareSubjects(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		first              *v1.FoundSubject
 		second             *v1.FoundSubject
@@ -130,7 +131,7 @@ func TestCompareSubjects(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(fmt.Sprintf("%s vs %s", FormatSubject(tc.first), FormatSubject(tc.second)), func(t *testing.T) {
 			err := CheckEquivalentSubjects(tc.first, tc.second)
 			if tc.expectedEquivalent {

--- a/pkg/caveats/compile_test.go
+++ b/pkg/caveats/compile_test.go
@@ -212,6 +212,7 @@ func TestCompile(t *testing.T) {
 }
 
 func TestDeserializeEmpty(t *testing.T) {
+	t.Parallel()
 	_, err := DeserializeCaveat([]byte{})
 	require.NotNil(t, err)
 }

--- a/pkg/caveats/compile_test.go
+++ b/pkg/caveats/compile_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestCompile(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name           string
 		env            *Environment
@@ -188,7 +189,9 @@ func TestCompile(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			compiled, err := compileCaveat(tc.env, tc.exprString)
 			if len(tc.expectedErrors) == 0 {
 				require.NoError(t, err)
@@ -214,10 +217,13 @@ func TestDeserializeEmpty(t *testing.T) {
 }
 
 func TestSerialization(t *testing.T) {
+	t.Parallel()
 	exprs := []string{"a == 1", "a + b == 2", "b - a == 4"}
 
 	for _, expr := range exprs {
+		expr := expr
 		t.Run(expr, func(t *testing.T) {
+			t.Parallel()
 			env := MustEnvForVariables(map[string]types.VariableType{
 				"a": types.IntType,
 				"b": types.IntType,
@@ -239,6 +245,7 @@ func TestSerialization(t *testing.T) {
 }
 
 func TestSerializeName(t *testing.T) {
+	t.Parallel()
 	env := MustEnvForVariables(map[string]types.VariableType{
 		"a": types.IntType,
 		"b": types.IntType,

--- a/pkg/caveats/env_test.go
+++ b/pkg/caveats/env_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAddVariable(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 	env := NewEnvironment()
 	err := env.AddVariable("foobar", types.IntType)

--- a/pkg/caveats/eval_test.go
+++ b/pkg/caveats/eval_test.go
@@ -13,6 +13,7 @@ import (
 var noMissingVars []string
 
 func TestEvaluateCaveat(t *testing.T) {
+	t.Parallel()
 	wetTz, err := time.LoadLocation("WET")
 	require.NoError(t, err)
 	tcs := []struct {
@@ -264,7 +265,9 @@ func TestEvaluateCaveat(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			compiled, err := compileCaveat(tc.env, tc.exprString)
 			require.NoError(t, err)
 
@@ -303,6 +306,7 @@ func TestEvaluateCaveat(t *testing.T) {
 }
 
 func TestPartialEvaluation(t *testing.T) {
+	t.Parallel()
 	compiled, err := compileCaveat(MustEnvForVariables(map[string]types.VariableType{
 		"a": types.IntType,
 		"b": types.IntType,
@@ -339,6 +343,7 @@ func TestPartialEvaluation(t *testing.T) {
 }
 
 func TestEvalWithMaxCost(t *testing.T) {
+	t.Parallel()
 	compiled, err := compileCaveat(MustEnvForVariables(map[string]types.VariableType{
 		"a": types.IntType,
 		"b": types.IntType,
@@ -356,6 +361,7 @@ func TestEvalWithMaxCost(t *testing.T) {
 }
 
 func TestEvalWithNesting(t *testing.T) {
+	t.Parallel()
 	compiled, err := compileCaveat(MustEnvForVariables(map[string]types.VariableType{
 		"foo.a": types.IntType,
 		"foo.b": types.IntType,

--- a/pkg/caveats/structure_test.go
+++ b/pkg/caveats/structure_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestReferencedParameters(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		env                  *Environment
 		expr                 string
@@ -89,7 +90,9 @@ func TestReferencedParameters(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.expr, func(t *testing.T) {
+			t.Parallel()
 			compiled, err := compileCaveat(tc.env, tc.expr)
 			require.NoError(t, err)
 

--- a/pkg/caveats/types/encoded_test.go
+++ b/pkg/caveats/types/encoded_test.go
@@ -13,6 +13,7 @@ type testCase struct {
 }
 
 func TestEncodeDecodeTypes(t *testing.T) {
+	t.Parallel()
 	tcs := []testCase{
 		{
 			vtype: IntType,
@@ -45,7 +46,9 @@ func TestEncodeDecodeTypes(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.vtype.String(), func(t *testing.T) {
+			t.Parallel()
 			encoded := EncodeParameterType(tc.vtype)
 			decoded, err := DecodeParameterType(encoded)
 			require.NoError(t, err)
@@ -55,6 +58,7 @@ func TestEncodeDecodeTypes(t *testing.T) {
 }
 
 func TestDecodeUnknownType(t *testing.T) {
+	t.Parallel()
 	_, err := DecodeParameterType(&core.CaveatTypeReference{
 		TypeName: "unknown",
 	})
@@ -63,6 +67,7 @@ func TestDecodeUnknownType(t *testing.T) {
 }
 
 func TestDecodeWrongChildTypeCount(t *testing.T) {
+	t.Parallel()
 	_, err := DecodeParameterType(&core.CaveatTypeReference{
 		TypeName: "list",
 	})

--- a/pkg/caveats/types/map_test.go
+++ b/pkg/caveats/types/map_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestMapSubtree(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		map1    map[string]any
 		map2    map[string]any
@@ -53,7 +54,7 @@ func TestMapSubtree(t *testing.T) {
 			true,
 		},
 	}
-	for _, tt := range tcs {
+	for _, tt := range tcs { // nolint: paralleltest
 		t.Run("", func(t *testing.T) {
 			require.Equal(t, tt.subtree, subtree(tt.map1, tt.map2))
 		})

--- a/pkg/caveats/types/types_test.go
+++ b/pkg/caveats/types/types_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestConversion(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name          string
 		vtype         VariableType
@@ -282,7 +283,9 @@ func TestConversion(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := tc.vtype.ConvertValue(tc.inputValue)
 			if err != nil {
 				require.Equal(t, tc.expectedErr, err.Error())

--- a/pkg/caveats/types_test.go
+++ b/pkg/caveats/types_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestIPAddress(t *testing.T) {
+	t.Parallel()
 	compiled, err := compileCaveat(MustEnvForVariables(map[string]types.VariableType{
 		"user_ip": types.IPAddressType,
 	}), "user_ip.in_cidr('192.168.0.0/16')")
@@ -30,6 +31,7 @@ func TestIPAddress(t *testing.T) {
 }
 
 func TestIPAddressInvalidCIDR(t *testing.T) {
+	t.Parallel()
 	compiled, err := compileCaveat(MustEnvForVariables(map[string]types.VariableType{
 		"user_ip": types.IPAddressType,
 	}), "user_ip.in_cidr('invalidcidr')")

--- a/pkg/cmd/server/cacheconfig_test.go
+++ b/pkg/cmd/server/cacheconfig_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestParsePercent(t *testing.T) {
+	t.Parallel()
 	table := []struct {
 		percent     string
 		freeMem     uint64

--- a/pkg/cmd/util/util_test.go
+++ b/pkg/cmd/util/util_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestDisabledGRPC(t *testing.T) {
+	t.Parallel()
 	s, err := (&GRPCServerConfig{Enabled: false}).Complete(zerolog.InfoLevel, nil)
 	require.NoError(t, err)
 	require.NoError(t, s.Listen(context.Background())())
@@ -17,6 +18,7 @@ func TestDisabledGRPC(t *testing.T) {
 }
 
 func TestDisabledHTTP(t *testing.T) {
+	t.Parallel()
 	s, err := (&HTTPServerConfig{Enabled: false}).Complete(zerolog.InfoLevel, nil)
 	require.NoError(t, err)
 	require.NoError(t, s.ListenAndServe())

--- a/pkg/consistent/hashring_test.go
+++ b/pkg/consistent/hashring_test.go
@@ -22,6 +22,7 @@ func (tn testNode) Key() string {
 }
 
 func TestHashring(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		replicationFactor uint16
 		nodes             []testNode
@@ -35,7 +36,9 @@ func TestHashring(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(strconv.Itoa(int(tc.replicationFactor)), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ring := NewHashring(xxhash.Sum64, tc.replicationFactor)
@@ -131,11 +134,13 @@ func TestHashring(t *testing.T) {
 const numTestKeys = 1_000_000
 
 func TestBackendBalance(t *testing.T) {
+	t.Parallel()
 	hasherFunc := xxhash.Sum64
 
 	testCases := []int{1, 2, 3, 5, 10, 100}
 
 	for _, numMembers := range testCases {
+		numMembers := numMembers
 		t.Run(strconv.Itoa(numMembers), func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)
@@ -268,6 +273,7 @@ func verify(require *require.Assertions, ring *Hashring,
 }
 
 func TestConsistency(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ring := NewHashring(xxhash.Sum64, 100)

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRelationshipsFilterFromPublicFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    *v1.RelationshipFilter
@@ -89,7 +90,9 @@ func TestRelationshipsFilterFromPublicFilter(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			computed := RelationshipsFilterFromPublicFilter(test.input)
 			require.Equal(t, test.expected, computed)
 		})

--- a/pkg/datastore/errors_test.go
+++ b/pkg/datastore/errors_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestError(t *testing.T) {
+	t.Parallel()
 	logging.Info().Err(ErrNamespaceNotFound{
 		error:         fmt.Errorf("test"),
 		namespaceName: "test/test",

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -23,6 +23,7 @@ import (
 )
 
 func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	req := require.New(t)
 	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 1)
 	req.NoError(err)
@@ -97,6 +98,7 @@ func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 }
 
 func WriteCaveatedRelationshipTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	req := require.New(t)
 	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 1)
 	req.NoError(err)
@@ -170,6 +172,7 @@ func WriteCaveatedRelationshipTest(t *testing.T, tester DatastoreTester) {
 }
 
 func CaveatedRelationshipFilterTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	req := require.New(t)
 	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 1)
 	req.NoError(err)
@@ -212,6 +215,7 @@ func CaveatedRelationshipFilterTest(t *testing.T, tester DatastoreTester) {
 }
 
 func CaveatSnapshotReadsTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	req := require.New(t)
 	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 1)
 	req.NoError(err)
@@ -247,6 +251,7 @@ func CaveatSnapshotReadsTest(t *testing.T, tester DatastoreTester) {
 }
 
 func CaveatedRelationshipWatchTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	req := require.New(t)
 	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 16)
 	req.NoError(err)

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -33,6 +33,7 @@ var (
 // NamespaceWriteTest tests whether or not the requirements for writing
 // namespaces hold for a particular datastore.
 func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds, err := tester.New(0, veryLargeGCWindow, 1)
@@ -125,6 +126,7 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 // NamespaceDeleteTest tests whether or not the requirements for deleting
 // namespaces hold for a particular datastore.
 func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
@@ -201,6 +203,7 @@ func NamespaceMultiDeleteTest(t *testing.T, tester DatastoreTester) {
 
 // EmptyNamespaceDeleteTest tests deleting an empty namespace in the datastore.
 func EmptyNamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
@@ -222,6 +225,7 @@ func EmptyNamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 // StableNamespaceReadWriteTest tests writing a namespace to the datastore and reading it back,
 // ensuring that it does not change in any way and that the deserialized data matches that stored.
 func StableNamespaceReadWriteTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	schemaString := `caveat foo(someParam int) {

--- a/pkg/datastore/test/revisions.go
+++ b/pkg/datastore/test/revisions.go
@@ -27,6 +27,7 @@ func RevisionQuantizationTest(t *testing.T, tester DatastoreTester) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("quantization%s", tc.quantizationRange), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ds, err := tester.New(tc.quantizationRange, veryLargeGCWindow, 1)

--- a/pkg/datastore/test/stats.go
+++ b/pkg/datastore/test/stats.go
@@ -13,6 +13,7 @@ import (
 const statsRetryCount = 3
 
 func StatsTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	ctx := context.Background()
 	require := require.New(t)
 

--- a/pkg/datastore/test/tuples.go
+++ b/pkg/datastore/test/tuples.go
@@ -31,6 +31,7 @@ const (
 // SimpleTest tests whether or not the requirements for simple reading and
 // writing of relationships hold for a particular datastore.
 func SimpleTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	testCases := []int{1, 2, 4, 32, 256}
 
 	for _, numTuples := range testCases {
@@ -316,6 +317,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 // DeleteRelationshipsTest tests whether or not the requirements for deleting
 // relationships hold for a particular datastore.
 func DeleteRelationshipsTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	var testTuples []*core.RelationTuple
 	for i := 0; i < 10; i++ {
 		newTuple := makeTestTuple(fmt.Sprintf("resource%d", i), fmt.Sprintf("user%d", i%2))
@@ -431,6 +433,7 @@ func DeleteRelationshipsTest(t *testing.T, tester DatastoreTester) {
 // invalid revisions hold for a particular datastore.
 func InvalidReadsTest(t *testing.T, tester DatastoreTester) {
 	t.Run("revision expiration", func(t *testing.T) {
+		t.Parallel()
 		testGCDuration := 600 * time.Millisecond
 
 		require := require.New(t)
@@ -477,6 +480,7 @@ func InvalidReadsTest(t *testing.T, tester DatastoreTester) {
 
 // DeleteNotExistantTest tests the deletion of a non-existant relationship.
 func DeleteNotExistantTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
@@ -498,6 +502,7 @@ func DeleteNotExistantTest(t *testing.T, tester DatastoreTester) {
 
 // DeleteAlreadyDeletedTest tests the deletion of an already-deleted relationship.
 func DeleteAlreadyDeletedTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
@@ -533,6 +538,7 @@ func DeleteAlreadyDeletedTest(t *testing.T, tester DatastoreTester) {
 
 // WriteDeleteWriteTest tests writing a relationship, deleting it, and then writing it again.
 func WriteDeleteWriteTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
@@ -554,6 +560,7 @@ func WriteDeleteWriteTest(t *testing.T, tester DatastoreTester) {
 
 // CreateAlreadyExistingTest tests creating a relationship twice.
 func CreateAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
@@ -574,6 +581,7 @@ func CreateAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 
 // TouchAlreadyExistingTest tests touching a relationship twice.
 func TouchAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
@@ -594,6 +602,7 @@ func TouchAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 // UsersetsTest tests whether or not the requirements for reading usersets hold
 // for a particular datastore.
 func UsersetsTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	testCases := []int{1, 2, 4, 32, 1024}
 
 	t.Run("multiple usersets tuple query", func(t *testing.T) {
@@ -646,6 +655,7 @@ func UsersetsTest(t *testing.T, tester DatastoreTester) {
 }
 
 func MultipleReadsInRWTTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
@@ -675,6 +685,7 @@ func MultipleReadsInRWTTest(t *testing.T, tester DatastoreTester) {
 // ConcurrentWriteSerializationTest uses goroutines and channels to intentionally set up a
 // deadlocking dependency between transactions.
 func ConcurrentWriteSerializationTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := tester.New(0, veryLargeGCWindow, 1)

--- a/pkg/datastore/test/watch.go
+++ b/pkg/datastore/test/watch.go
@@ -25,6 +25,7 @@ const waitForChangesTimeout = 5 * time.Second
 // WatchTest tests whether or not the requirements for watching changes hold
 // for a particular datastore.
 func WatchTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	testCases := []struct {
 		numTuples        int
 		expectFallBehind bool
@@ -45,6 +46,7 @@ func WatchTest(t *testing.T, tester DatastoreTester) {
 
 	for _, tc := range testCases {
 		t.Run(strconv.Itoa(tc.numTuples), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ds, err := tester.New(0, veryLargeGCWindow, 16)
@@ -169,6 +171,7 @@ func setOfChanges(changes []*core.RelationTupleUpdate) *strset.Set {
 // WatchCancelTest tests whether or not the requirements for cancelling watches
 // hold for a particular datastore.
 func WatchCancelTest(t *testing.T, tester DatastoreTester) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds, err := tester.New(0, veryLargeGCWindow, 1)

--- a/pkg/development/development_test.go
+++ b/pkg/development/development_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestDevelopment(t *testing.T) {
+	t.Parallel()
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"), goleak.IgnoreCurrent())
 
 	devCtx, devErrs, err := NewDevContext(context.Background(), &devinterface.RequestContext{
@@ -46,6 +47,7 @@ definition document {
 }
 
 func TestDevelopmentInvalidRelationship(t *testing.T) {
+	t.Parallel()
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"), goleak.IgnoreCurrent())
 
 	_, _, err := NewDevContext(context.Background(), &devinterface.RequestContext{

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -45,6 +45,7 @@ type fakeConnPool struct{}
 type fakeTx struct{}
 
 func TestContextError(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 	ctx, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(1*time.Millisecond))
 	m := NewManager[Driver[fakeConnPool, fakeTx], fakeConnPool, fakeTx]()
@@ -71,6 +72,7 @@ type revisionRangeTest struct {
 }
 
 func TestRevisionWalking(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		migrations map[string]migration[fakeConnPool, fakeTx]
 		ranges     []revisionRangeTest
@@ -131,6 +133,7 @@ func TestRevisionWalking(t *testing.T) {
 }
 
 func TestComputeHeadRevision(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		migrations   map[string]migration[fakeConnPool, fakeTx]
 		headRevision string
@@ -153,6 +156,7 @@ func TestComputeHeadRevision(t *testing.T) {
 }
 
 func TestIsHeadCompatible(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		migrations       map[string]migration[fakeConnPool, fakeTx]
 		currentMigration string
@@ -180,6 +184,7 @@ func TestIsHeadCompatible(t *testing.T) {
 }
 
 func TestManagerEnsureVersionIsWritten(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 	m := NewManager[Driver[fakeConnPool, fakeTx], fakeConnPool, fakeTx]()
 	err := m.Register("0", "", noNonatomicMigration, noTxMigration)

--- a/pkg/namespace/metadata_test.go
+++ b/pkg/namespace/metadata_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMetadata(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	marshalled, err := anypb.New(&iv1.DocComment{

--- a/pkg/releases/versions_test.go
+++ b/pkg/releases/versions_test.go
@@ -15,6 +15,7 @@ type testCase struct {
 }
 
 func TestCheckIsLatestVersion(t *testing.T) {
+	t.Parallel()
 	testCases := []testCase{
 		{"up to date", "v1.5.6", "v1.5.6", UpToDate},
 		{"ahead of version", "v1.7.0", "v1.5.6", UpToDate},
@@ -27,7 +28,9 @@ func TestCheckIsLatestVersion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			state, _, _, _ := CheckIsLatestVersion(context.Background(), func() (string, error) {
 				return tc.version, nil
 			}, func(ctx context.Context) (*Release, error) {

--- a/pkg/schemadsl/compiler/compiler_test.go
+++ b/pkg/schemadsl/compiler/compiler_test.go
@@ -17,6 +17,7 @@ import (
 var someTenant = "sometenant"
 
 func TestCompile(t *testing.T) {
+	t.Parallel()
 	type compileTest struct {
 		name           string
 		implicitTenant *string
@@ -719,7 +720,9 @@ func TestCompile(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			compiled, err := Compile(InputSchema{
 				input.Source(test.name), test.input,

--- a/pkg/schemadsl/generator/generator_test.go
+++ b/pkg/schemadsl/generator/generator_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestGenerateCaveat(t *testing.T) {
+	t.Parallel()
 	type generatorTest struct {
 		name     string
 		input    *core.CaveatDefinition
@@ -212,7 +213,9 @@ definition foos/document {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			source, ok := GenerateSource(test.input)
 			require.Equal(test.expected, source)
@@ -222,6 +225,7 @@ definition foos/document {
 }
 
 func TestFormatting(t *testing.T) {
+	t.Parallel()
 	type formattingTest struct {
 		name     string
 		input    string
@@ -352,7 +356,9 @@ definition foos/document {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			compiled, err := compiler.Compile(compiler.InputSchema{
 				Source:       input.Source(test.name),

--- a/pkg/schemadsl/generator/generator_test.go
+++ b/pkg/schemadsl/generator/generator_test.go
@@ -68,7 +68,9 @@ caveat somecaveat(someParam int) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			source, ok := GenerateCaveatSource(test.input)
 			require.Equal(strings.TrimSpace(test.expected), source)
@@ -78,6 +80,7 @@ caveat somecaveat(someParam int) {
 }
 
 func TestGenerateNamespace(t *testing.T) {
+	t.Parallel()
 	type generatorTest struct {
 		name     string
 		input    *core.NamespaceDefinition

--- a/pkg/schemadsl/input/sourcepositionmapper_test.go
+++ b/pkg/schemadsl/input/sourcepositionmapper_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestPositionMapping(t *testing.T) {
+	t.Parallel()
 	mappingText, err := os.ReadFile("tests/mapping.txt")
 	if !assert.Nil(t, err, "Got error reading mapping file") {
 		return

--- a/pkg/schemadsl/lexer/lex_test.go
+++ b/pkg/schemadsl/lexer/lex_test.go
@@ -237,8 +237,11 @@ var lexerTests = []lexerTest{
 }
 
 func TestLexer(t *testing.T) {
+	t.Parallel()
 	for _, test := range lexerTests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			test := test // Close over test and not the pointer that is reused.
 			tokens := performLex(&test)
 			if !equal(tokens, test.tokens) {

--- a/pkg/schemadsl/parser/parser_test.go
+++ b/pkg/schemadsl/parser/parser_test.go
@@ -90,6 +90,7 @@ func (tn *testNode) DecorateWithInt(property string, value int) AstNode {
 }
 
 func TestParser(t *testing.T) {
+	t.Parallel()
 	parserTests := []parserTest{
 		{"empty file test", "empty"},
 		{"basic definition test", "basic"},
@@ -116,7 +117,9 @@ func TestParser(t *testing.T) {
 	}
 
 	for _, test := range parserTests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			root := Parse(createAstNode, input.Source(test.name), test.input())
 			parseTree := getParseTree((root).(*testNode), 0)
 			assert := assert.New(t)

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -11,6 +11,7 @@ var tests = []uint8{
 }
 
 func TestTokenBytes(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	for _, nbytes := range tests {
 		res, err := TokenBytes(nbytes)
@@ -20,6 +21,7 @@ func TestTokenBytes(t *testing.T) {
 }
 
 func TestTokenHex(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	for _, nbytes := range tests {
 		res, err := TokenHex(nbytes)

--- a/pkg/testutil/proto_test.go
+++ b/pkg/testutil/proto_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAreProtoEqual(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name          string
 		first         proto.Message
@@ -95,7 +96,7 @@ func TestAreProtoEqual(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(tc.name, func(t *testing.T) {
 			err := AreProtoEqual(tc.first, tc.second, "something went wrong")
 			require.True(t, (err == nil) == (tc.expectedEqual))
@@ -104,6 +105,7 @@ func TestAreProtoEqual(t *testing.T) {
 }
 
 func TestRequireProtoEqual(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name   string
 		first  proto.Message
@@ -149,7 +151,7 @@ func TestRequireProtoEqual(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(tc.name, func(t *testing.T) {
 			RequireProtoEqual(t, tc.first, tc.second, "something went wrong")
 		})
@@ -157,6 +159,7 @@ func TestRequireProtoEqual(t *testing.T) {
 }
 
 func TestAreProtoSlicesEqual(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name          string
 		first         []*core.ObjectAndRelation
@@ -216,7 +219,7 @@ func TestAreProtoSlicesEqual(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(tc.name, func(t *testing.T) {
 			err := AreProtoSlicesEqual(tc.first, tc.second, func(first *core.ObjectAndRelation, second *core.ObjectAndRelation) int {
 				return strings.Compare(first.ObjectId, second.ObjectId)
@@ -227,6 +230,7 @@ func TestAreProtoSlicesEqual(t *testing.T) {
 }
 
 func TestRequireProtoSlicesEqual(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name   string
 		first  []*core.ObjectAndRelation
@@ -261,7 +265,7 @@ func TestRequireProtoSlicesEqual(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs { // nolint: paralleltest
 		t.Run(tc.name, func(t *testing.T) {
 			RequireProtoSlicesEqual(t, tc.first, tc.second, func(first *core.ObjectAndRelation, second *core.ObjectAndRelation) int {
 				return strings.Compare(first.ObjectId, second.ObjectId)

--- a/pkg/testutil/require_test.go
+++ b/pkg/testutil/require_test.go
@@ -3,6 +3,7 @@ package testutil
 import "testing"
 
 func TestRequireEqualEmptyNil(t *testing.T) {
+	t.Parallel()
 	RequireEqualEmptyNil(t, []int(nil), []int(nil))
 	RequireEqualEmptyNil(t, []int(nil), []int{})
 	RequireEqualEmptyNil(t, []int{}, []int(nil))

--- a/pkg/tuple/onr_test.go
+++ b/pkg/tuple/onr_test.go
@@ -35,12 +35,15 @@ var onrTestCases = []struct {
 }
 
 func TestSerializeONR(t *testing.T) {
+	t.Parallel()
 	for _, tc := range onrTestCases {
+		tc := tc
 		if tc.objectFormat == nil {
 			continue
 		}
 
 		t.Run(tc.serialized, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			serialized := StringONR(tc.objectFormat)
 			require.Equal(tc.serialized, serialized)
@@ -49,8 +52,11 @@ func TestSerializeONR(t *testing.T) {
 }
 
 func TestParseONR(t *testing.T) {
+	t.Parallel()
 	for _, tc := range onrTestCases {
+		tc := tc
 		t.Run(tc.serialized, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			parsed := ParseONR(tc.serialized)
@@ -94,8 +100,11 @@ var subjectOnrTestCases = []struct {
 }
 
 func TestParseSubjectONR(t *testing.T) {
+	t.Parallel()
 	for _, tc := range subjectOnrTestCases {
+		tc := tc
 		t.Run(tc.serialized, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			parsed := ParseSubjectONR(tc.serialized)

--- a/pkg/tuple/onrbytypeset_test.go
+++ b/pkg/tuple/onrbytypeset_test.go
@@ -17,6 +17,7 @@ func RR(namespaceName string, relationName string) *core.RelationReference {
 }
 
 func TestONRByTypeSet(t *testing.T) {
+	t.Parallel()
 	assertHasObjectIds := func(s *ONRByTypeSet, rr *core.RelationReference, expected []string) {
 		wasFound := false
 		s.ForEachType(func(foundRR *core.RelationReference, objectIds []string) {

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -138,8 +138,11 @@ var testCases = []struct {
 }
 
 func TestSerialize(t *testing.T) {
+	t.Parallel()
 	for _, tc := range testCases {
+		tc := tc
 		t.Run("tuple/"+tc.input, func(t *testing.T) {
+			t.Parallel()
 			if tc.tupleFormat == nil {
 				return
 			}
@@ -150,7 +153,9 @@ func TestSerialize(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run("relationship/"+tc.input, func(t *testing.T) {
+			t.Parallel()
 			if tc.relFormat == nil {
 				return
 			}
@@ -162,22 +167,29 @@ func TestSerialize(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
+	t.Parallel()
 	for _, tc := range testCases {
+		tc := tc
 		t.Run("tuple/"+tc.input, func(t *testing.T) {
 			require.Equal(t, tc.tupleFormat, Parse(tc.input))
 		})
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run("relationship/"+tc.input, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tc.relFormat, ParseRel(tc.input))
 		})
 	}
 }
 
 func TestConvert(t *testing.T) {
+	t.Parallel()
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			parsed := Parse(tc.input)
@@ -200,8 +212,11 @@ func TestConvert(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	t.Parallel()
 	for _, tc := range testCases {
+		tc := tc
 		t.Run("validate/"+tc.input, func(t *testing.T) {
+			t.Parallel()
 			parsed := ParseRel(tc.input)
 			if parsed != nil {
 				require.NoError(t, ValidateResourceID(parsed.Resource.ObjectId))

--- a/pkg/util/chunking_test.go
+++ b/pkg/util/chunking_test.go
@@ -8,9 +8,13 @@ import (
 )
 
 func TestForEachChunk(t *testing.T) {
+	t.Parallel()
 	for _, datasize := range []int{0, 1, 5, 10, 50, 100, 250} {
+		datasize := datasize
 		for _, chunksize := range []uint64{1, 2, 3, 5, 10, 50} {
+			chunksize := chunksize
 			t.Run(fmt.Sprintf("test-%d-%d", datasize, chunksize), func(t *testing.T) {
+				t.Parallel()
 				data := []int{}
 				for i := 0; i < datasize; i++ {
 					data = append(data, i)

--- a/pkg/util/multimap_test.go
+++ b/pkg/util/multimap_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestMultimapOperations(t *testing.T) {
+	t.Parallel()
 	mm := NewMultiMap[string, int]()
 	require.Equal(t, 0, mm.Len())
 	require.True(t, mm.IsEmpty())

--- a/pkg/util/set_test.go
+++ b/pkg/util/set_test.go
@@ -77,6 +77,7 @@ func TestSetOperations(t *testing.T) {
 }
 
 func TestSetIntersect(t *testing.T) {
+	t.Parallel()
 	// Create a set and ensure it is empty.
 	set := NewSet[string]()
 	require.True(t, set.IsEmpty())
@@ -99,6 +100,7 @@ func TestSetIntersect(t *testing.T) {
 }
 
 func TestSetSubtract(t *testing.T) {
+	t.Parallel()
 	// Create a set and ensure it is empty.
 	set := NewSet[string]()
 	require.True(t, set.IsEmpty())

--- a/pkg/util/set_test.go
+++ b/pkg/util/set_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestSetOperations(t *testing.T) {
+	t.Parallel()
 	// Create a set and ensure it is empty.
 	set := NewSet[string]()
 	require.True(t, set.IsEmpty())
@@ -118,6 +119,7 @@ func TestSetSubtract(t *testing.T) {
 }
 
 func TestSetIntersectionDifference(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		first    []int
 		second   []int
@@ -141,7 +143,9 @@ func TestSetIntersectionDifference(t *testing.T) {
 	}
 
 	for index, tc := range tcs {
+		tc := tc
 		t.Run(fmt.Sprintf("%d", index), func(t *testing.T) {
+			t.Parallel()
 			firstSet := NewSet[int]()
 			firstSet.Extend(tc.first)
 

--- a/pkg/validationfile/blocks/assertions_test.go
+++ b/pkg/validationfile/blocks/assertions_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestParseAssertions(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		name               string
 		contents           string
@@ -93,7 +94,9 @@ assertFalse: garbage
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			a := Assertions{}
 			err := yamlv3.Unmarshal([]byte(tc.contents), &a)

--- a/pkg/validationfile/blocks/expectedrelations_test.go
+++ b/pkg/validationfile/blocks/expectedrelations_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestValidationString(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		name            string
 		input           string
@@ -81,7 +82,9 @@ func TestValidationString(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			vs := ValidationString(tc.input)
 
@@ -106,6 +109,7 @@ func TestValidationString(t *testing.T) {
 }
 
 func TestParseExpectedRelations(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		name          string
 		contents      string
@@ -168,7 +172,9 @@ document:seconddoc#view:
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			per := ParsedExpectedRelations{}
 			err := yamlv3.Unmarshal([]byte(tc.contents), &per)

--- a/pkg/validationfile/blocks/relationships_test.go
+++ b/pkg/validationfile/blocks/relationships_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestParseRelationships(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		contents         string
@@ -45,7 +46,9 @@ document:second#viewer@user:1`,
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			pr := ParsedRelationships{}
 			err := yamlv3.Unmarshal([]byte(tt.contents), &pr)
 			if tt.expectedError != "" {

--- a/pkg/validationfile/blocks/schema_test.go
+++ b/pkg/validationfile/blocks/schema_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestParseSchema(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		contents         string
@@ -41,7 +42,9 @@ func TestParseSchema(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ps := ParsedSchema{}
 			err := yamlv3.Unmarshal([]byte(tt.contents), &ps)
 			if tt.expectedError != "" {

--- a/pkg/validationfile/fileformat_test.go
+++ b/pkg/validationfile/fileformat_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestDecodeValidationFile(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                     string
 		contents                 string
@@ -81,7 +82,9 @@ validation:
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			decoded, err := DecodeValidationFile([]byte(tt.contents))
 			if tt.expectedError != "" {
 				require.NotNil(t, err)
@@ -101,6 +104,7 @@ validation:
 }
 
 func TestDecodeRelationshipsErrorLineNumber(t *testing.T) {
+	t.Parallel()
 	_, err := DecodeValidationFile([]byte(`schema: >-
   definition user {}
 
@@ -118,6 +122,7 @@ relationships: >-
 }
 
 func TestDecodeRelationshipsErrorLineNumberLater(t *testing.T) {
+	t.Parallel()
 	_, err := DecodeValidationFile([]byte(`schema: >-
   definition user {}
 
@@ -135,6 +140,7 @@ relationships: >-
 }
 
 func TestDecodeRelationshipsErrorLineNumberEventLater(t *testing.T) {
+	t.Parallel()
 	_, err := DecodeValidationFile([]byte(`schema: >-
   definition user {}
 
@@ -158,6 +164,7 @@ relationships: >-
 }
 
 func TestDecodeAssertionsErrorLineNumber(t *testing.T) {
+	t.Parallel()
 	_, err := DecodeValidationFile([]byte(`
 schema: >-
   definition user {}
@@ -182,6 +189,7 @@ assertions:
 }
 
 func TestDecodeAssertionsErrorLineNumberSmallerToken(t *testing.T) {
+	t.Parallel()
 	_, err := DecodeValidationFile([]byte(`
 schema: >-
   definition user {}

--- a/pkg/validationfile/loader_test.go
+++ b/pkg/validationfile/loader_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestPopulateFromFiles(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		filePaths     []string
@@ -78,7 +79,9 @@ func TestPopulateFromFiles(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			ds, err := memdb.NewMemdbDatastore(0, 0, 0)
 			require.NoError(err)

--- a/pkg/zedtoken/zedtoken_test.go
+++ b/pkg/zedtoken/zedtoken_test.go
@@ -27,8 +27,11 @@ var encodeRevisionTests = []datastore.Revision{
 }
 
 func TestZedTokenEncode(t *testing.T) {
+	t.Parallel()
 	for _, rev := range encodeRevisionTests {
+		rev := rev
 		t.Run(rev.String(), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			encoded := NewFromRevision(rev)
 			decoded, err := DecodeRevision(encoded, revision.DecimalDecoder{})
@@ -113,9 +116,12 @@ var decodeTests = []struct {
 }
 
 func TestDecode(t *testing.T) {
+	t.Parallel()
 	for _, testCase := range decodeTests {
+		testCase := testCase
 		testName := fmt.Sprintf("%s(%s)=>%s", testCase.format, testCase.token, testCase.expectedRevision)
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			decoded, err := DecodeRevision(&v1.ZedToken{

--- a/tools/analyzers/exprstatementcheck/exprstatementcheck_test.go
+++ b/tools/analyzers/exprstatementcheck/exprstatementcheck_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAnalyzer(t *testing.T) {
+	t.Parallel()
 	analyzer := Analyzer()
 	analyzer.Flags.Set("disallowed-expr-statement-types", "*missingsend.Event:missing Send or Msg for zerolog log statement")
 

--- a/tools/analyzers/nilvaluecheck/nilvaluecheck_test.go
+++ b/tools/analyzers/nilvaluecheck/nilvaluecheck_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAnalyzer(t *testing.T) {
+	t.Parallel()
 	analyzer := Analyzer()
 	analyzer.Flags.Set("disallowed-nil-return-type-paths", "*nilreturn.someStruct")
 


### PR DESCRIPTION
## What

turns every test into a parallel test, and enables `paralleltest` linter

## How
- added `paralleltest`
- added `t.Parallel()` everywhere the linter indicated
- addressed range variable errors identified by the linter
- added a new CI job to run all tests without race detector and get quick feedback loop
- enabled parallel in `e2e`. It would seem as if the CI job became slower 

Note: All tests executed in an Intel-based MacBookPro 2,4 GHz 8-Core Intel Core i9, 64 GB 2667 MHz DDR4

## Without parallel

```
unit tests no datastore: 111.71s user 19.76s system 618% cpu 21.255 total

unit tests all datastores: 215.38s user 72.96s system 47% cpu 10:10.28 total (timeout)
 
memdb: 2.50s user 1.01s system 112% cpu 3.114 total

CRDB: 6.11s user 3.38s system 10% cpu 1:26.89 total

postgres (failures): 44.39s user 26.15s system 11% cpu 10:04.10 total

MySQL: 10.76s user 5.55s system 11% cpu 2:24.48 total

Spanner: 12.48s user 7.97s system 35% cpu 57.954 total
```

## With Parallel

```
unit tests no datastore: 117.61s user 20.29s system 717% cpu 19.209 total

unit tests all datastores: 195.30s user 66.42s system 230% cpu 1:53.34 total

memdb: 2.65s user 0.99s system 125% cpu 2.902 total

CRDB: 7.03s user 4.19s system 29% cpu 38.237 total

postgres (failures): 53.29s user 38.67s system 74% cpu 2:02.89 total

MySQL: 10.16s user 6.24s system 40% cpu 40.265 total

Spanner: 11.60s user 7.57s system 53% cpu 35.846 total
```

## TODO

- [ ] address race detector flakes