### PR TITLE
Add context and default timeout for validationfile loading

### DIFF
--- a/internal/middleware/pertoken/pertoken.go
+++ b/internal/middleware/pertoken/pertoken.go
@@ -51,7 +51,7 @@ func (m *MiddlewareForTesting) getOrCreateDatastore(ctx context.Context) (datast
 		return nil, fmt.Errorf("failed to init datastore: %w", err)
 	}
 
-	_, _, err = validationfile.PopulateFromFiles(ds, m.configFilePaths)
+	_, _, err = validationfile.PopulateFromFiles(ctx, ds, m.configFilePaths)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config files: %w", err)
 	}

--- a/internal/services/integrationtesting/benchmark_test.go
+++ b/internal/services/integrationtesting/benchmark_test.go
@@ -164,7 +164,7 @@ func BenchmarkServices(b *testing.B) {
 					contents, err := testFiles.ReadFile(bt.fileName)
 					require.NoError(b, err)
 
-					_, revision, err := validationfile.PopulateFromFilesContents(ds, map[string][]byte{
+					_, revision, err := validationfile.PopulateFromFilesContents(context.Background(), ds, map[string][]byte{
 						"testfile": contents,
 					})
 					brequire.NoError(err)

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -72,8 +72,9 @@ func TestConsistency(t *testing.T) {
 							ds, err := memdb.NewMemdbDatastore(0, delta, memdb.DisableGC)
 							require.NoError(t, err)
 
-							fullyResolved, revision, err := validationfile.PopulateFromFiles(ds, []string{filePath})
+							fullyResolved, revision, err := validationfile.PopulateFromFiles(context.Background(), ds, []string{filePath})
 							require.NoError(t, err)
+
 							conn, cleanup := testserver.TestClusterWithDispatch(t, 1, ds)
 							t.Cleanup(cleanup)
 

--- a/internal/testserver/datastore/config/config.go
+++ b/internal/testserver/datastore/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,7 @@ import (
 // an independent test with CLI-like config where possible.
 func DatastoreConfigInitFunc(t testing.TB, options ...dsconfig.ConfigOption) testdatastore.InitFunc {
 	return func(engine, uri string) datastore.Datastore {
-		ds, err := dsconfig.NewDatastore(
+		ds, err := dsconfig.NewDatastore(context.Background(),
 			append(options,
 				dsconfig.WithEngine(engine),
 				dsconfig.WithEnableDatastoreMetrics(false),

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -32,6 +32,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.DisableStats = c.DisableStats
 		to.BootstrapFiles = c.BootstrapFiles
 		to.BootstrapOverwrite = c.BootstrapOverwrite
+		to.BootstrapTimeout = c.BootstrapTimeout
 		to.RequestHedgingEnabled = c.RequestHedgingEnabled
 		to.RequestHedgingInitialSlowValue = c.RequestHedgingInitialSlowValue
 		to.RequestHedgingMaxRequests = c.RequestHedgingMaxRequests
@@ -168,6 +169,13 @@ func SetBootstrapFiles(bootstrapFiles []string) ConfigOption {
 func WithBootstrapOverwrite(bootstrapOverwrite bool) ConfigOption {
 	return func(c *Config) {
 		c.BootstrapOverwrite = bootstrapOverwrite
+	}
+}
+
+// WithBootstrapTimeout returns an option that can set BootstrapTimeout on a Config
+func WithBootstrapTimeout(bootstrapTimeout time.Duration) ConfigOption {
+	return func(c *Config) {
+		c.BootstrapTimeout = bootstrapTimeout
 	}
 }
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -126,7 +126,7 @@ func (c *Config) Complete() (RunnableServer, error) {
 	ds := c.Datastore
 	if ds == nil {
 		var err error
-		ds, err = datastorecfg.NewDatastore(c.DatastoreConfig.ToOption())
+		ds, err = datastorecfg.NewDatastore(context.Background(), c.DatastoreConfig.ToOption())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create datastore: %w", err)
 		}

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -293,6 +293,16 @@ func MustFromRelationship(r *v1.Relationship) *core.RelationTuple {
 	return FromRelationship(r)
 }
 
+// MustFromRelationships converts a slice of Relationship's into a slice of RelationTuple's.
+func MustFromRelationships(rels []*v1.Relationship) []*core.RelationTuple {
+	tuples := make([]*core.RelationTuple, 0, len(rels))
+	for _, rel := range rels {
+		tpl := MustFromRelationship(rel)
+		tuples = append(tuples, tpl)
+	}
+	return tuples
+}
+
 // FromRelationship converts a Relationship into a RelationTuple.
 func FromRelationship(r *v1.Relationship) *core.RelationTuple {
 	var caveat *core.ContextualizedCaveat

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -33,7 +33,7 @@ type PopulatedValidationFile struct {
 
 // PopulateFromFiles populates the given datastore with the namespaces and tuples found in
 // the validation file(s) specified.
-func PopulateFromFiles(ds datastore.Datastore, filePaths []string) (*PopulatedValidationFile, datastore.Revision, error) {
+func PopulateFromFiles(ctx context.Context, ds datastore.Datastore, filePaths []string) (*PopulatedValidationFile, datastore.Revision, error) {
 	contents := map[string][]byte{}
 
 	for _, filePath := range filePaths {
@@ -45,12 +45,12 @@ func PopulateFromFiles(ds datastore.Datastore, filePaths []string) (*PopulatedVa
 		contents[filePath] = fileContents
 	}
 
-	return PopulateFromFilesContents(ds, contents)
+	return PopulateFromFilesContents(ctx, ds, contents)
 }
 
 // PopulateFromFilesContents populates the given datastore with the namespaces and tuples found in
 // the validation file(s) contents specified.
-func PopulateFromFilesContents(ds datastore.Datastore, filesContents map[string][]byte) (*PopulatedValidationFile, datastore.Revision, error) {
+func PopulateFromFilesContents(ctx context.Context, ds datastore.Datastore, filesContents map[string][]byte) (*PopulatedValidationFile, datastore.Revision, error) {
 	var schema string
 	var objectDefs []*core.NamespaceDefinition
 	var caveatDefs []*core.CaveatDefinition
@@ -101,7 +101,6 @@ func PopulateFromFilesContents(ds datastore.Datastore, filesContents map[string]
 	}
 
 	// Load the definitions and relationships into the datastore.
-	ctx := context.Background()
 	revision, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 		// Write the caveat definitions.
 		err := rwt.WriteCaveats(ctx, caveatDefs)

--- a/pkg/validationfile/loader_test.go
+++ b/pkg/validationfile/loader_test.go
@@ -1,6 +1,7 @@
 package validationfile
 
 import (
+	"context"
 	"sort"
 	"testing"
 
@@ -83,7 +84,7 @@ func TestPopulateFromFiles(t *testing.T) {
 			ds, err := memdb.NewMemdbDatastore(0, 0, 0)
 			require.NoError(err)
 
-			parsed, _, err := PopulateFromFiles(ds, tt.filePaths)
+			parsed, _, err := PopulateFromFiles(context.Background(), ds, tt.filePaths)
 			if tt.expectedError == "" {
 				require.NoError(err)
 


### PR DESCRIPTION
Pipes context through to the validationfile loading and adds a default timeout when used for bootstrapping