### PR TITLE
introduce caveat support in MySQL

### DIFF
--- a/internal/datastore/mysql/caveat.go
+++ b/internal/datastore/mysql/caveat.go
@@ -2,25 +2,173 @@ package mysql
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
+	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/datastore/revision"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/shopspring/decimal"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	errDeleteCaveat = "unable to delete caveats: %w"
+	errReadCaveat   = "unable to read caveat: %w"
+	errListCaveats  = "unable to list caveats: %w"
+	errWriteCaveats = "unable to write caveats: %w"
 )
 
 func (mr *mysqlReader) ReadCaveatByName(ctx context.Context, name string) (*core.CaveatDefinition, datastore.Revision, error) {
-	return nil, datastore.NoRevision, fmt.Errorf("unimplemented caveat support in datastore")
+	ctx = datastore.SeparateContextWithTracing(ctx)
+	ctx, span := tracer.Start(ctx, "ReadCaveatByName", trace.WithAttributes(
+		common.CaveatNameKey.String(name)))
+	defer span.End()
+
+	filteredReadCaveat := mr.filterer(mr.ReadCaveatQuery)
+	sqlStatement, args, err := filteredReadCaveat.Where(sq.Eq{colName: name}).ToSql()
+	if err != nil {
+		return nil, datastore.NoRevision, err
+	}
+
+	tx, txCleanup, err := mr.txSource(ctx)
+	if err != nil {
+		return nil, datastore.NoRevision, fmt.Errorf(errReadCaveat, err)
+	}
+	defer common.LogOnError(ctx, txCleanup)
+
+	var serializedDef []byte
+	var rev decimal.Decimal
+	err = tx.QueryRowContext(ctx, sqlStatement, args...).Scan(&serializedDef, &rev)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, datastore.NoRevision, datastore.NewCaveatNameNotFoundErr(name)
+		}
+		return nil, datastore.NoRevision, fmt.Errorf(errReadCaveat, err)
+	}
+	def := core.CaveatDefinition{}
+	err = def.UnmarshalVT(serializedDef)
+	if err != nil {
+		return nil, datastore.NoRevision, fmt.Errorf(errReadCaveat, err)
+	}
+	return &def, revision.NewFromDecimal(rev), nil
 }
 
 func (mr *mysqlReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
-	// Unimplemented, but returns empty to not break callers.
-	return nil, nil
+	ctx = datastore.SeparateContextWithTracing(ctx)
+	ctx, span := tracer.Start(ctx, "ListCaveats", trace.WithAttributes(
+		common.CaveatNameKey.StringSlice(caveatNames)))
+	defer span.End()
+
+	caveatsWithNames := mr.ListCaveatsQuery
+	if len(caveatNames) > 0 {
+		caveatsWithNames = caveatsWithNames.Where(sq.Eq{colName: caveatNames})
+	}
+
+	filteredListCaveat := mr.filterer(caveatsWithNames)
+	listSQL, listArgs, err := filteredListCaveat.ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	tx, txCleanup, err := mr.txSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf(errListCaveats, err)
+	}
+	defer common.LogOnError(ctx, txCleanup)
+
+	rows, err := tx.QueryContext(ctx, listSQL, listArgs...)
+	if err != nil {
+		return nil, fmt.Errorf(errListCaveats, err)
+	}
+	defer common.LogOnError(ctx, rows.Close)
+
+	var caveats []*core.CaveatDefinition
+	for rows.Next() {
+		var defBytes []byte
+		err = rows.Scan(&defBytes)
+		if err != nil {
+			return nil, fmt.Errorf(errListCaveats, err)
+		}
+		c := core.CaveatDefinition{}
+		err = c.UnmarshalVT(defBytes)
+		if err != nil {
+			return nil, fmt.Errorf(errListCaveats, err)
+		}
+		caveats = append(caveats, &c)
+	}
+	if rows.Err() != nil {
+		return nil, fmt.Errorf(errListCaveats, rows.Err())
+	}
+
+	return caveats, nil
 }
 
 func (rwt *mysqlReadWriteTXN) WriteCaveats(ctx context.Context, caveats []*core.CaveatDefinition) error {
-	return fmt.Errorf("unimplemented caveat support in datastore")
+	ctx = datastore.SeparateContextWithTracing(ctx)
+	ctx, span := tracer.Start(ctx, "WriteNamespaces")
+	defer span.End()
+
+	writeQuery := rwt.WriteCaveatQuery
+
+	caveatNamesToWrite := make([]string, 0, len(caveats))
+	for _, newCaveat := range caveats {
+		serialized, err := newCaveat.MarshalVT()
+		if err != nil {
+			return fmt.Errorf("unable to write caveat: %w", err)
+		}
+
+		writeQuery = writeQuery.Values(newCaveat.Name, serialized, rwt.newTxnID)
+		caveatNamesToWrite = append(caveatNamesToWrite, newCaveat.Name)
+	}
+
+	span.SetAttributes(common.CaveatNameKey.StringSlice(caveatNamesToWrite))
+
+	err := rwt.deleteCaveatsFromNames(ctx, caveatNamesToWrite)
+	if err != nil {
+		return fmt.Errorf(errWriteCaveats, err)
+	}
+	span.AddEvent("previous caveat revisions marked deleted")
+
+	querySQL, writeArgs, err := writeQuery.ToSql()
+	if err != nil {
+		return fmt.Errorf(errWriteCaveats, err)
+	}
+
+	_, err = rwt.tx.ExecContext(ctx, querySQL, writeArgs...)
+	if err != nil {
+		return fmt.Errorf(errWriteCaveats, err)
+	}
+	span.AddEvent("new caveat revisions marked alive")
+
+	return nil
 }
 
 func (rwt *mysqlReadWriteTXN) DeleteCaveats(ctx context.Context, names []string) error {
-	return fmt.Errorf("unimplemented caveat support in datastore")
+	ctx = datastore.SeparateContextWithTracing(ctx)
+	ctx, span := tracer.Start(ctx, "DeleteCaveats", trace.WithAttributes(
+		common.CaveatNameKey.StringSlice(names)))
+	defer span.End()
+
+	return rwt.deleteCaveatsFromNames(ctx, names)
+}
+
+func (rwt *mysqlReadWriteTXN) deleteCaveatsFromNames(ctx context.Context, names []string) error {
+	delSQL, delArgs, err := rwt.DeleteCaveatQuery.
+		Set(colDeletedTxn, rwt.newTxnID).
+		Where(sq.Eq{colName: names}).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf(errDeleteCaveat, err)
+	}
+
+	_, err = rwt.tx.ExecContext(ctx, delSQL, delArgs...)
+	if err != nil {
+		return fmt.Errorf(errDeleteCaveat, err)
+	}
+	return nil
 }

