### PR TITLE
prevent poisoning via build job

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -43,6 +43,8 @@ jobs:
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: "true"
+      - name: "go mod download" # prevent CI cache poisoning by getting all deps
+        run: "go mod download"
       - uses: "authzed/actions/go-build@main"
 
   image-build:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -198,6 +198,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
+          cache: "false" # do not cache to prevent cache poisoning
       - name: "Install Go Tools"
         run: "./hack/install-tools.sh"
       - uses: "authzed/actions/buf-generate@main"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -184,7 +184,7 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
-          cache: "true"
+          cache: "false" # do not cache to prevent cache poisoning
       - name: "Install wasmbrowsertest"
         run: "go install github.com/agnivade/wasmbrowsertest@latest"
       - name: "Run WASM Tests"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -198,7 +198,6 @@ jobs:
       - uses: "actions/setup-go@v3"
         with:
           go-version: "${{ env.GO_VERSION }}"
-          cache: "true"
       - name: "Install Go Tools"
         run: "./hack/install-tools.sh"
       - uses: "authzed/actions/buf-generate@main"


### PR DESCRIPTION
Close https://github.com/authzed/spicedb/issues/959 (for realz?)

- building only downloads the deps needed by non-test code, which is a smaller subset. We fix it by calling `go mod download` before `go build`, which will get all dependencies
- Protobuf build also poisoned the cache, disabled cache there since its a fast build
- WASM also poisoned the cache, disabled cache there since it's relatively fast

I checked the logs and I believe this time the problem should be circumented. We fare better by using the cache action explicitly instead of using `setup-go` built in functionality