### PR TITLE
Fix revision checking in memdb to allow for past `now`

### DIFF
--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -103,7 +103,7 @@ func (mdb *memdbDatastore) SnapshotReader(revisionRaw datastore.Revision) datast
 		return &memdbReader{nil, nil, fmt.Errorf("memdb datastore is not ready")}
 	}
 
-	if err := mdb.checkRevisionLocal(dr); err != nil {
+	if err := mdb.checkRevisionLocalCallerMustLock(dr); err != nil {
 		return &memdbReader{nil, nil, err}
 	}
 

--- a/internal/datastore/memdb/revisions.go
+++ b/internal/datastore/memdb/revisions.go
@@ -38,7 +38,10 @@ func (mdb *memdbDatastore) newRevisionID() revision.Decimal {
 }
 
 func (mdb *memdbDatastore) HeadRevision(ctx context.Context) (datastore.Revision, error) {
-	head, err := mdb.headRevision(ctx)
+	mdb.RLock()
+	defer mdb.RUnlock()
+
+	head, err := mdb.headRevisionNoLock()
 	if err != nil {
 		return nil, err
 	}
@@ -46,10 +49,7 @@ func (mdb *memdbDatastore) HeadRevision(ctx context.Context) (datastore.Revision
 	return revision.NewFromDecimal(head), nil
 }
 
-func (mdb *memdbDatastore) headRevision(ctx context.Context) (decimal.Decimal, error) {
-	mdb.Lock()
-	defer mdb.Unlock()
-
+func (mdb *memdbDatastore) headRevisionNoLock() (decimal.Decimal, error) {
 	return mdb.revisions[len(mdb.revisions)-1].revision, nil
 }
 
@@ -59,23 +59,41 @@ func (mdb *memdbDatastore) OptimizedRevision(ctx context.Context) (datastore.Rev
 }
 
 func (mdb *memdbDatastore) CheckRevision(ctx context.Context, revisionRaw datastore.Revision) error {
+	mdb.RLock()
+	defer mdb.RUnlock()
+
 	dr, ok := revisionRaw.(revision.Decimal)
 	if !ok {
 		return datastore.NewInvalidRevisionErr(revisionRaw, datastore.CouldNotDetermineRevision)
 	}
-	return mdb.checkRevisionLocal(dr)
+	return mdb.checkRevisionLocalCallerMustLock(dr)
 }
 
-func (mdb *memdbDatastore) checkRevisionLocal(revisionRaw revision.Decimal) error {
+func (mdb *memdbDatastore) checkRevisionLocalCallerMustLock(revisionRaw revision.Decimal) error {
 	now := revisionFromTimestamp(time.Now().UTC())
 
-	if revisionRaw.GreaterThan(now) {
-		return datastore.NewInvalidRevisionErr(revisionRaw, datastore.CouldNotDetermineRevision)
-	}
-
+	// Ensure the revision has not fallen outside of the GC window. If it has, it is considered
+	// invalid.
 	oldest := revision.NewFromDecimal(now.Add(mdb.negativeGCWindow))
 	if revisionRaw.LessThan(oldest) {
 		return datastore.NewInvalidRevisionErr(revisionRaw, datastore.RevisionStale)
+	}
+
+	// If the revision <= now and later than the GC window, it is assumed to be valid, even if
+	// HEAD revision is behind it.
+	if revisionRaw.GreaterThan(now) {
+		// If the revision is in the "future", then check to ensure that it is <= of HEAD to handle
+		// the microsecond granularity on macos (see comment above in newRevisionID)
+		headRevision, err := mdb.headRevisionNoLock()
+		if err != nil {
+			return err
+		}
+
+		if revisionRaw.LessThanOrEqual(headRevision) {
+			return nil
+		}
+
+		return datastore.NewInvalidRevisionErr(revisionRaw, datastore.CouldNotDetermineRevision)
 	}
 
 	return nil


### PR DESCRIPTION
We need to allow for revision later than `now` due to our recent fix for time granularity on macos