### PR TITLE
Add len checks to WriteCaveats before attempting to write nothing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,12 @@ In order to build and test the project, the [latest stable version of Go] and kn
 go test -v ./...
 ```
 
+To run integration tests (for example when testing datastores):
+
+```sh
+go test -v --failfast --tags 'ci,docker' -count=1 ./...
+```
+
 ### Adding dependencies
 
 This project does not use anything other than the standard [Go modules] toolchain for managing dependencies.

--- a/internal/datastore/crdb/caveat.go
+++ b/internal/datastore/crdb/caveat.go
@@ -109,6 +109,9 @@ func (cr *crdbReader) ListCaveats(ctx context.Context, caveatNames ...string) ([
 }
 
 func (rwt *crdbReadWriteTXN) WriteCaveats(ctx context.Context, caveats []*core.CaveatDefinition) error {
+	if len(caveats) == 0 {
+		return nil
+	}
 	write := writeCaveat
 	writtenCaveatNames := make([]string, 0, len(caveats))
 	for _, caveat := range caveats {

--- a/internal/datastore/mysql/caveat.go
+++ b/internal/datastore/mysql/caveat.go
@@ -98,6 +98,9 @@ func (mr *mysqlReader) ListCaveats(ctx context.Context, caveatNames ...string) (
 }
 
 func (rwt *mysqlReadWriteTXN) WriteCaveats(ctx context.Context, caveats []*core.CaveatDefinition) error {
+	if len(caveats) == 0 {
+		return nil
+	}
 	writeQuery := rwt.WriteCaveatQuery
 
 	caveatNamesToWrite := make([]string, 0, len(caveats))

--- a/internal/datastore/postgres/caveat.go
+++ b/internal/datastore/postgres/caveat.go
@@ -104,6 +104,9 @@ func (r *pgReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*c
 }
 
 func (rwt *pgReadWriteTXN) WriteCaveats(ctx context.Context, caveats []*core.CaveatDefinition) error {
+	if len(caveats) == 0 {
+		return nil
+	}
 	write := writeCaveat
 	writtenCaveatNames := make([]string, 0, len(caveats))
 	for _, caveat := range caveats {

--- a/internal/datastore/spanner/caveat.go
+++ b/internal/datastore/spanner/caveat.go
@@ -73,9 +73,6 @@ func (sr spannerReader) ListCaveats(ctx context.Context, caveatNames ...string) 
 }
 
 func (rwt spannerReadWriteTXN) WriteCaveats(ctx context.Context, caveats []*core.CaveatDefinition) error {
-	if len(caveats) == 0 {
-		return nil
-	}
 	names := map[string]struct{}{}
 	mutations := make([]*spanner.Mutation, 0, len(caveats))
 	for _, caveat := range caveats {

--- a/internal/datastore/spanner/caveat.go
+++ b/internal/datastore/spanner/caveat.go
@@ -73,6 +73,9 @@ func (sr spannerReader) ListCaveats(ctx context.Context, caveatNames ...string) 
 }
 
 func (rwt spannerReadWriteTXN) WriteCaveats(ctx context.Context, caveats []*core.CaveatDefinition) error {
+	if len(caveats) == 0 {
+		return nil
+	}
 	names := map[string]struct{}{}
 	mutations := make([]*spanner.Mutation, 0, len(caveats))
 	for _, caveat := range caveats {

--- a/pkg/datastore/caveat.go
+++ b/pkg/datastore/caveat.go
@@ -21,7 +21,7 @@ type CaveatStorer interface {
 	CaveatReader
 
 	// WriteCaveats stores the provided caveats, and returns the assigned IDs
-	// Each element o the returning slice corresponds by possition to the input slice
+	// Each element of the returning slice corresponds by possition to the input slice
 	WriteCaveats(context.Context, []*core.CaveatDefinition) error
 
 	// DeleteCaveats deletes the provided caveats by name

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -29,8 +29,12 @@ func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 
 	skipIfNotCaveatStorer(t, ds)
 
-	// Dupes in same transaction are fail to be written
 	ctx := context.Background()
+	// Don't fail on writing empty caveat list
+	_, err = writeCaveats(ctx, ds)
+	req.NoError(err)
+
+	// Dupes in same transaction fail to be written
 	coreCaveat := createCoreCaveat(t)
 	coreCaveat.Name = "a"
 	_, err = writeCaveats(ctx, ds, coreCaveat, coreCaveat)


### PR DESCRIPTION
Closes #1005 

I have very little knowledge of Go, but I gave the fix a shot anyways. Feel free to advice me on how to do this better. Also tried adding some tests around `loader_test.go` to use the internal testservers to try out the different engines, but I failed to figure that out in the few hours I wanted to spend on this.

Only tested the solution for `crdb` following the same steps I described in the issue, with this the bootstrapping works neatly.