### PR TITLE
Change experimental caveats flag to be handled at the service level

### DIFF
--- a/internal/datastore/memdb/caveat.go
+++ b/internal/datastore/memdb/caveat.go
@@ -26,10 +26,6 @@ func (c *caveat) Unwrap() (*core.CaveatDefinition, error) {
 }
 
 func (r *memdbReader) ReadCaveatByName(_ context.Context, name string) (*core.CaveatDefinition, datastore.Revision, error) {
-	if !r.enableCaveats {
-		return nil, datastore.NoRevision, fmt.Errorf("caveats are not enabled")
-	}
-
 	r.lockOrPanic()
 	defer r.Unlock()
 
@@ -65,11 +61,6 @@ func (r *memdbReader) readUnwrappedCaveatByName(tx *memdb.Txn, name string) (*co
 }
 
 func (r *memdbReader) ListCaveats(_ context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
-	if !r.enableCaveats {
-		// Return empty in the case caveats are not enabled, to not break callers.
-		return nil, nil
-	}
-
 	r.lockOrPanic()
 	defer r.Unlock()
 

--- a/internal/datastore/memdb/readonly.go
+++ b/internal/datastore/memdb/readonly.go
@@ -17,9 +17,8 @@ type txFactory func() (*memdb.Txn, error)
 
 type memdbReader struct {
 	TryLocker
-	txSource      txFactory
-	initErr       error
-	enableCaveats bool
+	txSource txFactory
+	initErr  error
 }
 
 // QueryRelationships reads relationships starting from the resource side.

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -20,6 +20,9 @@ type SchemaServiceOption int
 // WatchServiceOption defines the options for enabling or disabling the V1 Watch service.
 type WatchServiceOption int
 
+// CaveatsOption defines the options for enabling or disabling caveats in the V1 services.
+type CaveatsOption int
+
 const (
 	// V1SchemaServiceDisabled indicates that the V1 schema service is disabled.
 	V1SchemaServiceDisabled SchemaServiceOption = 0
@@ -32,6 +35,12 @@ const (
 
 	// WatchServiceEnabled indicates that the V1 watch service is enabled.
 	WatchServiceEnabled WatchServiceOption = 1
+
+	// CaveatsDisabled indicates that caveats are disabled.
+	CaveatsDisabled CaveatsOption = 0
+
+	// CaveatsEnabled indicates that caveats are enabled.
+	CaveatsEnabled CaveatsOption = 1
 )
 
 const (
@@ -47,14 +56,15 @@ func RegisterGrpcServices(
 	prefixRequired v1alpha1svc.PrefixRequiredOption,
 	schemaServiceOption SchemaServiceOption,
 	watchServiceOption WatchServiceOption,
+	caveatsOption CaveatsOption,
 	permSysConfig v1svc.PermissionsServerConfig,
 ) {
 	healthManager.RegisterReportedService(OverallServerHealthCheckKey)
 
-	v1alpha1.RegisterSchemaServiceServer(srv, v1alpha1svc.NewSchemaServer(prefixRequired))
+	v1alpha1.RegisterSchemaServiceServer(srv, v1alpha1svc.NewSchemaServer(prefixRequired, caveatsOption == CaveatsEnabled))
 	healthManager.RegisterReportedService(v1alpha1.SchemaService_ServiceDesc.ServiceName)
 
-	v1.RegisterPermissionsServiceServer(srv, v1svc.NewPermissionsServer(dispatch, permSysConfig))
+	v1.RegisterPermissionsServiceServer(srv, v1svc.NewPermissionsServer(dispatch, permSysConfig, caveatsOption == CaveatsEnabled))
 	healthManager.RegisterReportedService(v1.PermissionsService_ServiceDesc.ServiceName)
 
 	if watchServiceOption == WatchServiceEnabled {
@@ -63,7 +73,7 @@ func RegisterGrpcServices(
 	}
 
 	if schemaServiceOption == V1SchemaServiceEnabled {
-		v1.RegisterSchemaServiceServer(srv, v1svc.NewSchemaServer())
+		v1.RegisterSchemaServiceServer(srv, v1svc.NewSchemaServer(caveatsOption == CaveatsEnabled))
 		healthManager.RegisterReportedService(v1.SchemaService_ServiceDesc.ServiceName)
 	}
 

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -68,6 +68,7 @@ func NewTestServerWithConfig(require *require.Assertions,
 		server.WithDashboardAPI(util.HTTPServerConfig{Enabled: false}),
 		server.WithMetricsAPI(util.HTTPServerConfig{Enabled: false}),
 		server.WithDispatchServer(util.GRPCServerConfig{Enabled: false}),
+		server.WithExperimentalCaveatsEnabled(true),
 	).Complete()
 	require.NoError(err)
 	srv.SetMiddleware([]grpc.UnaryServerInterceptor{

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -86,9 +86,6 @@ type Config struct {
 	// Internal
 	WatchBufferLength uint16
 
-	// Experiments
-	ExperimentEnableCaveats bool
-
 	// Migrations
 	MigrationPhase string
 }
@@ -124,11 +121,6 @@ func RegisterDatastoreFlags(cmd *cobra.Command, opts *Config) {
 	cmd.Flags().StringVar(&opts.SpannerEmulatorHost, "datastore-spanner-emulator-host", "", "URI of spanner emulator instance used for development and testing (e.g. localhost:9010)")
 	cmd.Flags().StringVar(&opts.TablePrefix, "datastore-mysql-table-prefix", "", "prefix to add to the name of all SpiceDB database tables")
 	cmd.Flags().StringVar(&opts.MigrationPhase, "datastore-migration-phase", "", "datastore-specific flag that should be used to signal to a datastore which phase of a multi-step migration it is in")
-
-	cmd.Flags().BoolVar(&opts.ExperimentEnableCaveats, "experiment-enable-caveats", false, "if true, experimental support for caveats is enabled; note that these are not fully implemented and may break")
-	if err := cmd.Flags().MarkDeprecated("experiment-enable-caveats", "this is an experiment"); err != nil {
-		panic("failed to mark flag deprecated: " + err.Error())
-	}
 
 	// disabling stats is only for tests
 	cmd.Flags().BoolVar(&opts.DisableStats, "datastore-disable-stats", false, "disable recording relationship counts to the stats table")
@@ -307,5 +299,5 @@ func newMySQLDatastore(opts Config) (datastore.Datastore, error) {
 
 func newMemoryDatstore(opts Config) (datastore.Datastore, error) {
 	log.Warn().Msg("in-memory datastore is not persistent and not feasible to run in a high availability fashion")
-	return memdb.NewMemdbDatastoreWithCaveatsOption(opts.WatchBufferLength, opts.RevisionQuantization, opts.GCWindow, opts.ExperimentEnableCaveats)
+	return memdb.NewMemdbDatastore(opts.WatchBufferLength, opts.RevisionQuantization, opts.GCWindow)
 }

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -47,7 +47,6 @@ func (c *Config) ToOption() ConfigOption {
 		to.SpannerEmulatorHost = c.SpannerEmulatorHost
 		to.TablePrefix = c.TablePrefix
 		to.WatchBufferLength = c.WatchBufferLength
-		to.ExperimentEnableCaveats = c.ExperimentEnableCaveats
 		to.MigrationPhase = c.MigrationPhase
 	}
 }
@@ -274,13 +273,6 @@ func WithTablePrefix(tablePrefix string) ConfigOption {
 func WithWatchBufferLength(watchBufferLength uint16) ConfigOption {
 	return func(c *Config) {
 		c.WatchBufferLength = watchBufferLength
-	}
-}
-
-// WithExperimentEnableCaveats returns an option that can set ExperimentEnableCaveats on a Config
-func WithExperimentEnableCaveats(experimentEnableCaveats bool) ConfigOption {
-	return func(c *Config) {
-		c.ExperimentEnableCaveats = experimentEnableCaveats
 	}
 }
 

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -103,6 +103,11 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) {
 	cmd.Flags().StringVar(&config.TelemetryEndpoint, "telemetry-endpoint", telemetry.DefaultEndpoint, "endpoint to which telemetry is reported, empty string to disable")
 	cmd.Flags().StringVar(&config.TelemetryCAOverridePath, "telemetry-ca-override-path", "", "TODO")
 	cmd.Flags().DurationVar(&config.TelemetryInterval, "telemetry-interval", telemetry.DefaultInterval, "approximate period between telemetry reports, minimum 1 minute")
+
+	cmd.Flags().BoolVar(&config.ExperimentalCaveatsEnabled, "experiment-enable-caveats", false, "if true, experimental support for caveats is enabled; note that these are not fully implemented and may break")
+	if err := cmd.Flags().MarkDeprecated("experiment-enable-caveats", "this is an experiment"); err != nil {
+		panic("failed to mark flag deprecated: " + err.Error())
+	}
 }
 
 func NewServeCommand(programName string, config *server.Config) *cobra.Command {

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -52,6 +52,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.DisableV1SchemaAPI = c.DisableV1SchemaAPI
 		to.MaximumUpdatesPerWrite = c.MaximumUpdatesPerWrite
 		to.MaximumPreconditionCount = c.MaximumPreconditionCount
+		to.ExperimentalCaveatsEnabled = c.ExperimentalCaveatsEnabled
 		to.DashboardAPI = c.DashboardAPI
 		to.MetricsAPI = c.MetricsAPI
 		to.UnaryMiddleware = c.UnaryMiddleware
@@ -273,6 +274,13 @@ func WithMaximumUpdatesPerWrite(maximumUpdatesPerWrite uint16) ConfigOption {
 func WithMaximumPreconditionCount(maximumPreconditionCount uint16) ConfigOption {
 	return func(c *Config) {
 		c.MaximumPreconditionCount = maximumPreconditionCount
+	}
+}
+
+// WithExperimentalCaveatsEnabled returns an option that can set ExperimentalCaveatsEnabled on a Config
+func WithExperimentalCaveatsEnabled(experimentalCaveatsEnabled bool) ConfigOption {
+	return func(c *Config) {
+		c.ExperimentalCaveatsEnabled = experimentalCaveatsEnabled
 	}
 }
 

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -63,6 +63,7 @@ func (c *Config) Complete() (RunnableTestServer, error) {
 			v1alpha1svc.PrefixNotRequired,
 			services.V1SchemaServiceEnabled,
 			services.WatchServiceEnabled,
+			services.CaveatsEnabled,
 			v1svc.PermissionsServerConfig{
 				MaxPreconditionsCount: c.MaximumPreconditionCount,
 				MaxUpdatesPerWrite:    c.MaximumUpdatesPerWrite,


### PR DESCRIPTION
Previously, we did so at the datastore level, but now that most datastores are getting support, we do so at the service level