### PR TITLE
refactor datastore flags to make them reusable

### DIFF
--- a/pkg/cmd/datastore.go
+++ b/pkg/cmd/datastore.go
@@ -31,7 +31,7 @@ func NewDatastoreCommand(programName string) (*cobra.Command, error) {
 	cfg := datastore.Config{}
 
 	gcCmd := NewGCDatastoreCommand(datastoreCmd.Use, &cfg)
-	if err := datastore.RegisterDatastoreFlags(gcCmd, &cfg); err != nil {
+	if err := datastore.RegisterDatastoreFlagsWithPrefix(gcCmd.Flags(), "", &cfg); err != nil {
 		return nil, err
 	}
 	datastoreCmd.AddCommand(gcCmd)


### PR DESCRIPTION
This PR refactors `datastore.RegisterDatastoreFlags` to make them reusable in new scenarios, particularly when we may have a process that runs multiple SpiceDB with various datastores.
