### PR TITLE
Fix metadata on ErrCannotWriteToPermission

### DIFF
--- a/internal/relationships/errors.go
+++ b/internal/relationships/errors.go
@@ -79,7 +79,8 @@ func (err ErrCannotWriteToPermission) GRPCStatus() *status.Status {
 		spiceerrors.ForReason(
 			v1.ErrorReason_ERROR_REASON_CANNOT_UPDATE_PERMISSION,
 			map[string]string{
-				"caveat_name": err.update.Tuple.Caveat.CaveatName,
+				"definition_name": err.update.Tuple.ResourceAndRelation.Namespace,
+				"permission_name": err.update.Tuple.ResourceAndRelation.Relation,
 			},
 		),
 	)

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -494,6 +494,13 @@ func TestInvalidWriteRelationship(t *testing.T) {
 			"caused by: invalid RelationshipFilter.OptionalResourceId: value does not match regex pattern",
 		},
 		{
+			"write permission",
+			nil,
+			[]*v1.Relationship{rel("document", "newdoc", "view", "user", "tom", "")},
+			codes.InvalidArgument,
+			"cannot write a relationship to permission `view`",
+		},
+		{
 			"write non-existing resource namespace",
 			nil,
 			[]*v1.Relationship{rel("notdocument", "newdoc", "parent", "folder", "afolder", "")},


### PR DESCRIPTION
We should be returning the definition name and the permission name

Also adds a test