### PR TITLE
add caveat covering index

### DIFF
--- a/internal/datastore/crdb/migrations/zz_migration.0005_add_caveat_covering_index.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0005_add_caveat_covering_index.go
@@ -1,0 +1,29 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+)
+
+const (
+	createCaveatsCoveringIndex = `CREATE INDEX ix_relation_tuple_caveat_covering ON relation_tuple
+	(namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, caveat_name) 
+	STORING 
+	(caveat_context)`
+)
+
+func init() {
+	err := CRDBMigrations.Register("add-caveat-covering-index", "add-caveats", addCaveatToTuplesIndexFunc, noAtomicMigration)
+	if err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}
+
+func addCaveatToTuplesIndexFunc(ctx context.Context, conn *pgx.Conn) error {
+	if _, err := conn.Exec(ctx, createCaveatsCoveringIndex); err != nil {
+		return err
+	}
+	// A primary key's index cannot be dropped
+	return nil
+}

--- a/internal/datastore/mysql/migrations/zz_migration.0005_add_caveat_covering_index.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0005_add_caveat_covering_index.go
@@ -1,0 +1,36 @@
+package migrations
+
+import "fmt"
+
+// we need to get some index headroom back in order to add caveat_name to the covering index
+// 128 is already enforced at the application level
+func shrinkCaveatNameLengthRelationTupleTable(t *tables) string {
+	return fmt.Sprintf(`ALTER TABLE %s MODIFY caveat_name VARCHAR(128);`, t.RelationTuple())
+}
+
+// 128 is already enforced at the application level
+func shrinkCaveatNameLengthCaveatTable(t *tables) string {
+	return fmt.Sprintf(`ALTER TABLE %s MODIFY name VARCHAR(128);`, t.Caveat())
+}
+
+// We cannot do a covering index including the JSON caveat_context column. Unfortunately MySQL couples covering
+// index with the index definition itself, compared to other databases.
+// - JSON column cannot be indexed
+// - generated column over JSON column does not fit max index length 3072 bytes
+// - functional indexes lead to the same index length
+func createCaveatCoveringIndex(t *tables) string {
+	return fmt.Sprintf(`CREATE INDEX ix_relation_tuple_caveat_covering 
+		ON %s (namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, caveat_name);`,
+		t.RelationTuple(),
+	)
+}
+
+func init() {
+	mustRegisterMigration("add_caveat_covering_index", "add_caveat", noNonatomicMigration,
+		newStatementBatch(
+			shrinkCaveatNameLengthCaveatTable,
+			shrinkCaveatNameLengthRelationTupleTable,
+			createCaveatCoveringIndex).
+			execute,
+	)
+}

--- a/internal/datastore/postgres/migrations/zz_migration.0015_add_caveat_covering_index.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0015_add_caveat_covering_index.go
@@ -1,0 +1,26 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+)
+
+// See https://www.postgresql.org/docs/current/indexes-index-only-scans.html
+const createCaveatsCoveringIndex = `CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_relation_tuple_caveat_covering
+	ON relation_tuple(namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, caveat_name) 
+	INCLUDE (caveat_context)`
+
+func init() {
+	if err := DatabaseMigrations.Register("add-caveat-covering-index", "drop-bigserial-ids",
+		func(ctx context.Context, conn *pgx.Conn) error {
+			if _, err := conn.Exec(ctx, createCaveatsCoveringIndex); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		noTxMigration); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -31,7 +31,7 @@ func TestPostgresDatastore(t *testing.T) {
 		targetMigration string
 		migrationPhase  string
 	}{
-		{"drop-bigserial-ids", ""},
+		{"add-caveat-covering-index", ""},
 	} {
 		config := config
 		t.Run(fmt.Sprintf("%s-%s", config.targetMigration, config.migrationPhase), func(t *testing.T) {

--- a/internal/datastore/spanner/migrations/zz_migration.0004_add_caveat_covering_index.go
+++ b/internal/datastore/spanner/migrations/zz_migration.0004_add_caveat_covering_index.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"context"
+
+	"google.golang.org/genproto/googleapis/spanner/admin/database/v1"
+)
+
+// See https://cloud.google.com/spanner/docs/secondary-indexes
+const createCaveatsCoveringIndex = `CREATE INDEX ix_relation_tuple_caveat_covering ON relation_tuple(namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, caveat_name) STORING (caveat_context)`
+
+func init() {
+	if err := SpannerMigrations.Register("add-caveat-covering-index", "add-caveats", func(ctx context.Context, w Wrapper) error {
+		updateOp, err := w.adminClient.UpdateDatabaseDdl(ctx, &database.UpdateDatabaseDdlRequest{
+			Database: w.client.DatabaseName(),
+			Statements: []string{
+				createCaveatsCoveringIndex,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		return updateOp.Wait(ctx)
+	}, nil); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}


### PR DESCRIPTION
# What

tries to optimize relationship lookup for various datastores by making sure caveat name and context are part of a covering index. 

# How

this PR explores making sure every relationship query is served from the index (aka covering index). This was the case before, but it stopped the moment we added caveats to the table.

This functionality is nicely handled in all databases, except MySQL, which does not support "including a column in the covering index".

In MySQL case, we also had to shrink the `caveat_name` column because adding any new element to the index hit the 3072 bytes InnoDB limit. The migration won't make this a covering index, but:
- it will allow us to have an index for `ReadRelationships` with a `RelationshipFilter` that filters on caveat name
- it will allow us to select all columns but `column_context` and make decisions based on the existence of a caveat in the row.