### PR TITLE
specifies cache-dependency-path to prevent poisoning

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -121,6 +121,7 @@ jobs:
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: "true"
+          cache-dependency-path: "e2e/go.sum"
       - name: "Cache Binaries"
         id: "cache-binaries"
         uses: "actions/cache@v2"
@@ -169,6 +170,7 @@ jobs:
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: "true"
+          cache-dependency-path: "tools/analyzers/go.sum"
       - uses: "authzed/actions/go-test@main"
         with:
           working_directory: "tools/analyzers"


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb/issues/959

These modules have very little dependencies, and end up "winning" in the race to cache, poisoning the cache.

By introducing the path we can have the Github Action disambiguate the cache key name by path.

From the docs:
>The action defaults to search for the dependency file - go.sum in the repository root, and uses its hash as a part of the cache key. Use cache-dependency-path input for cases when multiple dependency files are used, or they are located in different subdirectories.