### PR TITLE
Consistency test reimplementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/jackc/pgtype v1.12.0
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/johannesboyne/gofakes3 v0.0.0-20220314170512-33c13122505e
-	github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6
 	github.com/jzelinskie/cobrautil/v2 v2.0.0-20221215210038-3f120e7f595f
 	github.com/jzelinskie/stringz v0.0.1
 	github.com/lib/pq v1.10.7

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6 h1:OzCtZaD1uI5Fc1C+4oNAp7kZ4ibh5OIgxI29moH/IbE=
-github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6/go.mod h1:CEusGbCRDFcHX9EgEhPsgJX33kpp9CfSFRBAoSGOems=
 github.com/jzelinskie/cobrautil/v2 v2.0.0-20221215210038-3f120e7f595f h1:Roeu56yDjhb2yFC6/KupOm7V3qSf5YP7/JDOUeWOJXw=
 github.com/jzelinskie/cobrautil/v2 v2.0.0-20221215210038-3f120e7f595f/go.mod h1:iqQf0oijpU31L1tuvD9+dKxkhdAv9IaKlnzVattaDwo=
 github.com/jzelinskie/stringz v0.0.1 h1:IahR+y8ct2nyj7B6i8UtFsGFj4ex1SX27iKFYsAheLk=

--- a/internal/developmentmembership/foundsubject.go
+++ b/internal/developmentmembership/foundsubject.go
@@ -107,6 +107,10 @@ func (fs FoundSubject) ToValidationString() string {
 	return validationString
 }
 
+func (fs FoundSubject) String() string {
+	return fs.ToValidationString()
+}
+
 // FoundSubjects contains the subjects found for a specific ONR.
 type FoundSubjects struct {
 	// subjects is a map from the Subject ONR (as a string) to the FoundSubject information.

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -6,413 +6,668 @@ package integrationtesting_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"path"
-	"path/filepath"
-	"runtime"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/jwangsadinata/go-multimap/setmultimap"
-	"github.com/jwangsadinata/go-multimap/slicemultimap"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 	yamlv2 "gopkg.in/yaml.v2"
 
-	"github.com/authzed/spicedb/internal/datastore/memdb"
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+
 	"github.com/authzed/spicedb/internal/developmentmembership"
 	"github.com/authzed/spicedb/internal/dispatch"
-	"github.com/authzed/spicedb/internal/dispatch/caching"
-	"github.com/authzed/spicedb/internal/dispatch/graph"
-	"github.com/authzed/spicedb/internal/dispatch/keys"
-	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/internal/namespace"
-	"github.com/authzed/spicedb/internal/testserver"
+	"github.com/authzed/spicedb/internal/services/integrationtesting/consistencytestutil"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/development"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	devinterface "github.com/authzed/spicedb/pkg/proto/developer/v1"
 	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
-	"github.com/authzed/spicedb/pkg/testutil"
 	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/util"
 	"github.com/authzed/spicedb/pkg/validationfile"
+	"github.com/authzed/spicedb/pkg/validationfile/blocks"
 )
 
-var testTimedeltas = []time.Duration{1 * time.Second}
+const testTimedelta = 1 * time.Second
 
