### PR TITLE
Adjust estimated query count metric to only count dispatch if it was necessary

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -214,12 +214,9 @@ func (cc *ConcurrentChecker) checkDirect(ctx context.Context, crc currentRequest
 	hadDirectResult := false
 	hadDispatchedResult := false
 	defer (func() {
-		estimatedQueryCount := 0.0
-		if hadDirectResult {
-			estimatedQueryCount++
-		}
-		if hadDispatchedResult {
-			estimatedQueryCount++
+		estimatedQueryCount := 1.0
+		if !hadDirectResult && hadDispatchedResult {
+			estimatedQueryCount = 2
 		}
 		estimatedDirectDispatchQueryHistogram.Observe(estimatedQueryCount)
 	})()


### PR DESCRIPTION
This is a more accurate estimate