### PR TITLE
add missing caveat test, update caveat example

### DIFF
--- a/internal/dispatch/graph/computecheck_test.go
+++ b/internal/dispatch/graph/computecheck_test.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/authzed/spicedb/internal/datastore/memdb"
+	log "github.com/authzed/spicedb/internal/logging"
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/pkg/caveats"
 	"github.com/authzed/spicedb/pkg/caveats/types"
@@ -16,7 +17,6 @@ import (
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/tuple"
 
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -540,7 +540,7 @@ func TestComputeCheckWithCaveats(t *testing.T) {
 						"provided": map[string]any{
 							"type": "backend", "region": "us", "team": "shop",
 							"additional_attrs": map[string]any{
-								"tag1": 200,
+								"tag1": 200.0,
 								"tag2": false,
 							},
 						},

--- a/internal/dispatch/graph/computecheck_test.go
+++ b/internal/dispatch/graph/computecheck_test.go
@@ -469,7 +469,7 @@ func TestComputeCheckWithCaveats(t *testing.T) {
 			}`,
 			map[string]caveatDefinition{
 				"attributes_match": {
-					"expected.all(x, expected[x] == provided[x])",
+					"expected.isSubtreeOf(provided)",
 					map[string]types.VariableType{
 						"expected": types.MapType(types.AnyType),
 						"provided": types.MapType(types.AnyType),
@@ -525,8 +525,9 @@ func TestComputeCheckWithCaveats(t *testing.T) {
 						"provided": map[string]any{
 							"type": "backend", "region": "us", "team": "shop",
 							"additional_attrs": map[string]any{
-								"tag1": 100,
+								"tag1": 100.0,
 								"tag2": false,
+								"tag3": "hi",
 							},
 						},
 					},

--- a/internal/services/v1/errors.go
+++ b/internal/services/v1/errors.go
@@ -7,13 +7,13 @@ import (
 	"strconv"
 
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
 	"github.com/authzed/spicedb/internal/graph"
+	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/internal/services/shared"
 	"github.com/authzed/spicedb/internal/sharederrors"

--- a/internal/services/v1alpha1/errors.go
+++ b/internal/services/v1alpha1/errors.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/internal/services/shared"
 	"github.com/authzed/spicedb/internal/sharederrors"

--- a/pkg/caveats/env.go
+++ b/pkg/caveats/env.go
@@ -66,6 +66,8 @@ func (e *Environment) asCelEnvironment() (*cel.Env, error) {
 		opts = append(opts, customTypeOpts...)
 	}
 
+	opts = append(opts, types.TypeMethods...)
+
 	// Set options.
 	// DefaultUTCTimeZone: ensure all timestamps are evaluated at UTC
 	opts = append(opts, cel.DefaultUTCTimeZone(true))

--- a/pkg/caveats/env.go
+++ b/pkg/caveats/env.go
@@ -65,8 +65,7 @@ func (e *Environment) asCelEnvironment() (*cel.Env, error) {
 	for _, customTypeOpts := range types.CustomTypes {
 		opts = append(opts, customTypeOpts...)
 	}
-
-	opts = append(opts, types.TypeMethods...)
+	opts = append(opts, types.CustomMethodsOnTypes...)
 
 	// Set options.
 	// DefaultUTCTimeZone: ensure all timestamps are evaluated at UTC

--- a/pkg/caveats/types/map.go
+++ b/pkg/caveats/types/map.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+func init() {
+	registerMethodOnDefinedType(cel.MapType(cel.StringType, cel.AnyType),
+		"isSubtreeOf",
+		[]*cel.Type{cel.MapType(cel.StringType, cel.AnyType)},
+		cel.BoolType,
+		func(arg ...ref.Val) ref.Val {
+			map0 := arg[0].Value().(map[string]any)
+			map1 := arg[1].Value().(map[string]any)
+			return types.Bool(subtree(map0, map1))
+		},
+	)
+}
+
+func subtree(map0 map[string]any, map1 map[string]any) bool {
+	for k, v := range map0 {
+		val, ok := map1[k]
+		if !ok {
+			return false
+		}
+		nestedMap0, ok := v.(map[string]any)
+		if ok {
+			nestedMap1, ok := val.(map[string]any)
+			if !ok {
+				return false
+			}
+			nestedResult := subtree(nestedMap0, nestedMap1)
+			if !nestedResult {
+				return false
+			}
+		} else {
+			if v != val {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/pkg/caveats/types/map_test.go
+++ b/pkg/caveats/types/map_test.go
@@ -1,0 +1,61 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapSubtree(t *testing.T) {
+	tcs := []struct {
+		map1    map[string]any
+		map2    map[string]any
+		subtree bool
+	}{
+		{
+			map[string]any{"a": 1},
+			map[string]any{"a": 1},
+			true,
+		},
+		{
+			map[string]any{"a": 1, "b": 2},
+			map[string]any{"a": 1},
+			false,
+		},
+		{
+			map[string]any{"a": 1},
+			map[string]any{"a": 1, "b": 1},
+			true,
+		},
+		{
+			map[string]any{"a": 1, "b": map[string]any{"a": 1}},
+			map[string]any{"a": 1},
+			false,
+		},
+		{
+			map[string]any{"a": 1, "b": map[string]any{"a": 1}},
+			map[string]any{"a": 1, "b": map[string]any{"a": 1}},
+			true,
+		},
+		{
+			map[string]any{"a": 1, "b": map[string]any{"a": 1}},
+			map[string]any{"a": 1, "b": map[string]any{"a": 1, "b": 1}},
+			true,
+		},
+		{
+			map[string]any{"a": 1, "b": map[string]any{"a": 1}},
+			map[string]any{"a": 1, "b": map[string]any{"a": "1", "b": 1}},
+			false,
+		},
+		{
+			map[string]any{"a": 1, "b": map[string]any{"a": 1}},
+			map[string]any{"a": 1, "b": map[string]any{"a": 1, "b": map[string]any{}}},
+			true,
+		},
+	}
+	for _, tt := range tcs {
+		t.Run("", func(t *testing.T) {
+			require.Equal(t, tt.subtree, subtree(tt.map1, tt.map2))
+		})
+	}
+}

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -146,6 +146,17 @@ func WriteCaveatedRelationshipTest(t *testing.T, tester DatastoreTester) {
 	req.NoError(err)
 	assertTupleCorrectlyStored(req, ds, rev, tpl)
 
+	// RelationTupleUpdate_DELETE ignores caveat part of the request
+	tpl.Caveat.CaveatName = "rando"
+	rev, err = common.WriteTuples(ctx, sds, core.RelationTupleUpdate_DELETE, tpl)
+	req.NoError(err)
+	iter, err := ds.SnapshotReader(rev).QueryRelationships(context.Background(), datastore.RelationshipsFilter{
+		ResourceType: tpl.ResourceAndRelation.Namespace,
+	})
+	req.NoError(err)
+	defer iter.Close()
+	req.Nil(iter.Next())
+
 	// Caveated tuple can reference non-existing caveat - controller layer is responsible for validation
 	tpl = createTestCaveatedTuple(t, "document:rando#parent@folder:company#...", "rando")
 	_, err = common.WriteTuples(ctx, sds, core.RelationTupleUpdate_CREATE, tpl)

--- a/pkg/spiceerrors/withstatus.go
+++ b/pkg/spiceerrors/withstatus.go
@@ -3,7 +3,8 @@ package spiceerrors
 import (
 	"errors"
 
-	"github.com/rs/zerolog/log"
+	log "github.com/authzed/spicedb/internal/logging"
+
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"


### PR DESCRIPTION
- test delete caveated relationship with `RelationTupleUpdate_DELETE`. The caveat is not part of the primary key of the relationship and so it's ignored when it comes to delete operations
- updates application caveats use-case with "recursing subset" behaviour
- removes occurences of `zerolog/log` global logger in favour of SpiceDB's own global logger