### PR TITLE
datastore: DeleteNamespace => DeleteNamespaces

### DIFF
--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -887,7 +887,7 @@ func XIDMigrationAssumptionsTest(t *testing.T, b testdatastore.RunningEngineForT
 			ResourceType: "one_namespace",
 		}))
 
-		require.NoError(rwt.DeleteNamespace(ctx, "one_namespace"))
+		require.NoError(rwt.DeleteNamespaces(ctx, "one_namespace"))
 
 		require.NoError(rwt.WriteNamespaces(ctx, namespace.Namespace(
 			"three_namespace", namespace.Relation("parent", nil, nil))))
@@ -955,7 +955,7 @@ func XIDMigrationAssumptionsTest(t *testing.T, b testdatastore.RunningEngineForT
 			ResourceType: "two_namespace",
 		}))
 
-		require.NoError(rwt.DeleteNamespace(ctx, "two_namespace"))
+		require.NoError(rwt.DeleteNamespaces(ctx, "two_namespace"))
 
 		require.NoError(rwt.WriteNamespaces(ctx, namespace.Namespace(
 			"four_namespace", namespace.Relation("parent", nil, nil))))
@@ -1022,7 +1022,7 @@ func XIDMigrationAssumptionsTest(t *testing.T, b testdatastore.RunningEngineForT
 			ResourceType: "three_namespace",
 		}))
 
-		require.NoError(rwt.DeleteNamespace(ctx, "three_namespace"))
+		require.NoError(rwt.DeleteNamespaces(ctx, "three_namespace"))
 
 		require.NoError(rwt.WriteNamespaces(ctx, namespace.Namespace(
 			"five_namespace", namespace.Relation("parent", nil, nil))))

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -251,14 +251,14 @@ func (rwt *observableRWT) WriteNamespaces(ctx context.Context, newConfigs ...*co
 	return rwt.delegate.WriteNamespaces(ctx, newConfigs...)
 }
 
-func (rwt *observableRWT) DeleteNamespace(ctx context.Context, nsName string) error {
+func (rwt *observableRWT) DeleteNamespaces(ctx context.Context, nsNames ...string) error {
 	var span trace.Span
 	ctx, span = tracer.Start(ctx, "DeleteNamespace", trace.WithAttributes(
-		attribute.String("name", nsName),
+		attribute.StringSlice("names", nsNames),
 	))
 	defer span.End()
 
-	return rwt.delegate.DeleteNamespace(ctx, nsName)
+	return rwt.delegate.DeleteNamespaces(ctx, nsNames...)
 }
 
 func (rwt *observableRWT) DeleteRelationships(ctx context.Context, filter *v1.RelationshipFilter) error {

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -240,8 +240,13 @@ func (dm *MockReadWriteTransaction) WriteNamespaces(ctx context.Context, newConf
 	return args.Error(0)
 }
 
-func (dm *MockReadWriteTransaction) DeleteNamespace(ctx context.Context, nsName string) error {
-	args := dm.Called(nsName)
+func (dm *MockReadWriteTransaction) DeleteNamespaces(ctx context.Context, nsNames ...string) error {
+	xs := make([]any, 0, len(nsNames))
+	for _, nsName := range nsNames {
+		xs = append(xs, nsName)
+	}
+
+	args := dm.Called(xs...)
 	return args.Error(0)
 }
 

--- a/internal/datastore/proxy/readonly_test.go
+++ b/internal/datastore/proxy/readonly_test.go
@@ -35,7 +35,7 @@ func TestRWOperationErrors(t *testing.T) {
 	ctx := context.Background()
 
 	rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
-		return rwt.DeleteNamespace(ctx, "fake")
+		return rwt.DeleteNamespaces(ctx, "fake")
 	})
 	require.ErrorAs(err, &datastore.ErrReadOnly{})
 	require.Equal(datastore.NoRevision, rev)

--- a/internal/services/v1/schema.go
+++ b/internal/services/v1/schema.go
@@ -214,10 +214,10 @@ func (ss *schemaServer) WriteSchema(ctx context.Context, in *v1.WriteSchemaReque
 		})
 
 		// Delete the removed namespaces.
-		if err := removedObjectDefNames.ForEach(func(value string) error {
-			return rwt.DeleteNamespace(ctx, value)
-		}); err != nil {
-			return err
+		if removedObjectDefNames.Len() > 0 {
+			if err := rwt.DeleteNamespaces(ctx, removedObjectDefNames.AsSlice()...); err != nil {
+				return err
+			}
 		}
 
 		// Delete the removed caveats.

--- a/internal/services/v1alpha1/schema_test.go
+++ b/internal/services/v1alpha1/schema_test.go
@@ -263,7 +263,7 @@ func TestSchemaReadDeleteAndFailWrite(t *testing.T) {
 	// Issue a delete out of band for the namespace.
 	_, err = ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 		for _, nsName := range requestedObjectDefNames {
-			derr := rwt.DeleteNamespace(ctx, nsName)
+			derr := rwt.DeleteNamespaces(ctx, nsName)
 			if derr != nil {
 				return derr
 			}

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -167,8 +167,8 @@ func (vrwt validatingReadWriteTransaction) WriteNamespaces(ctx context.Context, 
 	return vrwt.delegate.WriteNamespaces(ctx, newConfigs...)
 }
 
-func (vrwt validatingReadWriteTransaction) DeleteNamespace(ctx context.Context, nsName string) error {
-	return vrwt.delegate.DeleteNamespace(ctx, nsName)
+func (vrwt validatingReadWriteTransaction) DeleteNamespaces(ctx context.Context, nsNames ...string) error {
+	return vrwt.delegate.DeleteNamespaces(ctx, nsNames...)
 }
 
 func (vrwt validatingReadWriteTransaction) WriteRelationships(ctx context.Context, mutations []*core.RelationTupleUpdate) error {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -188,8 +188,8 @@ type ReadWriteTransaction interface {
 	// WriteNamespaces takes proto namespace definitions and persists them.
 	WriteNamespaces(ctx context.Context, newConfigs ...*core.NamespaceDefinition) error
 
-	// DeleteNamespace deletes a namespace and any associated tuples.
-	DeleteNamespace(ctx context.Context, nsName string) error
+	// DeleteNamespaces deletes namespaces including associated relationships.
+	DeleteNamespaces(ctx context.Context, nsNames ...string) error
 }
 
 // TxUserFunc is a type for the function that users supply when they invoke a read-write transaction.

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -34,6 +34,7 @@ func (f DatastoreTesterFunc) New(revisionQuantization, gcWindow time.Duration, w
 func All(t *testing.T, tester DatastoreTester) {
 	t.Run("TestNamespaceWrite", func(t *testing.T) { NamespaceWriteTest(t, tester) })
 	t.Run("TestNamespaceDelete", func(t *testing.T) { NamespaceDeleteTest(t, tester) })
+	t.Run("TestNamespaceMultiDelete", func(t *testing.T) { NamespaceMultiDeleteTest(t, tester) })
 	t.Run("TestEmptyNamespaceDelete", func(t *testing.T) { EmptyNamespaceDeleteTest(t, tester) })
 	t.Run("TestStableNamespaceReadWrite", func(t *testing.T) { StableNamespaceReadWriteTest(t, tester) })
 


### PR DESCRIPTION
This cleans up some of the tracing in the DeleteNamespace path, too.

Fixes #935