### PR TITLE
Fix bug in reachable resources that was causing extra work

### DIFF
--- a/internal/graph/reachableresources.go
+++ b/internal/graph/reachableresources.go
@@ -246,6 +246,10 @@ func (crr *ConcurrentReachableResources) chunkedRedispatch(
 	it.Close()
 
 	if rsm.len() > 0 {
+		if rsm.len() > datastore.FilterMaximumIDCount {
+			return fmt.Errorf("found reachableresources chunk in excess of expected max size")
+		}
+
 		toBeHandled = append(toBeHandled, rsm)
 	}
 

--- a/internal/graph/reachableresources.go
+++ b/internal/graph/reachableresources.go
@@ -240,6 +240,7 @@ func (crr *ConcurrentReachableResources) chunkedRedispatch(
 		if rsm.len() == chunkSize {
 			chunkIndex++
 			toBeHandled = append(toBeHandled, rsm)
+			rsm = newResourcesSubjectMap(resourceType)
 		}
 	}
 	it.Close()


### PR DESCRIPTION
We need to instantiate a new resources subject map for each chunk, otherwise we just keep adding more work each dispatch