### PR TITLE
Fix for PG when schema is specified in the db url

### DIFF
--- a/internal/datastore/postgres/migrations/zz_migration.0012_add_xid_constraints.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0012_add_xid_constraints.go
@@ -10,7 +10,7 @@ import (
 const (
 	getNSConfigPkeyName = `
 	SELECT constraint_name FROM information_schema.table_constraints
-		WHERE table_schema = 'public'
+		WHERE table_schema = current_schema()
       	AND table_name = 'namespace_config'
       	AND constraint_type = 'PRIMARY KEY';`
 


### PR DESCRIPTION
This patch lets you put the datastore in any schema like this: postgres://user:pass@host/spicedb?**search_path=hello_world**