### PR TITLE
Add validation of relationships to file loader

### DIFF
--- a/internal/relationships/errors.go
+++ b/internal/relationships/errors.go
@@ -1,0 +1,118 @@
+package relationships
+
+import (
+	"fmt"
+
+	"github.com/authzed/spicedb/internal/namespace"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
+	"github.com/authzed/spicedb/pkg/tuple"
+)
+
+// ErrInvalidSubjectType indicates that a write was attempted with a subject type which is not
+// allowed on relation.
+type ErrInvalidSubjectType struct {
+	error
+	update       *core.RelationTupleUpdate
+	relationType *core.AllowedRelation
+}
+
+// NewInvalidSubjectTypeError constructs a new error for attempting to write an invalid subject type.
+func NewInvalidSubjectTypeError(update *core.RelationTupleUpdate, relationType *core.AllowedRelation) ErrInvalidSubjectType {
+	return ErrInvalidSubjectType{
+		error: fmt.Errorf(
+			"subjects of type `%s` are not allowed on relation `%s#%s`",
+			namespace.SourceForAllowedRelation(relationType),
+			update.Tuple.ResourceAndRelation.Namespace,
+			update.Tuple.ResourceAndRelation.Relation,
+		),
+		update:       update,
+		relationType: relationType,
+	}
+}
+
+// GRPCStatus implements retrieving the gRPC status for the error.
+func (err ErrInvalidSubjectType) GRPCStatus() *status.Status {
+	return spiceerrors.WithCodeAndDetails(
+		err,
+		codes.InvalidArgument,
+		spiceerrors.ForReason(
+			v1.ErrorReason_ERROR_REASON_INVALID_SUBJECT_TYPE,
+			map[string]string{
+				"definition_name": err.update.Tuple.ResourceAndRelation.Namespace,
+				"relation_name":   err.update.Tuple.ResourceAndRelation.Relation,
+				"subject_type":    namespace.SourceForAllowedRelation(err.relationType),
+			},
+		),
+	)
+}
+
+// ErrCannotWriteToPermission indicates that a write was attempted on a permission.
+type ErrCannotWriteToPermission struct {
+	error
+	update *core.RelationTupleUpdate
+}
+
+// NewCannotWriteToPermissionError constructs a new error for attempting to write to a permission.
+func NewCannotWriteToPermissionError(update *core.RelationTupleUpdate) ErrCannotWriteToPermission {
+	return ErrCannotWriteToPermission{
+		error: fmt.Errorf(
+			"cannot write a relationship to permission `%s` under definition `%s`",
+			update.Tuple.ResourceAndRelation.Relation,
+			update.Tuple.ResourceAndRelation.Namespace,
+		),
+		update: update,
+	}
+}
+
+// GRPCStatus implements retrieving the gRPC status for the error.
+func (err ErrCannotWriteToPermission) GRPCStatus() *status.Status {
+	return spiceerrors.WithCodeAndDetails(
+		err,
+		codes.InvalidArgument,
+		spiceerrors.ForReason(
+			v1.ErrorReason_ERROR_REASON_CANNOT_UPDATE_PERMISSION,
+			map[string]string{
+				"caveat_name": err.update.Tuple.Caveat.CaveatName,
+			},
+		),
+	)
+}
+
+// ErrCaveatNotFound indicates that a caveat referenced in a relationship update was not found.
+type ErrCaveatNotFound struct {
+	error
+	update *core.RelationTupleUpdate
+}
+
+// NewCaveatNotFoundError constructs a new caveat not found error.
+func NewCaveatNotFoundError(update *core.RelationTupleUpdate) ErrCaveatNotFound {
+	return ErrCaveatNotFound{
+		error: fmt.Errorf(
+			"the caveat `%s` was not found for relationship `%s`",
+			update.Tuple.Caveat.CaveatName,
+			tuple.String(update.Tuple),
+		),
+		update: update,
+	}
+}
+
+// GRPCStatus implements retrieving the gRPC status for the error.
+func (err ErrCaveatNotFound) GRPCStatus() *status.Status {
+	return spiceerrors.WithCodeAndDetails(
+		err,
+		codes.FailedPrecondition,
+		spiceerrors.ForReason(
+			v1.ErrorReason_ERROR_REASON_UNKNOWN_CAVEAT,
+			map[string]string{
+				"caveat_name": err.update.Tuple.Caveat.CaveatName,
+			},
+		),
+	)
+}

