### PR TITLE
redesigns middlware options for RunnableServer

### DIFF
--- a/internal/services/integrationtesting/cert_test.go
+++ b/internal/services/integrationtesting/cert_test.go
@@ -136,18 +136,18 @@ func TestCertRotation(t *testing.T) {
 		server.WithDashboardAPI(util.HTTPServerConfig{Enabled: false}),
 		server.WithMetricsAPI(util.HTTPServerConfig{Enabled: false}),
 		server.WithDispatchServer(util.GRPCServerConfig{Enabled: false}),
+		server.SetReplaceDefaultUnaryMiddleware([]grpc.UnaryServerInterceptor{
+			datastoremw.UnaryServerInterceptor(ds),
+			consistency.UnaryServerInterceptor(),
+			servicespecific.UnaryServerInterceptor,
+		}),
+		server.SetReplaceDefaultStreamingMiddleware([]grpc.StreamServerInterceptor{
+			datastoremw.StreamServerInterceptor(ds),
+			consistency.StreamServerInterceptor(),
+			servicespecific.StreamServerInterceptor,
+		}),
 	).Complete(ctx)
 	require.NoError(t, err)
-
-	srv.SetMiddleware([]grpc.UnaryServerInterceptor{
-		datastoremw.UnaryServerInterceptor(ds),
-		consistency.UnaryServerInterceptor(),
-		servicespecific.UnaryServerInterceptor,
-	}, []grpc.StreamServerInterceptor{
-		datastoremw.StreamServerInterceptor(ds),
-		consistency.StreamServerInterceptor(),
-		servicespecific.StreamServerInterceptor,
-	})
 
 	wait := make(chan struct{}, 1)
 	go func() {

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -90,8 +90,12 @@ type Config struct {
 	MetricsAPI   util.HTTPServerConfig
 
 	// Middleware for grpc
-	UnaryMiddleware     []grpc.UnaryServerInterceptor
-	StreamingMiddleware []grpc.StreamServerInterceptor
+	PrependUnaryMiddleware            []grpc.UnaryServerInterceptor
+	PrependStreamingMiddleware        []grpc.StreamServerInterceptor
+	ReplaceDefaultUnaryMiddleware     []grpc.UnaryServerInterceptor
+	ReplaceDefaultStreamingMiddleware []grpc.StreamServerInterceptor
+	AppendUnaryMiddleware             []grpc.UnaryServerInterceptor
+	AppendStreamingMiddleware         []grpc.StreamServerInterceptor
 
 	// Middleware for dispatch
 	DispatchUnaryMiddleware     []grpc.UnaryServerInterceptor
@@ -238,9 +242,10 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		watchServiceOption = services.WatchServiceDisabled
 	}
 
-	if len(c.UnaryMiddleware) == 0 && len(c.StreamingMiddleware) == 0 {
-		c.UnaryMiddleware, c.StreamingMiddleware = DefaultMiddleware(log.Logger, c.GRPCAuthFunc, !c.DisableVersionResponse, dispatcher, ds)
+	defaultMiddlewareFunc := func() ([]grpc.UnaryServerInterceptor, []grpc.StreamServerInterceptor) {
+		return DefaultMiddleware(log.Logger, c.GRPCAuthFunc, !c.DisableVersionResponse, dispatcher, ds)
 	}
+	unaryMiddleware, streamingMiddleware := c.buildMiddleware(defaultMiddlewareFunc)
 
 	permSysConfig := v1svc.PermissionsServerConfig{
 		MaxPreconditionsCount: c.MaximumPreconditionCount,
@@ -318,8 +323,8 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		gatewayServer:       gatewayServer,
 		metricsServer:       metricsServer,
 		dashboardServer:     dashboardServer,
-		unaryMiddleware:     c.UnaryMiddleware,
-		streamingMiddleware: c.StreamingMiddleware,
+		unaryMiddleware:     unaryMiddleware,
+		streamingMiddleware: streamingMiddleware,
 		presharedKeys:       c.PresharedKey,
 		telemetryReporter:   reporter,
 		healthManager:       healthManager,
@@ -343,6 +348,39 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 			return nil
 		},
 	}, nil
+}
+
+func (c *Config) buildMiddleware(defaultMiddlewareFunc func() ([]grpc.UnaryServerInterceptor, []grpc.StreamServerInterceptor)) ([]grpc.UnaryServerInterceptor, []grpc.StreamServerInterceptor) {
+	var outputUnaryMiddleware []grpc.UnaryServerInterceptor
+	var outputStreamingMiddleware []grpc.StreamServerInterceptor
+
+	if defaultMiddlewareFunc != nil {
+		outputUnaryMiddleware, outputStreamingMiddleware = defaultMiddlewareFunc()
+	}
+	if len(c.ReplaceDefaultUnaryMiddleware) != 0 {
+		outputUnaryMiddleware = c.ReplaceDefaultUnaryMiddleware
+	}
+	if len(c.ReplaceDefaultStreamingMiddleware) != 0 {
+		outputStreamingMiddleware = c.ReplaceDefaultStreamingMiddleware
+	}
+	if len(c.PrependUnaryMiddleware) != 0 {
+		tempMiddlewareChain := make([]grpc.UnaryServerInterceptor, len(c.PrependUnaryMiddleware))
+		copy(tempMiddlewareChain, c.PrependUnaryMiddleware)
+		outputUnaryMiddleware = append(tempMiddlewareChain, outputUnaryMiddleware...) //nolint makezero
+	}
+	if len(c.PrependStreamingMiddleware) != 0 {
+		tempMiddlewareChain := make([]grpc.StreamServerInterceptor, len(c.PrependStreamingMiddleware))
+		copy(tempMiddlewareChain, c.PrependStreamingMiddleware)
+		outputStreamingMiddleware = append(tempMiddlewareChain, outputStreamingMiddleware...) //nolint makezero
+	}
+	if len(c.AppendUnaryMiddleware) != 0 {
+		outputUnaryMiddleware = append(outputUnaryMiddleware, c.AppendUnaryMiddleware...)
+	}
+	if len(c.AppendStreamingMiddleware) != 0 {
+		outputStreamingMiddleware = append(outputStreamingMiddleware, c.AppendStreamingMiddleware...)
+	}
+
+	return outputUnaryMiddleware, outputStreamingMiddleware
 }
 
 // initializeGateway Configures the gateway to serve HTTP
