### PR TITLE
Add configurable concurrency limits per dispatch type

### DIFF
--- a/internal/dispatch/graph/graph_test.go
+++ b/internal/dispatch/graph/graph_test.go
@@ -1,0 +1,47 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrencyLimitsWithOverallDefaultLimit(t *testing.T) {
+	cl := ConcurrencyLimits{}
+	require.Equal(t, uint16(0), cl.Check)
+	require.Equal(t, uint16(0), cl.LookupResources)
+	require.Equal(t, uint16(0), cl.LookupSubjects)
+	require.Equal(t, uint16(0), cl.ReachableResources)
+
+	withDefaults := cl.WithOverallDefaultLimit(51)
+
+	require.Equal(t, uint16(0), cl.Check)
+	require.Equal(t, uint16(0), cl.LookupResources)
+	require.Equal(t, uint16(0), cl.LookupSubjects)
+	require.Equal(t, uint16(0), cl.ReachableResources)
+
+	require.Equal(t, uint16(51), withDefaults.Check)
+	require.Equal(t, uint16(51), withDefaults.LookupResources)
+	require.Equal(t, uint16(51), withDefaults.LookupSubjects)
+	require.Equal(t, uint16(51), withDefaults.ReachableResources)
+}
+
+func TestSharedConcurrencyLimits(t *testing.T) {
+	cl := SharedConcurrencyLimits(42)
+	require.Equal(t, uint16(42), cl.Check)
+	require.Equal(t, uint16(42), cl.LookupResources)
+	require.Equal(t, uint16(42), cl.LookupSubjects)
+	require.Equal(t, uint16(42), cl.ReachableResources)
+
+	withDefaults := cl.WithOverallDefaultLimit(51)
+
+	require.Equal(t, uint16(42), cl.Check)
+	require.Equal(t, uint16(42), cl.LookupResources)
+	require.Equal(t, uint16(42), cl.LookupSubjects)
+	require.Equal(t, uint16(42), cl.ReachableResources)
+
+	require.Equal(t, uint16(42), withDefaults.Check)
+	require.Equal(t, uint16(42), withDefaults.LookupResources)
+	require.Equal(t, uint16(42), withDefaults.LookupSubjects)
+	require.Equal(t, uint16(42), withDefaults.ReachableResources)
+}

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -106,7 +106,7 @@ func TestConsistency(t *testing.T) {
 								cachingDispatcher, err := caching.NewCachingDispatcher(nil, "", &keys.CanonicalKeyHandler{})
 								lrequire.NoError(err)
 
-								localDispatcher := graph.NewDispatcher(cachingDispatcher, 10)
+								localDispatcher := graph.NewDispatcher(cachingDispatcher, graph.SharedConcurrencyLimits(10))
 								defer localDispatcher.Close()
 								cachingDispatcher.SetDelegate(localDispatcher)
 								dispatcher = cachingDispatcher

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -87,7 +87,13 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) {
 	cmd.Flags().Uint32Var(&config.DispatchMaxDepth, "dispatch-max-depth", 50, "maximum recursion depth for nested calls")
 	cmd.Flags().StringVar(&config.DispatchUpstreamAddr, "dispatch-upstream-addr", "", "upstream grpc address to dispatch to")
 	cmd.Flags().StringVar(&config.DispatchUpstreamCAPath, "dispatch-upstream-ca-path", "", "local path to the TLS CA used when connecting to the dispatch cluster")
-	cmd.Flags().Uint16Var(&config.DispatchConcurrencyLimit, "dispatch-concurrency-limit", 50, "maximum number of parallel goroutines to create for each request or subrequest")
+
+	cmd.Flags().Uint16Var(&config.GlobalDispatchConcurrencyLimit, "dispatch-concurrency-limit", 50, "maximum number of parallel goroutines to create for each request or subrequest")
+
+	cmd.Flags().Uint16Var(&config.DispatchConcurrencyLimits.Check, "dispatch-check-permission-concurrency-limit", 0, "maximum number of parallel goroutines to create for each check request or subrequest. defaults to --dispatch-concurrency-limit")
+	cmd.Flags().Uint16Var(&config.DispatchConcurrencyLimits.LookupResources, "dispatch-lookup-resources-concurrency-limit", 0, "maximum number of parallel goroutines to create for each lookup resources request or subrequest. defaults to --dispatch-concurrency-limit")
+	cmd.Flags().Uint16Var(&config.DispatchConcurrencyLimits.LookupSubjects, "dispatch-lookup-subjects-concurrency-limit", 0, "maximum number of parallel goroutines to create for each lookup subjects request or subrequest. defaults to --dispatch-concurrency-limit")
+	cmd.Flags().Uint16Var(&config.DispatchConcurrencyLimits.ReachableResources, "dispatch-reachable-resources-concurrency-limit", 0, "maximum number of parallel goroutines to create for each reachable resources request or subrequest. defaults to --dispatch-concurrency-limit")
 
 	// Flags for configuring API behavior
 	cmd.Flags().BoolVar(&config.DisableV1SchemaAPI, "disable-v1-schema-api", false, "disables the V1 schema API")

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -3,6 +3,7 @@ package server
 
 import (
 	dispatch "github.com/authzed/spicedb/internal/dispatch"
+	graph "github.com/authzed/spicedb/internal/dispatch/graph"
 	datastore "github.com/authzed/spicedb/pkg/cmd/datastore"
 	util "github.com/authzed/spicedb/pkg/cmd/util"
 	datastore1 "github.com/authzed/spicedb/pkg/datastore"
@@ -41,7 +42,8 @@ func (c *Config) ToOption() ConfigOption {
 		to.SchemaPrefixesRequired = c.SchemaPrefixesRequired
 		to.DispatchServer = c.DispatchServer
 		to.DispatchMaxDepth = c.DispatchMaxDepth
-		to.DispatchConcurrencyLimit = c.DispatchConcurrencyLimit
+		to.GlobalDispatchConcurrencyLimit = c.GlobalDispatchConcurrencyLimit
+		to.DispatchConcurrencyLimits = c.DispatchConcurrencyLimits
 		to.DispatchUpstreamAddr = c.DispatchUpstreamAddr
 		to.DispatchUpstreamCAPath = c.DispatchUpstreamCAPath
 		to.DispatchClientMetricsPrefix = c.DispatchClientMetricsPrefix
@@ -201,10 +203,17 @@ func WithDispatchMaxDepth(dispatchMaxDepth uint32) ConfigOption {
 	}
 }
 
-// WithDispatchConcurrencyLimit returns an option that can set DispatchConcurrencyLimit on a Config
-func WithDispatchConcurrencyLimit(dispatchConcurrencyLimit uint16) ConfigOption {
+// WithGlobalDispatchConcurrencyLimit returns an option that can set GlobalDispatchConcurrencyLimit on a Config
+func WithGlobalDispatchConcurrencyLimit(globalDispatchConcurrencyLimit uint16) ConfigOption {
 	return func(c *Config) {
-		c.DispatchConcurrencyLimit = dispatchConcurrencyLimit
+		c.GlobalDispatchConcurrencyLimit = globalDispatchConcurrencyLimit
+	}
+}
+
+// WithDispatchConcurrencyLimits returns an option that can set DispatchConcurrencyLimits on a Config
+func WithDispatchConcurrencyLimits(dispatchConcurrencyLimits graph.ConcurrencyLimits) ConfigOption {
+	return func(c *Config) {
+		c.DispatchConcurrencyLimits = dispatchConcurrencyLimits
 	}
 }
 


### PR DESCRIPTION
This allows for overrides on the concurrency limits for specific types of dispatch, as a basic form of QoS for different kinds of API calls