--- a/internal/datastore/mysql/migrations/tables.go
+++ b/internal/datastore/mysql/migrations/tables.go
@@ -8,6 +8,7 @@ const (
 	tableTupleDefault       = "relation_tuple"
 	tableMigrationVersion   = "mysql_migration_version"
 	tableMetadataDefault    = "mysql_metadata"
+	tableCaveatDefault      = "caveat"
 )
 
 type tables struct {
@@ -16,6 +17,7 @@ type tables struct {
 	tableTuple            string
 	tableNamespace        string
 	tableMetadata         string
+	tableCaveat           string
 }
 
 func newTables(prefix string) *tables {
@@ -25,6 +27,7 @@ func newTables(prefix string) *tables {
 		tableTuple:            fmt.Sprintf("%s%s", prefix, tableTupleDefault),
 		tableNamespace:        fmt.Sprintf("%s%s", prefix, tableNamespaceDefault),
 		tableMetadata:         fmt.Sprintf("%s%s", prefix, tableMetadataDefault),
+		tableCaveat:           fmt.Sprintf("%s%s", prefix, tableCaveatDefault),
 	}
 }
 
@@ -49,4 +52,8 @@ func (tn *tables) Namespace() string {
 
 func (tn *tables) Metadata() string {
 	return tn.tableMetadata
+}
+
+func (tn *tables) Caveat() string {
+	return tn.tableCaveat
 }

--- a/internal/datastore/mysql/migrations/zz_migration.0004_add_caveat.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0004_add_caveat.go
@@ -1,0 +1,38 @@
+package migrations
+
+import "fmt"
+
+// primary key size limit in InnoDB is 3KB.
+// 3072 / 4 bytes per character = 768 - 2 bigints (4 bytes) = 764 bytes.
+// we choose 700 to leave headroom for potential future new columns in the PK
+func createCaveatTable(t *tables) string {
+	return fmt.Sprintf(`CREATE TABLE %s (
+		name VARCHAR(700) NOT NULL,
+		definition BLOB NOT NULL,
+		created_transaction BIGINT NOT NULL,
+		deleted_transaction BIGINT NOT NULL DEFAULT '9223372036854775807',
+		CONSTRAINT pk_caveat PRIMARY KEY (name, deleted_transaction),
+		CONSTRAINT uq_caveat UNIQUE (name, created_transaction, deleted_transaction)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`,
+		t.Caveat(),
+	)
+}
+
+// given column size subtracts from the max allowed row size, we define a conservative value of 128 bytes
+// for caveat name. This gives larger headroom for JSON column size.
+// See https://dev.mysql.com/doc/refman/5.7/en/char.html
+func addCaveatToRelationTuplesTable(t *tables) string {
+	return fmt.Sprintf(`ALTER TABLE %s
+			ADD COLUMN caveat_name VARCHAR(700),
+			ADD COLUMN caveat_context JSON;`,
+		t.RelationTuple(),
+	)
+}
+
+func init() {
+	mustRegisterMigration("add_caveat", "add_ns_config_id", noNonatomicMigration,
+		newStatementBatch(
+			createCaveatTable,
+			addCaveatToRelationTuplesTable,
+		).execute,
+	)
+}

--- a/internal/datastore/mysql/reader.go
+++ b/internal/datastore/mysql/reader.go
@@ -46,6 +46,7 @@ var schema = common.SchemaInformation{
 	ColUsersetNamespace: colUsersetNamespace,
 	ColUsersetObjectID:  colUsersetObjectID,
 	ColUsersetRelation:  colUsersetRelation,
+	ColCaveatName:       colCaveatName,
 }
 
 func (mr *mysqlReader) QueryRelationships(

--- a/internal/datastore/mysql/watch.go
+++ b/internal/datastore/mysql/watch.go
@@ -122,6 +122,8 @@ func (mds *Datastore) loadChanges(
 
 		var createdTxn uint64
 		var deletedTxn uint64
+		var caveatName string
+		var caveatContext caveatContextWrapper
 		err = rows.Scan(
 			&nextTuple.ResourceAndRelation.Namespace,
 			&nextTuple.ResourceAndRelation.ObjectId,
@@ -129,9 +131,15 @@ func (mds *Datastore) loadChanges(
 			&nextTuple.Subject.Namespace,
 			&nextTuple.Subject.ObjectId,
 			&nextTuple.Subject.Relation,
+			&caveatName,
+			&caveatContext,
 			&createdTxn,
 			&deletedTxn,
 		)
+		if err != nil {
+			return
+		}
+		nextTuple.Caveat, err = common.ContextualizedCaveatFrom(caveatName, caveatContext)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb/issues/918

## What

Implements support for caveats and caveated relationships in MySQL datastore

## How

- The strategy is not very different from other datastores, the implementation is similar to Postgres'
- MySQL JSON column was used to align with other datastores. Unfortunately MySQL's go driver does not come with built-in marshalling/unmarshalling of maps into the JSON datatype, so a wrapper struct was created to implement the `Valuer` and `Scanner` interfaces the driver defines to allow custom data types to be marshalled/unmarshalled.


## Some additional changes to Postgres datastore

I introduced some improvements into Postgres datastore which I have missed in https://github.com/authzed/spicedb/pull/890:
- context severing was not in place
- do not construct `OR` condition by looping - squirrel turns slices into an `IN` clause
- cosmetic adjustment to errors, and turning them into constants
- missing error wrapping in some return statements
- redundant `EQ` condition in `deleteCaveatsWithClause`