+// TestConsistency is a system-wide consistency test suite that reads in various
+// validation files in the testconfigs directory, and executes a full set of APIs
+// against the data within, ensuring that all results of the various APIs are
+// consistent with one another.
+//
+// This test suite acts as essentially a full integration test for the API,
+// dispatching, caching, computation and datastore layers. It should reflect
+// both real-world schemas, as well as the full set of hand-constructed corner
+// cases so that the system can be fully exercised.
 func TestConsistency(t *testing.T) {
-	_, filename, _, _ := runtime.Caller(0)
-	consistencyTestFiles := []string{}
-	err := filepath.Walk(path.Join(path.Dir(filename), "testconfigs"), func(path string, info os.FileInfo, err error) error {
-		if info == nil || info.IsDir() {
-			return nil
-		}
+	// List all the defined consistency test files.
+	consistencyTestFiles, err := consistencytestutil.ListTestConfigs()
+	require.NoError(t, err)
 
-		if strings.HasSuffix(info.Name(), ".yaml") {
-			consistencyTestFiles = append(consistencyTestFiles, path)
-		}
+	for _, filePath := range consistencyTestFiles {
+		t.Run(path.Base(filePath), func(t *testing.T) {
+			for _, dispatcherKind := range []string{"local", "caching"} {
+				dispatcherKind := dispatcherKind
 
-		return nil
-	})
-
-	rrequire := require.New(t)
-	rrequire.NoError(err)
-
-	for _, delta := range testTimedeltas {
-		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
-			for _, filePath := range consistencyTestFiles {
-				t.Run(path.Base(filePath), func(t *testing.T) {
-					for _, dispatcherKind := range []string{"local", "caching"} {
-						t.Run(dispatcherKind, func(t *testing.T) {
-							t.Parallel()
-							lrequire := require.New(t)
-
-							ds, err := memdb.NewMemdbDatastore(0, delta, memdb.DisableGC)
-							require.NoError(t, err)
-
-							fullyResolved, revision, err := validationfile.PopulateFromFiles(context.Background(), ds, []string{filePath})
-							require.NoError(t, err)
-
-							conn, cleanup := testserver.TestClusterWithDispatch(t, 1, ds)
-							t.Cleanup(cleanup)
-
-							dsCtx := datastoremw.ContextWithHandle(context.Background())
-							lrequire.NoError(datastoremw.SetInContext(dsCtx, ds))
-
-							// Validate the type system for each namespace.
-							for _, nsDef := range fullyResolved.NamespaceDefinitions {
-								_, ts, err := namespace.ReadNamespaceAndTypes(
-									dsCtx,
-									nsDef.Name,
-									ds.SnapshotReader(revision),
-								)
-								lrequire.NoError(err)
-
-								_, err = ts.Validate(dsCtx)
-								lrequire.NoError(err)
-							}
-
-							// Build the list of tuples per namespace.
-							tuplesPerNamespace := slicemultimap.New()
-							for _, tpl := range fullyResolved.Tuples {
-								tuplesPerNamespace.Put(tpl.ResourceAndRelation.Namespace, tpl)
-							}
-
-							// Run the consistency tests for each service.
-							dispatcher := graph.NewLocalOnlyDispatcher(10)
-							if dispatcherKind == "caching" {
-								cachingDispatcher, err := caching.NewCachingDispatcher(nil, "", &keys.CanonicalKeyHandler{})
-								lrequire.NoError(err)
-
-								localDispatcher := graph.NewDispatcher(cachingDispatcher, graph.SharedConcurrencyLimits(10))
-								defer localDispatcher.Close()
-								cachingDispatcher.SetDelegate(localDispatcher)
-								dispatcher = cachingDispatcher
-							}
-							defer dispatcher.Close()
-
-							testers := []serviceTester{
-								v1ServiceTester{v1.NewPermissionsServiceClient(conn[0])},
-							}
-
-							runCrossVersionTests(t, testers, fullyResolved, revision)
-
-							for _, tester := range testers {
-								t.Run(tester.Name(), func(t *testing.T) {
-									runConsistencyTests(t, tester, ds, dispatcher, fullyResolved, tuplesPerNamespace, revision)
-									runAssertions(t, tester, dispatcher, fullyResolved, revision)
-								})
-							}
-						})
-					}
+				t.Run(dispatcherKind, func(t *testing.T) {
+					t.Parallel()
+					runConsistencyTestSuiteForFile(t, filePath, dispatcherKind == "caching")
 				})
 			}
 		})
 	}
 }
 
-func runAssertions(t *testing.T,
-	tester serviceTester,
-	dispatch dispatch.Dispatcher,
-	fullyResolved *validationfile.PopulatedValidationFile,
-	revision datastore.Revision,
-) {
-	for _, parsedFile := range fullyResolved.ParsedFiles {
-		for _, assertTrue := range parsedFile.Assertions.AssertTrue {
-			// Ensure the assertion passes Check.
-			rel := tuple.MustFromRelationship(assertTrue.Relationship)
-			result, err := tester.Check(context.Background(), rel.ResourceAndRelation, rel.Subject, revision)
-			require.NoError(t, err)
-			require.True(t, result, "Assertion `%s` returned false; true expected", tuple.MustString(rel))
+func runConsistencyTestSuiteForFile(t *testing.T, filePath string, useCachingDispatcher bool) {
+	cad := consistencytestutil.LoadDataAndCreateClusterForTesting(t, filePath, testTimedelta)
 
-			// Ensure the assertion passes Lookup.
-			resolvedObjectIds, err := tester.Lookup(context.Background(), &core.RelationReference{
-				Namespace: rel.ResourceAndRelation.Namespace,
-				Relation:  rel.ResourceAndRelation.Relation,
-			}, rel.Subject, revision)
-			require.NoError(t, err)
-			require.Contains(t, resolvedObjectIds, rel.ResourceAndRelation.ObjectId, "Missing object %s in lookup for assertion %s", rel.ResourceAndRelation, rel)
-		}
+	// Validate the type system for each namespace.
+	headRevision, err := cad.DataStore.HeadRevision(cad.Ctx)
+	require.NoError(t, err)
 
-		for _, assertFalse := range parsedFile.Assertions.AssertFalse {
-			// Ensure the assertion passes Check.
-			rel := tuple.MustFromRelationship(assertFalse.Relationship)
+	for _, nsDef := range cad.Populated.NamespaceDefinitions {
+		_, ts, err := namespace.ReadNamespaceAndTypes(
+			cad.Ctx,
+			nsDef.Name,
+			cad.DataStore.SnapshotReader(headRevision),
+		)
+		require.NoError(t, err)
 
-			// Ensure the assertion does not pass Check.
-			result, err := tester.Check(context.Background(), rel.ResourceAndRelation, rel.Subject, revision)
-			require.NoError(t, err)
-			require.False(t, result, "Assertion `%s` returned true; false expected", tuple.MustString(rel))
+		_, err = ts.Validate(cad.Ctx)
+		require.NoError(t, err)
+	}
 
-			// Ensure the assertion does not pass Lookup.
-			resolvedObjectIds, err := tester.Lookup(context.Background(), &core.RelationReference{
-				Namespace: rel.ResourceAndRelation.Namespace,
-				Relation:  rel.ResourceAndRelation.Relation,
-			}, rel.Subject, revision)
-			require.NoError(t, err)
-			require.NotContains(t, resolvedObjectIds, rel.ResourceAndRelation.ObjectId, "Found unexpected object %s in lookup for false assertion %s", rel.ResourceAndRelation, rel)
-		}
+	// Run consistency tests.
+	testers := consistencytestutil.ServiceTesters(cad.Conn)
+	for _, tester := range testers {
+		tester := tester
+
+		t.Run(tester.Name(), func(t *testing.T) {
+			runConsistencyTestsWithServiceTester(t, cad, tester, headRevision, useCachingDispatcher)
+		})
 	}
 }
 
-func runCrossVersionTests(t *testing.T,
-	testers []serviceTester,
-	fullyResolved *validationfile.PopulatedValidationFile,
-	revision datastore.Revision,
-) {
-	// NOTE: added to skip tests when there is only one version defined.
-	if len(testers) < 2 {
-		return
-	}
-
-	for _, nsDef := range fullyResolved.NamespaceDefinitions {
-		for _, relation := range nsDef.Relation {
-			verifyCrossVersion(t, "read", testers, func(tester serviceTester) (interface{}, error) {
-				return tester.Read(context.Background(), nsDef.Name, revision)
-			})
-
-			for _, tpl := range fullyResolved.Tuples {
-				if tpl.ResourceAndRelation.Namespace != nsDef.Name {
-					continue
-				}
-
-				verifyCrossVersion(t, "expand", testers, func(tester serviceTester) (interface{}, error) {
-					return tester.Expand(context.Background(), &core.ObjectAndRelation{
-						Namespace: nsDef.Name,
-						Relation:  relation.Name,
-						ObjectId:  tpl.ResourceAndRelation.ObjectId,
-					}, revision)
-				})
-
-				verifyCrossVersion(t, "lookup", testers, func(tester serviceTester) (interface{}, error) {
-					return tester.Lookup(context.Background(), &core.RelationReference{
-						Namespace: nsDef.Name,
-						Relation:  relation.Name,
-					}, &core.ObjectAndRelation{
-						Namespace: tpl.ResourceAndRelation.Namespace,
-						Relation:  tpl.ResourceAndRelation.Relation,
-						ObjectId:  tpl.ResourceAndRelation.ObjectId,
-					}, revision)
-				})
-			}
-		}
-	}
+type validationContext struct {
+	clusterAndData   consistencytestutil.ConsistencyClusterAndData
+	accessibilitySet *consistencytestutil.AccessibilitySet
+	serviceTester    consistencytestutil.ServiceTester
+	revision         datastore.Revision
+	dispatcher       dispatch.Dispatcher
 }
 
-type apiRunner func(tester serviceTester) (interface{}, error)
-
-func verifyCrossVersion(t *testing.T, name string, testers []serviceTester, runAPI apiRunner) {
-	t.Run(fmt.Sprintf("crossversion_%s", name), func(t *testing.T) {
-		var result interface{}
-		for _, tester := range testers {
-			value, err := runAPI(tester)
-			require.NoError(t, err)
-			if result == nil {
-				result = value
-			} else {
-				testutil.RequireEqualEmptyNil(t, result, value, "found mismatch between versions")
-			}
-		}
-	})
-}
-
-func runConsistencyTests(t *testing.T,
-	tester serviceTester,
-	ds datastore.Datastore,
-	dispatch dispatch.Dispatcher,
-	fullyResolved *validationfile.PopulatedValidationFile,
-	tuplesPerNamespace *slicemultimap.MultiMap,
+func runConsistencyTestsWithServiceTester(
+	t *testing.T,
+	cad consistencytestutil.ConsistencyClusterAndData,
+	tester consistencytestutil.ServiceTester,
 	revision datastore.Revision,
+	useCachingDispatcher bool,
 ) {
-	lrequire := require.New(t)
+	// Build an accessibility set.
+	accessibilitySet := consistencytestutil.BuildAccessibilitySet(t, cad)
 
-	// Read all tuples defined in the namespaces.
-	for _, nsDef := range fullyResolved.NamespaceDefinitions {
-		tuples, err := tester.Read(context.Background(), nsDef.Name, revision)
-		lrequire.NoError(err)
+	dispatcher := consistencytestutil.CreateDispatcherForTesting(t, useCachingDispatcher)
 
-		expected, _ := tuplesPerNamespace.Get(nsDef.Name)
-		lrequire.Equal(len(expected), len(tuples))
+	vctx := validationContext{
+		clusterAndData:   cad,
+		accessibilitySet: accessibilitySet,
+		serviceTester:    tester,
+		revision:         revision,
+		dispatcher:       dispatcher,
 	}
 
-	// Call a write on each tuple to make sure it type checks.
-	for _, nsDef := range fullyResolved.NamespaceDefinitions {
-		tuples, ok := tuplesPerNamespace.Get(nsDef.Name)
+	// Call a write on each relationship to make sure it type checks.
+	ensureRelationshipWrites(t, vctx)
+
+	// TODO(jschorr): Add read consistency test here.
+
+	// Run the assertions defined in the file.
+	runAssertions(t, vctx)
+
+	// Run basic expansion on each relation and ensure no errors are raised.
+	ensureNoExpansionErrors(t, vctx)
+
+	// Run a fully recursive expand on each relation and ensure all terminal subjects are reached.
+	validateExpansionSubjects(t, vctx)
+
+	// For each relation in each namespace, for each subject, collect the resources accessible
+	// to that subject and then verify the lookup resources returns the same set of subjects.
+	validateLookupResources(t, vctx)
+
+	// For each object accessible, validate that the subjects that can access it are found.
+	validateLookupSubjects(t, vctx)
+
+	// Run the development system over the full set of context and ensure they also return the expected information.
+	validateDevelopment(t, vctx)
+}
+
+// testForEachResource runs a subtest for each possible resource+relation in the schema.
+func testForEachResource(
+	t *testing.T,
+	vctx validationContext,
+	prefix string,
+	handler func(t *testing.T, resource *core.ObjectAndRelation),
+) {
+	t.Helper()
+
+	for _, resourceType := range vctx.clusterAndData.Populated.NamespaceDefinitions {
+		resources, ok := vctx.accessibilitySet.ResourcesByNamespace.Get(resourceType.Name)
 		if !ok {
 			continue
 		}
 
-		for _, itpl := range tuples {
-			tpl := itpl.(*core.RelationTuple)
-			err := tester.Write(context.Background(), tpl)
-			lrequire.NoError(err, "failed to write %s", tuple.MustString(tpl))
-		}
-	}
-
-	// Collect the set of objects and subjects.
-	objectsPerNamespace := setmultimap.New()
-	subjects := tuple.NewONRSet()
-	subjectsNoWildcard := tuple.NewONRSet()
-	for _, tpl := range fullyResolved.Tuples {
-		objectsPerNamespace.Put(tpl.ResourceAndRelation.Namespace, tpl.ResourceAndRelation.ObjectId)
-		subjects.Add(tpl.Subject)
-
-		if tpl.Subject.ObjectId != tuple.PublicWildcard {
-			objectsPerNamespace.Put(tpl.Subject.Namespace, tpl.Subject.ObjectId)
-			subjectsNoWildcard.Add(tpl.Subject)
-		}
-	}
-
-	// Collect the set of accessible objects for each namespace and subject.
-	accessibilitySet := newAccessibilitySet()
-
-	for _, nsDef := range fullyResolved.NamespaceDefinitions {
-		for _, relation := range nsDef.Relation {
-			for _, subject := range subjects.AsSlice() {
-				allObjectIds, ok := objectsPerNamespace.Get(nsDef.Name)
-				if !ok {
-					continue
-				}
-
-				for _, objectID := range allObjectIds {
-					objectIDStr := objectID.(string)
-
-					onr := &core.ObjectAndRelation{
-						Namespace: nsDef.Name,
-						Relation:  relation.Name,
-						ObjectId:  objectIDStr,
-					}
-
-					if subject.ObjectId == tuple.PublicWildcard {
-						accessibilitySet.Set(onr, subject, isWildcard)
-						continue
-					}
-
-					hasPermission, err := tester.Check(context.Background(), onr, subject, revision)
-					require.NoError(t, err)
-
-					// If a member, check if due to a wildcard only.
-					if hasPermission && accessibleViaWildcardOnly(t, ds, dispatch, onr, subject, revision) {
-						accessibilitySet.Set(onr, subject, isMemberViaWildcard)
-						continue
-					}
-
-					if hasPermission {
-						accessibilitySet.Set(onr, subject, isMember)
-					} else {
-						accessibilitySet.Set(onr, subject, isNotMember)
-					}
-				}
+		for _, relation := range resourceType.Relation {
+			for _, resource := range resources {
+				t.Run(fmt.Sprintf("%s_%s_%s_%s", prefix, resourceType.Name, resource.ObjectId, relation.Name),
+					func(t *testing.T) {
+						handler(t, &core.ObjectAndRelation{
+							Namespace: resourceType.Name,
+							ObjectId:  resource.ObjectId,
+							Relation:  relation.Name,
+						})
+					})
 			}
 		}
 	}
+}
 
-	vctx := &validationContext{
-		fullyResolved:       fullyResolved,
-		objectsPerNamespace: objectsPerNamespace,
-		accessibilitySet:    accessibilitySet,
-		dispatch:            dispatch,
-		subjects:            subjects,
-		subjectsNoWildcard:  subjectsNoWildcard,
-		tester:              tester,
-		revision:            revision,
+// testForEachResourceType runs a subtest for each possible resource type+relation in the schema.
+func testForEachResourceType(
+	t *testing.T,
+	vctx validationContext,
+	prefix string,
+	handler func(t *testing.T, resourceType *core.RelationReference),
+) {
+	for _, resourceType := range vctx.clusterAndData.Populated.NamespaceDefinitions {
+		for _, relation := range resourceType.Relation {
+			t.Run(fmt.Sprintf("%s_%s_%s", prefix, resourceType.Name, relation.Name),
+				func(t *testing.T) {
+					handler(t, &core.RelationReference{
+						Namespace: resourceType.Name,
+						Relation:  relation.Name,
+					})
+				})
+		}
+	}
+}
+
+// ensureRelationshipWrites ensures that all relationships can be written via the API.
+func ensureRelationshipWrites(t *testing.T, vctx validationContext) {
+	for _, nsDef := range vctx.clusterAndData.Populated.NamespaceDefinitions {
+		relationships, ok := vctx.accessibilitySet.RelationshipsByResourceNamespace.Get(nsDef.Name)
+		if !ok {
+			continue
+		}
+
+		for _, relationship := range relationships {
+			err := vctx.serviceTester.Write(context.Background(), relationship)
+			require.NoError(t, err, "failed to write %s", tuple.MustString(relationship))
+		}
+	}
+}
+
+// ensureNoExpansionErrors runs basic expansion on each relation and ensures no errors are raised.
+func ensureNoExpansionErrors(t *testing.T, vctx validationContext) {
+	testForEachResource(t, vctx, "run_expand",
+		func(t *testing.T, resource *core.ObjectAndRelation) {
+			_, err := vctx.serviceTester.Expand(context.Background(),
+				resource,
+				vctx.revision,
+			)
+			require.NoError(t, err)
+		})
+}
+
+// validateExpansionSubjects runs a fully recursive expand on each relation and ensures that all expected terminal subjects are reached.
+func validateExpansionSubjects(t *testing.T, vctx validationContext) {
+	testForEachResource(t, vctx, "validate_expand",
+		func(t *testing.T, resource *core.ObjectAndRelation) {
+			// Run a *recursive* expansion to collect all the reachable subjects.
+			resp, err := vctx.dispatcher.DispatchExpand(
+				vctx.clusterAndData.Ctx,
+				&dispatchv1.DispatchExpandRequest{
+					ResourceAndRelation: resource,
+					Metadata: &dispatchv1.ResolverMeta{
+						AtRevision:     vctx.revision.String(),
+						DepthRemaining: 100,
+					},
+					ExpansionMode: dispatchv1.DispatchExpandRequest_RECURSIVE,
+				})
+			require.NoError(t, err)
+
+			// Build an accessible subject set from the expansion tree.
+			subjectsFoundSet, err := developmentmembership.AccessibleExpansionSubjects(resp.TreeNode)
+			require.NoError(t, err)
+
+			// Ensure all non-wildcard terminal subjects that were found in the expansion are accessible.
+			for _, foundSubject := range subjectsFoundSet.ToSlice() {
+				if foundSubject.GetSubjectId() != tuple.PublicWildcard {
+					accessiblity, permissionship, ok := vctx.accessibilitySet.AccessibiliyAndPermissionshipFor(resource, foundSubject.Subject())
+					require.True(t, ok, "missing accessibility for resource %s and subject %s", tuple.StringONR(resource), tuple.StringONR(foundSubject.Subject()))
+
+					// NOTE: an expanded subject must either be accessible directly (e.g. not via a wildcard)
+					// OR must be removed due to a static caveat context removing it from the set.
+					require.True(t,
+						accessiblity == consistencytestutil.AccessibleDirectly ||
+							accessiblity == consistencytestutil.NotAccessibleDueToPrespecifiedCaveat,
+						"mismatch between expand and accessibility for resource %s and subject %s. accessibility: %v, permissionship: %v",
+						tuple.StringONR(resource),
+						tuple.StringONR(foundSubject.Subject()),
+						accessiblity,
+						permissionship,
+					)
+				}
+			}
+
+			// Ensure all terminal subjects are found in the expansion.
+			for _, expectedSubject := range vctx.accessibilitySet.DirectlyAccessibleDefinedSubjects(resource) {
+				found := subjectsFoundSet.Contains(expectedSubject)
+				require.True(t, found, "missing expected subject %s in expand for resource %s", tuple.StringONR(expectedSubject), tuple.StringONR(resource))
+			}
+		})
+}
+
+func requireSameSets(t *testing.T, expected []string, found []string) {
+	expectedSet := util.NewSet[string](expected...)
+	foundSet := util.NewSet[string](found...)
+
+	orderedExpected := expectedSet.AsSlice()
+	orderedFound := foundSet.AsSlice()
+
+	sort.Strings(orderedExpected)
+	sort.Strings(orderedFound)
+
+	require.Equal(t, orderedExpected, orderedFound)
+}
+
+func requireSubsetOf(t *testing.T, found []string, expected []string) {
+	if len(expected) == 0 {
+		return
 	}
 
-	// Run basic expansion on each relation and ensure it matches the structure of the relation.
-	validateExpansion(t, vctx)
-
-	// Run a fully recursive expand on each relation and ensure all terminal subjects are reached.
-	validateExpansionSubjects(t, ds, vctx)
-
-	// For each relation in each namespace, for each user, collect the objects accessible
-	// to that user and then verify the lookup resources returns the same set of objects.
-	validateLookupResources(t, vctx)
-
-	// For each object accessible, validate that the subjects that can access it are found.
-	validateLookupSubject(t, vctx)
-
-	// Run the developer APIs over the full set of context and ensure they also return the expected information.
-	validateDeveloper(t, vctx)
+	foundSet := util.NewSet[string](found...)
+	for _, expectedObjectID := range expected {
+		require.True(t, foundSet.Has(expectedObjectID), "missing expected object ID %s", expectedObjectID)
+	}
 }
 
-func accessibleViaWildcardOnly(t *testing.T, ds datastore.Datastore, dispatch dispatch.Dispatcher, onr *core.ObjectAndRelation, subject *core.ObjectAndRelation, revision datastore.Revision) bool {
-	ctx := datastoremw.ContextWithHandle(context.Background())
-	require.NoError(t, datastoremw.SetInContext(ctx, ds))
+// validateLookupResources ensures that a lookup resources call returns the expected objects and
+// only those expected.
+func validateLookupResources(t *testing.T, vctx validationContext) {
+	testForEachResourceType(t, vctx, "validate_lookup_resources",
+		func(t *testing.T, resourceRelation *core.RelationReference) {
+			for _, subject := range vctx.accessibilitySet.AllSubjectsNoWildcards() {
+				t.Run(tuple.StringONR(subject), func(t *testing.T) {
+					// Perform a lookup call and ensure it returns the at least the same set of object IDs.
+					resolvedResources, err := vctx.serviceTester.LookupResources(context.Background(), resourceRelation, subject, vctx.revision)
+					require.NoError(t, err)
 
-	resp, err := dispatch.DispatchExpand(ctx, &dispatchv1.DispatchExpandRequest{
-		ResourceAndRelation: onr,
-		Metadata: &dispatchv1.ResolverMeta{
-			AtRevision:     revision.String(),
-			DepthRemaining: 100,
-		},
-		ExpansionMode: dispatchv1.DispatchExpandRequest_RECURSIVE,
+					accessibleResources := vctx.accessibilitySet.LookupAccessibleResources(resourceRelation, subject)
+					requireSameSets(t, maps.Keys(accessibleResources), maps.Keys(resolvedResources))
+
+					// Ensure that every returned concrete object Checks directly.
+					for _, resolvedResource := range resolvedResources {
+						permissionship, err := vctx.serviceTester.Check(context.Background(),
+							&core.ObjectAndRelation{
+								Namespace: resourceRelation.Namespace,
+								Relation:  resourceRelation.Relation,
+								ObjectId:  resolvedResource.ResourceObjectId,
+							},
+							subject,
+							vctx.revision,
+							nil,
+						)
+
+						expectedPermissionship := v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION
+						if resolvedResource.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
+							expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+						}
+
+						require.NoError(t, err)
+						require.Equal(t,
+							expectedPermissionship,
+							permissionship,
+							"Found Check failure for relation %s:%s#%s and subject %s in lookup resources; expected %v, found %v",
+							resourceRelation.Namespace,
+							resolvedResource.ResourceObjectId,
+							resourceRelation.Relation,
+							tuple.StringONR(subject),
+							expectedPermissionship,
+							permissionship,
+						)
+					}
+				})
+			}
+		})
+}
+
+// validateLookupSubjects validates that the subjects that can access it are those expected.
+func validateLookupSubjects(t *testing.T, vctx validationContext) {
+	testForEachResource(t, vctx, "validate_lookup_subjects",
+		func(t *testing.T, resource *core.ObjectAndRelation) {
+			for _, subjectType := range vctx.accessibilitySet.SubjectTypes() {
+				t.Run(fmt.Sprintf("%s#%s", subjectType.Namespace, subjectType.Relation),
+					func(t *testing.T) {
+						resolvedSubjects, err := vctx.serviceTester.LookupSubjects(context.Background(), resource, subjectType, vctx.revision)
+						require.NoError(t, err)
+
+						// Ensure the subjects found include those defined as expected. Since the
+						// accessibility set does not include "inferred" subjects (e.g. those with
+						// permissions as their subject relation, or wildcards), this should be a
+						// subset.
+						expectedDefinedSubjects := vctx.accessibilitySet.DirectlyAccessibleDefinedSubjectsOfType(resource, subjectType)
+						requireSubsetOf(t, maps.Keys(resolvedSubjects), maps.Keys(expectedDefinedSubjects))
+
+						// Ensure all subjects in true and caveated assertions for the subject type are found
+						// in the LookupSubject result, except those added via wildcard.
+						for _, parsedFile := range vctx.clusterAndData.Populated.ParsedFiles {
+							for _, entry := range []struct {
+								assertions         []blocks.Assertion
+								requiresPermission bool
+							}{
+								{
+									assertions:         parsedFile.Assertions.AssertTrue,
+									requiresPermission: true,
+								},
+								{
+									assertions:         parsedFile.Assertions.AssertCaveated,
+									requiresPermission: false,
+								},
+							} {
+								for _, assertion := range entry.assertions {
+									assertionRel := tuple.MustFromRelationship(assertion.Relationship)
+									if !assertionRel.ResourceAndRelation.EqualVT(resource) {
+										continue
+									}
+
+									if assertionRel.Subject.Namespace != subjectType.Namespace ||
+										assertionRel.Subject.Relation != subjectType.Relation {
+										continue
+									}
+
+									// For subjects found solely via wildcard, check that a wildcard instead exists in
+									// the result and that the subject is not excluded.
+									accessibility, _, ok := vctx.accessibilitySet.AccessibiliyAndPermissionshipFor(resource, assertionRel.Subject)
+									if !ok || accessibility == consistencytestutil.AccessibleViaWildcardOnly {
+										resolvedSubject, ok := resolvedSubjects[tuple.PublicWildcard]
+										require.True(t, ok, "expected wildcard in lookupsubjects response for assertion `%s`", assertion.RelationshipWithContextString)
+
+										if entry.requiresPermission {
+											require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, resolvedSubject.Subject.Permissionship)
+										}
+
+										// Ensure that the subject is not excluded. If a caveated assertion, then the exclusion
+										// can be caveated.
+										for _, excludedSubject := range resolvedSubject.ExcludedSubjects {
+											if entry.requiresPermission {
+												require.NotEqual(t, excludedSubject.SubjectObjectId, assertionRel.Subject.ObjectId, "wildcard excludes the asserted subject ID: %s", assertionRel.Subject.ObjectId)
+											} else if excludedSubject.SubjectObjectId == assertionRel.Subject.ObjectId {
+												require.NotEqual(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, excludedSubject.Permissionship, "wildcard concretely excludes the asserted subject ID: %s", assertionRel.Subject.ObjectId)
+											}
+										}
+										continue
+									}
+
+									_, ok = resolvedSubjects[assertionRel.Subject.ObjectId]
+									require.True(t, ok, "missing expected subject %s from assertion %s", assertionRel.Subject.ObjectId, assertion.RelationshipWithContextString)
+								}
+							}
+						}
+
+						// Ensure that all excluded subjects from wildcards do not have access.
+						for _, resolvedSubject := range resolvedSubjects {
+							if resolvedSubject.Subject.SubjectObjectId != tuple.PublicWildcard {
+								continue
+							}
+
+							for _, excludedSubject := range resolvedSubject.ExcludedSubjects {
+								permissionship, err := vctx.serviceTester.Check(context.Background(),
+									resource,
+									&core.ObjectAndRelation{
+										Namespace: subjectType.Namespace,
+										ObjectId:  excludedSubject.SubjectObjectId,
+										Relation:  subjectType.Relation,
+									},
+									vctx.revision,
+									nil,
+								)
+								require.NoError(t, err)
+
+								expectedPermissionship := v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION
+								if resolvedSubject.Subject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
+									expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+								}
+								if excludedSubject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
+									expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+								}
+
+								require.Equal(t,
+									expectedPermissionship,
+									permissionship,
+									"Found Check failure for resource %s and excluded subject %s in lookup subjects",
+									tuple.StringONR(resource),
+									excludedSubject.SubjectObjectId,
+								)
+							}
+						}
+
+						// Ensure that every returned defined, non-wildcard subject found checks as expected.
+						for _, resolvedSubject := range resolvedSubjects {
+							if resolvedSubject.Subject.SubjectObjectId == tuple.PublicWildcard {
+								continue
+							}
+
+							subject := &core.ObjectAndRelation{
+								Namespace: subjectType.Namespace,
+								ObjectId:  resolvedSubject.Subject.SubjectObjectId,
+								Relation:  subjectType.Relation,
+							}
+
+							permissionship, err := vctx.serviceTester.Check(context.Background(),
+								resource,
+								subject,
+								vctx.revision,
+								nil,
+							)
+							require.NoError(t, err)
+
+							expectedPermissionship := v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION
+							if resolvedSubject.Subject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
+								expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+							}
+
+							require.Equal(t,
+								expectedPermissionship,
+								permissionship,
+								"Found Check failure for resource %s and subject %s in lookup subjects",
+								tuple.StringONR(resource),
+								tuple.StringONR(subject),
+							)
+						}
+					})
+			}
+		})
+}
+
+// runAssertions runs all assertions defined in the validation files and ensures they
+// return the expected results.
+func runAssertions(t *testing.T, vctx validationContext) {
+	t.Run("assertions", func(t *testing.T) {
+		for _, parsedFile := range vctx.clusterAndData.Populated.ParsedFiles {
+			for _, entry := range []struct {
+				name                   string
+				assertions             []blocks.Assertion
+				expectedPermissionship v1.CheckPermissionResponse_Permissionship
+			}{
+				{
+					"true",
+					parsedFile.Assertions.AssertTrue,
+					v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION,
+				},
+				{
+					"caveated",
+					parsedFile.Assertions.AssertCaveated,
+					v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION,
+				},
+				{
+					"false",
+					parsedFile.Assertions.AssertFalse,
+					v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION,
+				},
+			} {
+				t.Run(entry.name, func(t *testing.T) {
+					for _, assertion := range entry.assertions {
+						t.Run(assertion.RelationshipWithContextString, func(t *testing.T) {
+							rel := tuple.MustFromRelationship(assertion.Relationship)
+							permissionship, err := vctx.serviceTester.Check(context.Background(), rel.ResourceAndRelation, rel.Subject, vctx.revision, assertion.CaveatContext)
+							require.NoError(t, err)
+							require.Equal(t, entry.expectedPermissionship, permissionship, "Assertion `%s` returned %s; expected %s", tuple.MustString(rel), permissionship, entry.expectedPermissionship)
+
+							// Ensure the assertion passes LookupResources.
+							resolvedResources, err := vctx.serviceTester.LookupResources(context.Background(), &core.RelationReference{
+								Namespace: rel.ResourceAndRelation.Namespace,
+								Relation:  rel.ResourceAndRelation.Relation,
+							}, rel.Subject, vctx.revision)
+							require.NoError(t, err)
+
+							resolvedResourceIds := maps.Keys(resolvedResources)
+							accessibility, _, _ := vctx.accessibilitySet.AccessibiliyAndPermissionshipFor(rel.ResourceAndRelation, rel.Subject)
+
+							switch permissionship {
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION:
+								// If the caveat context given is empty, then the lookup result must not exist at all.
+								// Otherwise, it *could* be caveated or not exist, depending on the context given.
+								if len(assertion.CaveatContext) == 0 {
+									require.NotContains(t, resolvedResourceIds, rel.ResourceAndRelation.ObjectId, "Found unexpected object %s in lookup for assertion %s", rel.ResourceAndRelation, rel)
+								} else if accessibility != consistencytestutil.NotAccessibleDueToPrespecifiedCaveat {
+									require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION, resolvedResources[rel.ResourceAndRelation.ObjectId].Permissionship)
+								}
+
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION:
+								require.Contains(t, resolvedResourceIds, rel.ResourceAndRelation.ObjectId, "Missing object %s in lookup for assertion %s", rel.ResourceAndRelation, rel)
+								// If the caveat context given is empty, then the lookup result must be fully permissioned.
+								// Otherwise, it *could* be caveated or fully permissioned, depending on the context given.
+								if len(assertion.CaveatContext) == 0 {
+									require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, resolvedResources[rel.ResourceAndRelation.ObjectId].Permissionship)
+								}
+
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION:
+								require.Contains(t, resolvedResourceIds, rel.ResourceAndRelation.ObjectId, "Missing object %s in lookup for assertion %s", rel.ResourceAndRelation, rel)
+								require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION, resolvedResources[rel.ResourceAndRelation.ObjectId].Permissionship)
+
+							default:
+								panic("unknown permissionship")
+							}
+						})
+					}
+				})
+			}
+		}
 	})
-	require.NoError(t, err)
-
-	subjectsFound, err := developmentmembership.AccessibleExpansionSubjects(resp.TreeNode)
-	require.NoError(t, err)
-	return !subjectsFound.Contains(subject)
 }
 
-type validationContext struct {
-	fullyResolved *validationfile.PopulatedValidationFile
-
-	objectsPerNamespace *setmultimap.MultiMap
-	subjects            *tuple.ONRSet
-	subjectsNoWildcard  *tuple.ONRSet
-	accessibilitySet    *accessibilitySet
-
-	dispatch dispatch.Dispatcher
-
-	tester   serviceTester
-	revision datastore.Revision
-}
-
-func validateDeveloper(t *testing.T, vctx *validationContext) {
-	schema := vctx.fullyResolved.Schema
+// validateDevelopment runs the development package against the validation context and
+// ensures its output matches that expected.
+func validateDevelopment(t *testing.T, vctx validationContext) {
 	reqContext := &devinterface.RequestContext{
-		Schema:        schema,
-		Relationships: vctx.fullyResolved.Tuples,
+		Schema:        vctx.clusterAndData.Populated.Schema,
+		Relationships: vctx.clusterAndData.Populated.Tuples,
 	}
 
 	devContext, _, err := development.NewDevContext(context.Background(), reqContext)
 	require.NoError(t, err)
 
-	// Validate edit checks (check watches).
-	validateEditChecks(t, devContext, vctx)
+	// Validate checks.
+	validateDevelopmentChecks(t, devContext, vctx)
 
-	// Validate assertions and expected relations.
-	validateValidation(t, devContext, vctx)
+	// Validate assertions.
+	validateDevelopmentAssertions(t, devContext, vctx)
+
+	// Validate expected relationships.
+	validateDevelopmentExpectedRels(t, devContext, vctx)
 }
 
-func validateValidation(t *testing.T, devContext *development.DevContext, vctx *validationContext) {
+// validateDevelopmentChecks validates that the Check operation in the development package
+// returns the expected permissionship.
+func validateDevelopmentChecks(t *testing.T, devContext *development.DevContext, vctx validationContext) {
+	testForEachResource(t, vctx, "validate_check_watch",
+		func(t *testing.T, resource *core.ObjectAndRelation) {
+			for _, subject := range vctx.accessibilitySet.AllSubjectsNoWildcards() {
+				t.Run(tuple.StringONR(subject), func(t *testing.T) {
+					cr, err := development.RunCheck(devContext, resource, subject, nil)
+					require.NoError(t, err, "Got unexpected error from development check")
+
+					_, permissionship, ok := vctx.accessibilitySet.AccessibiliyAndPermissionshipFor(resource, subject)
+					require.True(t, ok)
+					require.Equal(t, permissionship, cr.Permissionship,
+						"Found unexpected membership difference for %s@%s. Expected %v, Found: %v",
+						tuple.StringONR(resource),
+						tuple.StringONR(subject),
+						permissionship,
+						cr.Permissionship)
+				})
+			}
+		})
+}
+
+// validateDevelopmentAssertions validates that Assertions in the development package return
+// the expected results.
+func validateDevelopmentAssertions(t *testing.T, devContext *development.DevContext, vctx validationContext) {
+	// Build the assertions YAML.
+	var trueAssertions []string
+	var caveatedAssertions []string
+	var falseAssertions []string
+
+	for relString, permissionship := range vctx.accessibilitySet.PermissionshipByRelationship {
+		switch permissionship {
+		case dispatchv1.ResourceCheckResult_MEMBER:
+			trueAssertions = append(trueAssertions, relString)
+		case dispatchv1.ResourceCheckResult_CAVEATED_MEMBER:
+			caveatedAssertions = append(caveatedAssertions, relString)
+		case dispatchv1.ResourceCheckResult_NOT_MEMBER:
+			falseAssertions = append(falseAssertions, relString)
+		default:
+			require.Fail(t, "unknown permissionship")
+		}
+	}
+
+	require.Greater(t, len(trueAssertions), 0, "missing expected true assertions")
+	require.Greater(t, len(falseAssertions), 0, "missing expected false assertions")
+
+	assertionsMap := map[string]interface{}{
+		"assertTrue":     trueAssertions,
+		"assertCaveated": caveatedAssertions,
+		"assertFalse":    falseAssertions,
+	}
+	assertions, err := yamlv2.Marshal(assertionsMap)
+	require.NoError(t, err, "Could not marshal assertions map")
+
+	// Run validation with the assertions and the updated YAML.
+	parsedAssertions, devErr := development.ParseAssertionsYAML(string(assertions))
+	require.NoError(t, err, "Got unexpected error from assertions")
+	require.Nil(t, devErr, "Got unexpected request error from assertions: %v", devErr)
+
+	devErrs, err := development.RunAllAssertions(devContext, parsedAssertions)
+	require.NoError(t, err, "Got unexpected error from assertions")
+	require.Equal(t, 0, len(devErrs), "Got unexpected errors from validation: %v", devErrs)
+}
+
+// validateDevelopmentExpectedRels validates that the generated expected relationships matches
+// that expected.
+func validateDevelopmentExpectedRels(t *testing.T, devContext *development.DevContext, vctx validationContext) {
 	// Build the Expected Relations (inputs only).
 	expectedMap := map[string]interface{}{}
-	for _, result := range vctx.accessibilitySet.results {
-		if result.isMember == isMember {
-			expectedMap[tuple.StringONR(result.object)] = []string{}
+	for relString, permissionship := range vctx.accessibilitySet.PermissionshipByRelationship {
+		if permissionship == dispatchv1.ResourceCheckResult_NOT_MEMBER {
+			continue
 		}
+
+		relationship := tuple.MustParse(relString)
+		expectedMap[tuple.StringONR(relationship.ResourceAndRelation)] = []string{}
 	}
 
 	expectedRelations, err := yamlv2.Marshal(expectedMap)
@@ -432,484 +687,39 @@ func validateValidation(t *testing.T, devContext *development.DevContext, vctx *
 	validationMap, err := validationfile.ParseExpectedRelationsBlock([]byte(updatedValidationYaml))
 	require.NoError(t, err)
 
-	for onrKey, expectedSubjects := range validationMap.ValidationMap {
+	for resourceKey, expectedSubjects := range validationMap.ValidationMap {
 		for _, expectedSubject := range expectedSubjects {
-			onr := onrKey.ObjectAndRelation
+			resourceAndRelation := resourceKey.ObjectAndRelation
 			subjectWithExceptions := expectedSubject.SubjectWithExceptions
-
-			// TODO(jschorr): Fix for caveats once caveats are fully supported in consistency tests
-			require.False(t, subjectWithExceptions.Subject.IsCaveated)
-
 			require.NotNil(t, subjectWithExceptions, "Found expected relation without subject: %s", expectedSubject.ValidationString)
-			require.Nil(t, err)
-			require.True(t,
-				(vctx.accessibilitySet.GetIsMember(onr, subjectWithExceptions.Subject.Subject) == isMember ||
-					vctx.accessibilitySet.GetIsMember(onr, subjectWithExceptions.Subject.Subject) == isWildcard),
-				"Generated expected relations returned inaccessible member %s for %s in `%s`",
-				tuple.StringONR(subjectWithExceptions.Subject.Subject),
-				tuple.StringONR(onr),
-				updatedValidationYaml)
-		}
-	}
 
-	// Build the assertions YAML.
-	var trueAssertions []string
-	var falseAssertions []string
+			// For non-wildcard subjects, ensure they are accessible.
+			if subjectWithExceptions.Subject.Subject.ObjectId != tuple.PublicWildcard {
+				accessibility, permissionship, ok := vctx.accessibilitySet.AccessibiliyAndPermissionshipFor(resourceAndRelation, subjectWithExceptions.Subject.Subject)
+				require.True(t, ok, "missing expected subject %s in accessibility set", tuple.StringONR(subjectWithExceptions.Subject.Subject))
 
-	for _, result := range vctx.accessibilitySet.results {
-		if result.isMember == isMember || result.isMember == isMemberViaWildcard {
-			trueAssertions = append(trueAssertions, fmt.Sprintf("%s@%s", tuple.StringONR(result.object), tuple.StringONR(result.subject)))
-		} else if result.isMember == isNotMember {
-			falseAssertions = append(falseAssertions, fmt.Sprintf("%s@%s", tuple.StringONR(result.object), tuple.StringONR(result.subject)))
-		}
-	}
+				switch permissionship {
+				case dispatchv1.ResourceCheckResult_MEMBER:
+					// May be caveated or uncaveated, so check the uncomputed permissionship.
+					uncomputed, ok := vctx.accessibilitySet.UncomputedPermissionshipFor(resourceAndRelation, subjectWithExceptions.Subject.Subject)
+					require.True(t, ok, "missing expected subject in accessibility set")
+					require.True(t, subjectWithExceptions.Subject.IsCaveated == (uncomputed == dispatchv1.ResourceCheckResult_CAVEATED_MEMBER), "found mismatch in uncomputed permissionship")
 
-	assertionsMap := map[string]interface{}{
-		"assertTrue":  trueAssertions,
-		"assertFalse": falseAssertions,
-	}
-	assertions, err := yamlv2.Marshal(assertionsMap)
-	require.NoError(t, err, "Could not marshal assertions map")
+				case dispatchv1.ResourceCheckResult_CAVEATED_MEMBER:
+					require.True(t, subjectWithExceptions.Subject.IsCaveated, "found uncaveated expected subject for caveated subject")
 
-	// Run validation with the assertions and the updated YAML.
-	parsedAssertions, devErr := development.ParseAssertionsYAML(string(assertions))
-	require.NoError(t, err, "Got unexpected error from assertions")
-	require.Nil(t, devErr, "Got unexpected request error from assertions: %v", devErr)
+				case dispatchv1.ResourceCheckResult_NOT_MEMBER:
+					// May be caveated or uncaveated, so check the accessibility.
+					if accessibility == consistencytestutil.NotAccessibleDueToPrespecifiedCaveat {
+						require.True(t, subjectWithExceptions.Subject.IsCaveated, "found uncaveated expected subject for caveated subject")
+					} else {
+						require.Failf(t, "found unexpected subject", "%s", tuple.StringONR(subjectWithExceptions.Subject.Subject))
+					}
 
-	devErrs, err := development.RunAllAssertions(devContext, parsedAssertions)
-	require.NoError(t, err, "Got unexpected error from assertions")
-	require.Equal(t, 0, len(devErrs), "Got unexpected errors from validation: %v", devErrs)
-}
-
-func validateEditChecks(t *testing.T, devContext *development.DevContext, vctx *validationContext) {
-	for _, nsDef := range vctx.fullyResolved.NamespaceDefinitions {
-		for _, relation := range nsDef.Relation {
-			for _, subject := range vctx.subjectsNoWildcard.AsSlice() {
-				objectRelation := &core.RelationReference{
-					Namespace: nsDef.Name,
-					Relation:  relation.Name,
+				default:
+					require.Fail(t, "expected valid permissionship")
 				}
-
-				// Run EditCheck to validate checks for each object under the namespace.
-				t.Run(fmt.Sprintf("editcheck_%s_%s_to_%s_%s_%s", objectRelation.Namespace, objectRelation.Relation, subject.Namespace, subject.ObjectId, subject.Relation), func(t *testing.T) {
-					vrequire := require.New(t)
-
-					allObjectIds, ok := vctx.objectsPerNamespace.Get(nsDef.Name)
-					if !ok {
-						return
-					}
-
-					for _, objectID := range allObjectIds {
-						objectIDStr := objectID.(string)
-						resource := &core.ObjectAndRelation{
-							Namespace: objectRelation.Namespace,
-							ObjectId:  objectIDStr,
-							Relation:  objectRelation.Relation,
-						}
-
-						// TODO(jschorr): add support for caveat context here
-						cr, err := development.RunCheck(devContext, resource, subject, nil)
-						vrequire.NoError(err, "Got unexpected error from edit check")
-
-						expectedMember := vctx.accessibilitySet.GetIsMember(resource, subject)
-						vrequire.Equal(expectedMember == isMember || expectedMember == isMemberViaWildcard,
-							cr.Permissionship == dispatchv1.ResourceCheckResult_MEMBER,
-							"Found unexpected membership difference for %s@%s. Expected %v, Found: %v",
-							tuple.StringONR(resource),
-							tuple.StringONR(subject),
-							expectedMember,
-							cr.Permissionship)
-					}
-				})
 			}
 		}
 	}
-}
-
-func validateLookupResources(t *testing.T, vctx *validationContext) {
-	for _, nsDef := range vctx.fullyResolved.NamespaceDefinitions {
-		for _, relation := range nsDef.Relation {
-			for _, subject := range vctx.subjectsNoWildcard.AsSlice() {
-				objectRelation := &core.RelationReference{
-					Namespace: nsDef.Name,
-					Relation:  relation.Name,
-				}
-
-				t.Run(fmt.Sprintf("lookupresources_%s_%s_to_%s_%s_%s", objectRelation.Namespace, objectRelation.Relation, subject.Namespace, subject.ObjectId, subject.Relation), func(t *testing.T) {
-					vrequire := require.New(t)
-					accessibleObjectIds := vctx.accessibilitySet.AccessibleObjectIDs(objectRelation.Namespace, objectRelation.Relation, subject)
-
-					// Perform a lookup call and ensure it returns the at least the same set of object IDs.
-					resolvedObjectIds, err := vctx.tester.Lookup(context.Background(), objectRelation, subject, vctx.revision)
-					vrequire.NoError(err)
-
-					sort.Strings(accessibleObjectIds)
-					sort.Strings(resolvedObjectIds)
-
-					for _, accessibleObjectID := range accessibleObjectIds {
-						vrequire.True(
-							contains(resolvedObjectIds, accessibleObjectID),
-							"Object `%s` missing in lookup results for %s#%s@%s: Expected: %v. Found: %v",
-							accessibleObjectID,
-							nsDef.Name,
-							relation.Name,
-							tuple.StringONR(subject),
-							accessibleObjectIds,
-							resolvedObjectIds,
-						)
-					}
-
-					// Ensure that every returned object Checks.
-					for _, resolvedObjectID := range resolvedObjectIds {
-						isMember, err := vctx.tester.Check(context.Background(),
-							&core.ObjectAndRelation{
-								Namespace: nsDef.Name,
-								Relation:  relation.Name,
-								ObjectId:  resolvedObjectID,
-							},
-							subject,
-							vctx.revision,
-						)
-						vrequire.NoError(err)
-						vrequire.True(
-							isMember,
-							"Found Check failure for relation %s:%s#%s and subject %s",
-							nsDef.Name,
-							resolvedObjectID,
-							relation.Name,
-							tuple.StringONR(subject),
-						)
-					}
-				})
-			}
-		}
-	}
-}
-
-func validateLookupSubject(t *testing.T, vctx *validationContext) {
-	for _, nsDef := range vctx.fullyResolved.NamespaceDefinitions {
-		allObjectIds, ok := vctx.objectsPerNamespace.Get(nsDef.Name)
-		if !ok {
-			continue
-		}
-
-		for _, relation := range nsDef.Relation {
-			for _, objectID := range allObjectIds {
-				objectIDStr := objectID.(string)
-
-				accessibleSubjectsByType := vctx.accessibilitySet.AccessibleSubjectsByType(nsDef.Name, relation.Name, objectIDStr)
-				accessibleSubjectsByType.ForEachType(func(subjectType *core.RelationReference, expectedObjectIds []string) {
-					t.Run(fmt.Sprintf("lookupsubjects_%s_%s_%s_to_%s_%s", nsDef.Name, relation.Name, objectID, subjectType.Namespace, subjectType.Relation), func(t *testing.T) {
-						vrequire := require.New(t)
-
-						// Perform a lookup call and ensure it returns the at least the same set of object IDs.
-						resource := &core.ObjectAndRelation{
-							Namespace: nsDef.Name,
-							ObjectId:  objectIDStr,
-							Relation:  relation.Name,
-						}
-						resolvedObjectIds, err := vctx.tester.LookupSubjects(context.Background(), resource, subjectType, vctx.revision)
-						vrequire.NoError(err)
-
-						sort.Strings(expectedObjectIds)
-						sort.Strings(resolvedObjectIds)
-
-						// Ensure the object IDs match.
-						for _, expectedObjectID := range expectedObjectIds {
-							vrequire.True(
-								contains(resolvedObjectIds, expectedObjectID),
-								"Object `%s` missing in lookup subjects results for subjects of %s under %s: Expected: %v. Found: %v",
-								expectedObjectID,
-								tuple.StringRR(subjectType),
-								tuple.StringONR(resource),
-								expectedObjectIds,
-								resolvedObjectIds,
-							)
-						}
-
-						// Ensure that every returned object Checks.
-						for _, resolvedObjectID := range resolvedObjectIds {
-							if resolvedObjectID == tuple.PublicWildcard {
-								continue
-							}
-
-							subject := &core.ObjectAndRelation{
-								Namespace: subjectType.Namespace,
-								ObjectId:  resolvedObjectID,
-								Relation:  subjectType.Relation,
-							}
-							isMember, err := vctx.tester.Check(context.Background(),
-								resource,
-								subject,
-								vctx.revision,
-							)
-							vrequire.NoError(err)
-							vrequire.True(
-								isMember,
-								"Found Check failure for resource %s and subject %s",
-								nsDef.Name,
-								tuple.StringONR(resource),
-								tuple.StringONR(subject),
-							)
-						}
-					})
-				})
-			}
-		}
-	}
-}
-
-func validateExpansion(t *testing.T, vctx *validationContext) {
-	for _, nsDef := range vctx.fullyResolved.NamespaceDefinitions {
-		allObjectIds, ok := vctx.objectsPerNamespace.Get(nsDef.Name)
-		if !ok {
-			continue
-		}
-
-		for _, relation := range nsDef.Relation {
-			for _, objectID := range allObjectIds {
-				objectIDStr := objectID.(string)
-				t.Run(fmt.Sprintf("expand_%s_%s_%s", nsDef.Name, objectIDStr, relation.Name), func(t *testing.T) {
-					vrequire := require.New(t)
-
-					_, err := vctx.tester.Expand(context.Background(),
-						&core.ObjectAndRelation{
-							Namespace: nsDef.Name,
-							Relation:  relation.Name,
-							ObjectId:  objectIDStr,
-						},
-						vctx.revision,
-					)
-					vrequire.NoError(err)
-				})
-			}
-		}
-	}
-}
-
-func validateExpansionSubjects(t *testing.T, ds datastore.Datastore, vctx *validationContext) {
-	ctx := datastoremw.ContextWithHandle(context.Background())
-	require.NoError(t, datastoremw.SetInContext(ctx, ds))
-	for _, nsDef := range vctx.fullyResolved.NamespaceDefinitions {
-		allObjectIds, ok := vctx.objectsPerNamespace.Get(nsDef.Name)
-		if !ok {
-			continue
-		}
-
-		for _, relation := range nsDef.Relation {
-			for _, objectID := range allObjectIds {
-				objectIDStr := objectID.(string)
-				t.Run(fmt.Sprintf("expand_subjects_%s_%s_%s", nsDef.Name, objectIDStr, relation.Name), func(t *testing.T) {
-					vrequire := require.New(t)
-					accessibleTerminalSubjects := vctx.accessibilitySet.AccessibleTerminalSubjects(nsDef.Name, relation.Name, objectIDStr)
-
-					// Run a non-recursive expansion to verify no errors are raised.
-					_, err := vctx.dispatch.DispatchExpand(ctx, &dispatchv1.DispatchExpandRequest{
-						ResourceAndRelation: &core.ObjectAndRelation{
-							Namespace: nsDef.Name,
-							Relation:  relation.Name,
-							ObjectId:  objectIDStr,
-						},
-						Metadata: &dispatchv1.ResolverMeta{
-							AtRevision:     vctx.revision.String(),
-							DepthRemaining: 100,
-						},
-						ExpansionMode: dispatchv1.DispatchExpandRequest_SHALLOW,
-					})
-					vrequire.NoError(err)
-
-					// Run a *recursive* expansion and ensure that the subjects found matches those found via Check.
-					resp, err := vctx.dispatch.DispatchExpand(ctx, &dispatchv1.DispatchExpandRequest{
-						ResourceAndRelation: &core.ObjectAndRelation{
-							Namespace: nsDef.Name,
-							Relation:  relation.Name,
-							ObjectId:  objectIDStr,
-						},
-						Metadata: &dispatchv1.ResolverMeta{
-							AtRevision:     vctx.revision.String(),
-							DepthRemaining: 100,
-						},
-						ExpansionMode: dispatchv1.DispatchExpandRequest_RECURSIVE,
-					})
-					vrequire.NoError(err)
-
-					subjectsFoundSet, err := developmentmembership.AccessibleExpansionSubjects(resp.TreeNode)
-					vrequire.NoError(err)
-
-					// Ensure all terminal subjects were found in the expansion.
-					vrequire.EqualValues(0, len(accessibleTerminalSubjects.Exclude(subjectsFoundSet).ToSlice()), "Expected %s, Found: %s", accessibleTerminalSubjects.ToSlice(), subjectsFoundSet.ToSlice())
-
-					// Ensure every subject found matches Check.
-					for _, foundSubject := range subjectsFoundSet.ToSlice() {
-						excludedSubjectsWithCaveats, isWildcard := foundSubject.ExcludedSubjectsFromWildcard()
-
-						// If the subject is a wildcard, then check every matching subject.
-						if isWildcard {
-							// TODO(jschorr): Fix for caveats once fully supported in consistency tests.
-							excludedSubjectsSet := tuple.NewONRSet()
-							for _, excludedSubject := range excludedSubjectsWithCaveats {
-								excludedSubjectsSet.Add(excludedSubject.Subject())
-							}
-
-							allSubjectObjectIds, ok := vctx.objectsPerNamespace.Get(foundSubject.Subject().Namespace)
-							if !ok {
-								continue
-							}
-
-							for _, subjectID := range allSubjectObjectIds {
-								subjectIDStr := subjectID.(string)
-								localSubject := &core.ObjectAndRelation{
-									Namespace: foundSubject.Subject().Namespace,
-									Relation:  foundSubject.Subject().Relation,
-									ObjectId:  subjectIDStr,
-								}
-								isMember, err := vctx.tester.Check(context.Background(),
-									&core.ObjectAndRelation{
-										Namespace: nsDef.Name,
-										Relation:  relation.Name,
-										ObjectId:  objectIDStr,
-									},
-									localSubject,
-									vctx.revision,
-								)
-								vrequire.NoError(err)
-								vrequire.Equal(
-									!excludedSubjectsSet.Has(localSubject),
-									isMember,
-									"Found Check under Expand failure for relation %s:%s#%s and subject %s (checked because of wildcard %s). Expected: %v, Found: %v",
-									nsDef.Name,
-									objectIDStr,
-									relation.Name,
-									tuple.StringONR(localSubject),
-									tuple.StringONR(foundSubject.Subject()),
-									!excludedSubjectsSet.Has(localSubject),
-									isMember,
-								)
-							}
-						} else {
-							// Otherwise, check directly.
-							isMember, err := vctx.tester.Check(context.Background(),
-								&core.ObjectAndRelation{
-									Namespace: nsDef.Name,
-									Relation:  relation.Name,
-									ObjectId:  objectIDStr,
-								},
-								foundSubject.Subject(),
-								vctx.revision,
-							)
-							vrequire.NoError(err)
-							vrequire.True(
-								isMember,
-								"Found Check under Expand failure for relation %s:%s#%s and subject %s",
-								nsDef.Name,
-								objectIDStr,
-								relation.Name,
-								tuple.StringONR(foundSubject.Subject()),
-							)
-						}
-					}
-				})
-			}
-		}
-	}
-}
-
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
-type isMemberStatus int
-
-const (
-	isNotMember         isMemberStatus = 0
-	isMember            isMemberStatus = 1
-	isMemberViaWildcard isMemberStatus = 2
-	isWildcard          isMemberStatus = 3
-)
-
-type checkResult struct {
-	object   *core.ObjectAndRelation
-	subject  *core.ObjectAndRelation
-	isMember isMemberStatus
-}
-
-// TODO(jschorr): optimize the accessibility set if the consistency tests ever become slow enough
-// that it matters.
-type accessibilitySet struct {
-	results []checkResult
-}
-
-func newAccessibilitySet() *accessibilitySet {
-	return &accessibilitySet{
-		results: []checkResult{},
-	}
-}
-
-func (rs *accessibilitySet) Set(object *core.ObjectAndRelation, subject *core.ObjectAndRelation, isMember isMemberStatus) {
-	rs.results = append(rs.results, checkResult{object: object, subject: subject, isMember: isMember})
-}
-
-func (rs *accessibilitySet) GetIsMember(object *core.ObjectAndRelation, subject *core.ObjectAndRelation) isMemberStatus {
-	objectStr := tuple.StringONR(object)
-	subjectStr := tuple.StringONR(subject)
-
-	for _, result := range rs.results {
-		if tuple.StringONR(result.object) == objectStr && tuple.StringONR(result.subject) == subjectStr {
-			return result.isMember
-		}
-	}
-
-	panic(fmt.Sprintf("Missing matching result for %s %s", object, subject))
-}
-
-// AccessibleObjectIDs returns the set of object IDs accessible for the given subject from the given relation on the namespace.
-func (rs *accessibilitySet) AccessibleObjectIDs(namespaceName string, relationName string, subject *core.ObjectAndRelation) []string {
-	var accessibleObjectIDs []string
-	subjectStr := tuple.StringONR(subject)
-	for _, result := range rs.results {
-		if result.isMember == isNotMember {
-			continue
-		}
-
-		if result.object.Namespace == namespaceName && result.object.Relation == relationName && tuple.StringONR(result.subject) == subjectStr {
-			accessibleObjectIDs = append(accessibleObjectIDs, result.object.ObjectId)
-		}
-	}
-	return accessibleObjectIDs
-}
-
-// AccessibleSubjects returns the set of subjects with accessible for the given object on the given relation on the namespace
-func (rs *accessibilitySet) AccessibleSubjectsByType(namespaceName string, relationName string, objectIDStr string) *tuple.ONRByTypeSet {
-	accessibleSubjects := tuple.NewONRByTypeSet()
-	for _, result := range rs.results {
-		if result.isMember == isNotMember || result.isMember == isWildcard || result.isMember == isMemberViaWildcard {
-			continue
-		}
-
-		if result.object.Namespace == namespaceName && result.object.Relation == relationName && result.object.ObjectId == objectIDStr {
-			accessibleSubjects.Add(result.subject)
-		}
-	}
-	return accessibleSubjects
-}
-
-// AccessibleTerminalSubjects returns the set of terminal subjects with accessible for the given object on the given relation on the namespace
-func (rs *accessibilitySet) AccessibleTerminalSubjects(namespaceName string, relationName string, objectIDStr string) *developmentmembership.TrackingSubjectSet {
-	accessibleSubjects := developmentmembership.NewTrackingSubjectSet()
-	for _, result := range rs.results {
-		if result.isMember == isNotMember || result.isMember == isWildcard {
-			continue
-		}
-
-		if result.object.Namespace == namespaceName && result.object.Relation == relationName && result.object.ObjectId == objectIDStr && result.subject.Relation == "..." {
-			// TODO(jschorr): update to support caveats
-			accessibleSubjects.MustAdd(developmentmembership.NewFoundSubject(&core.DirectSubject{Subject: result.subject}, result.object))
-		}
-	}
-	return accessibleSubjects
 }

--- a/internal/services/integrationtesting/consistencytestutil/accessibilityset.go
+++ b/internal/services/integrationtesting/consistencytestutil/accessibilityset.go
@@ -1,0 +1,367 @@
+package consistencytestutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+
+	"github.com/authzed/spicedb/internal/developmentmembership"
+	"github.com/authzed/spicedb/internal/dispatch"
+	"github.com/authzed/spicedb/internal/dispatch/graph"
+	"github.com/authzed/spicedb/internal/graph/computed"
+	"github.com/authzed/spicedb/pkg/datastore"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/util"
+)
+
+// ObjectAndPermission contains an object ID and whether it is a caveated result.
+type ObjectAndPermission struct {
+	ObjectID   string
+	IsCaveated bool
+}
+
+type Accessibility int
+
+const (
+	// NotAccessible indicates that the subject is not accessible for the resource+permission.
+	NotAccessible Accessibility = 0
+
+	// NotAccessibleDueToPrespecifiedCaveat indicates that the subject is not accessible for the
+	// resource+permission due to a caveat whose context is fully prespecified on the relationship.
+	NotAccessibleDueToPrespecifiedCaveat Accessibility = 1
+
+	// AccessibleDirectly indicates that the subject is directly accessible for the resource+permission,
+	// rather than via a wildcard.
+	AccessibleDirectly Accessibility = 2
+
+	// AccessibleViaWildcardOnly indicates that the subject is only granted permission by virtue
+	// of a wildcard being present, i.e. the subject is not directly found for a relation used by
+	// the permission.
+	AccessibleViaWildcardOnly Accessibility = 3
+
+	// AccessibleBecauseTheSame indicates that the resource+permission and subject are exactly
+	// the same.
+	AccessibleBecauseTheSame Accessibility = 4
+)
+
+// AccessibilitySet is a helper for tracking the accessibility, permissions, resources
+// and subjects found for consistency testing.
+type AccessibilitySet struct {
+	// ResourcesByNamespace is a multimap of all defined resources, by resource namespace.
+	ResourcesByNamespace *util.MultiMap[string, *core.ObjectAndRelation]
+
+	// SubjectsByNamespace is a multimap of all defined subjects, by subject namespace.
+	SubjectsByNamespace *util.MultiMap[string, *core.ObjectAndRelation]
+
+	// RelationshipsByResourceNamespace is a multimap of all defined relationships, by resource namespace.
+	RelationshipsByResourceNamespace *util.MultiMap[string, *core.RelationTuple]
+
+	// UncomputedPermissionshipByRelationship is a map from a relationship string of the form
+	// "resourceType:resourceObjectID#permission@subjectType:subjectObjectID" to its
+	// associated *uncomputed* (i.e. caveats not processed) permissionship state.
+	UncomputedPermissionshipByRelationship map[string]dispatchv1.ResourceCheckResult_Membership
+
+	// PermissionshipByRelationship is a map from a relationship string of the form
+	// "resourceType:resourceObjectID#permission@subjectType:subjectObjectID" to its
+	// associated computed (i.e. caveats processed) permissionship state.
+	PermissionshipByRelationship map[string]dispatchv1.ResourceCheckResult_Membership
+
+	// AccessibilityByRelationship is a map from a relationship string of the form
+	// "resourceType:resourceObjectID#permission@subjectType:subjectObjectID" to its
+	// associated computed accessibility state.
+	AccessibilityByRelationship map[string]Accessibility
+}
+
+// BuildAccessibilitySet builds and returns an accessibility set for the given consistency
+// cluster and data. Note that this function does *a lot* of checks, and should not be used
+// outside of testing.
+func BuildAccessibilitySet(t *testing.T, ccd ConsistencyClusterAndData) *AccessibilitySet {
+	// Compute all relationships and objects by namespace.
+	relsByResourceNamespace := util.NewMultiMap[string, *core.RelationTuple]()
+	resourcesByNamespace := util.NewMultiMap[string, *core.ObjectAndRelation]()
+	subjectsByNamespace := util.NewMultiMap[string, *core.ObjectAndRelation]()
+	allObjectIds := util.NewSet[string]()
+
+	for _, tpl := range ccd.Populated.Tuples {
+		relsByResourceNamespace.Add(tpl.ResourceAndRelation.Namespace, tpl)
+		resourcesByNamespace.Add(tpl.ResourceAndRelation.Namespace, tpl.ResourceAndRelation)
+		subjectsByNamespace.Add(tpl.Subject.Namespace, tpl.Subject)
+		allObjectIds.Add(tpl.ResourceAndRelation.ObjectId)
+
+		if tpl.Subject.ObjectId != tuple.PublicWildcard {
+			allObjectIds.Add(tpl.Subject.ObjectId)
+		}
+	}
+
+	// Run a *dispatched* check for each {resource+permission, defined subject} pair and
+	// record the results. Note that we use a dispatched check to ensure that we
+	// find caveated subjects. We then run a fully caveated-processed check on the
+	// caveated results to see if they are static.
+	//
+	// NOTE: We only conduct checks here for the *defined* subjects from the relationships,
+	// rather than every possible subject, as the latter would make the consistency test suite
+	// VERY slow, due to the combinatorial size of all possible subjects.
+	headRevision, err := ccd.DataStore.HeadRevision(ccd.Ctx)
+	require.NoError(t, err)
+
+	dispatcher := graph.NewLocalOnlyDispatcher(defaultConcurrencyLimit)
+	permissionshipByRelationship := map[string]dispatchv1.ResourceCheckResult_Membership{}
+	uncomputedPermissionshipByRelationship := map[string]dispatchv1.ResourceCheckResult_Membership{}
+	accessibilityByRelationship := map[string]Accessibility{}
+
+	for _, resourceType := range ccd.Populated.NamespaceDefinitions {
+		for _, possibleResourceID := range allObjectIds.AsSlice() {
+			for _, relationOrPermission := range resourceType.Relation {
+				for _, subject := range subjectsByNamespace.Values() {
+					if subject.ObjectId == tuple.PublicWildcard {
+						continue
+					}
+
+					resourceRelation := &core.RelationReference{
+						Namespace: resourceType.Name,
+						Relation:  relationOrPermission.Name,
+					}
+
+					results, err := dispatcher.DispatchCheck(ccd.Ctx, &dispatchv1.DispatchCheckRequest{
+						ResourceRelation: resourceRelation,
+						ResourceIds:      []string{possibleResourceID},
+						Subject:          subject,
+						ResultsSetting:   dispatchv1.DispatchCheckRequest_ALLOW_SINGLE_RESULT,
+						Metadata: &dispatchv1.ResolverMeta{
+							AtRevision:     headRevision.String(),
+							DepthRemaining: 50,
+						},
+					})
+					require.NoError(t, err)
+
+					resourceAndRelation := &core.ObjectAndRelation{
+						Namespace: resourceType.Name,
+						ObjectId:  possibleResourceID,
+						Relation:  relationOrPermission.Name,
+					}
+					permString := tuple.MustString(&core.RelationTuple{
+						ResourceAndRelation: resourceAndRelation,
+						Subject:             subject,
+					})
+
+					if result, ok := results.ResultsByResourceId[possibleResourceID]; ok {
+						membership := result.Membership
+						uncomputedPermissionshipByRelationship[permString] = membership
+
+						// If the subject is caveated, run a computed check to determine if it
+						// statically has permission (or not). This can happen if the caveat context
+						// is fully specified on the relationship.
+						if membership == dispatchv1.ResourceCheckResult_CAVEATED_MEMBER {
+							cr, _, err := computed.ComputeCheck(ccd.Ctx, dispatcher,
+								computed.CheckParameters{
+									ResourceType:  resourceRelation,
+									Subject:       subject,
+									CaveatContext: nil,
+									AtRevision:    headRevision,
+									MaximumDepth:  50,
+								},
+								possibleResourceID,
+							)
+							require.NoError(t, err)
+							membership = cr.Membership
+						}
+
+						permissionshipByRelationship[permString] = membership
+
+						switch membership {
+						case dispatchv1.ResourceCheckResult_NOT_MEMBER:
+							accessibilityByRelationship[permString] = NotAccessibleDueToPrespecifiedCaveat
+
+						case dispatchv1.ResourceCheckResult_CAVEATED_MEMBER:
+							fallthrough
+
+						case dispatchv1.ResourceCheckResult_MEMBER:
+							if resourceAndRelation.EqualVT(subject) {
+								accessibilityByRelationship[permString] = AccessibleBecauseTheSame
+							} else {
+								if isAccessibleViaWildcardOnly(t, ccd, dispatcher, headRevision, resourceAndRelation, subject) {
+									accessibilityByRelationship[permString] = AccessibleViaWildcardOnly
+								} else {
+									accessibilityByRelationship[permString] = AccessibleDirectly
+								}
+							}
+
+						default:
+							panic("unknown membership result")
+						}
+					} else {
+						uncomputedPermissionshipByRelationship[permString] = dispatchv1.ResourceCheckResult_NOT_MEMBER
+						permissionshipByRelationship[permString] = dispatchv1.ResourceCheckResult_NOT_MEMBER
+						accessibilityByRelationship[permString] = NotAccessible
+					}
+				}
+			}
+		}
+	}
+
+	return &AccessibilitySet{
+		RelationshipsByResourceNamespace:       relsByResourceNamespace,
+		ResourcesByNamespace:                   resourcesByNamespace,
+		SubjectsByNamespace:                    subjectsByNamespace,
+		PermissionshipByRelationship:           permissionshipByRelationship,
+		UncomputedPermissionshipByRelationship: uncomputedPermissionshipByRelationship,
+		AccessibilityByRelationship:            accessibilityByRelationship,
+	}
+}
+
+// UncomputedPermissionshipFor returns the uncomputed permissionship for the given
+// resource+permission and subject. If not found, returns false.
+func (as *AccessibilitySet) UncomputedPermissionshipFor(resourceAndRelation *core.ObjectAndRelation, subject *core.ObjectAndRelation) (dispatchv1.ResourceCheckResult_Membership, bool) {
+	relString := tuple.MustString(&core.RelationTuple{
+		ResourceAndRelation: resourceAndRelation,
+		Subject:             subject,
+	})
+	permissionship, ok := as.UncomputedPermissionshipByRelationship[relString]
+	return permissionship, ok
+}
+
+// AccessibiliyAndPermissionshipFor returns the computed accessibility and permissionship for the
+// given resource+permission and subject. If not found, returns false.
+func (as *AccessibilitySet) AccessibiliyAndPermissionshipFor(resourceAndRelation *core.ObjectAndRelation, subject *core.ObjectAndRelation) (Accessibility, dispatchv1.ResourceCheckResult_Membership, bool) {
+	relString := tuple.MustString(&core.RelationTuple{
+		ResourceAndRelation: resourceAndRelation,
+		Subject:             subject,
+	})
+	accessibility, ok := as.AccessibilityByRelationship[relString]
+	if !ok {
+		return NotAccessible, dispatchv1.ResourceCheckResult_UNKNOWN, false
+	}
+
+	permissionship := as.PermissionshipByRelationship[relString]
+	return accessibility, permissionship, ok
+}
+
+// DirectlyAccessibleDefinedSubjects returns all subjects that have direct access/permission on the
+// resource+permission. Direct access is defined as not being granted access via a wildcard.
+func (as *AccessibilitySet) DirectlyAccessibleDefinedSubjects(resourceAndRelation *core.ObjectAndRelation) []*core.ObjectAndRelation {
+	found := make([]*core.ObjectAndRelation, 0)
+	for relString, accessibility := range as.AccessibilityByRelationship {
+		if accessibility != AccessibleDirectly {
+			continue
+		}
+
+		parsed := tuple.MustParse(relString)
+		if !parsed.ResourceAndRelation.EqualVT(resourceAndRelation) {
+			continue
+		}
+
+		found = append(found, parsed.Subject)
+	}
+	return found
+}
+
+// DirectlyAccessibleDefinedSubjectsOfType returns all subjects that have direct access/permission on the
+// resource+permission and match the given subject type.
+// Direct access is defined as not being granted access via a wildcard.
+func (as *AccessibilitySet) DirectlyAccessibleDefinedSubjectsOfType(resourceAndRelation *core.ObjectAndRelation, subjectType *core.RelationReference) map[string]ObjectAndPermission {
+	found := map[string]ObjectAndPermission{}
+	for relString, accessibility := range as.AccessibilityByRelationship {
+		// NOTE: we also ignore subjects granted access by being themselves.
+		if accessibility != AccessibleDirectly && accessibility != AccessibleBecauseTheSame {
+			continue
+		}
+
+		parsed := tuple.MustParse(relString)
+		if !parsed.ResourceAndRelation.EqualVT(resourceAndRelation) {
+			continue
+		}
+
+		if parsed.Subject.Namespace != subjectType.Namespace || parsed.Subject.Relation != subjectType.Relation {
+			continue
+		}
+
+		permissionship := as.PermissionshipByRelationship[relString]
+
+		found[parsed.Subject.ObjectId] = ObjectAndPermission{
+			ObjectID:   parsed.Subject.ObjectId,
+			IsCaveated: permissionship == dispatchv1.ResourceCheckResult_CAVEATED_MEMBER,
+		}
+	}
+	return found
+}
+
+// SubjectTypes returns all *defined* subject types found.
+func (as *AccessibilitySet) SubjectTypes() []*core.RelationReference {
+	subjectTypes := map[string]*core.RelationReference{}
+	for _, subject := range as.SubjectsByNamespace.Values() {
+		rr := &core.RelationReference{
+			Namespace: subject.Namespace,
+			Relation:  subject.Relation,
+		}
+		subjectTypes[tuple.StringRR(rr)] = rr
+	}
+	return maps.Values(subjectTypes)
+}
+
+// AllSubjectsNoWildcards returns all *defined*, non-wildcard subjects found.
+func (as *AccessibilitySet) AllSubjectsNoWildcards() []*core.ObjectAndRelation {
+	subjects := make([]*core.ObjectAndRelation, 0)
+	for _, subject := range as.SubjectsByNamespace.Values() {
+		if subject.ObjectId == tuple.PublicWildcard {
+			continue
+		}
+		subjects = append(subjects, subject)
+	}
+	return subjects
+}
+
+// LookupAccessibleResources returns all resources of the given type that are accessible to the
+// given subject.
+func (as *AccessibilitySet) LookupAccessibleResources(resourceType *core.RelationReference, subject *core.ObjectAndRelation) map[string]ObjectAndPermission {
+	foundResources := map[string]ObjectAndPermission{}
+	for permString, permissionship := range as.PermissionshipByRelationship {
+		if permissionship == dispatchv1.ResourceCheckResult_NOT_MEMBER {
+			continue
+		}
+
+		parsed := tuple.MustParse(permString)
+		if parsed.ResourceAndRelation.Namespace != resourceType.Namespace ||
+			parsed.ResourceAndRelation.Relation != resourceType.Relation {
+			continue
+		}
+
+		if parsed.Subject.Namespace != subject.Namespace ||
+			parsed.Subject.ObjectId != subject.ObjectId ||
+			parsed.Subject.Relation != subject.Relation {
+			continue
+		}
+
+		foundResources[parsed.ResourceAndRelation.ObjectId] = ObjectAndPermission{
+			ObjectID:   parsed.ResourceAndRelation.ObjectId,
+			IsCaveated: permissionship == dispatchv1.ResourceCheckResult_CAVEATED_MEMBER,
+		}
+	}
+
+	return foundResources
+}
+
+func isAccessibleViaWildcardOnly(
+	t *testing.T,
+	ccd ConsistencyClusterAndData,
+	dispatcher dispatch.Dispatcher,
+	revision datastore.Revision,
+	resourceAndPermission *core.ObjectAndRelation,
+	subject *core.ObjectAndRelation,
+) bool {
+	resp, err := dispatcher.DispatchExpand(ccd.Ctx, &dispatchv1.DispatchExpandRequest{
+		ResourceAndRelation: resourceAndPermission,
+		Metadata: &dispatchv1.ResolverMeta{
+			AtRevision:     revision.String(),
+			DepthRemaining: 100,
+		},
+		ExpansionMode: dispatchv1.DispatchExpandRequest_RECURSIVE,
+	})
+	require.NoError(t, err)
+
+	subjectsFound, err := developmentmembership.AccessibleExpansionSubjects(resp.TreeNode)
+	require.NoError(t, err)
+	return !subjectsFound.Contains(subject)
+}

--- a/internal/services/integrationtesting/consistencytestutil/clusteranddata.go
+++ b/internal/services/integrationtesting/consistencytestutil/clusteranddata.go
@@ -1,0 +1,104 @@
+package consistencytestutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/authzed/spicedb/internal/dispatch"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/authzed/spicedb/internal/datastore/memdb"
+	"github.com/authzed/spicedb/internal/dispatch/caching"
+	"github.com/authzed/spicedb/internal/dispatch/graph"
+	"github.com/authzed/spicedb/internal/dispatch/keys"
+	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
+	"github.com/authzed/spicedb/internal/namespace"
+	"github.com/authzed/spicedb/internal/testserver"
+	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/validationfile"
+)
+
+const defaultConcurrencyLimit = 10
+
+// ConsistencyClusterAndData holds a connection to a SpiceDB "cluster" (size 1)
+// running the V1 API for the given data.
+type ConsistencyClusterAndData struct {
+	Conn      *grpc.ClientConn
+	DataStore datastore.Datastore
+	Ctx       context.Context
+	Populated *validationfile.PopulatedValidationFile
+}
+
+// LoadDataAndCreateClusterForTesting loads the data found in a consistency test file,
+// builds a cluster for it, and returns both the data and cluster.
+func LoadDataAndCreateClusterForTesting(t *testing.T, consistencyTestFilePath string, revisionDelta time.Duration) ConsistencyClusterAndData {
+	require := require.New(t)
+
+	ds, err := memdb.NewMemdbDatastore(0, revisionDelta, memdb.DisableGC)
+	require.NoError(err)
+
+	return BuildDataAndCreateClusterForTesting(t, consistencyTestFilePath, ds)
+}
+
+// BuildDataAndCreateClusterForTesting loads the data found in a consistency test file,
+// builds a cluster for it, and returns both the data and cluster.
+func BuildDataAndCreateClusterForTesting(t *testing.T, consistencyTestFilePath string, ds datastore.Datastore) ConsistencyClusterAndData {
+	require := require.New(t)
+
+	populated, revision, err := validationfile.PopulateFromFiles(context.Background(), ds, []string{consistencyTestFilePath})
+	require.NoError(err)
+
+	connections, cleanup := testserver.TestClusterWithDispatch(t, 1, ds)
+	t.Cleanup(cleanup)
+
+	dsCtx := datastoremw.ContextWithHandle(context.Background())
+	require.NoError(datastoremw.SetInContext(dsCtx, ds))
+
+	// Validate the type system for each namespace.
+	for _, nsDef := range populated.NamespaceDefinitions {
+		_, ts, err := namespace.ReadNamespaceAndTypes(
+			dsCtx,
+			nsDef.Name,
+			ds.SnapshotReader(revision),
+		)
+		require.NoError(err)
+
+		_, err = ts.Validate(dsCtx)
+		require.NoError(err)
+	}
+
+	return ConsistencyClusterAndData{
+		Conn:      connections[0],
+		DataStore: ds,
+		Ctx:       dsCtx,
+		Populated: populated,
+	}
+}
+
+// CreateDispatcherForTesting creates a dispatcher for consistency testing, with or without
+// caching enabled.
+func CreateDispatcherForTesting(t *testing.T, withCaching bool) dispatch.Dispatcher {
+	require := require.New(t)
+	dispatcher := graph.NewLocalOnlyDispatcher(defaultConcurrencyLimit)
+	if withCaching {
+		cachingDispatcher, err := caching.NewCachingDispatcher(nil, "", &keys.CanonicalKeyHandler{})
+		require.NoError(err)
+
+		localDispatcher := graph.NewDispatcher(cachingDispatcher, graph.SharedConcurrencyLimits(10))
+		t.Cleanup(func() {
+			err := localDispatcher.Close()
+			require.NoError(err)
+		})
+
+		cachingDispatcher.SetDelegate(localDispatcher)
+		dispatcher = cachingDispatcher
+	}
+	t.Cleanup(func() {
+		err := dispatcher.Close()
+		require.NoError(err)
+	})
+	return dispatcher
+}

--- a/internal/services/integrationtesting/consistencytestutil/configs.go
+++ b/internal/services/integrationtesting/consistencytestutil/configs.go
@@ -1,0 +1,31 @@
+package consistencytestutil
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const testconfigsDirectory = "testconfigs"
+
+// ListTestConfigs returns a list of all test configuration files defined in the testconfigs
+// directory. Must be invoked from a test defined in the integrationtesting folder.
+func ListTestConfigs() ([]string, error) {
+	_, filename, _, _ := runtime.Caller(1) // 1 for the parent caller.
+	consistencyTestFiles := []string{}
+	err := filepath.Walk(path.Join(path.Dir(filename), testconfigsDirectory), func(path string, info os.FileInfo, err error) error {
+		if info == nil || info.IsDir() {
+			return nil
+		}
+
+		if strings.HasSuffix(info.Name(), ".yaml") {
+			consistencyTestFiles = append(consistencyTestFiles, path)
+		}
+
+		return nil
+	})
+
+	return consistencyTestFiles, err
+}

--- a/internal/services/integrationtesting/testconfigs/basiccaveat.yaml
+++ b/internal/services/integrationtesting/testconfigs/basiccaveat.yaml
@@ -1,0 +1,33 @@
+---
+schema: |+
+  definition user {}
+
+  caveat some_caveat(somecondition int) {
+    somecondition == 42
+  }
+
+  definition document {
+  	relation viewer: user with some_caveat | user
+    permission view = viewer
+  }
+
+relationships: >-
+  document:firstdoc#viewer@user:tom[some_caveat:{"somecondition":42}]
+
+  document:firstdoc#viewer@user:fred[some_caveat:{"somecondition":41}]
+
+  document:firstdoc#viewer@user:sarah[some_caveat]
+
+  document:firstdoc#viewer@user:tracy
+assertions:
+  assertTrue:
+    - "document:firstdoc#view@user:tom"
+    - "document:firstdoc#view@user:tracy"
+    - 'document:firstdoc#view@user:sarah with {"somecondition": 42}'
+    - 'document:firstdoc#view@user:tom with {"somecondition": 41}' # Context written overrides specified at check time.
+  assertCaveated:
+    - "document:firstdoc#view@user:sarah"
+  assertFalse:
+    - "document:firstdoc#view@user:fred"
+    - 'document:firstdoc#view@user:sarah with {"somecondition": 41}'
+    - 'document:firstdoc#view@user:fred with {"somecondition": 42}' # Context written overrides specified at check time.

--- a/internal/services/integrationtesting/testconfigs/basicrbac.yaml
+++ b/internal/services/integrationtesting/testconfigs/basicrbac.yaml
@@ -1,26 +1,26 @@
 ---
 schema: |+
-    definition example/user {}
+  definition example/user {}
 
-    definition example/document {
-    	relation writer: example/user
-    	relation reader: example/user
-        permission write = writer
-        permission view = reader + write
-    }
+  definition example/document {
+  	relation writer: example/user
+  	relation reader: example/user
+      permission write = writer
+      permission view = reader + write
+  }
 
 relationships: >-
-    example/document:firstdoc#writer@example/user:tom#...
+  example/document:firstdoc#writer@example/user:tom#...
 
-    example/document:firstdoc#reader@example/user:fred#...
+  example/document:firstdoc#reader@example/user:fred#...
 
-    example/document:seconddoc#reader@example/user:tom#...
+  example/document:seconddoc#reader@example/user:tom#...
 assertions:
-    assertTrue:
-        - "example/document:firstdoc#write@example/user:tom#..."
-        - "example/document:firstdoc#view@example/user:tom#..."
-        - "example/document:firstdoc#view@example/user:fred#..."
-        - "example/document:seconddoc#view@example/user:tom#..."
-    assertFalse:
-        - "example/document:firstdoc#write@example/user:fred#..."
-        - "example/document:seconddoc#write@example/user:tom#..."
+  assertTrue:
+    - "example/document:firstdoc#write@example/user:tom#..."
+    - "example/document:firstdoc#view@example/user:tom#..."
+    - "example/document:firstdoc#view@example/user:fred#..."
+    - "example/document:seconddoc#view@example/user:tom#..."
+  assertFalse:
+    - "example/document:firstdoc#write@example/user:fred#..."
+    - "example/document:seconddoc#write@example/user:tom#..."

--- a/internal/services/integrationtesting/testconfigs/caveatarrow.yaml
+++ b/internal/services/integrationtesting/testconfigs/caveatarrow.yaml
@@ -1,0 +1,61 @@
+---
+schema: |+
+  definition user {}
+
+  caveat some_caveat(somecondition int) {
+    somecondition == 42
+  }
+
+  caveat another_caveat(anothercondition string) {
+    anothercondition == 'hello world'
+  }
+
+  definition organization {
+    relation viewer: user with some_caveat | user
+    permission view = viewer
+  }
+
+  definition document {
+    relation org: organization with another_caveat | organization
+    permission view = org->view
+  }
+
+relationships: >-
+  organization:someorg#viewer@user:tom[some_caveat:{"somecondition":42}]
+
+  organization:someorg#viewer@user:fred[some_caveat:{"somecondition":41}]
+
+  organization:someorg#viewer@user:sarah[some_caveat]
+
+  organization:anotherorg#viewer@user:tom[some_caveat:{"somecondition":42}]
+
+  organization:anotherorg#viewer@user:fred[some_caveat:{"somecondition":41}]
+
+  organization:anotherorg#viewer@user:sarah[some_caveat]
+
+  document:directorgdoc#org@organization:someorg
+
+  document:caveatedorgdoc#org@organization:anotherorg[another_caveat]
+
+  document:staticorgdoc#org@organization:anotherorg[another_caveat:{"anothercondition":"hello world"}]
+
+  document:staticnoorgdoc#org@organization:anotherorg[another_caveat:{"anothercondition":"nope"}]
+assertions:
+  assertTrue:
+    - "document:directorgdoc#view@user:tom"
+    - "document:staticorgdoc#view@user:tom"
+    - 'document:caveatedorgdoc#view@user:tom with {"anothercondition": "hello world"}'
+    - 'document:caveatedorgdoc#view@user:sarah with {"somecondition": 42, "anothercondition": "hello world"}'
+  assertCaveated:
+    - "document:directorgdoc#view@user:sarah"
+    - "document:caveatedorgdoc#view@user:tom"
+    - "document:staticorgdoc#view@user:sarah"
+    - "document:caveatedorgdoc#view@user:sarah"
+    - "document:caveatedorgdoc#view@user:fred"
+    - 'document:caveatedorgdoc#view@user:sarah with {"anothercondition": "hello world"}'
+  assertFalse:
+    - "document:directorgdoc#view@user:fred"
+    - "document:staticnoorgdoc#view@user:tom"
+    - "document:staticorgdoc#view@user:fred"
+    - 'document:caveatedorgdoc#view@user:tom with {"anothercondition": "nope"}'
+    - 'document:caveatedorgdoc#view@user:sarah with {"somecondition": 41, "anothercondition": "hello world"}'

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -196,6 +196,7 @@ func TestClusterWithDispatchAndCacheConfig(t testing.TB, size uint, ds datastore
 				Network: util.BufferedNetwork,
 				Enabled: true,
 			}),
+			server.WithExperimentalCaveatsEnabled(true),
 			server.WithSchemaPrefixesRequired(false),
 			server.WithGRPCAuthFunc(func(ctx context.Context) (context.Context, error) {
 				return ctx, nil

--- a/pkg/util/multimap.go
+++ b/pkg/util/multimap.go
@@ -21,6 +21,9 @@ type ReadOnlyMultimap[T comparable, Q any] interface {
 
 	// Keys returns the keys of the map.
 	Keys() []T
+
+	// Values returns all values in the map.
+	Values() []Q
 }
 
 // NewMultiMap creates and returns a new MultiMap from keys of type T to values of type Q.
@@ -88,6 +91,15 @@ func (mm *MultiMap[T, Q]) Keys() []T {
 	return maps.Keys(mm.items)
 }
 
+// Values returns all values in the map.
+func (mm MultiMap[T, Q]) Values() []Q {
+	values := make([]Q, 0, len(mm.items)*2)
+	for _, valueSlice := range maps.Values(mm.items) {
+		values = append(values, valueSlice...)
+	}
+	return values
+}
+
 // AsReadOnly returns a read-only *copy* of the mulitmap.
 func (mm *MultiMap[T, Q]) AsReadOnly() ReadOnlyMultimap[T, Q] {
 	return readOnlyMultimap[T, Q]{
@@ -129,4 +141,13 @@ func (mm readOnlyMultimap[T, Q]) Len() int {
 // Keys returns the keys of the map.
 func (mm readOnlyMultimap[T, Q]) Keys() []T {
 	return maps.Keys(mm.items)
+}
+
+// Values returns all values in the map.
+func (mm readOnlyMultimap[T, Q]) Values() []Q {
+	values := make([]Q, 0, len(mm.items)*2)
+	for _, valueSlice := range maps.Values(mm.items) {
+		values = append(values, valueSlice...)
+	}
+	return values
 }


### PR DESCRIPTION
Re-engineer consistency tests to make them cleaner, cover more cases and, most importantly, support caveats

Adds two basic caveat consistency tests, with more to follow in followup PR(s)

Fixes #1088