### PR TITLE
Fix memdb to always generate unique revision IDs

### DIFF
--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -62,7 +62,7 @@ func NewMemdbDatastore(
 		db: db,
 		revisions: []snapshot{
 			{
-				revision: decimal.Zero,
+				revision: revisionFromTimestamp(time.Now().UTC()).Decimal,
 				db:       db,
 			},
 		},
@@ -160,8 +160,7 @@ func (mdb *memdbDatastore) ReadWriteTx(
 			return tx, err
 		}
 
-		newRevision := newRevisionID()
-
+		newRevision := mdb.newRevisionID()
 		rwt := &memdbReadWriteTx{memdbReader{&sync.Mutex{}, txSrc, nil}, newRevision}
 		if err := f(rwt); err != nil {
 			mdb.Lock()
@@ -263,7 +262,7 @@ func (mdb *memdbDatastore) Close() error {
 	if db := mdb.db; db != nil {
 		mdb.revisions = []snapshot{
 			{
-				revision: decimal.Zero,
+				revision: revisionFromTimestamp(time.Now().UTC()).Decimal,
 				db:       db,
 			},
 		}

--- a/internal/datastore/memdb/revisions.go
+++ b/internal/datastore/memdb/revisions.go
@@ -10,33 +10,52 @@ import (
 	"github.com/authzed/spicedb/pkg/datastore/revision"
 )
 
-// NOTE: The time.Now().UTC() only appears to have *microsecond* level
-// precision on macOS Monterey in Go 1.19.1. This means that HeadRevision
-// and the result of a ReadWriteTx can return the *same* transaction ID
-// if both are executed in sequence without any other forms of delay on
-// macOS. As memdb should only be used for testing and tooling this *should*
-// be okay, but we should investigate if there is a further fix.
-//
-// See: https://github.com/golang/go/issues/22037 which appeared to fix
-// this in Go 1.9.2, but there appears to have been a reversion with either
-// the new version of macOS or Go.
-//
-// TODO(jschorr): Investigate if there is a way to fix this.
-func newRevisionID() revision.Decimal {
-	return revisionFromTimestamp(time.Now().UTC())
-}
-
 func revisionFromTimestamp(t time.Time) revision.Decimal {
 	return revision.NewFromDecimal(decimal.NewFromInt(t.UnixNano()))
 }
 
-func (mdb *memdbDatastore) OptimizedRevision(ctx context.Context) (datastore.Revision, error) {
-	head := revisionFromTimestamp(time.Now().UTC())
-	return revision.NewFromDecimal(head.Sub(head.Mod(mdb.quantizationPeriod))), nil
+func (mdb *memdbDatastore) newRevisionID() revision.Decimal {
+	mdb.Lock()
+	defer mdb.Unlock()
+
+	existing := mdb.revisions[len(mdb.revisions)-1].revision
+	created := revisionFromTimestamp(time.Now().UTC()).Decimal
+
+	// NOTE: The time.Now().UTC() only appears to have *microsecond* level
+	// precision on macOS Monterey in Go 1.19.1. This means that HeadRevision
+	// and the result of a ReadWriteTx could return the *same* transaction ID
+	// if both are executed in sequence without any other forms of delay on
+	// macOS. We therefore check if the created transaction ID matches that
+	// previously created and, if not, add to it.
+	//
+	// See: https://github.com/golang/go/issues/22037 which appeared to fix
+	// this in Go 1.9.2, but there appears to have been a reversion with either
+	// the new version of macOS or Go.
+	if created.Equals(existing) {
+		return revision.NewFromDecimal(created.Add(decimal.NewFromInt(1)))
+	}
+	return revision.NewFromDecimal(created)
 }
 
 func (mdb *memdbDatastore) HeadRevision(ctx context.Context) (datastore.Revision, error) {
-	return revisionFromTimestamp(time.Now().UTC()), nil
+	head, err := mdb.headRevision(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return revision.NewFromDecimal(head), nil
+}
+
+func (mdb *memdbDatastore) headRevision(ctx context.Context) (decimal.Decimal, error) {
+	mdb.Lock()
+	defer mdb.Unlock()
+
+	return mdb.revisions[len(mdb.revisions)-1].revision, nil
+}
+
+func (mdb *memdbDatastore) OptimizedRevision(ctx context.Context) (datastore.Revision, error) {
+	now := revisionFromTimestamp(time.Now().UTC())
+	return revision.NewFromDecimal(now.Sub(now.Mod(mdb.quantizationPeriod))), nil
 }
 
 func (mdb *memdbDatastore) CheckRevision(ctx context.Context, revisionRaw datastore.Revision) error {

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -271,9 +271,6 @@ func CaveatedRelationshipWatchTest(t *testing.T, tester DatastoreTester) {
 	revBeforeWrite, err := ds.HeadRevision(ctx)
 	require.NoError(t, err)
 
-	// NOTE: sleep added to ensure different revisions on macOS.
-	time.Sleep(1 * time.Microsecond)
-
 	writeRev, err := common.WriteTuples(ctx, ds, core.RelationTupleUpdate_CREATE, tupleWithContext)
 	require.NoError(t, err)
 	require.NotEqual(t, revBeforeWrite, writeRev, "found same transaction IDs: %v and %v", revBeforeWrite, writeRev)
@@ -290,9 +287,6 @@ func CaveatedRelationshipWatchTest(t *testing.T, tester DatastoreTester) {
 	secondRevBeforeWrite, err := ds.HeadRevision(ctx)
 	require.NoError(t, err)
 
-	// NOTE: sleep added to ensure different revisions on macOS.
-	time.Sleep(1 * time.Microsecond)
-
 	secondWriteRev, err := common.WriteTuples(ctx, ds, core.RelationTupleUpdate_CREATE, tupleWithEmptyContext)
 	require.NoError(t, err)
 	require.NotEqual(t, secondRevBeforeWrite, secondWriteRev)
@@ -305,9 +299,6 @@ func CaveatedRelationshipWatchTest(t *testing.T, tester DatastoreTester) {
 
 	thirdRevBeforeWrite, err := ds.HeadRevision(ctx)
 	require.NoError(t, err)
-
-	// NOTE: sleep added to ensure different revisions on macOS.
-	time.Sleep(1 * time.Microsecond)
 
 	thirdWriteRev, err := common.WriteTuples(ctx, ds, core.RelationTupleUpdate_CREATE, tupleWithNilContext)
 	req.NoError(err)


### PR DESCRIPTION
This is necessary because Go on macOS only returns microsecond precision for the `time.Now()` call. We now check to see if the revision ID was previously used and, if so, increment until we find a valid one.