### PR TITLE
do not run CRDB migration in transaction

### DIFF
--- a/internal/datastore/crdb/migrations/manager.go
+++ b/internal/datastore/crdb/migrations/manager.go
@@ -6,7 +6,10 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
-var noNonatomicMigration migrate.MigrationFunc[*pgx.Conn]
+var (
+	noNonAtomicMigration migrate.MigrationFunc[*pgx.Conn]
+	noAtomicMigration    migrate.TxMigrationFunc[pgx.Tx]
+)
 
 // CRDBMigrations implements a migration manager for the CRDBDriver.
 var CRDBMigrations = migrate.NewManager[*CRDBDriver, *pgx.Conn, pgx.Tx]()

--- a/internal/datastore/crdb/migrations/zz_migration.0001_initial_schema.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0001_initial_schema.go
@@ -35,7 +35,7 @@ const (
 )
 
 func init() {
-	if err := CRDBMigrations.Register("initial", "", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
+	if err := CRDBMigrations.Register("initial", "", noNonAtomicMigration, func(ctx context.Context, tx pgx.Tx) error {
 		statements := []string{
 			createNamespaceConfig,
 			createRelationTuple,

--- a/internal/datastore/crdb/migrations/zz_migration.0002_add_transactions.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0002_add_transactions.go
@@ -14,7 +14,7 @@ const (
 )
 
 func init() {
-	if err := CRDBMigrations.Register("add-transactions-table", "initial", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
+	if err := CRDBMigrations.Register("add-transactions-table", "initial", noNonAtomicMigration, func(ctx context.Context, tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, createTransactions)
 		return err
 	}); err != nil {

--- a/internal/datastore/crdb/migrations/zz_migration.0003_add_metadata_and_counters.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0003_add_metadata_and_counters.go
@@ -21,7 +21,7 @@ const (
 )
 
 func init() {
-	if err := CRDBMigrations.Register("add-metadata-and-counters", "add-transactions-table", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
+	if err := CRDBMigrations.Register("add-metadata-and-counters", "add-transactions-table", noNonAtomicMigration, func(ctx context.Context, tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, createMetadataTable); err != nil {
 			return err
 		}

--- a/internal/datastore/crdb/migrations/zz_migration.0004_add_caveats.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0004_add_caveats.go
@@ -20,15 +20,18 @@ const (
 )
 
 func init() {
-	if err := CRDBMigrations.Register("add-caveats", "add-metadata-and-counters", noNonatomicMigration, func(ctx context.Context, tx pgx.Tx) error {
-		if _, err := tx.Exec(ctx, createCaveatTable); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(ctx, addRelationshipCaveatContext); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
+	err := CRDBMigrations.Register("add-caveats", "add-metadata-and-counters", addCaveatFunc, noAtomicMigration)
+	if err != nil {
 		panic("failed to register migration: " + err.Error())
 	}
+}
+
+func addCaveatFunc(ctx context.Context, conn *pgx.Conn) error {
+	if _, err := conn.Exec(ctx, createCaveatTable); err != nil {
+		return err
+	}
+	if _, err := conn.Exec(ctx, addRelationshipCaveatContext); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This is a recommendation from CRDB docs:

>Schema changes keep your data consistent at all times, but they do not run inside [transactions](https://www.cockroachlabs.com/docs/v22.1/transactions) in the general case. Making schema changes transactional would mean requiring a given schema change to propagate across all the nodes of a cluster. This would block all user-initiated transactions being run by your application, since the schema change would have to commit before any other transactions could make progress. This would prevent the cluster from servicing reads and writes during the schema change, requiring application downtime.