### PR TITLE
Mark devtools gRPC endpoint enabled by default for the serve-devtools command

### DIFF
--- a/pkg/cmd/devtools.go
+++ b/pkg/cmd/devtools.go
@@ -134,6 +134,7 @@ func grpcServiceBuilder() *cobragrpc.Builder {
 	return cobragrpc.New("grpc",
 		cobragrpc.WithLogger(zerologr.New(&log.Logger)),
 		cobragrpc.WithFlagPrefix("grpc"),
+		cobragrpc.WithDefaultEnabled(true),
 	)
 }
 


### PR DESCRIPTION
regressed in https://github.com/authzed/spicedb/pull/844/