### PR TITLE
Faster CI Feedback Loop

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -31,6 +31,8 @@ on:  # yamllint disable-line rule:truthy
       - "e2e/**"
       - "internal/**"
       - "proto/**"
+env:
+  GO_VERSION: "~1.19.2"
 jobs:
   build:
     name: "Build Binary"
@@ -39,7 +41,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.2"
+          go-version: "${{ env.GO_VERSION }}"
       - uses: "authzed/actions/go-build@main"
 
   image-build:
@@ -47,15 +49,15 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
-      - uses: "actions/setup-go@v3"
-        with:
-          go-version: "~1.19.2"
       - uses: "authzed/actions/docker-build@main"
         with:
           push: false
           tags: "authzed/spicedb:ci"
           buildx: false
           qemu: false
+      - uses: "actions/setup-go@v3"
+        with:
+          go-version: "${{ env.GO_VERSION }}"
       - uses: "authzed/actions/go-test@main"
         with:
           working_directory: "cmd/spicedb"
@@ -68,11 +70,12 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.2"
+          go-version: "${{ env.GO_VERSION }}"
       - uses: "authzed/actions/go-test@main"
         with:
           tags: "ci,skipintegrationtests"
           timeout: "10m"
+
   integration:
     name: "Integration Tests"
     runs-on: "ubuntu-latest"
@@ -80,17 +83,13 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.2"
+          go-version: "${{ env.GO_VERSION }}"
       - uses: "authzed/actions/go-test@main"
         with:
           tags: "ci,docker"
           timeout: "10m"
           working_directory: "internal/services/integrationtesting"
-      - uses: "authzed/actions/go-test@main"
-        with:
-          tags: "ci,docker"
-          timeout: "5m"
-          working_directory: "cmd/spicedb"
+
   datastore:
     name: "Datastore Tests"
     runs-on: "ubuntu-latest"
@@ -101,7 +100,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.2"
+          go-version: "${{ env.GO_VERSION }}"
       - uses: "authzed/actions/go-test@main"
         with:
           tags: "ci,docker"
@@ -114,7 +113,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.2"
+          go-version: "${{ env.GO_VERSION }}"
       - name: "Cache Binaries"
         id: "cache-binaries"
         uses: "actions/cache@v2"
@@ -154,15 +153,25 @@ jobs:
         with:
           name: "node-logs"
           path: "e2e/newenemy/*.log"
-
-  development:
-    name: "Development Package"
+  analyzers-unit-tests:
+    name: "Analyzers Unit Tests"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.2"
+          go-version: "${{ env.GO_VERSION }}"
+      - uses: "authzed/actions/go-test@main"
+        with:
+          working_directory: "tools/analyzers"
+  development:
+    name: "WASM Tests"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-go@v3"
+        with:
+          go-version: "${{ env.GO_VERSION }}"
       - name: "Install wasmbrowsertest"
         run: "go install github.com/agnivade/wasmbrowsertest@latest"
       - name: "Run WASM Tests"
@@ -175,7 +184,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.2"
+          go-version: "${{ env.GO_VERSION }}"
       - name: "Install Go Tools"
         run: "./hack/install-tools.sh"
       - uses: "authzed/actions/buf-generate@main"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -42,6 +42,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - uses: "authzed/actions/go-build@main"
 
   image-build:
@@ -58,6 +59,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - uses: "authzed/actions/go-test@main"
         with:
           working_directory: "cmd/spicedb"
@@ -71,6 +73,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - uses: "authzed/actions/go-test@main"
         with:
           tags: "ci,skipintegrationtests"
@@ -84,6 +87,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - uses: "authzed/actions/go-test@main"
         with:
           tags: "ci,docker"
@@ -101,6 +105,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - uses: "authzed/actions/go-test@main"
         with:
           tags: "ci,docker"
@@ -114,6 +119,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - name: "Cache Binaries"
         id: "cache-binaries"
         uses: "actions/cache@v2"
@@ -161,6 +167,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - uses: "authzed/actions/go-test@main"
         with:
           working_directory: "tools/analyzers"
@@ -172,6 +179,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - name: "Install wasmbrowsertest"
         run: "go install github.com/agnivade/wasmbrowsertest@latest"
       - name: "Run WASM Tests"
@@ -185,6 +193,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - name: "Install Go Tools"
         run: "./hack/install-tools.sh"
       - uses: "authzed/actions/buf-generate@main"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -98,6 +98,7 @@ jobs:
     name: "Datastore Tests"
     runs-on: "ubuntu-latest"
     strategy:
+      fail-fast: false
       matrix:
         datastore: ["crdb", "mysql", "postgres", "spanner"]
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - uses: "authzed/actions/gofumpt@main"
       - uses: "authzed/actions/gofumpt@main"
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,19 +7,9 @@ on:  # yamllint disable-line rule:truthy
       - "main"
   pull_request:
     branches: ["*"]