@@ -390,8 +428,6 @@ func (c *Config) initializeGateway(ctx context.Context) (util.RunnableHTTPServer
 // RunnableServer is a spicedb service set ready to run
 type RunnableServer interface {
 	Run(ctx context.Context) error
-	Middleware() ([]grpc.UnaryServerInterceptor, []grpc.StreamServerInterceptor)
-	SetMiddleware(unaryInterceptors []grpc.UnaryServerInterceptor, streamingInterceptors []grpc.StreamServerInterceptor) RunnableServer
 	GRPCDialContext(ctx context.Context, opts ...grpc.DialOption) (*grpc.ClientConn, error)
 	DispatchNetDialContext(ctx context.Context, s string) (net.Conn, error)
 }
@@ -412,16 +448,6 @@ type completedServerConfig struct {
 	streamingMiddleware []grpc.StreamServerInterceptor
 	presharedKeys       []string
 	closeFunc           func() error
-}
-
-func (c *completedServerConfig) Middleware() ([]grpc.UnaryServerInterceptor, []grpc.StreamServerInterceptor) {
-	return c.unaryMiddleware, c.streamingMiddleware
-}
-
-func (c *completedServerConfig) SetMiddleware(unaryInterceptors []grpc.UnaryServerInterceptor, streamingInterceptors []grpc.StreamServerInterceptor) RunnableServer {
-	c.unaryMiddleware = unaryInterceptors
-	c.streamingMiddleware = streamingInterceptors
-	return c
 }
 
 func (c *completedServerConfig) GRPCDialContext(ctx context.Context, opts ...grpc.DialOption) (*grpc.ClientConn, error) {

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -2,8 +2,11 @@ package server
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc"
 
 	"github.com/authzed/spicedb/internal/datastore/memdb"
 
@@ -28,4 +31,78 @@ func TestServerGracefulTermination(t *testing.T) {
 	}()
 	cancel()
 	<-ch
+}
+
+func TestBuildMiddleware(t *testing.T) {
+	// Test fully replacing default Middleware
+	var replaceUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 1}.unaryIntercept
+	var replaceStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("1")}.streamIntercept
+	replacedUnary := []grpc.UnaryServerInterceptor{replaceUnary}
+	replacedStream := []grpc.StreamServerInterceptor{replaceStream}
+	c := ConfigWithOptions(&Config{}, SetReplaceDefaultUnaryMiddleware(replacedUnary), SetReplaceDefaultStreamingMiddleware(replacedStream))
+	outUnary, outStream := c.buildMiddleware(nil)
+	require.Equal(t, replacedUnary, outUnary)
+	require.Equal(t, replacedStream, outStream)
+
+	// Test prepending and appending to Default middleware
+	var prependUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 2}.unaryIntercept
+	var prependStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("2")}.streamIntercept
+	var appendUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 3}.unaryIntercept
+	var appendStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("3")}.streamIntercept
+	defaultMiddlewareFunc := func() ([]grpc.UnaryServerInterceptor, []grpc.StreamServerInterceptor) {
+		return replacedUnary, replacedStream
+	}
+	c = ConfigWithOptions(&Config{},
+		SetPrependUnaryMiddleware([]grpc.UnaryServerInterceptor{prependUnary}),
+		SetPrependStreamingMiddleware([]grpc.StreamServerInterceptor{prependStream}),
+		SetAppendUnaryMiddleware([]grpc.UnaryServerInterceptor{appendUnary}),
+		SetAppendStreamingMiddleware([]grpc.StreamServerInterceptor{appendStream}),
+	)
+
+	// testing function equality is not possible, so we test the results of executing the functions
+
+	outUnary, outStream = c.buildMiddleware(defaultMiddlewareFunc)
+	require.Len(t, outUnary, 3)
+	require.Len(t, outStream, 3)
+	expectedPrepend, _ := prependUnary(context.Background(), nil, nil, nil)
+	receivedPrepend, _ := outUnary[0](context.Background(), nil, nil, nil)
+	require.Equal(t, expectedPrepend, receivedPrepend)
+	expectedReplace, _ := replaceUnary(context.Background(), nil, nil, nil)
+	receivedReplace, _ := outUnary[1](context.Background(), nil, nil, nil)
+	require.Equal(t, expectedReplace, receivedReplace)
+	expectedAppend, _ := appendUnary(context.Background(), nil, nil, nil)
+	receivedAppend, _ := outUnary[2](context.Background(), nil, nil, nil)
+	require.Equal(t, expectedAppend, receivedAppend)
+	require.NotEqual(t, receivedPrepend, receivedReplace)
+	require.NotEqual(t, receivedReplace, receivedAppend)
+	require.NotEqual(t, receivedPrepend, receivedAppend)
+
+	expectedPrepend = prependStream(nil, nil, nil, nil)
+	receivedPrepend = outStream[0](nil, nil, nil, nil)
+	require.Equal(t, expectedPrepend, receivedPrepend)
+	expectedReplace = replaceStream(nil, nil, nil, nil)
+	receivedReplace = outStream[1](nil, nil, nil, nil)
+	require.Equal(t, expectedReplace, receivedReplace)
+	expectedAppend = appendStream(nil, nil, nil, nil)
+	receivedAppend = outStream[2](nil, nil, nil, nil)
+	require.Equal(t, expectedAppend, receivedAppend)
+	require.NotEqual(t, receivedPrepend, receivedReplace)
+	require.NotEqual(t, receivedReplace, receivedAppend)
+	require.NotEqual(t, receivedPrepend, receivedAppend)
+}
+
+type mockUnaryInterceptor struct {
+	val int
+}
+
+func (m mockUnaryInterceptor) unaryIntercept(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return m.val, nil
+}
+
+type mockStreamInterceptor struct {
+	val error
+}
+
+func (m mockStreamInterceptor) streamIntercept(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return m.val
 }

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -58,8 +58,12 @@ func (c *Config) ToOption() ConfigOption {
 		to.ExperimentalCaveatsEnabled = c.ExperimentalCaveatsEnabled
 		to.DashboardAPI = c.DashboardAPI
 		to.MetricsAPI = c.MetricsAPI
-		to.UnaryMiddleware = c.UnaryMiddleware
-		to.StreamingMiddleware = c.StreamingMiddleware
+		to.PrependUnaryMiddleware = c.PrependUnaryMiddleware
+		to.PrependStreamingMiddleware = c.PrependStreamingMiddleware
+		to.ReplaceDefaultUnaryMiddleware = c.ReplaceDefaultUnaryMiddleware
+		to.ReplaceDefaultStreamingMiddleware = c.ReplaceDefaultStreamingMiddleware
+		to.AppendUnaryMiddleware = c.AppendUnaryMiddleware
+		to.AppendStreamingMiddleware = c.AppendStreamingMiddleware
 		to.DispatchUnaryMiddleware = c.DispatchUnaryMiddleware
 		to.DispatchStreamingMiddleware = c.DispatchStreamingMiddleware
 		to.SilentlyDisableTelemetry = c.SilentlyDisableTelemetry
@@ -315,31 +319,87 @@ func WithMetricsAPI(metricsAPI util.HTTPServerConfig) ConfigOption {
 	}
 }
 