--- a/internal/relationships/validation.go
+++ b/internal/relationships/validation.go
@@ -1,0 +1,151 @@
+package relationships
+
+import (
+	"context"
+
+	"github.com/authzed/spicedb/internal/namespace"
+	"github.com/authzed/spicedb/pkg/caveats"
+	"github.com/authzed/spicedb/pkg/datastore"
+	ns "github.com/authzed/spicedb/pkg/namespace"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/util"
+)
+
+// ValidateRelationshipUpdates performs validation on the given relationship updates, ensuring that
+// they can be applied against the datastore.
+func ValidateRelationshipUpdates(
+	ctx context.Context,
+	rwt datastore.ReadWriteTransaction,
+	updates []*core.RelationTupleUpdate,
+) error {
+	// Load caveats, if any.
+	var referencedCaveatMap map[string]*core.CaveatDefinition
+	referencedCaveatNamesWithContext := util.NewSet[string]()
+
+	for _, update := range updates {
+		if hasNonEmptyCaveatContext(update) {
+			referencedCaveatNamesWithContext.Add(update.Tuple.Caveat.CaveatName)
+		}
+	}
+
+	if !referencedCaveatNamesWithContext.IsEmpty() {
+		foundCaveats, err := rwt.ListCaveats(ctx, referencedCaveatNamesWithContext.AsSlice()...)
+		if err != nil {
+			return err
+		}
+
+		referencedCaveatMap = make(map[string]*core.CaveatDefinition, len(foundCaveats))
+		for _, caveatDef := range foundCaveats {
+			referencedCaveatMap[caveatDef.Name] = caveatDef
+		}
+	}
+
+	// TODO(jschorr): look into loading the type system once per type, rather than once per relationship
+	// Check each update.
+	for _, update := range updates {
+		// Validate the IDs of the resource and subject.
+		if err := tuple.ValidateResourceID(update.Tuple.ResourceAndRelation.ObjectId); err != nil {
+			return err
+		}
+
+		if err := tuple.ValidateSubjectID(update.Tuple.Subject.ObjectId); err != nil {
+			return err
+		}
+
+		// Ensure the namespace and relation for the resource and subject exist.
+		if err := namespace.CheckNamespaceAndRelation(
+			ctx,
+			update.Tuple.ResourceAndRelation.Namespace,
+			update.Tuple.ResourceAndRelation.Relation,
+			false,
+			rwt,
+		); err != nil {
+			return err
+		}
+
+		if err := namespace.CheckNamespaceAndRelation(
+			ctx,
+			update.Tuple.Subject.Namespace,
+			update.Tuple.Subject.Relation,
+			true,
+			rwt,
+		); err != nil {
+			return err
+		}
+
+		// Build the type system for the object type.
+		_, ts, err := namespace.ReadNamespaceAndTypes(
+			ctx,
+			update.Tuple.ResourceAndRelation.Namespace,
+			rwt,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Validate that the relationship is not writing to a permission.
+		if ts.IsPermission(update.Tuple.ResourceAndRelation.Relation) {
+			return NewCannotWriteToPermissionError(update)
+		}
+
+		// Validate the subject against the allowed relation(s).
+		var relationToCheck *core.AllowedRelation
+		var caveat *core.AllowedCaveat
+
+		if update.Tuple.Caveat != nil {
+			caveat = ns.AllowedCaveat(update.Tuple.Caveat.CaveatName)
+		}
+
+		if update.Tuple.Subject.ObjectId == tuple.PublicWildcard {
+			relationToCheck = ns.AllowedPublicNamespaceWithCaveat(update.Tuple.Subject.Namespace, caveat)
+		} else {
+			relationToCheck = ns.AllowedRelationWithCaveat(
+				update.Tuple.Subject.Namespace,
+				update.Tuple.Subject.Relation,
+				caveat)
+		}
+
+		isAllowed, err := ts.HasAllowedRelation(
+			update.Tuple.ResourceAndRelation.Relation,
+			relationToCheck,
+		)
+		if err != nil {
+			return err
+		}
+
+		if isAllowed != namespace.AllowedRelationValid {
+			return NewInvalidSubjectTypeError(update, relationToCheck)
+		}
+
+		// Validate caveat and its context, if applicable.
+		// TODO(jschorr): once caveats are supported on all datastores, we should elide this check if the
+		// provided context is empty, as the allowed relation check above will ensure the caveat exists.
+		if hasNonEmptyCaveatContext(update) {
+			caveat, ok := referencedCaveatMap[update.Tuple.Caveat.CaveatName]
+			if !ok {
+				// Should ideally never happen since the caveat is type checked above, but just in case.
+				return NewCaveatNotFoundError(update)
+			}
+
+			// Verify that the provided context information matches the types of the parameters defined.
+			_, err := caveats.ConvertContextToParameters(
+				update.Tuple.Caveat.Context.AsMap(),
+				caveat.ParameterTypes,
+				caveats.ErrorForUnknownParameters,
+			)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func hasNonEmptyCaveatContext(update *core.RelationTupleUpdate) bool {
+	return update.Tuple.Caveat != nil &&
+		update.Tuple.Caveat.CaveatName != "" &&
+		update.Tuple.Caveat.Context != nil &&
+		len(update.Tuple.Caveat.Context.GetFields()) > 0
+}

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -19,7 +19,6 @@ import (
 	"github.com/authzed/spicedb/internal/middleware/usagemetrics"
 	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/internal/services/shared"
-	"github.com/authzed/spicedb/pkg/caveats"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/middleware/consistency"
 	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/authzed/spicedb/internal/relationships"
+
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	grpcvalidate "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/validator"
 	"github.com/jzelinskie/stringz"
@@ -20,8 +22,6 @@ import (
 	"github.com/authzed/spicedb/pkg/caveats"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/middleware/consistency"
-	ns "github.com/authzed/spicedb/pkg/namespace"
-	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/authzed/spicedb/pkg/util"
@@ -162,31 +162,23 @@ func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.Writ
 
 	// Check for duplicate updates and create the set of caveat names to load.
 	updateRelationshipSet := util.NewSet[string]()
-	referencedCaveatNamesWithContext := util.NewSet[string]()
 	for _, update := range req.Updates {
 		tupleStr := tuple.StringRelationship(update.Relationship)
 		if !updateRelationshipSet.Add(tupleStr) {
 			return nil, rewriteError(
 				ctx,
-				status.Errorf(
-					codes.InvalidArgument,
-					"found duplicate update operation for relationship %s",
-					tupleStr,
-				),
+				NewDuplicateRelationshipErr(update),
 			)
 		}
 
-		// Only load the caveat if we need its type information for context checking.
-		if hasNonEmptyCaveatContext(update) {
-			if !ps.caveatsEnabled {
+		if !ps.caveatsEnabled {
+			if update.Relationship.OptionalCaveat != nil && update.Relationship.OptionalCaveat.CaveatName != "" {
 				return nil, fmt.Errorf("caveats are currently not supported")
 			}
-			referencedCaveatNamesWithContext.Add(update.Relationship.OptionalCaveat.CaveatName)
 		}
 	}
 
 	// Execute the write operation(s).
-	// TODO(jschorr): look into loading the type system once per type, rather than once per relationship
 	revision, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 		// Validate the preconditions.
 		for _, precond := range req.OptionalPreconditions {
@@ -195,123 +187,11 @@ func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.Writ
 			}
 		}
 
-		// Load caveats, if any.
-		var referencedCaveatMap map[string]*core.CaveatDefinition
-		if !referencedCaveatNamesWithContext.IsEmpty() {
-			foundCaveats, err := rwt.ListCaveats(ctx, referencedCaveatNamesWithContext.AsSlice()...)
-			if err != nil {
-				return err
-			}
-
-			referencedCaveatMap = make(map[string]*core.CaveatDefinition, len(foundCaveats))
-			for _, caveatDef := range foundCaveats {
-				referencedCaveatMap[caveatDef.Name] = caveatDef
-			}
-		}
-
 		// Validate the updates.
-		for _, update := range req.Updates {
-			if err := tuple.ValidateResourceID(update.Relationship.Resource.ObjectId); err != nil {
-				return err
-			}
-
-			if err := tuple.ValidateSubjectID(update.Relationship.Subject.Object.ObjectId); err != nil {
-				return err
-			}
-
-			if err := namespace.CheckNamespaceAndRelation(
-				ctx,
-				update.Relationship.Resource.ObjectType,
-				update.Relationship.Relation,
-				false,
-				rwt,
-			); err != nil {
-				return err
-			}
-
-			if err := namespace.CheckNamespaceAndRelation(
-				ctx,
-				update.Relationship.Subject.Object.ObjectType,
-				stringz.DefaultEmpty(update.Relationship.Subject.OptionalRelation, datastore.Ellipsis),
-				true,
-				rwt,
-			); err != nil {
-				return err
-			}
-
-			// Build the type system for the object type.
-			_, ts, err := namespace.ReadNamespaceAndTypes(
-				ctx,
-				update.Relationship.Resource.ObjectType,
-				rwt,
-			)
-			if err != nil {
-				return err
-			}
-
-			// Validate that the relationship is not writing to a permission.
-			if ts.IsPermission(update.Relationship.Relation) {
-				return status.Errorf(
-					codes.InvalidArgument,
-					"cannot write a relationship to permission %s",
-					update.Relationship.Relation,
-				)
-			}
-
-			// Validate the subject against the allowed relation(s).
-			var relationToCheck *core.AllowedRelation
-			var caveat *core.AllowedCaveat
-
-			if update.Relationship.OptionalCaveat != nil {
-				caveat = ns.AllowedCaveat(update.Relationship.OptionalCaveat.CaveatName)
-			}
-
-			if update.Relationship.Subject.Object.ObjectId == tuple.PublicWildcard {
-				relationToCheck = ns.AllowedPublicNamespaceWithCaveat(update.Relationship.Subject.Object.ObjectType, caveat)
-			} else {
-				relationToCheck = ns.AllowedRelationWithCaveat(
-					update.Relationship.Subject.Object.ObjectType,
-					stringz.DefaultEmpty(
-						update.Relationship.Subject.OptionalRelation,
-						datastore.Ellipsis),
-					caveat)
-			}
-
-			isAllowed, err := ts.HasAllowedRelation(
-				update.Relationship.Relation,
-				relationToCheck,
-			)
-			if err != nil {
-				return err
-			}
-
-			if isAllowed != namespace.AllowedRelationValid {
-				return status.Errorf(
-					codes.InvalidArgument,
-					"subjects of type `%s` are not allowed on relation `%v`",
-					namespace.SourceForAllowedRelation(relationToCheck),
-					tuple.StringObjectRef(update.Relationship.Resource),
-				)
-			}
-
-			// Validate caveat and its context, if applicable.
-			if hasNonEmptyCaveatContext(update) {
-				caveat, ok := referencedCaveatMap[update.Relationship.OptionalCaveat.CaveatName]
-				if !ok {
-					// This won't happen since caveat is type checked above
-					panic("caveat should have been type-checked but was not found")
-				}
-
-				// Verify that the provided context information matches the types of the parameters defined.
-				_, err := caveats.ConvertContextToParameters(
-					update.Relationship.OptionalCaveat.Context.AsMap(),
-					caveat.ParameterTypes,
-					caveats.ErrorForUnknownParameters,
-				)
-				if err != nil {
-					return rewriteError(ctx, err)
-				}
-			}
+		tupleUpdates := tuple.UpdateFromRelationshipUpdates(req.Updates)
+		err := relationships.ValidateRelationshipUpdates(ctx, rwt, tupleUpdates)
+		if err != nil {
+			return rewriteError(ctx, err)
 		}
 
 		usagemetrics.SetInContext(ctx, &dispatchv1.ResponseMeta{
@@ -323,7 +203,7 @@ func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.Writ
 			return err
 		}
 
-		return rwt.WriteRelationships(ctx, tuple.UpdateFromRelationshipUpdates(req.Updates))
+		return rwt.WriteRelationships(ctx, tupleUpdates)
 	})
 	if err != nil {
 		return nil, rewriteError(ctx, err)
@@ -332,13 +212,6 @@ func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.Writ
 	return &v1.WriteRelationshipsResponse{
 		WrittenAt: zedtoken.NewFromRevision(revision),
 	}, nil
-}
-
-func hasNonEmptyCaveatContext(update *v1.RelationshipUpdate) bool {
-	return update.Relationship.OptionalCaveat != nil &&
-		update.Relationship.OptionalCaveat.CaveatName != "" &&
-		update.Relationship.OptionalCaveat.Context != nil &&
-		len(update.Relationship.OptionalCaveat.Context.GetFields()) > 0
 }
 
 func (ps *permissionServer) DeleteRelationships(ctx context.Context, req *v1.DeleteRelationshipsRequest) (*v1.DeleteRelationshipsResponse, error) {

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -372,8 +372,7 @@ func TestWriteCaveatedRelationships(t *testing.T) {
 	_, err = client.WriteRelationships(ctx, writeReq)
 	grpcutil.RequireStatus(t, codes.InvalidArgument, err)
 
-	errorMsg := fmt.Sprintf("subjects of type `user with doesnotexist` are not allowed on relation `%s`", tuple.StringObjectRef(relWritten.Resource))
-	req.Contains(err.Error(), errorMsg)
+	req.Contains(err.Error(), "subjects of type `user with doesnotexist` are not allowed on relation `document#caveated_viewer`")
 
 	// should succeed
 	relWritten.OptionalCaveat.CaveatName = "test"

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -551,7 +551,7 @@ func TestInvalidWriteRelationship(t *testing.T) {
 				rel("document", "somedoc", "parent", "user", "tom", ""),
 			},
 			codes.InvalidArgument,
-			"duplicate",
+			"found more than one update",
 		},
 		{
 			"disallowed caveat",

--- a/pkg/validationfile/fileformat.go
+++ b/pkg/validationfile/fileformat.go
@@ -33,11 +33,11 @@ type ValidationFile struct {
 	ExpectedRelations blocks.ParsedExpectedRelations `yaml:"validation"`
 
 	// NamespaceConfigs are the namespace configuration protos, in text format.
-	// Deprecated: only for internal use. Use Schema.
+	// Deprecated: only for internal use. Use `schema`.
 	NamespaceConfigs []string `yaml:"namespace_configs"`
 
 	// ValidationTuples are the validation tuples, in tuple string syntax.
-	// Deprecated: only for internal use. Use Relationships.
+	// Deprecated: only for internal use. Use `relationships`.
 	ValidationTuples []string `yaml:"validation_tuples"`
 }
 

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"google.golang.org/protobuf/encoding/prototext"
-
 	log "github.com/authzed/spicedb/internal/logging"
 	dsctx "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/internal/namespace"
+	"github.com/authzed/spicedb/internal/relationships"
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -52,14 +51,19 @@ func PopulateFromFiles(ds datastore.Datastore, filePaths []string) (*PopulatedVa
 // PopulateFromFilesContents populates the given datastore with the namespaces and tuples found in
 // the validation file(s) contents specified.
 func PopulateFromFilesContents(ds datastore.Datastore, filesContents map[string][]byte) (*PopulatedValidationFile, datastore.Revision, error) {
-	var revision datastore.Revision
-	var nsDefs []*core.NamespaceDefinition
+	var schema string
+	var objectDefs []*core.NamespaceDefinition
 	var caveatDefs []*core.CaveatDefinition
-	schema := ""
 	var tuples []*core.RelationTuple
+	var updates []*core.RelationTupleUpdate
+
+	var revision datastore.Revision
+
 	files := make([]ValidationFile, 0, len(filesContents))
 
+	// Parse each file into definitions and relationship updates.
 	for filePath, fileContents := range filesContents {
+		// Decode the validation file.
 		parsed, err := DecodeValidationFile(fileContents)
 		if err != nil {
 			return nil, datastore.NoRevision, fmt.Errorf("error when parsing config file %s: %w", filePath, err)
@@ -67,109 +71,76 @@ func PopulateFromFilesContents(ds datastore.Datastore, filesContents map[string]
 
 		files = append(files, *parsed)
 
-		// Add schema-based namespace definitions.
+		// Disallow legacy sections.
+		if len(parsed.NamespaceConfigs) > 0 {
+			return nil, revision, fmt.Errorf("definitions must be specified in `schema`")
+		}
+
+		if len(parsed.ValidationTuples) > 0 {
+			return nil, revision, fmt.Errorf("relationships must be specified in `relationships`")
+		}
+
+		// Add schema definitions.
 		if parsed.Schema.CompiledSchema != nil {
 			defs := parsed.Schema.CompiledSchema.ObjectDefinitions
 			if len(defs) > 0 {
 				schema += parsed.Schema.Schema + "\n\n"
 			}
 
-			log.Info().Str("filePath", filePath).Int("schemaDefinitionCount", len(defs)).Msg("Loading schema definitions")
-			nsDefs = append(nsDefs, defs...)
+			log.Info().Str("filePath", filePath).Int("schemaDefinitionCount", len(parsed.Schema.CompiledSchema.OrderedDefinitions)).Msg("adding schema definitions")
+			objectDefs = append(objectDefs, defs...)
 			caveatDefs = append(caveatDefs, parsed.Schema.CompiledSchema.CaveatDefinitions...)
 		}
 
-		// Load the namespace configs.
-		log.Info().Str("filePath", filePath).Int("namespaceCount", len(parsed.NamespaceConfigs)).Msg("Loading namespaces")
-		for index, namespaceConfig := range parsed.NamespaceConfigs {
-			nsDef := core.NamespaceDefinition{}
-			nerr := prototext.Unmarshal([]byte(namespaceConfig), &nsDef)
-			if nerr != nil {
-				return nil, revision, fmt.Errorf("error when parsing namespace config #%v from file %s: %w", index, filePath, nerr)
-			}
-			nsDefs = append(nsDefs, &nsDef)
+		// Parse relationships for updates.
+		for _, rel := range parsed.Relationships.Relationships {
+			tpl := tuple.MustFromRelationship(rel)
+			updates = append(updates, tuple.Touch(tpl))
+			tuples = append(tuples, tpl)
+		}
+	}
+
+	// Load the definitions and relationships into the datastore.
+	ctx := context.Background()
+	revision, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
+		// Write the caveat definitions.
+		err := rwt.WriteCaveats(ctx, caveatDefs)
+		if err != nil {
+			return err
 		}
 
-		ctx := context.Background()
-
-		// Load the namespaces and type check.
-		var lnerr error
-		revision, lnerr = ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
-			// Write the caveat definitions.
-			err := rwt.WriteCaveats(ctx, caveatDefs)
+		// Validate and write the object definitions.
+		for _, objectDef := range objectDefs {
+			ts, err := namespace.NewNamespaceTypeSystem(objectDef,
+				namespace.ResolverForDatastoreReader(rwt).WithPredefinedElements(namespace.PredefinedElements{
+					Namespaces: objectDefs,
+				}))
 			if err != nil {
 				return err
 			}
 
-			// Write the object definitions.
-			for _, nsDef := range nsDefs {
-				ts, err := namespace.NewNamespaceTypeSystem(nsDef,
-					namespace.ResolverForDatastoreReader(rwt).WithPredefinedElements(namespace.PredefinedElements{
-						Namespaces: nsDefs,
-					}))
-				if err != nil {
-					return err
-				}
-
-				ctx := dsctx.ContextWithDatastore(ctx, ds)
-				vts, terr := ts.Validate(ctx)
-				if terr != nil {
-					return terr
-				}
-
-				aerr := namespace.AnnotateNamespace(vts)
-				if aerr != nil {
-					return aerr
-				}
-
-				// Write the namespaces.
-				log.Info().Str("filePath", filePath).Str("namespaceName", nsDef.Name).Msg("Loading namespace")
-				if err := rwt.WriteNamespaces(ctx, nsDef); err != nil {
-					return fmt.Errorf("error when loading namespace %s: %w", nsDef.Name, err)
-				}
-			}
-			return nil
-		})
-		if lnerr != nil {
-			return nil, revision, lnerr
-		}
-
-		// Load the validation tuples/relationships.
-		var updates []*core.RelationTupleUpdate
-		seenTuples := map[string]bool{}
-		for _, rel := range parsed.Relationships.Relationships {
-			tpl := tuple.MustFromRelationship(rel)
-			updates = append(updates, tuple.Create(tpl))
-			tuples = append(tuples, tpl)
-			seenTuples[tuple.String(tpl)] = true
-		}
-
-		log.Info().Str("filePath", filePath).Int("tupleCount", len(updates)+len(parsed.ValidationTuples)).Msg("Loading test data")
-		for index, validationTuple := range parsed.ValidationTuples {
-			tpl := tuple.Parse(validationTuple)
-			if tpl == nil {
-				return nil, datastore.NoRevision, fmt.Errorf("error parsing validation tuple #%v: %s", index, validationTuple)
+			ctx := dsctx.ContextWithDatastore(ctx, ds)
+			vts, terr := ts.Validate(ctx)
+			if terr != nil {
+				return terr
 			}
 
-			_, ok := seenTuples[tuple.String(tpl)]
-			if ok {
-				continue
+			aerr := namespace.AnnotateNamespace(vts)
+			if aerr != nil {
+				return aerr
 			}
-			seenTuples[tuple.String(tpl)] = true
 
-			tuples = append(tuples, tpl)
-			updates = append(updates, tuple.Create(tpl))
+			if err := rwt.WriteNamespaces(ctx, objectDef); err != nil {
+				return fmt.Errorf("error when loading object definition %s: %w", objectDef.Name, err)
+			}
 		}
 
-		wrevision, terr := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
-			return rwt.WriteRelationships(ctx, updates)
-		})
-		if terr != nil {
-			return nil, datastore.NoRevision, fmt.Errorf("error when loading validation tuples from file %s: %w", filePath, terr)
+		err = relationships.ValidateRelationshipUpdates(ctx, rwt, updates)
+		if err != nil {
+			return err
 		}
 
-		revision = wrevision
-	}
-
-	return &PopulatedValidationFile{schema, nsDefs, tuples, files}, revision, nil
+		return rwt.WriteRelationships(ctx, updates)
+	})
+	return &PopulatedValidationFile{schema, objectDefs, tuples, files}, revision, err
 }

--- a/pkg/validationfile/testdata/legacy.yaml
+++ b/pkg/validationfile/testdata/legacy.yaml
@@ -1,0 +1,3 @@
+---
+validation_tuples:
+  - 'foo'


### PR DESCRIPTION
- Adds validation of relationships being used in file loader
- Removes support for deprecated fields in the YAML file format
- Changes some of the validation errors into properly typed errors