### PR TITLE
Add mention about PHP library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 SpiceDB is an open source database system for managing security-critical application permissions inspired by Google's [Zanzibar] paper.
 
 Developers create a schema that models their permissions requirements and use a [client library] to apply the schema to the database, insert data into the database, and query the data to efficiently check permissions in their applications.
+For PHP [this library](https://github.com/linkorb/spicedb-php) can be used.
 
 [client library]: https://github.com/orgs/authzed/repositories?q=client+library
 


### PR DESCRIPTION
There's a PHP client library based on REST protocol (because of issues with generation from proto 2 & PHP). Since client libraries are official repos under authzed organisation, but because it can be beneficial for PHP developers to use this library in order being able to manage app permissions maybe can be useful to have a link related to this library in README. If you have better idea how to mention PHP library in this repo - please let me know, I'm open to suggestions