-// WithUnaryMiddleware returns an option that can append UnaryMiddlewares to Config.UnaryMiddleware
-func WithUnaryMiddleware(unaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
+// WithPrependUnaryMiddleware returns an option that can append PrependUnaryMiddlewares to Config.PrependUnaryMiddleware
+func WithPrependUnaryMiddleware(prependUnaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
 	return func(c *Config) {
-		c.UnaryMiddleware = append(c.UnaryMiddleware, unaryMiddleware)
+		c.PrependUnaryMiddleware = append(c.PrependUnaryMiddleware, prependUnaryMiddleware)
 	}
 }
 
-// SetUnaryMiddleware returns an option that can set UnaryMiddleware on a Config
-func SetUnaryMiddleware(unaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
+// SetPrependUnaryMiddleware returns an option that can set PrependUnaryMiddleware on a Config
+func SetPrependUnaryMiddleware(prependUnaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
 	return func(c *Config) {
-		c.UnaryMiddleware = unaryMiddleware
+		c.PrependUnaryMiddleware = prependUnaryMiddleware
 	}
 }
 
-// WithStreamingMiddleware returns an option that can append StreamingMiddlewares to Config.StreamingMiddleware
-func WithStreamingMiddleware(streamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
+// WithPrependStreamingMiddleware returns an option that can append PrependStreamingMiddlewares to Config.PrependStreamingMiddleware
+func WithPrependStreamingMiddleware(prependStreamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
 	return func(c *Config) {
-		c.StreamingMiddleware = append(c.StreamingMiddleware, streamingMiddleware)
+		c.PrependStreamingMiddleware = append(c.PrependStreamingMiddleware, prependStreamingMiddleware)
 	}
 }
 
-// SetStreamingMiddleware returns an option that can set StreamingMiddleware on a Config
-func SetStreamingMiddleware(streamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
+// SetPrependStreamingMiddleware returns an option that can set PrependStreamingMiddleware on a Config
+func SetPrependStreamingMiddleware(prependStreamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
 	return func(c *Config) {
-		c.StreamingMiddleware = streamingMiddleware
+		c.PrependStreamingMiddleware = prependStreamingMiddleware
+	}
+}
+
+// WithReplaceDefaultUnaryMiddleware returns an option that can append ReplaceDefaultUnaryMiddlewares to Config.ReplaceDefaultUnaryMiddleware
+func WithReplaceDefaultUnaryMiddleware(replaceDefaultUnaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.ReplaceDefaultUnaryMiddleware = append(c.ReplaceDefaultUnaryMiddleware, replaceDefaultUnaryMiddleware)
+	}
+}
+
+// SetReplaceDefaultUnaryMiddleware returns an option that can set ReplaceDefaultUnaryMiddleware on a Config
+func SetReplaceDefaultUnaryMiddleware(replaceDefaultUnaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.ReplaceDefaultUnaryMiddleware = replaceDefaultUnaryMiddleware
+	}
+}
+
+// WithReplaceDefaultStreamingMiddleware returns an option that can append ReplaceDefaultStreamingMiddlewares to Config.ReplaceDefaultStreamingMiddleware
+func WithReplaceDefaultStreamingMiddleware(replaceDefaultStreamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.ReplaceDefaultStreamingMiddleware = append(c.ReplaceDefaultStreamingMiddleware, replaceDefaultStreamingMiddleware)
+	}
+}
+
+// SetReplaceDefaultStreamingMiddleware returns an option that can set ReplaceDefaultStreamingMiddleware on a Config
+func SetReplaceDefaultStreamingMiddleware(replaceDefaultStreamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.ReplaceDefaultStreamingMiddleware = replaceDefaultStreamingMiddleware
+	}
+}
+
+// WithAppendUnaryMiddleware returns an option that can append AppendUnaryMiddlewares to Config.AppendUnaryMiddleware
+func WithAppendUnaryMiddleware(appendUnaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.AppendUnaryMiddleware = append(c.AppendUnaryMiddleware, appendUnaryMiddleware)
+	}
+}
+
+// SetAppendUnaryMiddleware returns an option that can set AppendUnaryMiddleware on a Config
+func SetAppendUnaryMiddleware(appendUnaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.AppendUnaryMiddleware = appendUnaryMiddleware
+	}
+}
+
+// WithAppendStreamingMiddleware returns an option that can append AppendStreamingMiddlewares to Config.AppendStreamingMiddleware
+func WithAppendStreamingMiddleware(appendStreamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.AppendStreamingMiddleware = append(c.AppendStreamingMiddleware, appendStreamingMiddleware)
+	}
+}
+
+// SetAppendStreamingMiddleware returns an option that can set AppendStreamingMiddleware on a Config
+func SetAppendStreamingMiddleware(appendStreamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.AppendStreamingMiddleware = appendStreamingMiddleware
 	}
 }
 


### PR DESCRIPTION
the methods to change middleware in `RunnableServer` were introduced because we needed a mechanism to be able to retain the default middleware and expand it.

This new design is explicit about it, by providing different operations to change the middleware layer: prepend, replace and append.

This allows us to remove the methods from `RunnableServer` and configure the final middleware chain through the `server.Config`, instead of having to do it in 2 different steps