### PR TITLE
adds log.Ctx(ctx) calls (almost) everywhere

### DIFF
--- a/internal/datastore/common/gc.go
+++ b/internal/datastore/common/gc.go
@@ -89,7 +89,7 @@ var MaxGCInterval = 60 * time.Minute
 // StartGarbageCollector loops forever until the context is canceled and
 // performs garbage collection on the provided interval.
 func StartGarbageCollector(ctx context.Context, gc GarbageCollector, interval, window, timeout time.Duration) error {
-	log.Info().
+	log.Ctx(ctx).Info().
 		Dur("interval", interval).
 		Msg("datastore garbage collection worker started")
 
@@ -116,7 +116,7 @@ func StartGarbageCollector(ctx context.Context, gc GarbageCollector, interval, w
 				continue
 			}
 			backoffInterval.Reset()
-			log.Debug().
+			log.Ctx(ctx).Debug().
 				Dur("next-run-in", interval).
 				Msg("datastore garbage collection completed successfully")
 		}

--- a/internal/datastore/common/revisions/optimized.go
+++ b/internal/datastore/common/revisions/optimized.go
@@ -45,13 +45,13 @@ func (cor *CachedOptimizedRevisions) OptimizedRevision(ctx context.Context) (dat
 	localNow := cor.clockFn.Now()
 	lastRevision := cor.lastQuantizedRevision.get()
 	if localNow.Before(lastRevision.validThrough) {
-		log.Debug().Time("now", localNow).Time("valid", lastRevision.validThrough).Msg("returning cached revision")
+		log.Ctx(ctx).Debug().Time("now", localNow).Time("valid", lastRevision.validThrough).Msg("returning cached revision")
 		span.AddEvent("returning cached revision")
 		return lastRevision.revision, nil
 	}
 
 	lastQuantizedRevision, err, _ := cor.updateGroup.Do("", func() (interface{}, error) {
-		log.Debug().Time("now", localNow).Time("valid", lastRevision.validThrough).Msg("computing new revision")
+		log.Ctx(ctx).Debug().Time("now", localNow).Time("valid", lastRevision.validThrough).Msg("computing new revision")
 		span.AddEvent("computing new revision")
 
 		optimized, validFor, err := cor.optimizedFunc(ctx)
@@ -63,7 +63,7 @@ func (cor *CachedOptimizedRevisions) OptimizedRevision(ctx context.Context) (dat
 			Add(validFor).
 			Add(cor.maxRevisionStaleness)
 		cor.lastQuantizedRevision.set(validRevision{optimized, rvt})
-		log.Debug().Time("now", localNow).Time("valid", rvt).Stringer("validFor", validFor).Msg("setting valid through")
+		log.Ctx(ctx).Debug().Time("now", localNow).Time("valid", rvt).Stringer("validFor", validFor).Msg("setting valid through")
 
 		return optimized, nil
 	})

--- a/internal/datastore/common/revisions/remoteclock.go
+++ b/internal/datastore/common/revisions/remoteclock.go
@@ -57,7 +57,7 @@ func (rcr *RemoteClockRevisions) optimizedRevisionFunc(ctx context.Context) (dat
 		quantized -= afterLastQuantization
 		validForNanos = rcr.quantizationNanos - afterLastQuantization
 	}
-	log.Debug().Int64("readSkew", rcr.followerReadDelayNanos).Int64("totalSkew", nowHLC.IntPart()-quantized).Msg("revision skews")
+	log.Ctx(ctx).Debug().Int64("readSkew", rcr.followerReadDelayNanos).Int64("totalSkew", nowHLC.IntPart()-quantized).Msg("revision skews")
 
 	return revision.NewFromDecimal(decimal.NewFromInt(quantized)), time.Duration(validForNanos) * time.Nanosecond, nil
 }
@@ -88,13 +88,13 @@ func (rcr *RemoteClockRevisions) CheckRevision(ctx context.Context, dsRevision d
 
 	isStale := revisionNanos < (nowNanos - rcr.gcWindowNanos)
 	if isStale {
-		log.Debug().Stringer("now", now).Stringer("revision", revision).Msg("stale revision")
+		log.Ctx(ctx).Debug().Stringer("now", now).Stringer("revision", revision).Msg("stale revision")
 		return datastore.NewInvalidRevisionErr(revision, datastore.RevisionStale)
 	}
 
 	isUnknown := revisionNanos > nowNanos
 	if isUnknown {
-		log.Debug().Stringer("now", now).Stringer("revision", revision).Msg("unknown revision")
+		log.Ctx(ctx).Debug().Stringer("now", now).Stringer("revision", revision).Msg("unknown revision")
 		return datastore.NewInvalidRevisionErr(revision, datastore.CouldNotDetermineRevision)
 	}
 

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -240,7 +240,7 @@ func (cds *crdbDatastore) SnapshotReader(rev datastore.Revision) datastore.Reade
 		setTxTime := fmt.Sprintf(querySetTransactionTime, rev)
 		if _, err := tx.Exec(ctx, setTxTime); err != nil {
 			if err := tx.Rollback(ctx); err != nil {
-				log.Warn().Err(err).Msg(
+				log.Ctx(ctx).Warn().Err(err).Msg(
 					"error rolling back transaction after failing to set transaction time",
 				)
 			}

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -532,7 +532,7 @@ func (mds *Datastore) seedDatabase(ctx context.Context) error {
 	if lastInsertID != noLastInsertID {
 		// If there was no error and `lastInsertID` is 0, the insert was ignored. This indicates the transaction
 		// was already seeded by another processes (i.e. race condition).
-		log.Info().Int64("headRevision", lastInsertID).Msg("seeded base datastore headRevision")
+		log.Ctx(ctx).Info().Int64("headRevision", lastInsertID).Msg("seeded base datastore headRevision")
 	}
 
 	uuidSQL, uuidArgs, err := sb.
@@ -558,7 +558,7 @@ func (mds *Datastore) seedDatabase(ctx context.Context) error {
 	if lastInsertID != noLastInsertID {
 		// If there was no error and `lastInsertID` is 0, the insert was ignored. This indicates the transaction
 		// was already seeded by another processes (i.e. race condition).
-		log.Info().Int64("headRevision", lastInsertID).Msg("seeded base datastore unique ID")
+		log.Ctx(ctx).Info().Int64("headRevision", lastInsertID).Msg("seeded base datastore unique ID")
 	}
 
 	err = tx.Commit()

--- a/internal/datastore/mysql/gc.go
+++ b/internal/datastore/mysql/gc.go
@@ -51,7 +51,7 @@ func (mds *Datastore) TxIDBefore(ctx context.Context, before time.Time) (datasto
 	}
 
 	if !value.Valid {
-		log.Debug().Time("before", before).Msg("no stale transactions found in the datastore")
+		log.Ctx(ctx).Debug().Time("before", before).Msg("no stale transactions found in the datastore")
 		return datastore.NoRevision, nil
 	}
 	return revision.NewFromDecimal(decimal.NewFromInt(value.Int64)), nil

--- a/internal/datastore/postgres/migrations/zz_migration.0011_backfill_xid_add_indices.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0011_backfill_xid_add_indices.go
@@ -129,13 +129,13 @@ func init() {
 			for _, stmt := range backfills {
 				concreteStmt := fmt.Sprintf(stmt, batchSize)
 
-				log.Info().Str("statement", concreteStmt).Msg("starting backfill")
+				log.Ctx(ctx).Info().Str("statement", concreteStmt).Msg("starting backfill")
 
 				var r pgconn.CommandTag
 				var err error
 
 				for r, err = conn.Exec(ctx, concreteStmt); err == nil && r.RowsAffected() > 0; r, err = conn.Exec(ctx, concreteStmt) {
-					log.Debug().Int64("count", r.RowsAffected()).Msg("updated rows")
+					log.Ctx(ctx).Debug().Int64("count", r.RowsAffected()).Msg("updated rows")
 				}
 				if err != nil {
 					return err

--- a/internal/datastore/spanner/migrations/driver.go
+++ b/internal/datastore/spanner/migrations/driver.go
@@ -42,8 +42,8 @@ func NewSpannerDriver(database, credentialsFilePath, emulatorHost string) (*Span
 			return nil, err
 		}
 	}
-	log.Info().Str("spanner-emulator-host", os.Getenv(emulatorSettingKey)).Msg("spanner emulator")
-	log.Info().Str("credentials", credentialsFilePath).Str("db", database).Msg("connecting")
+	log.Ctx(ctx).Info().Str("spanner-emulator-host", os.Getenv(emulatorSettingKey)).Msg("spanner emulator")
+	log.Ctx(ctx).Info().Str("credentials", credentialsFilePath).Str("db", database).Msg("connecting")
 	client, err := spanner.NewClient(ctx, database, option.WithCredentialsFile(credentialsFilePath))
 	if err != nil {
 		return nil, err

--- a/internal/datastore/spanner/stats.go
+++ b/internal/datastore/spanner/stats.go
@@ -85,7 +85,7 @@ func updateCounter(ctx context.Context, rwt *spanner.ReadWriteTransaction, chang
 		newValue += currentValue
 	}
 
-	log.Trace().
+	log.Ctx(ctx).Trace().
 		Bytes("counterID", counterID).
 		Int64("newValue", newValue).
 		Int64("change", change).

--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -296,7 +296,7 @@ func (cd *Dispatcher) DispatchLookup(ctx context.Context, req *v1.DispatchLookup
 		}
 
 		if req.Metadata.DepthRemaining >= response.Metadata.DepthRequired {
-			log.Trace().Object("cachedLookup", req).Int("resultCount", len(response.ResolvedResources)).Send()
+			log.Ctx(ctx).Trace().Object("cachedLookup", req).Int("resultCount", len(response.ResolvedResources)).Send()
 			cd.lookupFromCacheCounter.Inc()
 			return &response, nil
 		}
@@ -305,7 +305,7 @@ func (cd *Dispatcher) DispatchLookup(ctx context.Context, req *v1.DispatchLookup
 
 	// We only want to cache the result if there was no error.
 	if err == nil {
-		log.Trace().Object("cachingLookup", req).Int("resultCount", len(computed.ResolvedResources)).Send()
+		log.Ctx(ctx).Trace().Object("cachingLookup", req).Int("resultCount", len(computed.ResolvedResources)).Send()
 
 		adjustedComputed := computed.CloneVT()
 		adjustedComputed.Metadata.CachedDispatchCount = adjustedComputed.Metadata.DispatchCount

--- a/internal/middleware/pertoken/pertoken.go
+++ b/internal/middleware/pertoken/pertoken.go
@@ -45,7 +45,7 @@ func (m *MiddlewareForTesting) getOrCreateDatastore(ctx context.Context) (datast
 		return tokenDatastore.(datastore.Datastore), nil
 	}
 
-	log.Debug().Str("token", tokenStr).Msg("initializing new upstream for token")
+	log.Ctx(ctx).Debug().Str("token", tokenStr).Msg("initializing new upstream for token")
 	ds, err := memdb.NewMemdbDatastore(0, revisionQuantization, gcWindow)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init datastore: %w", err)

--- a/internal/services/dispatch/v1/acl.go
+++ b/internal/services/dispatch/v1/acl.go
@@ -82,7 +82,7 @@ func rewriteGraphError(ctx context.Context, err error) error {
 	case errors.As(err, &graph.ErrAlwaysFail{}):
 		fallthrough
 	default:
-		log.Err(err).Msg("unexpected graph error")
+		log.Ctx(ctx).Err(err).Msg("unexpected graph error")
 		return err
 	}
 }

--- a/internal/services/health/health.go
+++ b/internal/services/health/health.go
@@ -68,12 +68,12 @@ func (hm *healthManager) Checker(ctx context.Context) func() error {
 			select {
 			case _, ok := <-ticker:
 				if !ok {
-					log.Warn().Msg("backoff error while waiting for dispatcher or datastore health")
+					log.Ctx(ctx).Warn().Msg("backoff error while waiting for dispatcher or datastore health")
 					return nil
 				}
 
 			case <-ctx.Done():
-				log.Info().Msg("datastore health check canceled")
+				log.Ctx(ctx).Info().Msg("datastore health check canceled")
 				return nil
 			}
 
@@ -87,7 +87,7 @@ func (hm *healthManager) Checker(ctx context.Context) func() error {
 
 			nextPush := backoffInterval.NextBackOff()
 			if nextPush == backoff.Stop {
-				log.Warn().Msg("exceed max attempts to check for dispatch or datastore ready")
+				log.Ctx(ctx).Warn().Msg("exceed max attempts to check for dispatch or datastore ready")
 				return nil
 			}
 			ticker = time.After(nextPush)
@@ -96,17 +96,17 @@ func (hm *healthManager) Checker(ctx context.Context) func() error {
 }
 
 func (hm *healthManager) checkIsReady(ctx context.Context) bool {
-	log.Debug().Msg("checking if datastore and dispatcher are ready")
+	log.Ctx(ctx).Debug().Msg("checking if datastore and dispatcher are ready")
 
 	ctx, cancel := context.WithTimeout(ctx, datastoreReadyTimeout)
 	defer cancel()
 
 	dsReady, err := hm.dsc.IsReady(ctx)
 	if err != nil {
-		log.Warn().Err(err).Msg("could not check if the datastore was ready")
+		log.Ctx(ctx).Warn().Err(err).Msg("could not check if the datastore was ready")
 	}
 
 	dispatchReady := hm.dispatcher.IsReady()
-	log.Debug().Bool("datastoreReady", dsReady).Bool("dispatchReady", dispatchReady).Msg("completed dispatcher and datastore readiness checks")
+	log.Ctx(ctx).Debug().Bool("datastoreReady", dsReady).Bool("dispatchReady", dispatchReady).Msg("completed dispatcher and datastore readiness checks")
 	return dsReady && dispatchReady
 }

--- a/internal/telemetry/reporter.go
+++ b/internal/telemetry/reporter.go
@@ -167,7 +167,7 @@ func RemoteReporter(
 		// Smear the startup delay out over 10% of the reporting interval
 		startupDelay := time.Duration(rand.Int63n(int64(interval.Seconds()/10))) * time.Second
 
-		log.Info().
+		log.Ctx(ctx).Info().
 			Stringer("interval", interval).
 			Str("endpoint", endpoint).
 			Stringer("next", startupDelay).
@@ -188,13 +188,13 @@ func RemoteReporter(
 				nextPush := backoffInterval.InitialInterval
 				if err := discoverAndWriteMetrics(ctx, registry, client, endpoint); err != nil {
 					nextPush = backoffInterval.NextBackOff()
-					log.Warn().
+					log.Ctx(ctx).Warn().
 						Err(err).
 						Str("endpoint", endpoint).
 						Stringer("next", nextPush).
 						Msg("failed to push telemetry metric")
 				} else {
-					log.Debug().
+					log.Ctx(ctx).Debug().
 						Str("endpoint", endpoint).
 						Stringer("next", nextPush).
 						Msg("reported telemetry")
@@ -216,7 +216,7 @@ func RemoteReporter(
 }
 
 func DisabledReporter(ctx context.Context) error {
-	log.Info().Msg("telemetry disabled")
+	log.Ctx(ctx).Info().Msg("telemetry disabled")
 	return nil
 }
 

--- a/pkg/cmd/datastore.go
+++ b/pkg/cmd/datastore.go
@@ -70,12 +70,12 @@ func NewGCDatastoreCommand(programName string, cfg *datastore.Config) *cobra.Com
 				return fmt.Errorf("datastore of type %T does not support garbage collection", ds)
 			}
 
-			log.Info().Msg("Running garbage collection...")
+			log.Ctx(ctx).Info().Msg("Running garbage collection...")
 			err = common.RunGarbageCollection(gc, cfg.GCWindow, cfg.GCMaxOperationTime)
 			if err != nil {
 				return err
 			}
-			log.Info().Msg("Garbage collection completed")
+			log.Ctx(ctx).Info().Msg("Garbage collection completed")
 			return nil
 		},
 	}

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -198,7 +198,7 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 	}
 
 	if opts.LegacyFuzzing >= 0 {
-		log.Warn().Stringer("period", opts.LegacyFuzzing).Msg("deprecated datastore-revision-fuzzing-duration flag specified")
+		log.Ctx(ctx).Warn().Stringer("period", opts.LegacyFuzzing).Msg("deprecated datastore-revision-fuzzing-duration flag specified")
 		opts.RevisionQuantization = opts.LegacyFuzzing
 	}
 
@@ -206,7 +206,7 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 	if !ok {
 		return nil, fmt.Errorf("unknown datastore engine type: %s", opts.Engine)
 	}
-	log.Info().Msgf("using %s datastore engine", opts.Engine)
+	log.Ctx(ctx).Info().Msgf("using %s datastore engine", opts.Engine)
 
 	ds, err := dsBuilder(*opts)
 	if err != nil {
@@ -227,7 +227,7 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 			return nil, fmt.Errorf("unable to determine datastore state before applying bootstrap data: %w", err)
 		}
 		if opts.BootstrapOverwrite || len(nsDefs) == 0 {
-			log.Info().Msg("initializing datastore from bootstrap files")
+			log.Ctx(ctx).Info().Msg("initializing datastore from bootstrap files")
 			_, _, err = validationfile.PopulateFromFiles(ctx, ds, opts.BootstrapFiles)
 			if err != nil {
 				return nil, fmt.Errorf("failed to load bootstrap files: %w", err)
@@ -238,7 +238,7 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 	}
 
 	if opts.RequestHedgingEnabled {
-		log.Info().
+		log.Ctx(ctx).Info().
 			Stringer("initialSlowRequest", opts.RequestHedgingInitialSlowValue).
 			Uint64("maxRequests", opts.RequestHedgingMaxRequests).
 			Float64("hedgingQuantile", opts.RequestHedgingQuantile).
@@ -257,7 +257,7 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 	}
 
 	if opts.ReadOnly {
-		log.Warn().Msg("setting the datastore to read-only")
+		log.Ctx(ctx).Warn().Msg("setting the datastore to read-only")
 		ds = proxy.NewReadonlyDatastore(ds)
 	}
 	return ds, nil

--- a/pkg/cmd/signals.go
+++ b/pkg/cmd/signals.go
@@ -18,21 +18,21 @@ func SignalContextWithGracePeriod(ctx context.Context, gracePeriod time.Duration
 	go func() {
 		signalctx, _ := signal.NotifyContext(newCtx, os.Interrupt, syscall.SIGTERM)
 		<-signalctx.Done()
-		log.Info().Msg("received interrupt")
+		log.Ctx(ctx).Info().Msg("received interrupt")
 
 		if gracePeriod > 0 {
 			interruptGrace, _ := signal.NotifyContext(context.Background(), os.Interrupt)
 			graceTimer := time.NewTimer(gracePeriod)
 
-			log.Info().Stringer("timeout", gracePeriod).Msg("starting shutdown grace period")
+			log.Ctx(ctx).Info().Stringer("timeout", gracePeriod).Msg("starting shutdown grace period")
 
 			select {
 			case <-graceTimer.C:
 			case <-interruptGrace.Done():
-				log.Warn().Msg("interrupted shutdown grace period")
+				log.Ctx(ctx).Warn().Msg("interrupted shutdown grace period")
 			}
 		}
-		log.Info().Msg("shutting down")
+		log.Ctx(ctx).Info().Msg("shutting down")
 		cancelfn()
 	}()
 

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -180,7 +180,7 @@ func (c *completedTestServer) Run(ctx context.Context) error {
 	g.Go(stopOnCancel(c.readOnlyGatewayServer.Close))
 
 	if err := g.Wait(); err != nil {
-		log.Warn().Err(err).Msg("error shutting down servers")
+		log.Ctx(ctx).Warn().Err(err).Msg("error shutting down servers")
 	}
 
 	return nil

--- a/pkg/cmd/util/util.go
+++ b/pkg/cmd/util/util.go
@@ -233,7 +233,7 @@ func (c *completedGRPCServer) Listen(ctx context.Context) func() error {
 	if c.certWatcher != nil {
 		go func() {
 			if err := c.certWatcher.Start(ctx); err != nil {
-				log.Error().Err(err).Msg("error watching tls certs")
+				log.Ctx(ctx).Error().Err(err).Msg("error watching tls certs")
 			}
 		}()
 	}

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -117,7 +117,7 @@ func (m *Manager[D, C, T]) Run(ctx context.Context, driver D, throughRevision st
 		return fmt.Errorf("unable to compute migration list: %w", err)
 	}
 	if len(toRun) == 0 {
-		log.Info().Str("targetRevision", requestedRevision).Msg("server already at requested revision")
+		log.Ctx(ctx).Info().Str("targetRevision", requestedRevision).Msg("server already at requested revision")
 	}
 
 	if !dryRun {
@@ -132,7 +132,7 @@ func (m *Manager[D, C, T]) Run(ctx context.Context, driver D, throughRevision st
 				return fmt.Errorf("migration attempting to run out of order: %s != %s", currentVersion, migrationToRun.replaces)
 			}
 
-			log.Info().Str("from", migrationToRun.replaces).Str("to", migrationToRun.version).Msg("migrating")
+			log.Ctx(ctx).Info().Str("from", migrationToRun.replaces).Str("to", migrationToRun.version).Msg("migrating")
 			if migrationToRun.up != nil {
 				if err = migrationToRun.up(ctx, driver.Conn()); err != nil {
 					return fmt.Errorf("error executing migration function: %w", err)

--- a/pkg/releases/cli.go
+++ b/pkg/releases/cli.go
@@ -30,25 +30,25 @@ func CheckAndLogRunE() cobrautil.CobraRunFunc {
 
 		state, currentVersion, release, err := CheckIsLatestVersion(ctx, CurrentVersion, GetLatestRelease)
 		if err != nil {
-			log.Warn().Str("this-version", currentVersion).Err(err).Msg("could not perform version checking; if this problem persists or to skip this check, add --skip-release-check=true")
+			log.Ctx(ctx).Warn().Str("this-version", currentVersion).Err(err).Msg("could not perform version checking; if this problem persists or to skip this check, add --skip-release-check=true")
 			return nil
 		}
 
 		switch state {
 		case UnreleasedVersion:
-			log.Warn().Str("version", currentVersion).Msg("not running a released version of SpiceDB")
+			log.Ctx(ctx).Warn().Str("version", currentVersion).Msg("not running a released version of SpiceDB")
 			return nil
 
 		case UpdateAvailable:
-			log.Warn().Str("this-version", currentVersion).Str("latest-released-version", release.Version).Msgf("this version of SpiceDB is out of date. See: %s", release.ViewURL)
+			log.Ctx(ctx).Warn().Str("this-version", currentVersion).Str("latest-released-version", release.Version).Msgf("this version of SpiceDB is out of date. See: %s", release.ViewURL)
 			return nil
 
 		case UpToDate:
-			log.Info().Str("latest-released-version", release.Version).Msg("this is the latest released version of SpiceDB")
+			log.Ctx(ctx).Info().Str("latest-released-version", release.Version).Msg("this is the latest released version of SpiceDB")
 			return nil
 
 		case Unknown:
-			log.Warn().Str("unknown-released-version", release.Version).Msg("unable to check for a new SpiceDB version")
+			log.Ctx(ctx).Warn().Str("unknown-released-version", release.Version).Msg("unable to check for a new SpiceDB version")
 			return nil
 
 		default:

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -89,7 +89,7 @@ func PopulateFromFilesContents(ctx context.Context, ds datastore.Datastore, file
 				schema += parsed.Schema.Schema + "\n\n"
 			}
 
-			log.Info().Str("filePath", filePath).Int("schemaDefinitionCount", len(parsed.Schema.CompiledSchema.OrderedDefinitions)).Msg("adding schema definitions")
+			log.Ctx(ctx).Info().Str("filePath", filePath).Int("schemaDefinitionCount", len(parsed.Schema.CompiledSchema.OrderedDefinitions)).Msg("adding schema definitions")
 			objectDefs = append(objectDefs, defs...)
 			caveatDefs = append(caveatDefs, parsed.Schema.CompiledSchema.CaveatDefinitions...)
 		}


### PR DESCRIPTION
This is so that logs can be enriched with new tags via the context