### PR TITLE
move off ristretto fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/dalzilio/rudd v1.1.1-0.20220422201445-0a0cd32c7df9
-	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dlmiddlecote/sqlstats v1.0.2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/ecordell/optgen v0.0.6
@@ -48,6 +47,7 @@ require (
 	github.com/mostynb/go-grpc-compression v1.1.17
 	github.com/ngrok/sqlmw v0.0.0-20211220175533-9d16fdc47b31
 	github.com/ory/dockertest/v3 v3.9.1
+	github.com/outcaste-io/ristretto v0.2.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/planetscale/vtprotobuf v0.3.1-0.20220817155510-0ae748fd2007
 	github.com/prometheus/client_golang v1.13.0
@@ -190,6 +190,3 @@ require (
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 )
-
-// TODO(jschorr): Remove once https://github.com/dgraph-io/ristretto/pull/286 is merged
-replace github.com/dgraph-io/ristretto => github.com/josephschorr/ristretto v0.1.1-0.20211227180020-ae4c2c35d79d

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/johannesboyne/gofakes3 v0.0.0-20220314170512-33c13122505e h1:vyS7N0o/a00uLggd0QtEh3sGlK1Uhuu/YyVczES6/sw=
 github.com/johannesboyne/gofakes3 v0.0.0-20220314170512-33c13122505e/go.mod h1:LIAXxPvcUXwOcTIj9LSNSUpE9/eMHalTWxsP/kmWxQI=
-github.com/josephschorr/ristretto v0.1.1-0.20211227180020-ae4c2c35d79d h1:VAmp70+MqqRCQfKpPFbzf5jVuTzwOBPSptNIXRX+pe0=
-github.com/josephschorr/ristretto v0.1.1-0.20211227180020-ae4c2c35d79d/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -503,6 +501,8 @@ github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuh
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ory/dockertest/v3 v3.9.1 h1:v4dkG+dlu76goxMiTT2j8zV7s4oPPEppKT8K8p2f1kY=
 github.com/ory/dockertest/v3 v3.9.1/go.mod h1:42Ir9hmvaAPm0Mgibk6mBPi7SFvTXxEcnztDYOJ//uM=
+github.com/outcaste-io/ristretto v0.2.0 h1:47w059XTZWFt01OucwjcBt8mEa3VUUhntUWEfmgVBFc=
+github.com/outcaste-io/ristretto v0.2.0/go.mod h1:iBZA7RCt6jaOr0z6hiBQ6t662/oZ6Gx/yauuPvIWHAI=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -136,7 +136,7 @@ func TestMaxDepthCaching(t *testing.T) {
 				require.Equal(v1.ResourceCheckResult_MEMBER, resp.ResultsByResourceId[parsed.ObjectId].Membership)
 
 				// We have to sleep a while to let the cache converge:
-				// https://github.com/dgraph-io/ristretto/blob/01b9f37dd0fd453225e042d6f3a27cd14f252cd0/cache_test.go#L17
+				// https://github.com/outcaste-io/ristretto/blob/01b9f37dd0fd453225e042d6f3a27cd14f252cd0/cache_test.go#L17
 				time.Sleep(10 * time.Millisecond)
 			}
 

--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -27,8 +27,8 @@ var ONR = tuple.ObjectAndRelation
 
 var goleakIgnores = []goleak.Option{
 	goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"),
-	goleak.IgnoreTopFunction("github.com/dgraph-io/ristretto.(*lfuPolicy).processItems"),
-	goleak.IgnoreTopFunction("github.com/dgraph-io/ristretto.(*Cache).processItems"),
+	goleak.IgnoreTopFunction("github.com/outcaste-io/ristretto.(*lfuPolicy).processItems"),
+	goleak.IgnoreTopFunction("github.com/outcaste-io/ristretto.(*Cache).processItems"),
 	goleak.IgnoreCurrent(),
 }
 

--- a/internal/dispatch/graph/lookup_test.go
+++ b/internal/dispatch/graph/lookup_test.go
@@ -128,7 +128,7 @@ func TestSimpleLookup(t *testing.T) {
 			require.Equal(tc.expectedDepthRequired, int(lookupResult.Metadata.DepthRequired), "Depth required mismatch")
 
 			// We have to sleep a while to let the cache converge:
-			// https://github.com/dgraph-io/ristretto/blob/01b9f37dd0fd453225e042d6f3a27cd14f252cd0/cache_test.go#L17
+			// https://github.com/outcaste-io/ristretto/blob/01b9f37dd0fd453225e042d6f3a27cd14f252cd0/cache_test.go#L17
 			time.Sleep(10 * time.Millisecond)
 
 			// Run again with the cache available.

--- a/internal/dispatch/keys/hasher_ristretto.go
+++ b/internal/dispatch/keys/hasher_ristretto.go
@@ -60,7 +60,7 @@ func (h *dispatchCacheKeyHasher) WriteString(value string) {
 	}
 }
 
-// From: https://github.com/dgraph-io/ristretto/blob/master/z/rtutil.go
+// From: https://github.com/outcaste-io/ristretto/blob/master/z/rtutil.go
 type stringStruct struct {
 	str unsafe.Pointer
 	len int

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Config for caching.
-// See: https://github.com/dgraph-io/ristretto#Config
+// See: https://github.com/outcaste-io/ristretto#Config
 type Config struct {
 	// NumCounters determines the number of counters (keys) to keep that hold
 	// access frequency information. It's generally a good idea to have more

--- a/pkg/cache/cache_ristretto.go
+++ b/pkg/cache/cache_ristretto.go
@@ -4,8 +4,8 @@
 package cache
 
 import (
-	"github.com/dgraph-io/ristretto"
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/outcaste-io/ristretto"
+	"github.com/outcaste-io/ristretto/z"
 	"github.com/rs/zerolog"
 
 	"github.com/authzed/spicedb/internal/dispatch/keys"


### PR DESCRIPTION
closes https://github.com/authzed/spicedb/issues/1011

Our submission got merged so we can move back to using upstream repo. This also fixes the inability to run `go install` due to the replacement directive.