### PR TITLE
Don't return the caveat key in the ObjectDefinitionNames in v1alpha1 …

### DIFF
--- a/internal/services/v1alpha1/schema.go
+++ b/internal/services/v1alpha1/schema.go
@@ -260,7 +260,6 @@ func (ss *schemaServiceServer) WriteSchema(ctx context.Context, in *v1alpha1.Wri
 	}
 	for _, caveat := range compiled.CaveatDefinitions {
 		key := caveatKeyPrefix + caveat.Name
-		names = append(names, key)
 		revs[key] = revision
 	}
 


### PR DESCRIPTION
…WriteSchemaResponse