+env:
+  GO_VERSION: "~1.19.2"
 jobs:
-  unit-analyzers:
-    name: "Unit Test Analyzers"
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: "actions/checkout@v3"
-      - uses: "actions/setup-go@v3"
-        with:
-          go-version: "~1.19.2"
-      - uses: "authzed/actions/go-test@main"
-        with:
-          working_directory: "tools/analyzers"
-
   go-lint:
     name: "Lint Go"
     runs-on: "ubuntu-latest"
@@ -27,7 +17,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.2"
+          go-version: "${{ env.GO_VERSION }}"
       - uses: "authzed/actions/gofumpt@main"
       - uses: "authzed/actions/gofumpt@main"
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: "write"
   packages: "write"
+env:
+  GO_VERSION: "~1.19.2"
 jobs:
   goreleaser:
     runs-on: "ubuntu-latest"
@@ -16,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.2"
+          go-version: "${{ env.GO_VERSION }}"
       - uses: "authzed/actions/docker-login@main"
         with:
           quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - uses: "authzed/actions/docker-login@main"
         with:
           quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -5,6 +5,8 @@ on:  # yamllint disable-line rule:truthy
     types: ["created"]
 permissions:
   contents: "write"
+env:
+  GO_VERSION: "~1.19.2"
 jobs:
   build:
     name: "Build WASM"
@@ -15,7 +17,7 @@ jobs:
           ref: "${{ env.GITHUB_SHA }}"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.2"
+          go-version: "${{ env.GO_VERSION }}"
       - run: |
           echo "Building WASM..."
           GOOS=js GOARCH=wasm go build  -o dist/development.wasm ./pkg/development/wasm/...

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -18,6 +18,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "true"
       - run: |
           echo "Building WASM..."
           GOOS=js GOARCH=wasm go build  -o dist/development.wasm ./pkg/development/wasm/...

--- a/cmd/spicedb/migrate_integration_test.go
+++ b/cmd/spicedb/migrate_integration_test.go
@@ -23,6 +23,7 @@ import (
 var toSkip = []string{"memory"}
 
 func TestMigrate(t *testing.T) {
+	t.Parallel()
 	bridgeNetworkName := fmt.Sprintf("bridge-%s", uuid.New().String())
 
 	pool, err := dockertest.NewPool("")
@@ -43,6 +44,8 @@ func TestMigrate(t *testing.T) {
 		}
 
 		t.Run(engineKey, func(t *testing.T) {
+			engineKey := engineKey
+			t.Parallel()
 			r := testdatastore.RunDatastoreEngineWithBridge(t, engineKey, bridgeNetworkName)
 			db := r.NewDatabase(t)
 

--- a/cmd/spicedb/restgateway_integration_test.go
+++ b/cmd/spicedb/restgateway_integration_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestRESTGateway(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	tester, err := newTester(t,

--- a/cmd/spicedb/serve_integration_test.go
+++ b/cmd/spicedb/serve_integration_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestServe(t *testing.T) {
+	t.Parallel()
 	requireParent := require.New(t)
 
 	tester, err := newTester(t,

--- a/cmd/spicedb/servetesting_integration_test.go
+++ b/cmd/spicedb/servetesting_integration_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestTestServer(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	tester, err := newTester(t,

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -43,6 +43,8 @@ func TestPostgresDatastore(t *testing.T) {
 		{"drop-bigserial-ids", ""},
 	} {
 		t.Run(fmt.Sprintf("%s-%s", config.targetMigration, config.migrationPhase), func(t *testing.T) {
+			config := config
+			t.Parallel()
 			b := testdatastore.RunPostgresForTesting(t, "", config.targetMigration)
 
 			test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {

--- a/internal/testfixtures/datastore.go
+++ b/internal/testfixtures/datastore.go
@@ -125,7 +125,8 @@ func StandardDatastoreWithSchema(ds datastore.Datastore, require *require.Assert
 	ctx := context.Background()
 	validating := NewValidatingDatastore(ds)
 
-	allDefs := []*core.NamespaceDefinition{UserNS, FolderNS, DocumentNS}
+	// clone to avoid races due to annotations on schema write
+	allDefs := []*core.NamespaceDefinition{UserNS.CloneVT(), FolderNS.CloneVT(), DocumentNS.CloneVT()}
 
 	newRevision, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 		for _, nsDef := range allDefs {


### PR DESCRIPTION
A handful of improvements for a faster feedback loop and other miscellaneous changes

- move Analyzer Unit tests to Build / Test job
- rename "Development Package" to "WASM tests"
- faster: remove ineffective cmd/spicedb integration tests: the tests were being ignored due to wrong label, and would have not worked due to missing container image
- faster: build spicedb container before setting up go
- faster: parallel postgres tests (and fix to the race that made them fail)
- do not cancel datastore tests if one fails
- use `setup-go` module caching (disabled by default)