### PR TITLE
redesigns middlware options for RunnableServer v2

### DIFF
--- a/internal/services/integrationtesting/cert_test.go
+++ b/internal/services/integrationtesting/cert_test.go
@@ -136,18 +136,18 @@ func TestCertRotation(t *testing.T) {
 		server.WithDashboardAPI(util.HTTPServerConfig{Enabled: false}),
 		server.WithMetricsAPI(util.HTTPServerConfig{Enabled: false}),
 		server.WithDispatchServer(util.GRPCServerConfig{Enabled: false}),
+		server.SetReplaceDefaultUnaryMiddleware([]grpc.UnaryServerInterceptor{
+			datastoremw.UnaryServerInterceptor(ds),
+			consistency.UnaryServerInterceptor(),
+			servicespecific.UnaryServerInterceptor,
+		}),
+		server.SetReplaceDefaultStreamingMiddleware([]grpc.StreamServerInterceptor{
+			datastoremw.StreamServerInterceptor(ds),
+			consistency.StreamServerInterceptor(),
+			servicespecific.StreamServerInterceptor,
+		}),
 	).Complete(ctx)
 	require.NoError(t, err)
-
-	srv.SetMiddleware([]grpc.UnaryServerInterceptor{
-		datastoremw.UnaryServerInterceptor(ds),
-		consistency.UnaryServerInterceptor(),
-		servicespecific.UnaryServerInterceptor,
-	}, []grpc.StreamServerInterceptor{
-		datastoremw.StreamServerInterceptor(ds),
-		consistency.StreamServerInterceptor(),
-		servicespecific.StreamServerInterceptor,
-	})
 
 	wait := make(chan struct{}, 1)
 	go func() {

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/authzed/spicedb/internal/middleware/servicespecific"
+
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -11,7 +13,6 @@ import (
 	"github.com/authzed/spicedb/internal/dispatch/graph"
 	"github.com/authzed/spicedb/internal/middleware/consistency"
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
-	"github.com/authzed/spicedb/internal/middleware/servicespecific"
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/util"
 	"github.com/authzed/spicedb/pkg/datastore"
@@ -70,17 +71,32 @@ func NewTestServerWithConfig(require *require.Assertions,
 		server.WithMetricsAPI(util.HTTPServerConfig{Enabled: false}),
 		server.WithDispatchServer(util.GRPCServerConfig{Enabled: false}),
 		server.WithExperimentalCaveatsEnabled(true),
-		server.SetReplaceDefaultUnaryMiddleware([]grpc.UnaryServerInterceptor{
-			logging.UnaryServerInterceptor(),
-			datastoremw.UnaryServerInterceptor(ds),
-			consistency.UnaryServerInterceptor(),
-			servicespecific.UnaryServerInterceptor,
-		}),
-		server.SetReplaceDefaultStreamingMiddleware([]grpc.StreamServerInterceptor{
-			logging.StreamServerInterceptor(),
-			datastoremw.StreamServerInterceptor(ds),
-			consistency.StreamServerInterceptor(),
-			servicespecific.StreamServerInterceptor,
+		server.SetMiddlewareModification([]server.MiddlewareModification{
+			{
+				Operation: server.OperationReplaceAllUnsafe,
+				Middlewares: []server.ReferenceableMiddleware{
+					{
+						Name:                "logging",
+						UnaryMiddleware:     logging.UnaryServerInterceptor(),
+						StreamingMiddleware: logging.StreamServerInterceptor(),
+					},
+					{
+						Name:                "datastore",
+						UnaryMiddleware:     datastoremw.UnaryServerInterceptor(ds),
+						StreamingMiddleware: datastoremw.StreamServerInterceptor(ds),
+					},
+					{
+						Name:                "consistency",
+						UnaryMiddleware:     consistency.UnaryServerInterceptor(),
+						StreamingMiddleware: consistency.StreamServerInterceptor(),
+					},
+					{
+						Name:                "servicespecific",
+						UnaryMiddleware:     servicespecific.UnaryServerInterceptor,
+						StreamingMiddleware: servicespecific.StreamServerInterceptor,
+					},
+				},
+			},
 		}),
 	).Complete(ctx)
 	require.NoError(err)

--- a/pkg/cmd/server/middleware.go
+++ b/pkg/cmd/server/middleware.go
@@ -1,0 +1,218 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/authzed/spicedb/pkg/util"
+
+	"google.golang.org/grpc"
+)
+
+// MiddlewareChain describes an ordered sequence of middlewares that can be modified
+// with one or more MiddlewareModification. This struct is used to facilitate the
+// creation and modification of gRPC middleware chains
+type MiddlewareChain struct {
+	chain []ReferenceableMiddleware
+}
+
+// NewMiddlewareChain creates a new middleware chain given zero or more named middlewares.
+// An error will be returned in case validation of the NamedMiddlewares fail.
+func NewMiddlewareChain(mw ...ReferenceableMiddleware) (MiddlewareChain, error) {
+	if err := validate(mw); err != nil {
+		return MiddlewareChain{}, err
+	}
+	return MiddlewareChain{chain: mw}, nil
+}
+
+// MiddlewareModification describes an operation to modify a MiddlewareChain
+type MiddlewareModification struct {
+	// DependencyMiddlewareName is used to define with respect to which middleware an operation is performed.
+	// Dependency is not required for ReplaceAll operation
+	DependencyMiddlewareName string
+
+	// Operation describes the type of operation to be performed
+	Operation MiddlewareOperation
+
+	// Middlewares are the named middlewares that will be part of this modification
+	Middlewares []ReferenceableMiddleware
+}
+
+func (mm MiddlewareModification) validate() error {
+	if mm.Operation != OperationReplaceAllUnsafe && mm.DependencyMiddlewareName == "" {
+		return fmt.Errorf("cannot perform middleware modification without a dependency: %v", mm)
+	}
+	if err := validate(mm.Middlewares); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validate(mws []ReferenceableMiddleware) error {
+	names := util.NewSet[string]()
+	for _, mw := range mws {
+		if mw.Name == "" {
+			return fmt.Errorf("unnamed middleware found: %v", mw)
+		}
+		if !names.Add(mw.Name) {
+			return fmt.Errorf("found middleware with duplicate names in middleware modification: %s", mw.Name)
+		}
+	}
+	return nil
+}
+
+// ReferenceableMiddleware represents a middleware in a MiddlewareChain. Middlewares can
+// be referenced by name in MiddlewareModification, for example "append after middleware abc".
+// Internal middlewares can also be referenced for operations like append or prepend, but cannot
+// be referenced for replace operations. Middlewares must always be named.
+type ReferenceableMiddleware struct {
+	Name                string
+	Internal            bool
+	UnaryMiddleware     grpc.UnaryServerInterceptor
+	StreamingMiddleware grpc.StreamServerInterceptor
+}
+
+// MiddlewareOperation describes the type of operation that will be performed in a MiddlewareModification
+type MiddlewareOperation int
+
+const (
+	// OperationPrepend adds the middlewares right before the referenced dependency
+	OperationPrepend MiddlewareOperation = iota
+
+	// OperationReplace substitutes the referenced dependency with the middlewares of a modification.
+	// If replaced with an empty modification, this acts like a deletion
+	OperationReplace
+
+	// OperationAppend adds the middlewares right after the referenced dependency
+	OperationAppend
+
+	// OperationReplaceAllUnsafe replaces all middlewares in a chain with those in the modification
+	// this operation is only meant to be used in tests.
+	OperationReplaceAllUnsafe
+)
+
+// Names returns the names of the middlewares in a chain
+func (mc *MiddlewareChain) Names() *util.Set[string] {
+	names := util.NewSet[string]()
+	for _, mw := range mc.chain {
+		names.Add(mw.Name)
+	}
+	return names
+}
+
+// ToGRPCInterceptors generates slices of gRPC interceptors ready to be installed in a server
+func (mc *MiddlewareChain) ToGRPCInterceptors() ([]grpc.UnaryServerInterceptor, []grpc.StreamServerInterceptor) {
+	unaryInterceptors := make([]grpc.UnaryServerInterceptor, 0, len(mc.chain))
+	streamingInterceptors := make([]grpc.StreamServerInterceptor, 0, len(mc.chain))
+	for _, mw := range mc.chain {
+		unaryInterceptors = append(unaryInterceptors, mw.UnaryMiddleware)
+		streamingInterceptors = append(streamingInterceptors, mw.StreamingMiddleware)
+	}
+	return unaryInterceptors, streamingInterceptors
+}
+
+func (mc *MiddlewareChain) prepend(mod MiddlewareModification) error {
+	if err := mc.validate(mod); err != nil {
+		return err
+	}
+
+	newChain := make([]ReferenceableMiddleware, 0, len(mc.chain))
+	for _, mw := range mc.chain {
+		if mw.Name == mod.DependencyMiddlewareName {
+			newChain = append(newChain, mod.Middlewares...)
+		}
+		newChain = append(newChain, mw)
+	}
+	mc.chain = newChain
+	return nil
+}
+
+func (mc *MiddlewareChain) replace(mod MiddlewareModification) error {
+	if err := mc.validate(mod); err != nil {
+		return err
+	}
+	newChain := make([]ReferenceableMiddleware, 0, len(mc.chain))
+	for _, mw := range mc.chain {
+		if mw.Name == mod.DependencyMiddlewareName {
+			newChain = append(newChain, mod.Middlewares...)
+		} else {
+			newChain = append(newChain, mw)
+		}
+	}
+	mc.chain = newChain
+	return nil
+}
+
+func (mc *MiddlewareChain) append(mod MiddlewareModification) error {
+	if err := mc.validate(mod); err != nil {
+		return err
+	}
+
+	newChain := make([]ReferenceableMiddleware, 0, len(mc.chain))
+	for _, mw := range mc.chain {
+		newChain = append(newChain, mw)
+		if mw.Name == mod.DependencyMiddlewareName {
+			newChain = append(newChain, mod.Middlewares...)
+		}
+	}
+	mc.chain = newChain
+	return nil
+}
+
+func (mc *MiddlewareChain) replaceAll(mod MiddlewareModification) error {
+	if err := mod.validate(); err != nil {
+		return err
+	}
+	mc.chain = mod.Middlewares
+	return nil
+}
+
+func (mc *MiddlewareChain) validate(mod MiddlewareModification) error {
+	if err := mod.validate(); err != nil {
+		return err
+	}
+
+	// prevent referencing non-existing middlewares
+	existingNames := mc.Names()
+	if !existingNames.Has(mod.DependencyMiddlewareName) {
+		return fmt.Errorf("referenced dependency does not exist on chain: %s", mod.DependencyMiddlewareName)
+	}
+
+	// prevent appending/prepending a duplicate middleware
+	for _, middleware := range mod.Middlewares {
+		if existingNames.Has(middleware.Name) && mod.DependencyMiddlewareName == middleware.Name && mod.Operation != OperationReplace {
+			return fmt.Errorf("modification will cause a duplicate in chain: %s", middleware.Name)
+		}
+	}
+
+	// prevent replacing an internal middleware
+	for _, mw := range mc.chain {
+		if mw.Internal && mw.Name == mod.DependencyMiddlewareName && mod.Operation == OperationReplace {
+			return fmt.Errorf("modification attempts to replace an internal middleware: %s", mw.Name)
+		}
+	}
+	return nil
+}
+
+func (mc *MiddlewareChain) modify(modifications ...MiddlewareModification) error {
+	for _, mod := range modifications {
+		switch mod.Operation {
+		case OperationPrepend:
+			if err := mc.prepend(mod); err != nil {
+				return err
+			}
+		case OperationReplace:
+			if err := mc.replace(mod); err != nil {
+				return err
+			}
+		case OperationReplaceAllUnsafe:
+			if err := mc.replaceAll(mod); err != nil {
+				return err
+			}
+		case OperationAppend:
+			if err := mc.append(mod); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/server/middleware_test.go
+++ b/pkg/cmd/server/middleware_test.go
@@ -1,0 +1,393 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestInvalidModification(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		mod  MiddlewareModification
+		err  string
+	}{
+		{
+			name: "invalid operation without dependency",
+			mod: MiddlewareModification{
+				Operation: OperationReplace,
+				Middlewares: []ReferenceableMiddleware{
+					{
+						UnaryMiddleware:     nil,
+						StreamingMiddleware: nil,
+					},
+				},
+			},
+			err: "without a dependency",
+		},
+		{
+			name: "valid replace all without dependency",
+			mod: MiddlewareModification{
+				Operation: OperationReplaceAllUnsafe,
+				Middlewares: []ReferenceableMiddleware{
+					{
+						Name:                "foobar",
+						UnaryMiddleware:     nil,
+						StreamingMiddleware: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "invalid unnamed middleware",
+			mod: MiddlewareModification{
+				Operation:                OperationAppend,
+				DependencyMiddlewareName: "foobar",
+				Middlewares: []ReferenceableMiddleware{
+					{
+						UnaryMiddleware:     nil,
+						StreamingMiddleware: nil,
+					},
+				},
+			},
+			err: "unnamed middleware",
+		},
+		{
+			name: "invalid modification with duplicate middlewares",
+			mod: MiddlewareModification{
+				Operation:                OperationAppend,
+				DependencyMiddlewareName: "foobar",
+				Middlewares: []ReferenceableMiddleware{
+					{
+						Name:                "foo",
+						UnaryMiddleware:     nil,
+						StreamingMiddleware: nil,
+					},
+					{
+						Name:                "foo",
+						UnaryMiddleware:     nil,
+						StreamingMiddleware: nil,
+					},
+				},
+			},
+			err: "duplicate names in middleware modification",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.mod.validate()
+			if tt.err != "" {
+				require.ErrorContains(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewMiddlewareChain(t *testing.T) {
+	mc, err := NewMiddlewareChain(ReferenceableMiddleware{
+		Name:                "foobar",
+		UnaryMiddleware:     nil,
+		StreamingMiddleware: nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, mc.chain, 1)
+
+	_, err = NewMiddlewareChain(ReferenceableMiddleware{
+		UnaryMiddleware:     nil,
+		StreamingMiddleware: nil,
+	})
+	require.ErrorContains(t, err, "unnamed middleware")
+}
+
+func TestChainValidate(t *testing.T) {
+	mc, err := NewMiddlewareChain(ReferenceableMiddleware{
+		Name:                "public",
+		UnaryMiddleware:     nil,
+		StreamingMiddleware: nil,
+	}, ReferenceableMiddleware{
+		Name:                "internal",
+		Internal:            true,
+		UnaryMiddleware:     nil,
+		StreamingMiddleware: nil,
+	})
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name string
+		mod  MiddlewareModification
+		err  string
+	}{
+		{
+			name: "invalid modification on non-existing dependency",
+			mod: MiddlewareModification{
+				Operation:                OperationReplace,
+				DependencyMiddlewareName: "doesnotexist",
+			},
+			err: "dependency does not exist",
+		},
+		{
+			name: "invalid modification that causes a duplicate",
+			mod: MiddlewareModification{
+				Operation:                OperationAppend,
+				DependencyMiddlewareName: "public",
+				Middlewares: []ReferenceableMiddleware{
+					{
+						Name:                "public",
+						UnaryMiddleware:     nil,
+						StreamingMiddleware: nil,
+					},
+				},
+			},
+			err: "will cause a duplicate",
+		},
+		{
+			name: "invalid replace of an internal middlewares",
+			mod: MiddlewareModification{
+				Operation:                OperationReplace,
+				DependencyMiddlewareName: "internal",
+				Middlewares: []ReferenceableMiddleware{
+					{
+						Name:                "foobar",
+						UnaryMiddleware:     nil,
+						StreamingMiddleware: nil,
+					},
+				},
+			},
+			err: "attempts to replace an internal middleware",
+		},
+		{
+			name: "valid replace of a public middleware",
+			mod: MiddlewareModification{
+				Operation:                OperationReplace,
+				DependencyMiddlewareName: "public",
+				Middlewares: []ReferenceableMiddleware{
+					{
+						Name:                "foobar",
+						UnaryMiddleware:     nil,
+						StreamingMiddleware: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "valid replace of a public middleware with same name",
+			mod: MiddlewareModification{
+				Operation:                OperationReplace,
+				DependencyMiddlewareName: "public",
+				Middlewares: []ReferenceableMiddleware{
+					{
+						Name:                "public",
+						UnaryMiddleware:     nil,
+						StreamingMiddleware: nil,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := mc.validate(tt.mod)
+			if tt.err != "" {
+				require.ErrorContains(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReplaceAllMiddleware(t *testing.T) {
+	// Test fully replacing default Middleware
+	var replaceUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 1}.unaryIntercept
+	var replaceStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("1")}.streamIntercept
+	mod := MiddlewareModification{
+		Operation: OperationReplaceAllUnsafe,
+		Middlewares: []ReferenceableMiddleware{
+			{
+				Name:                "foobar",
+				UnaryMiddleware:     replaceUnary,
+				StreamingMiddleware: replaceStream,
+			},
+		},
+	}
+
+	mc, err := NewMiddlewareChain()
+	require.NoError(t, err)
+
+	err = mc.modify(mod)
+	require.NoError(t, err)
+
+	outUnary, outStream := mc.ToGRPCInterceptors()
+	require.NoError(t, err)
+
+	expectedReplaceUnary, _ := replaceUnary(context.Background(), nil, nil, nil)
+	receivedReplaceUnary, _ := outUnary[0](context.Background(), nil, nil, nil)
+	expectedReplaceStreaming := replaceStream(nil, nil, nil, nil)
+	receivedReplaceStreaming := outStream[0](nil, nil, nil, nil)
+	require.Equal(t, expectedReplaceUnary, receivedReplaceUnary)
+	require.Equal(t, expectedReplaceStreaming, receivedReplaceStreaming)
+}
+
+func TestPrependMiddleware(t *testing.T) {
+	// Test prepending and appending to Default middleware
+	var replaceUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 1}.unaryIntercept
+	var replaceStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("1")}.streamIntercept
+	var prependUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 2}.unaryIntercept
+	var prependStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("2")}.streamIntercept
+	defaultMiddleware, err := NewMiddlewareChain(
+		ReferenceableMiddleware{
+			Name:                "foobar",
+			UnaryMiddleware:     replaceUnary,
+			StreamingMiddleware: replaceStream,
+		})
+	require.NoError(t, err)
+
+	mod := MiddlewareModification{
+		Operation:                OperationPrepend,
+		DependencyMiddlewareName: "foobar",
+		Middlewares: []ReferenceableMiddleware{
+			{
+				Name:                "prepended",
+				UnaryMiddleware:     prependUnary,
+				StreamingMiddleware: prependStream,
+			},
+		},
+	}
+	err = defaultMiddleware.modify(mod)
+	require.NoError(t, err)
+
+	// testing function equality is not possible, so we test the results of executing the functions
+	outUnary, outStream := defaultMiddleware.ToGRPCInterceptors()
+	require.NoError(t, err)
+	require.Len(t, outUnary, 2)
+	require.Len(t, outStream, 2)
+
+	expectedPrepend, _ := prependUnary(context.Background(), nil, nil, nil)
+	receivedPrepend, _ := outUnary[0](context.Background(), nil, nil, nil)
+	require.Equal(t, expectedPrepend, receivedPrepend)
+
+	expectedReplace, _ := replaceUnary(context.Background(), nil, nil, nil)
+	receivedReplace, _ := outUnary[1](context.Background(), nil, nil, nil)
+	require.Equal(t, expectedReplace, receivedReplace)
+	require.NotEqual(t, receivedPrepend, receivedReplace)
+
+	expectedPrepend = prependStream(nil, nil, nil, nil)
+	receivedPrepend = outStream[0](nil, nil, nil, nil)
+	require.Equal(t, expectedPrepend, receivedPrepend)
+
+	expectedReplace = replaceStream(nil, nil, nil, nil)
+	receivedReplace = outStream[1](nil, nil, nil, nil)
+	require.Equal(t, expectedReplace, receivedReplace)
+	require.NotEqual(t, receivedPrepend, receivedReplace)
+}
+
+func TestAppendMiddleware(t *testing.T) {
+	// Test prepending and appending to Default middleware
+	var replaceUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 1}.unaryIntercept
+	var replaceStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("1")}.streamIntercept
+	var appendUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 3}.unaryIntercept
+	var appendStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("3")}.streamIntercept
+	defaultMiddleware := &MiddlewareChain{
+		chain: []ReferenceableMiddleware{
+			{
+				Name:                "foobar",
+				UnaryMiddleware:     replaceUnary,
+				StreamingMiddleware: replaceStream,
+			},
+		},
+	}
+	mod := MiddlewareModification{
+		Operation:                OperationAppend,
+		DependencyMiddlewareName: "foobar",
+		Middlewares: []ReferenceableMiddleware{
+			{
+				Name:                "appended",
+				UnaryMiddleware:     appendUnary,
+				StreamingMiddleware: appendStream,
+			},
+		},
+	}
+	err := defaultMiddleware.modify(mod)
+	require.NoError(t, err)
+
+	// testing function equality is not possible, so we test the results of executing the functions
+	outUnary, outStream := defaultMiddleware.ToGRPCInterceptors()
+	require.NoError(t, err)
+	require.Len(t, outUnary, 2)
+	require.Len(t, outStream, 2)
+
+	expectedReplace, _ := replaceUnary(context.Background(), nil, nil, nil)
+	receivedReplace, _ := outUnary[0](context.Background(), nil, nil, nil)
+	expectedAppend, _ := appendUnary(context.Background(), nil, nil, nil)
+	receivedAppend, _ := outUnary[1](context.Background(), nil, nil, nil)
+	require.Equal(t, expectedReplace, receivedReplace)
+	require.Equal(t, expectedAppend, receivedAppend)
+
+	expectedReplace = replaceStream(nil, nil, nil, nil)
+	receivedReplace = outStream[0](nil, nil, nil, nil)
+	expectedAppend = appendStream(nil, nil, nil, nil)
+	receivedAppend = outStream[1](context.Background(), nil, nil, nil)
+	require.Equal(t, expectedReplace, receivedReplace)
+	require.Equal(t, expectedAppend, receivedAppend)
+}
+
+func TestDeleteMiddleware(t *testing.T) {
+	defaultMiddleware := &MiddlewareChain{
+		chain: []ReferenceableMiddleware{
+			{
+				Name:                "foobar",
+				UnaryMiddleware:     mockUnaryInterceptor{}.unaryIntercept,
+				StreamingMiddleware: mockStreamInterceptor{}.streamIntercept,
+			},
+		},
+	}
+	mod := MiddlewareModification{
+		Operation:                OperationReplace,
+		DependencyMiddlewareName: "foobar",
+	}
+	err := defaultMiddleware.modify(mod)
+	require.NoError(t, err)
+
+	outUnary, outStream := defaultMiddleware.ToGRPCInterceptors()
+	require.NoError(t, err)
+	require.Len(t, outUnary, 0)
+	require.Len(t, outStream, 0)
+}
+
+func TestCannotReplaceInternalMiddleware(t *testing.T) {
+	defaultMiddleware := &MiddlewareChain{
+		chain: []ReferenceableMiddleware{
+			{
+				Name:                "foobar",
+				Internal:            true,
+				UnaryMiddleware:     mockUnaryInterceptor{}.unaryIntercept,
+				StreamingMiddleware: mockStreamInterceptor{}.streamIntercept,
+			},
+		},
+	}
+	mod := MiddlewareModification{
+		Operation:                OperationReplace,
+		DependencyMiddlewareName: "foobar",
+	}
+	err := defaultMiddleware.modify(mod)
+	require.ErrorContains(t, err, "replace an internal middleware")
+}
+
+type mockUnaryInterceptor struct {
+	val int
+}
+
+func (m mockUnaryInterceptor) unaryIntercept(_ context.Context, _ interface{}, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (resp interface{}, err error) {
+	return m.val, nil
+}
+
+type mockStreamInterceptor struct {
+	val error
+}
+
+func (m mockStreamInterceptor) streamIntercept(_ interface{}, _ grpc.ServerStream, _ *grpc.StreamServerInfo, _ grpc.StreamHandler) error {
+	return m.val
+}

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc"
-
 	"github.com/authzed/spicedb/internal/datastore/memdb"
+	"github.com/authzed/spicedb/internal/logging"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -20,6 +19,7 @@ func TestServerGracefulTermination(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ds, err := memdb.NewMemdbDatastore(0, 1*time.Second, 10*time.Second)
 	require.NoError(t, err)
+
 	c := ConfigWithOptions(&Config{}, WithPresharedKey("psk"), WithDatastore(ds))
 	rs, err := c.Complete(ctx)
 	require.NoError(t, err)
@@ -39,82 +39,61 @@ func TestServerGracefulTerminationOnError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ds, err := memdb.NewMemdbDatastore(0, 1*time.Second, 10*time.Second)
 	require.NoError(t, err)
+
 	c := ConfigWithOptions(&Config{}, WithPresharedKey("psk"), WithDatastore(ds))
 	cancel()
 	_, err = c.Complete(ctx)
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestBuildMiddleware(t *testing.T) {
-	// Test fully replacing default Middleware
-	var replaceUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 1}.unaryIntercept
-	var replaceStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("1")}.streamIntercept
-	replacedUnary := []grpc.UnaryServerInterceptor{replaceUnary}
-	replacedStream := []grpc.StreamServerInterceptor{replaceStream}
-	c := ConfigWithOptions(&Config{}, SetReplaceDefaultUnaryMiddleware(replacedUnary), SetReplaceDefaultStreamingMiddleware(replacedStream))
-	outUnary, outStream := c.buildMiddleware(nil)
-	require.Equal(t, replacedUnary, outUnary)
-	require.Equal(t, replacedStream, outStream)
+func TestReplaceMiddleware(t *testing.T) {
+	c := Config{MiddlewareModification: []MiddlewareModification{
+		{
+			Operation: OperationReplaceAllUnsafe,
+			Middlewares: []ReferenceableMiddleware{
+				{
+					Name:                "foobar",
+					UnaryMiddleware:     mockUnaryInterceptor{val: 1}.unaryIntercept,
+					StreamingMiddleware: mockStreamInterceptor{val: errors.New("hi")}.streamIntercept,
+				},
+			},
+		},
+	}}
+	unary, streaming, err := c.buildMiddleware(nil)
+	require.NoError(t, err)
+	require.Len(t, unary, 1)
+	require.Len(t, streaming, 1)
 
-	// Test prepending and appending to Default middleware
-	var prependUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 2}.unaryIntercept
-	var prependStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("2")}.streamIntercept
-	var appendUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 3}.unaryIntercept
-	var appendStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("3")}.streamIntercept
-	defaultMiddlewareFunc := func() ([]grpc.UnaryServerInterceptor, []grpc.StreamServerInterceptor) {
-		return replacedUnary, replacedStream
-	}
-	c = ConfigWithOptions(&Config{},
-		SetPrependUnaryMiddleware([]grpc.UnaryServerInterceptor{prependUnary}),
-		SetPrependStreamingMiddleware([]grpc.StreamServerInterceptor{prependStream}),
-		SetAppendUnaryMiddleware([]grpc.UnaryServerInterceptor{appendUnary}),
-		SetAppendStreamingMiddleware([]grpc.StreamServerInterceptor{appendStream}),
-	)
+	val, _ := unary[0](context.Background(), nil, nil, nil)
+	require.Equal(t, 1, val)
 
-	// testing function equality is not possible, so we test the results of executing the functions
-
-	outUnary, outStream = c.buildMiddleware(defaultMiddlewareFunc)
-	require.Len(t, outUnary, 3)
-	require.Len(t, outStream, 3)
-	expectedPrepend, _ := prependUnary(context.Background(), nil, nil, nil)
-	receivedPrepend, _ := outUnary[0](context.Background(), nil, nil, nil)
-	require.Equal(t, expectedPrepend, receivedPrepend)
-	expectedReplace, _ := replaceUnary(context.Background(), nil, nil, nil)
-	receivedReplace, _ := outUnary[1](context.Background(), nil, nil, nil)
-	require.Equal(t, expectedReplace, receivedReplace)
-	expectedAppend, _ := appendUnary(context.Background(), nil, nil, nil)
-	receivedAppend, _ := outUnary[2](context.Background(), nil, nil, nil)
-	require.Equal(t, expectedAppend, receivedAppend)
-	require.NotEqual(t, receivedPrepend, receivedReplace)
-	require.NotEqual(t, receivedReplace, receivedAppend)
-	require.NotEqual(t, receivedPrepend, receivedAppend)
-
-	expectedPrepend = prependStream(nil, nil, nil, nil)
-	receivedPrepend = outStream[0](nil, nil, nil, nil)
-	require.Equal(t, expectedPrepend, receivedPrepend)
-	expectedReplace = replaceStream(nil, nil, nil, nil)
-	receivedReplace = outStream[1](nil, nil, nil, nil)
-	require.Equal(t, expectedReplace, receivedReplace)
-	expectedAppend = appendStream(nil, nil, nil, nil)
-	receivedAppend = outStream[2](nil, nil, nil, nil)
-	require.Equal(t, expectedAppend, receivedAppend)
-	require.NotEqual(t, receivedPrepend, receivedReplace)
-	require.NotEqual(t, receivedReplace, receivedAppend)
-	require.NotEqual(t, receivedPrepend, receivedAppend)
+	err = streaming[0](context.Background(), nil, nil, nil)
+	require.ErrorContains(t, err, "hi")
 }
 
-type mockUnaryInterceptor struct {
-	val int
-}
+func TestModifyMiddleware(t *testing.T) {
+	c := Config{MiddlewareModification: []MiddlewareModification{
+		{
+			Operation:                OperationPrepend,
+			DependencyMiddlewareName: DefaultMiddlewareLog,
+			Middlewares: []ReferenceableMiddleware{
+				{
+					Name:                "foobar",
+					UnaryMiddleware:     mockUnaryInterceptor{val: 1}.unaryIntercept,
+					StreamingMiddleware: mockStreamInterceptor{val: errors.New("hi")}.streamIntercept,
+				},
+			},
+		},
+	}}
+	defaultMw := DefaultMiddleware(logging.Logger, nil, false, nil, nil)
+	unary, streaming, err := c.buildMiddleware(defaultMw)
+	require.NoError(t, err)
+	require.Len(t, unary, len(defaultMw.chain)+1)
+	require.Len(t, streaming, len(defaultMw.chain)+1)
 
-func (m mockUnaryInterceptor) unaryIntercept(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-	return m.val, nil
-}
+	val, _ := unary[1](context.Background(), nil, nil, nil)
+	require.Equal(t, 1, val)
 
-type mockStreamInterceptor struct {
-	val error
-}
-
-func (m mockStreamInterceptor) streamIntercept(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	return m.val
+	err = streaming[1](context.Background(), nil, nil, nil)
+	require.ErrorContains(t, err, "hi")
 }

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -2,8 +2,11 @@ package server
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc"
 
 	"github.com/authzed/spicedb/internal/datastore/memdb"
 
@@ -40,4 +43,78 @@ func TestServerGracefulTerminationOnError(t *testing.T) {
 	cancel()
 	_, err = c.Complete(ctx)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestBuildMiddleware(t *testing.T) {
+	// Test fully replacing default Middleware
+	var replaceUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 1}.unaryIntercept
+	var replaceStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("1")}.streamIntercept
+	replacedUnary := []grpc.UnaryServerInterceptor{replaceUnary}
+	replacedStream := []grpc.StreamServerInterceptor{replaceStream}
+	c := ConfigWithOptions(&Config{}, SetReplaceDefaultUnaryMiddleware(replacedUnary), SetReplaceDefaultStreamingMiddleware(replacedStream))
+	outUnary, outStream := c.buildMiddleware(nil)
+	require.Equal(t, replacedUnary, outUnary)
+	require.Equal(t, replacedStream, outStream)
+
+	// Test prepending and appending to Default middleware
+	var prependUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 2}.unaryIntercept
+	var prependStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("2")}.streamIntercept
+	var appendUnary grpc.UnaryServerInterceptor = mockUnaryInterceptor{val: 3}.unaryIntercept
+	var appendStream grpc.StreamServerInterceptor = mockStreamInterceptor{val: errors.New("3")}.streamIntercept
+	defaultMiddlewareFunc := func() ([]grpc.UnaryServerInterceptor, []grpc.StreamServerInterceptor) {
+		return replacedUnary, replacedStream
+	}
+	c = ConfigWithOptions(&Config{},
+		SetPrependUnaryMiddleware([]grpc.UnaryServerInterceptor{prependUnary}),
+		SetPrependStreamingMiddleware([]grpc.StreamServerInterceptor{prependStream}),
+		SetAppendUnaryMiddleware([]grpc.UnaryServerInterceptor{appendUnary}),
+		SetAppendStreamingMiddleware([]grpc.StreamServerInterceptor{appendStream}),
+	)
+
+	// testing function equality is not possible, so we test the results of executing the functions
+
+	outUnary, outStream = c.buildMiddleware(defaultMiddlewareFunc)
+	require.Len(t, outUnary, 3)
+	require.Len(t, outStream, 3)
+	expectedPrepend, _ := prependUnary(context.Background(), nil, nil, nil)
+	receivedPrepend, _ := outUnary[0](context.Background(), nil, nil, nil)
+	require.Equal(t, expectedPrepend, receivedPrepend)
+	expectedReplace, _ := replaceUnary(context.Background(), nil, nil, nil)
+	receivedReplace, _ := outUnary[1](context.Background(), nil, nil, nil)
+	require.Equal(t, expectedReplace, receivedReplace)
+	expectedAppend, _ := appendUnary(context.Background(), nil, nil, nil)
+	receivedAppend, _ := outUnary[2](context.Background(), nil, nil, nil)
+	require.Equal(t, expectedAppend, receivedAppend)
+	require.NotEqual(t, receivedPrepend, receivedReplace)
+	require.NotEqual(t, receivedReplace, receivedAppend)
+	require.NotEqual(t, receivedPrepend, receivedAppend)
+
+	expectedPrepend = prependStream(nil, nil, nil, nil)
+	receivedPrepend = outStream[0](nil, nil, nil, nil)
+	require.Equal(t, expectedPrepend, receivedPrepend)
+	expectedReplace = replaceStream(nil, nil, nil, nil)
+	receivedReplace = outStream[1](nil, nil, nil, nil)
+	require.Equal(t, expectedReplace, receivedReplace)
+	expectedAppend = appendStream(nil, nil, nil, nil)
+	receivedAppend = outStream[2](nil, nil, nil, nil)
+	require.Equal(t, expectedAppend, receivedAppend)
+	require.NotEqual(t, receivedPrepend, receivedReplace)
+	require.NotEqual(t, receivedReplace, receivedAppend)
+	require.NotEqual(t, receivedPrepend, receivedAppend)
+}
+
+type mockUnaryInterceptor struct {
+	val int
+}
+
+func (m mockUnaryInterceptor) unaryIntercept(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return m.val, nil
+}
+
+type mockStreamInterceptor struct {
+	val error
+}
+
+func (m mockStreamInterceptor) streamIntercept(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return m.val
 }

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -58,12 +58,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.ExperimentalCaveatsEnabled = c.ExperimentalCaveatsEnabled
 		to.DashboardAPI = c.DashboardAPI
 		to.MetricsAPI = c.MetricsAPI
-		to.PrependUnaryMiddleware = c.PrependUnaryMiddleware
-		to.PrependStreamingMiddleware = c.PrependStreamingMiddleware
-		to.ReplaceDefaultUnaryMiddleware = c.ReplaceDefaultUnaryMiddleware
-		to.ReplaceDefaultStreamingMiddleware = c.ReplaceDefaultStreamingMiddleware
-		to.AppendUnaryMiddleware = c.AppendUnaryMiddleware
-		to.AppendStreamingMiddleware = c.AppendStreamingMiddleware
+		to.MiddlewareModification = c.MiddlewareModification
 		to.DispatchUnaryMiddleware = c.DispatchUnaryMiddleware
 		to.DispatchStreamingMiddleware = c.DispatchStreamingMiddleware
 		to.SilentlyDisableTelemetry = c.SilentlyDisableTelemetry
@@ -319,87 +314,17 @@ func WithMetricsAPI(metricsAPI util.HTTPServerConfig) ConfigOption {
 	}
 }
 
-// WithPrependUnaryMiddleware returns an option that can append PrependUnaryMiddlewares to Config.PrependUnaryMiddleware
-func WithPrependUnaryMiddleware(prependUnaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
+// WithMiddlewareModification returns an option that can append MiddlewareModifications to Config.MiddlewareModification
+func WithMiddlewareModification(middlewareModification MiddlewareModification) ConfigOption {
 	return func(c *Config) {
-		c.PrependUnaryMiddleware = append(c.PrependUnaryMiddleware, prependUnaryMiddleware)
+		c.MiddlewareModification = append(c.MiddlewareModification, middlewareModification)
 	}
 }
 
-// SetPrependUnaryMiddleware returns an option that can set PrependUnaryMiddleware on a Config
-func SetPrependUnaryMiddleware(prependUnaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
+// SetMiddlewareModification returns an option that can set MiddlewareModification on a Config
+func SetMiddlewareModification(middlewareModification []MiddlewareModification) ConfigOption {
 	return func(c *Config) {
-		c.PrependUnaryMiddleware = prependUnaryMiddleware
-	}
-}
-
-// WithPrependStreamingMiddleware returns an option that can append PrependStreamingMiddlewares to Config.PrependStreamingMiddleware
-func WithPrependStreamingMiddleware(prependStreamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
-	return func(c *Config) {
-		c.PrependStreamingMiddleware = append(c.PrependStreamingMiddleware, prependStreamingMiddleware)
-	}
-}
-
-// SetPrependStreamingMiddleware returns an option that can set PrependStreamingMiddleware on a Config
-func SetPrependStreamingMiddleware(prependStreamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
-	return func(c *Config) {
-		c.PrependStreamingMiddleware = prependStreamingMiddleware
-	}
-}
-
-// WithReplaceDefaultUnaryMiddleware returns an option that can append ReplaceDefaultUnaryMiddlewares to Config.ReplaceDefaultUnaryMiddleware
-func WithReplaceDefaultUnaryMiddleware(replaceDefaultUnaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
-	return func(c *Config) {
-		c.ReplaceDefaultUnaryMiddleware = append(c.ReplaceDefaultUnaryMiddleware, replaceDefaultUnaryMiddleware)
-	}
-}
-
-// SetReplaceDefaultUnaryMiddleware returns an option that can set ReplaceDefaultUnaryMiddleware on a Config
-func SetReplaceDefaultUnaryMiddleware(replaceDefaultUnaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
-	return func(c *Config) {
-		c.ReplaceDefaultUnaryMiddleware = replaceDefaultUnaryMiddleware
-	}
-}
-
-// WithReplaceDefaultStreamingMiddleware returns an option that can append ReplaceDefaultStreamingMiddlewares to Config.ReplaceDefaultStreamingMiddleware
-func WithReplaceDefaultStreamingMiddleware(replaceDefaultStreamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
-	return func(c *Config) {
-		c.ReplaceDefaultStreamingMiddleware = append(c.ReplaceDefaultStreamingMiddleware, replaceDefaultStreamingMiddleware)
-	}
-}
-
-// SetReplaceDefaultStreamingMiddleware returns an option that can set ReplaceDefaultStreamingMiddleware on a Config
-func SetReplaceDefaultStreamingMiddleware(replaceDefaultStreamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
-	return func(c *Config) {
-		c.ReplaceDefaultStreamingMiddleware = replaceDefaultStreamingMiddleware
-	}
-}
-
-// WithAppendUnaryMiddleware returns an option that can append AppendUnaryMiddlewares to Config.AppendUnaryMiddleware
-func WithAppendUnaryMiddleware(appendUnaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
-	return func(c *Config) {
-		c.AppendUnaryMiddleware = append(c.AppendUnaryMiddleware, appendUnaryMiddleware)
-	}
-}
-
-// SetAppendUnaryMiddleware returns an option that can set AppendUnaryMiddleware on a Config
-func SetAppendUnaryMiddleware(appendUnaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
-	return func(c *Config) {
-		c.AppendUnaryMiddleware = appendUnaryMiddleware
-	}
-}
-
-// WithAppendStreamingMiddleware returns an option that can append AppendStreamingMiddlewares to Config.AppendStreamingMiddleware
-func WithAppendStreamingMiddleware(appendStreamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
-	return func(c *Config) {
-		c.AppendStreamingMiddleware = append(c.AppendStreamingMiddleware, appendStreamingMiddleware)
-	}
-}
-
-// SetAppendStreamingMiddleware returns an option that can set AppendStreamingMiddleware on a Config
-func SetAppendStreamingMiddleware(appendStreamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
-	return func(c *Config) {
-		c.AppendStreamingMiddleware = appendStreamingMiddleware
+		c.MiddlewareModification = middlewareModification
 	}
 }
 

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -58,8 +58,12 @@ func (c *Config) ToOption() ConfigOption {
 		to.ExperimentalCaveatsEnabled = c.ExperimentalCaveatsEnabled
 		to.DashboardAPI = c.DashboardAPI
 		to.MetricsAPI = c.MetricsAPI
-		to.UnaryMiddleware = c.UnaryMiddleware
-		to.StreamingMiddleware = c.StreamingMiddleware
+		to.PrependUnaryMiddleware = c.PrependUnaryMiddleware
+		to.PrependStreamingMiddleware = c.PrependStreamingMiddleware
+		to.ReplaceDefaultUnaryMiddleware = c.ReplaceDefaultUnaryMiddleware
+		to.ReplaceDefaultStreamingMiddleware = c.ReplaceDefaultStreamingMiddleware
+		to.AppendUnaryMiddleware = c.AppendUnaryMiddleware
+		to.AppendStreamingMiddleware = c.AppendStreamingMiddleware
 		to.DispatchUnaryMiddleware = c.DispatchUnaryMiddleware
 		to.DispatchStreamingMiddleware = c.DispatchStreamingMiddleware
 		to.SilentlyDisableTelemetry = c.SilentlyDisableTelemetry
@@ -315,31 +319,87 @@ func WithMetricsAPI(metricsAPI util.HTTPServerConfig) ConfigOption {
 	}
 }
 
-// WithUnaryMiddleware returns an option that can append UnaryMiddlewares to Config.UnaryMiddleware
-func WithUnaryMiddleware(unaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
+// WithPrependUnaryMiddleware returns an option that can append PrependUnaryMiddlewares to Config.PrependUnaryMiddleware
+func WithPrependUnaryMiddleware(prependUnaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
 	return func(c *Config) {
-		c.UnaryMiddleware = append(c.UnaryMiddleware, unaryMiddleware)
+		c.PrependUnaryMiddleware = append(c.PrependUnaryMiddleware, prependUnaryMiddleware)
 	}
 }
 
-// SetUnaryMiddleware returns an option that can set UnaryMiddleware on a Config
-func SetUnaryMiddleware(unaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
+// SetPrependUnaryMiddleware returns an option that can set PrependUnaryMiddleware on a Config
+func SetPrependUnaryMiddleware(prependUnaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
 	return func(c *Config) {
-		c.UnaryMiddleware = unaryMiddleware
+		c.PrependUnaryMiddleware = prependUnaryMiddleware
 	}
 }
 
-// WithStreamingMiddleware returns an option that can append StreamingMiddlewares to Config.StreamingMiddleware
-func WithStreamingMiddleware(streamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
+// WithPrependStreamingMiddleware returns an option that can append PrependStreamingMiddlewares to Config.PrependStreamingMiddleware
+func WithPrependStreamingMiddleware(prependStreamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
 	return func(c *Config) {
-		c.StreamingMiddleware = append(c.StreamingMiddleware, streamingMiddleware)
+		c.PrependStreamingMiddleware = append(c.PrependStreamingMiddleware, prependStreamingMiddleware)
 	}
 }
 
-// SetStreamingMiddleware returns an option that can set StreamingMiddleware on a Config
-func SetStreamingMiddleware(streamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
+// SetPrependStreamingMiddleware returns an option that can set PrependStreamingMiddleware on a Config
+func SetPrependStreamingMiddleware(prependStreamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
 	return func(c *Config) {
-		c.StreamingMiddleware = streamingMiddleware
+		c.PrependStreamingMiddleware = prependStreamingMiddleware
+	}
+}
+
+// WithReplaceDefaultUnaryMiddleware returns an option that can append ReplaceDefaultUnaryMiddlewares to Config.ReplaceDefaultUnaryMiddleware
+func WithReplaceDefaultUnaryMiddleware(replaceDefaultUnaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.ReplaceDefaultUnaryMiddleware = append(c.ReplaceDefaultUnaryMiddleware, replaceDefaultUnaryMiddleware)
+	}
+}
+
+// SetReplaceDefaultUnaryMiddleware returns an option that can set ReplaceDefaultUnaryMiddleware on a Config
+func SetReplaceDefaultUnaryMiddleware(replaceDefaultUnaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.ReplaceDefaultUnaryMiddleware = replaceDefaultUnaryMiddleware
+	}
+}
+
+// WithReplaceDefaultStreamingMiddleware returns an option that can append ReplaceDefaultStreamingMiddlewares to Config.ReplaceDefaultStreamingMiddleware
+func WithReplaceDefaultStreamingMiddleware(replaceDefaultStreamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.ReplaceDefaultStreamingMiddleware = append(c.ReplaceDefaultStreamingMiddleware, replaceDefaultStreamingMiddleware)
+	}
+}
+
+// SetReplaceDefaultStreamingMiddleware returns an option that can set ReplaceDefaultStreamingMiddleware on a Config
+func SetReplaceDefaultStreamingMiddleware(replaceDefaultStreamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.ReplaceDefaultStreamingMiddleware = replaceDefaultStreamingMiddleware
+	}
+}
+
+// WithAppendUnaryMiddleware returns an option that can append AppendUnaryMiddlewares to Config.AppendUnaryMiddleware
+func WithAppendUnaryMiddleware(appendUnaryMiddleware grpc.UnaryServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.AppendUnaryMiddleware = append(c.AppendUnaryMiddleware, appendUnaryMiddleware)
+	}
+}
+
+// SetAppendUnaryMiddleware returns an option that can set AppendUnaryMiddleware on a Config
+func SetAppendUnaryMiddleware(appendUnaryMiddleware []grpc.UnaryServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.AppendUnaryMiddleware = appendUnaryMiddleware
+	}
+}
+
+// WithAppendStreamingMiddleware returns an option that can append AppendStreamingMiddlewares to Config.AppendStreamingMiddleware
+func WithAppendStreamingMiddleware(appendStreamingMiddleware grpc.StreamServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.AppendStreamingMiddleware = append(c.AppendStreamingMiddleware, appendStreamingMiddleware)
+	}
+}
+
+// SetAppendStreamingMiddleware returns an option that can set AppendStreamingMiddleware on a Config
+func SetAppendStreamingMiddleware(appendStreamingMiddleware []grpc.StreamServerInterceptor) ConfigOption {
+	return func(c *Config) {
+		c.AppendStreamingMiddleware = appendStreamingMiddleware
 	}
 }
 


### PR DESCRIPTION
the methods to change middleware in `RunnableServer` were introduced because we needed a mechanism to be able to retain the default middleware and expand it.

This new design is explicit about it, by providing different operations to change the middleware layer: prepend, replace and append.

This allows us to remove the methods from `RunnableServer` and configure the final middleware chain through the `server.Config`, instead of having to do it in 2 different steps