### PR TITLE
fixes caching of loop variable in the wrong place

### DIFF
--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -42,8 +42,8 @@ func TestPostgresDatastore(t *testing.T) {
 		{"drop-id-constraints", ""},
 		{"drop-bigserial-ids", ""},
 	} {
+		config := config
 		t.Run(fmt.Sprintf("%s-%s", config.targetMigration, config.migrationPhase), func(t *testing.T) {
-			config := config
 			t.Parallel()
 			b := testdatastore.RunPostgresForTesting(t, "", config.targetMigration)
 


### PR DESCRIPTION
this is introduced to prevent races, but I messed it up