### PR TITLE
Elide updates of namespaces which have not changed at all

### DIFF
--- a/internal/services/v1alpha1/schema.go
+++ b/internal/services/v1alpha1/schema.go
@@ -185,7 +185,7 @@ func (ss *schemaServiceServer) WriteSchema(ctx context.Context, in *v1alpha1.Wri
 				return err
 			}
 
-			if err := shared.SanityCheckExistingRelationships(ctx, rwt, nsdef, existingObjectDefMap); err != nil {
+			if _, err := shared.SanityCheckNamespaceChanges(ctx, rwt, nsdef, existingObjectDefMap); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Should reduce some of the write work when updating larger schemas and produces less garbage

Fixes #902