### PR TITLE
Optimize allocations by removing sprintf, using strings.Cut

### DIFF
--- a/internal/datasets/subjectsetbytype.go
+++ b/internal/datasets/subjectsetbytype.go
@@ -72,7 +72,7 @@ func (s *SubjectByTypeSet) Map(mapper func(rr *core.RelationReference) (*core.Re
 		if updatedType == nil {
 			continue
 		}
-		mapped.byType[tuple.JoinRelRef(ns, rel)] = subjectset
+		mapped.byType[tuple.JoinRelRef(updatedType.Namespace, updatedType.Relation)] = subjectset
 	}
 	return mapped, nil
 }

--- a/internal/datastore/common/sql.go
+++ b/internal/datastore/common/sql.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"runtime"
 
@@ -110,7 +109,7 @@ func (sqf SchemaQueryFilterer) FilterToResourceIDs(resourceIds []string) (Schema
 		return sqf, spiceerrors.MustBugf("cannot have more than %d resources IDs in a single filter", datastore.FilterMaximumIDCount)
 	}
 
-	inClause := fmt.Sprintf("%s IN (", sqf.schema.ColObjectID)
+	inClause := sqf.schema.ColObjectID + " IN ("
 	args := make([]any, 0, len(resourceIds))
 
 	for index, resourceID := range resourceIds {
@@ -209,7 +208,7 @@ func (sqf SchemaQueryFilterer) FilterWithSubjectsSelectors(selectors ...datastor
 				return sqf, spiceerrors.MustBugf("cannot have more than %d subject IDs in a single filter", datastore.FilterMaximumIDCount)
 			}
 
-			inClause := fmt.Sprintf("%s IN (", sqf.schema.ColUsersetObjectID)
+			inClause := sqf.schema.ColUsersetObjectID + " IN ("
 			args := make([]any, 0, len(selector.OptionalSubjectIds))
 
 			for index, subjectID := range selector.OptionalSubjectIds {

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -62,9 +62,8 @@ const (
 	errUnableToInstantiate = "unable to instantiate datastore: %w"
 	errRevision            = "unable to find revision: %w"
 
-	querySelectNow          = "SELECT cluster_logical_timestamp()"
-	queryShowZoneConfig     = "SHOW ZONE CONFIGURATION FOR RANGE default;"
-	querySetTransactionTime = "SET TRANSACTION AS OF SYSTEM TIME %s"
+	querySelectNow      = "SELECT cluster_logical_timestamp()"
+	queryShowZoneConfig = "SHOW ZONE CONFIGURATION FOR RANGE default;"
 
 	livingTupleConstraint = "pk_relation_tuple"
 )
@@ -237,7 +236,7 @@ func (cds *crdbDatastore) SnapshotReader(rev datastore.Revision) datastore.Reade
 			}
 		}
 
-		setTxTime := fmt.Sprintf(querySetTransactionTime, rev)
+		setTxTime := "SET TRANSACTION AS OF SYSTEM TIME " + rev.String()
 		if _, err := tx.Exec(ctx, setTxTime); err != nil {
 			if err := tx.Rollback(ctx); err != nil {
 				log.Ctx(ctx).Warn().Err(err).Msg(

--- a/internal/datastore/crdb/keys.go
+++ b/internal/datastore/crdb/keys.go
@@ -43,9 +43,9 @@ func appendKeysFromNamespaceComponents(keySet keySet, namespace string) {
 
 // prefix returns the first namespace prefix or the default overlap key
 func prefix(s string) string {
-	parts := strings.Split(s, "/")
-	if len(parts) < 2 {
+	prefix, _, ok := strings.Cut(s, "/")
+	if !ok {
 		return defaultOverlapKey
 	}
-	return parts[0]
+	return prefix
 }

--- a/internal/datastore/memdb/schema.go
+++ b/internal/datastore/memdb/schema.go
@@ -1,8 +1,6 @@
 package memdb
 
 import (
-	"fmt"
-
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/hashicorp/go-memdb"
 	"github.com/jzelinskie/stringz"
@@ -70,19 +68,10 @@ func (cr *contextualizedCaveat) ContextualizedCaveat() (*core.ContextualizedCave
 func (r relationship) String() string {
 	caveat := ""
 	if r.caveat != nil {
-		caveat = fmt.Sprintf("[%s]", r.caveat.caveatName)
+		caveat = "[" + r.caveat.caveatName + "]"
 	}
 
-	return fmt.Sprintf(
-		"%s:%s#%s@%s:%s#%s%s",
-		r.namespace,
-		r.resourceID,
-		r.relation,
-		r.subjectNamespace,
-		r.subjectObjectID,
-		r.subjectRelation,
-		caveat,
-	)
+	return r.namespace + ":" + r.resourceID + "#" + r.relation + "@" + r.subjectNamespace + ":" + r.subjectObjectID + "#" + r.subjectRelation + caveat
 }
 
 func (r relationship) MarshalZerologObject(e *zerolog.Event) {

--- a/internal/datastore/mysql/connection.go
+++ b/internal/datastore/mysql/connection.go
@@ -113,7 +113,7 @@ func (s *sessionVariableConnector) Driver() driver.Driver {
 func addSessionVariables(c driver.Connector, variables map[string]string) (driver.Connector, error) {
 	statements := make([]string, 0, len(variables))
 	for sessionVar, value := range variables {
-		statements = append(statements, fmt.Sprintf("SET SESSION %s=%s", sessionVar, value))
+		statements = append(statements, "SET SESSION "+sessionVar+"="+value)
 	}
 
 	return &sessionVariableConnector{

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -114,7 +115,7 @@ func newMySQLDatastore(uri string, options ...Option) (*Datastore, error) {
 	if config.lockWaitTimeoutSeconds != nil {
 		log.Info().Uint8("timeout", *config.lockWaitTimeoutSeconds).Msg("overriding innodb_lock_wait_timeout")
 		connector, err = addSessionVariables(connector, map[string]string{
-			"innodb_lock_wait_timeout": fmt.Sprintf("%d", *config.lockWaitTimeoutSeconds),
+			"innodb_lock_wait_timeout": strconv.FormatUint(uint64(*config.lockWaitTimeoutSeconds), 10),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("NewMySQLDatastore: failed to add session variables to connector: %w", err)

--- a/internal/datastore/mysql/migrations/driver.go
+++ b/internal/datastore/mysql/migrations/driver.go
@@ -59,7 +59,7 @@ func NewMySQLDriverFromDB(db *sql.DB, tablePrefix string) *MySQLDriver {
 
 // revisionToColumnName generates the column name that will denote a given migration revision
 func revisionToColumnName(revision string) string {
-	return fmt.Sprintf("%s%s", migrationVersionColumnPrefix, revision)
+	return migrationVersionColumnPrefix + revision
 }
 
 func columnNameToRevision(columnName string) (string, bool) {

--- a/internal/datastore/mysql/migrations/tables.go
+++ b/internal/datastore/mysql/migrations/tables.go
@@ -1,7 +1,5 @@
 package migrations
 
-import "fmt"
-
 const (
 	tableNamespaceDefault   = "namespace_config"
 	tableTransactionDefault = "relation_tuple_transaction"
@@ -22,12 +20,12 @@ type tables struct {
 
 func newTables(prefix string) *tables {
 	return &tables{
-		tableMigrationVersion: fmt.Sprintf("%s%s", prefix, tableMigrationVersion),
-		tableTransaction:      fmt.Sprintf("%s%s", prefix, tableTransactionDefault),
-		tableTuple:            fmt.Sprintf("%s%s", prefix, tableTupleDefault),
-		tableNamespace:        fmt.Sprintf("%s%s", prefix, tableNamespaceDefault),
-		tableMetadata:         fmt.Sprintf("%s%s", prefix, tableMetadataDefault),
-		tableCaveat:           fmt.Sprintf("%s%s", prefix, tableCaveatDefault),
+		tableMigrationVersion: prefix + tableMigrationVersion,
+		tableTransaction:      prefix + tableTransactionDefault,
+		tableTuple:            prefix + tableTupleDefault,
+		tableNamespace:        prefix + tableNamespaceDefault,
+		tableMetadata:         prefix + tableMetadataDefault,
+		tableCaveat:           prefix + tableCaveatDefault,
 	}
 }
 

--- a/internal/datastore/mysql/stats.go
+++ b/internal/datastore/mysql/stats.go
@@ -16,15 +16,13 @@ const (
 	informationSchemaTablesTable     = "INFORMATION_SCHEMA.TABLES"
 	informationSchemaTableNameColumn = "table_name"
 
-	analyzeTableQuery = "ANALYZE TABLE %s"
-
 	metadataIDColumn       = "id"
 	metadataUniqueIDColumn = "unique_id"
 )
 
 func (mds *Datastore) Statistics(ctx context.Context) (datastore.Stats, error) {
 	if mds.analyzeBeforeStats {
-		_, err := mds.db.ExecContext(ctx, fmt.Sprintf(analyzeTableQuery, mds.driver.RelationTuple()))
+		_, err := mds.db.ExecContext(ctx, "ANALYZE TABLE "+mds.driver.RelationTuple())
 		if err != nil {
 			return datastore.Stats{}, fmt.Errorf("unable to run ANALYZE TABLE: %w", err)
 		}

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -213,9 +213,9 @@ func (pr postgresRevision) LessThan(rhsRaw datastore.Revision) bool {
 
 func (pr postgresRevision) String() string {
 	if pr.xmin.Status == pgtype.Present {
-		return fmt.Sprintf("%d.%d", pr.tx.Uint, pr.xmin.Uint)
+		return strconv.FormatUint(pr.tx.Uint, 10) + "." + strconv.FormatUint(pr.xmin.Uint, 10)
 	}
-	return fmt.Sprintf("%d", pr.tx.Uint)
+	return strconv.FormatUint(pr.tx.Uint, 10)
 }
 
 func (pr postgresRevision) MarshalBinary() ([]byte, error) {

--- a/internal/datastore/postgres/stats.go
+++ b/internal/datastore/postgres/stats.go
@@ -48,7 +48,7 @@ func (pgd *pgDatastore) Statistics(ctx context.Context) (datastore.Stats, error)
 	var relCount int64
 	if err := pgd.dbpool.BeginTxFunc(ctx, pgd.readTxOptions, func(tx pgx.Tx) error {
 		if pgd.analyzeBeforeStatistics {
-			if _, err := tx.Exec(ctx, fmt.Sprintf("ANALYZE %s", tableTuple)); err != nil {
+			if _, err := tx.Exec(ctx, "ANALYZE "+tableTuple); err != nil {
 				return fmt.Errorf("unable to analyze tuple table: %w", err)
 			}
 		}

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"time"
 
 	"cloud.google.com/go/spanner"
@@ -193,8 +194,7 @@ func (sd spannerDatastore) Close() error {
 func statementFromSQL(sql string, args []interface{}) spanner.Statement {
 	params := make(map[string]interface{}, len(args))
 	for index, arg := range args {
-		paramName := fmt.Sprintf("p%d", index+1)
-		params[paramName] = arg
+		params["p"+strconv.Itoa(index+1)] = arg
 	}
 
 	return spanner.Statement{

--- a/internal/developmentmembership/foundsubject.go
+++ b/internal/developmentmembership/foundsubject.go
@@ -1,7 +1,6 @@
 package developmentmembership
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
@@ -96,12 +95,12 @@ func (fs FoundSubject) ToValidationString() string {
 	onrString := tuple.StringONR(fs.Subject())
 	validationString := onrString
 	if fs.caveatExpression != nil {
-		validationString = fmt.Sprintf("%s[...]", validationString)
+		validationString = validationString + "[...]"
 	}
 
 	excluded, isWildcard := fs.ExcludedSubjectsFromWildcard()
 	if isWildcard && len(excluded) > 0 {
-		validationString = fmt.Sprintf("%s - {%s}", validationString, strings.Join(fs.excludedSubjectStrings(), ", "))
+		validationString = validationString + " - {" + strings.Join(fs.excludedSubjectStrings(), ", ") + "}"
 	}
 
 	return validationString

--- a/internal/developmentmembership/trackingsubjectset.go
+++ b/internal/developmentmembership/trackingsubjectset.go
@@ -86,7 +86,7 @@ func (tss *TrackingSubjectSet) getSetForKey(key string) datasets.BaseSubjectSet[
 		return existing
 	}
 
-	ns, rel := tuple.MustParseRelationTypeString(key)
+	ns, rel := tuple.MustSplitRelRef(key)
 	created := datasets.NewBaseSubjectSet(
 		func(subjectID string, caveatExpression *core.CaveatExpression, excludedSubjects []FoundSubject, sources ...FoundSubject) FoundSubject {
 			fs := NewFoundSubject(&core.DirectSubject{
@@ -112,12 +112,12 @@ func (tss *TrackingSubjectSet) getSetForKey(key string) datasets.BaseSubjectSet[
 }
 
 func (tss *TrackingSubjectSet) getSet(fs FoundSubject) datasets.BaseSubjectSet[FoundSubject] {
-	return tss.getSetForKey(tuple.RelationTypeString(fs.subject.Namespace, fs.subject.Relation))
+	return tss.getSetForKey(tuple.JoinRelRef(fs.subject.Namespace, fs.subject.Relation))
 }
 
 // Get returns the found subject in the set, if any.
 func (tss *TrackingSubjectSet) Get(subject *core.ObjectAndRelation) (FoundSubject, bool) {
-	set, ok := tss.setByType[tuple.RelationTypeString(subject.Namespace, subject.Relation)]
+	set, ok := tss.setByType[tuple.JoinRelRef(subject.Namespace, subject.Relation)]
 	if !ok {
 		return FoundSubject{}, false
 	}
@@ -194,7 +194,7 @@ func (tss *TrackingSubjectSet) ApplyParentCaveatExpression(parentCaveatExpr *cor
 // the exact matching wildcard will be removed.
 func (tss *TrackingSubjectSet) removeExact(subjects ...*core.ObjectAndRelation) {
 	for _, subject := range subjects {
-		if set, ok := tss.setByType[tuple.RelationTypeString(subject.Namespace, subject.Relation)]; ok {
+		if set, ok := tss.setByType[tuple.JoinRelRef(subject.Namespace, subject.Relation)]; ok {
 			set.UnsafeRemoveExact(FoundSubject{
 				subject: subject,
 			})

--- a/internal/developmentmembership/trackingsubjectset.go
+++ b/internal/developmentmembership/trackingsubjectset.go
@@ -1,7 +1,6 @@
 package developmentmembership
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/authzed/spicedb/internal/datasets"
@@ -84,8 +83,10 @@ func (tss *TrackingSubjectSet) Add(subjectsAndResources ...FoundSubject) error {
 	return nil
 }
 
+func typeKey(ns, rel string) string { return ns + "#" + rel }
+
 func keyFor(fs FoundSubject) string {
-	return fmt.Sprintf("%s#%s", fs.subject.Namespace, fs.subject.Relation)
+	return typeKey(fs.subject.Namespace, fs.subject.Relation)
 }
 
 func (tss *TrackingSubjectSet) getSetForKey(key string) datasets.BaseSubjectSet[FoundSubject] {
@@ -126,7 +127,7 @@ func (tss *TrackingSubjectSet) getSet(fs FoundSubject) datasets.BaseSubjectSet[F
 
 // Get returns the found subject in the set, if any.
 func (tss *TrackingSubjectSet) Get(subject *core.ObjectAndRelation) (FoundSubject, bool) {
-	set, ok := tss.setByType[fmt.Sprintf("%s#%s", subject.Namespace, subject.Relation)]
+	set, ok := tss.setByType[typeKey(subject.Namespace, subject.Relation)]
 	if !ok {
 		return FoundSubject{}, false
 	}
@@ -203,7 +204,7 @@ func (tss *TrackingSubjectSet) ApplyParentCaveatExpression(parentCaveatExpr *cor
 // the exact matching wildcard will be removed.
 func (tss *TrackingSubjectSet) removeExact(subjects ...*core.ObjectAndRelation) {
 	for _, subject := range subjects {
-		if set, ok := tss.setByType[fmt.Sprintf("%s#%s", subject.Namespace, subject.Relation)]; ok {
+		if set, ok := tss.setByType[typeKey(subject.Namespace, subject.Relation)]; ok {
 			set.UnsafeRemoveExact(FoundSubject{
 				subject: subject,
 			})

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -154,28 +154,12 @@ func (ld *localDispatcher) lookupRelation(ctx context.Context, ns *core.Namespac
 	return relation, nil
 }
 
-type stringableOnr struct {
-	*core.ObjectAndRelation
-}
-
-func (onr stringableOnr) String() string {
-	return tuple.StringONR(onr.ObjectAndRelation)
-}
-
-type stringableRelRef struct {
-	*core.RelationReference
-}
-
-func (rr stringableRelRef) String() string {
-	return tuple.StringRR(rr.RelationReference)
-}
-
 // DispatchCheck implements dispatch.Check interface
 func (ld *localDispatcher) DispatchCheck(ctx context.Context, req *v1.DispatchCheckRequest) (*v1.DispatchCheckResponse, error) {
 	ctx, span := tracer.Start(ctx, "DispatchCheck", trace.WithAttributes(
-		attribute.Stringer("resource-type", stringableRelRef{req.ResourceRelation}),
+		attribute.String("resource-type", tuple.StringRR(req.ResourceRelation)),
 		attribute.StringSlice("resource-ids", req.ResourceIds),
-		attribute.Stringer("subject", stringableOnr{req.Subject}),
+		attribute.String("subject", tuple.StringONR(req.Subject)),
 	))
 	defer span.End()
 
@@ -253,7 +237,7 @@ func (ld *localDispatcher) DispatchCheck(ctx context.Context, req *v1.DispatchCh
 // DispatchExpand implements dispatch.Expand interface
 func (ld *localDispatcher) DispatchExpand(ctx context.Context, req *v1.DispatchExpandRequest) (*v1.DispatchExpandResponse, error) {
 	ctx, span := tracer.Start(ctx, "DispatchExpand", trace.WithAttributes(
-		attribute.Stringer("start", stringableOnr{req.ResourceAndRelation}),
+		attribute.String("start", tuple.StringONR(req.ResourceAndRelation)),
 	))
 	defer span.End()
 
@@ -287,8 +271,8 @@ func (ld *localDispatcher) DispatchLookup(ctx context.Context, req *v1.DispatchL
 	// TODO(jschorr): Since lookup is now calling reachable resources exclusively, we should
 	// probably move it out of the dispatcher and into computed
 	ctx, span := tracer.Start(ctx, "DispatchLookup", trace.WithAttributes(
-		attribute.Stringer("start", stringableRelRef{req.ObjectRelation}),
-		attribute.Stringer("subject", stringableOnr{req.Subject}),
+		attribute.String("start", tuple.StringRR(req.ObjectRelation)),
+		attribute.String("subject", tuple.StringONR(req.Subject)),
 		attribute.Int64("limit", int64(req.Limit)),
 	))
 	defer span.End()
@@ -318,8 +302,8 @@ func (ld *localDispatcher) DispatchReachableResources(
 	stream dispatch.ReachableResourcesStream,
 ) error {
 	ctx, span := tracer.Start(stream.Context(), "DispatchReachableResources", trace.WithAttributes(
-		attribute.Stringer("resource-type", stringableRelRef{req.ResourceRelation}),
-		attribute.Stringer("subject-type", stringableRelRef{req.SubjectRelation}),
+		attribute.String("resource-type", tuple.StringRR(req.ResourceRelation)),
+		attribute.String("subject-type", tuple.StringRR(req.SubjectRelation)),
 		attribute.StringSlice("subject-ids", req.SubjectIds),
 	))
 	defer span.End()
@@ -348,8 +332,8 @@ func (ld *localDispatcher) DispatchLookupSubjects(
 	stream dispatch.LookupSubjectsStream,
 ) error {
 	ctx, span := tracer.Start(stream.Context(), "DispatchLookupSubjects", trace.WithAttributes(
-		attribute.Stringer("resource-type", stringableRelRef{req.ResourceRelation}),
-		attribute.Stringer("subject-type", stringableRelRef{req.SubjectRelation}),
+		attribute.String("resource-type", tuple.StringRR(req.ResourceRelation)),
+		attribute.String("subject-type", tuple.StringRR(req.SubjectRelation)),
 		attribute.StringSlice("resource-ids", req.ResourceIds),
 	))
 	defer span.End()

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -167,7 +167,7 @@ type stringableRelRef struct {
 }
 
 func (rr stringableRelRef) String() string {
-	return rr.Namespace + "::" + rr.Relation
+	return tuple.StringRR(rr.RelationReference)
 }
 
 // DispatchCheck implements dispatch.Check interface

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -167,7 +167,7 @@ type stringableRelRef struct {
 }
 
 func (rr stringableRelRef) String() string {
-	return fmt.Sprintf("%s::%s", rr.Namespace, rr.Relation)
+	return rr.Namespace + "::" + rr.Relation
 }
 
 // DispatchCheck implements dispatch.Check interface

--- a/internal/dispatch/keys/hasher_common.go
+++ b/internal/dispatch/keys/hasher_common.go
@@ -12,6 +12,7 @@ import (
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
 )
 
 type hashableValue interface {
@@ -27,7 +28,7 @@ type hashableRelationReference struct {
 }
 
 func (hrr hashableRelationReference) AppendToHash(hasher hasherInterface) {
-	hasher.WriteString(hrr.Namespace + "#" + hrr.Relation)
+	hasher.WriteString(tuple.StringRR(hrr.RelationReference))
 }
 
 type hashableResultSetting v1.DispatchCheckRequest_ResultsSetting

--- a/internal/dispatch/keys/hasher_common.go
+++ b/internal/dispatch/keys/hasher_common.go
@@ -27,9 +27,7 @@ type hashableRelationReference struct {
 }
 
 func (hrr hashableRelationReference) AppendToHash(hasher hasherInterface) {
-	hasher.WriteString(hrr.Namespace)
-	hasher.WriteString("#")
-	hasher.WriteString(hrr.Relation)
+	hasher.WriteString(hrr.Namespace + "#" + hrr.Relation)
 }
 
 type hashableResultSetting v1.DispatchCheckRequest_ResultsSetting
@@ -111,14 +109,13 @@ func (hsv hashableStructValue) AppendToHash(hasher hasherInterface) {
 		hasher.WriteString("null")
 
 	case *structpb.Value_NumberValue:
-		hasher.WriteString(fmt.Sprintf("%f", t.NumberValue))
+		// AFAICT, this is how Sprintf-style formats float64s
+		hasher.WriteString(strconv.FormatFloat(t.NumberValue, 'f', 6, 64))
 
 	case *structpb.Value_StringValue:
 		// NOTE: we escape the string value here to prevent accidental overlap in keys for string
 		// values that may themselves contain backticks.
-		hasher.WriteString("`")
-		hasher.WriteString(url.PathEscape(t.StringValue))
-		hasher.WriteString("`")
+		hasher.WriteString("`" + url.PathEscape(t.StringValue) + "`")
 
 	case *structpb.Value_StructValue:
 		hasher.WriteString("{")

--- a/internal/namespace/canonicalization_test.go
+++ b/internal/namespace/canonicalization_test.go
@@ -49,7 +49,7 @@ func TestCanonicalization(t *testing.T) {
 				"owner":  "owner",
 				"viewer": "viewer",
 				"edit":   computedKeyPrefix + "596a8660f9a0c085",
-				"view":   computedKeyPrefix + "cb51da20fc9f20f",
+				"view":   computedKeyPrefix + "0cb51da20fc9f20f",
 			},
 		},
 		{

--- a/internal/namespace/reachabilitygraph.go
+++ b/internal/namespace/reachabilitygraph.go
@@ -101,11 +101,12 @@ func (rg *ReachabilityGraph) HasOptimizedEntrypointsForSubjectToResource(
 	subjectType *core.RelationReference,
 	resourceType *core.RelationReference,
 ) (bool, error) {
-	cacheKey := subjectType.Namespace + "#" + subjectType.Relation + "=>" + resourceType.Namespace + "#" + resourceType.Relation
+	cacheKey := tuple.StringRR(subjectType) + "=>" + tuple.StringRR(resourceType)
 	if result, ok := rg.hasOptimizedEntrypointCache.Load(cacheKey); ok {
 		return result.(bool), nil
 	}
 
+	// TODO(jzelinskie): measure to see if it's worth singleflighting this
 	found, err := rg.entrypointsForSubjectToResource(ctx, subjectType, resourceType, reachabilityOptimized, entrypointLookupFindOne)
 	if err != nil {
 		return false, err
@@ -142,7 +143,7 @@ func (rg *ReachabilityGraph) entrypointsForSubjectToResource(
 func (rg *ReachabilityGraph) getOrBuildGraph(ctx context.Context, resourceType *core.RelationReference, reachabilityOption reachabilityOption) (*core.ReachabilityGraph, error) {
 	// Check the cache.
 	// TODO(jschorr): Move this to a global cache.
-	cacheKey := resourceType.Namespace + "#" + resourceType.Relation + "-" + strconv.Itoa(int(reachabilityOption))
+	cacheKey := tuple.StringRR(resourceType) + "-" + strconv.Itoa(int(reachabilityOption))
 	if cached, ok := rg.cachedGraphs.Load(cacheKey); ok {
 		return cached.(*core.ReachabilityGraph), nil
 	}

--- a/internal/namespace/reachabilitygraph.go
+++ b/internal/namespace/reachabilitygraph.go
@@ -3,6 +3,7 @@ package namespace
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -100,7 +101,7 @@ func (rg *ReachabilityGraph) HasOptimizedEntrypointsForSubjectToResource(
 	subjectType *core.RelationReference,
 	resourceType *core.RelationReference,
 ) (bool, error) {
-	cacheKey := fmt.Sprintf("%s#%s=>%s#%s", subjectType.Namespace, subjectType.Relation, resourceType.Namespace, resourceType.Relation)
+	cacheKey := subjectType.Namespace + "#" + subjectType.Relation + "=>" + resourceType.Namespace + "#" + resourceType.Relation
 	if result, ok := rg.hasOptimizedEntrypointCache.Load(cacheKey); ok {
 		return result.(bool), nil
 	}
@@ -141,7 +142,7 @@ func (rg *ReachabilityGraph) entrypointsForSubjectToResource(
 func (rg *ReachabilityGraph) getOrBuildGraph(ctx context.Context, resourceType *core.RelationReference, reachabilityOption reachabilityOption) (*core.ReachabilityGraph, error) {
 	// Check the cache.
 	// TODO(jschorr): Move this to a global cache.
-	cacheKey := fmt.Sprintf("%s#%s-%v", resourceType.Namespace, resourceType.Relation, reachabilityOption)
+	cacheKey := resourceType.Namespace + "#" + resourceType.Relation + "-" + strconv.Itoa(int(reachabilityOption))
 	if cached, ok := rg.cachedGraphs.Load(cacheKey); ok {
 		return cached.(*core.ReachabilityGraph), nil
 	}

--- a/internal/namespace/reachabilitygraph.go
+++ b/internal/namespace/reachabilitygraph.go
@@ -177,7 +177,7 @@ func (rg *ReachabilityGraph) collectEntrypoints(
 	entrypointLookupOption entrypointLookupOption,
 ) error {
 	// Ensure that we only process each relation once.
-	key := relationKey(resourceType.Namespace, resourceType.Relation)
+	key := tuple.JoinRelRef(resourceType.Namespace, resourceType.Relation)
 	if _, ok := encounteredRelations[key]; ok {
 		return nil
 	}
@@ -200,7 +200,7 @@ func (rg *ReachabilityGraph) collectEntrypoints(
 	}
 
 	// Add subject relation entrypoints.
-	subjectRelationEntrypoints, ok := rrg.EntrypointsBySubjectRelation[relationKey(subjectType.Namespace, subjectType.Relation)]
+	subjectRelationEntrypoints, ok := rrg.EntrypointsBySubjectRelation[tuple.JoinRelRef(subjectType.Namespace, subjectType.Relation)]
 	if ok {
 		addEntrypoints(subjectRelationEntrypoints, resourceType, collected)
 	}

--- a/internal/namespace/reachabilitygraph_test.go
+++ b/internal/namespace/reachabilitygraph_test.go
@@ -13,6 +13,7 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
+	"github.com/authzed/spicedb/pkg/tuple"
 )
 
 func TestReachabilityGraph(t *testing.T) {
@@ -528,14 +529,14 @@ func verifyEntrypoints(require *require.Assertions, foundEntrypoints []Reachabil
 	expectedEntrypointRelations := make([]string, 0, len(expectedEntrypoints))
 	isDirectMap := map[string]bool{}
 	for _, expected := range expectedEntrypoints {
-		expectedEntrypointRelations = append(expectedEntrypointRelations, relationRefKey(expected.relationRef))
-		isDirectMap[relationRefKey(expected.relationRef)] = expected.isDirect
+		expectedEntrypointRelations = append(expectedEntrypointRelations, tuple.StringRR(expected.relationRef))
+		isDirectMap[tuple.StringRR(expected.relationRef)] = expected.isDirect
 	}
 
 	foundRelations := make([]string, 0, len(foundEntrypoints))
 	for _, entrypoint := range foundEntrypoints {
-		foundRelations = append(foundRelations, relationRefKey(entrypoint.ContainingRelationOrPermission()))
-		if isDirect, ok := isDirectMap[relationRefKey(entrypoint.ContainingRelationOrPermission())]; ok {
+		foundRelations = append(foundRelations, tuple.StringRR(entrypoint.ContainingRelationOrPermission()))
+		if isDirect, ok := isDirectMap[tuple.StringRR(entrypoint.ContainingRelationOrPermission())]; ok {
 			require.Equal(isDirect, entrypoint.IsDirectResult(), "found mismatch for whether a direct result for entrypoint for %s", entrypoint.parentRelation.Relation)
 		}
 	}
@@ -556,8 +557,4 @@ func rr(namespace, relation string) *core.RelationReference {
 
 func rrt(namespace, relation string, isDirect bool) rrtStruct {
 	return rrtStruct{ns.RelationReference(namespace, relation), isDirect}
-}
-
-func relationRefKey(ref *core.RelationReference) string {
-	return relationKey(ref.Namespace, ref.GetRelation())
 }

--- a/internal/namespace/reachabilitygraphbuilder.go
+++ b/internal/namespace/reachabilitygraphbuilder.go
@@ -236,5 +236,5 @@ func addSubjectLinks(graph *core.ReachabilityGraph, operationResultState core.Re
 }
 
 func relationKey(namespaceName string, relationName string) string {
-	return fmt.Sprintf("%s#%s", namespaceName, relationName)
+	return namespaceName + "#" + relationName
 }

--- a/internal/namespace/reachabilitygraphbuilder.go
+++ b/internal/namespace/reachabilitygraphbuilder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/authzed/spicedb/pkg/spiceerrors"
+	"github.com/authzed/spicedb/pkg/tuple"
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
@@ -165,7 +166,7 @@ func computeRewriteOpReachability(ctx context.Context, children []*core.SetOpera
 }
 
 func addSubjectEntrypoint(graph *core.ReachabilityGraph, namespaceName string, relationName string, entrypoint *core.ReachabilityEntrypoint) error {
-	key := relationKey(namespaceName, relationName)
+	key := tuple.JoinRelRef(namespaceName, relationName)
 	if relationName == "" {
 		return spiceerrors.MustBugf("found empty relation name for subject entrypoint")
 	}
@@ -233,8 +234,4 @@ func addSubjectLinks(graph *core.ReachabilityGraph, operationResultState core.Re
 	}
 
 	return nil
-}
-
-func relationKey(namespaceName string, relationName string) string {
-	return namespaceName + "#" + relationName
 }

--- a/internal/namespace/typesystem.go
+++ b/internal/namespace/typesystem.go
@@ -265,7 +265,7 @@ func (nts *TypeSystem) referencesWildcardType(ctx context.Context, relationName 
 }
 
 func (nts *TypeSystem) computeReferencesWildcardType(ctx context.Context, relationName string, encountered map[string]bool) (*WildcardTypeReference, error) {
-	relString := fmt.Sprintf("%s#%s", nts.nsDef.Name, relationName)
+	relString := nts.nsDef.Name + "#" + relationName
 	if _, ok := encountered[relString]; ok {
 		return nil, nil
 	}
@@ -525,18 +525,18 @@ func SourceForAllowedRelation(allowedRelation *core.AllowedRelation) string {
 	caveatStr := ""
 
 	if allowedRelation.GetRequiredCaveat() != nil {
-		caveatStr = fmt.Sprintf(" with %s", allowedRelation.GetRequiredCaveat().CaveatName)
+		caveatStr = " with " + allowedRelation.RequiredCaveat.CaveatName
 	}
 
 	if allowedRelation.GetPublicWildcard() != nil {
-		return fmt.Sprintf("%s:*%s", allowedRelation.GetNamespace(), caveatStr)
+		return allowedRelation.Namespace + ":*" + caveatStr
 	}
 
-	if allowedRelation.GetRelation() != tuple.Ellipsis {
-		return fmt.Sprintf("%s#%s%s", allowedRelation.GetNamespace(), allowedRelation.GetRelation(), caveatStr)
+	if rel := allowedRelation.GetRelation(); rel != tuple.Ellipsis {
+		return allowedRelation.Namespace + "#" + rel + caveatStr
 	}
 
-	return fmt.Sprintf("%s%s", allowedRelation.GetNamespace(), caveatStr)
+	return allowedRelation.Namespace + caveatStr
 }
 
 func (nts *TypeSystem) typeSystemForNamespace(ctx context.Context, namespaceName string) (*TypeSystem, error) {

--- a/internal/namespace/typesystem.go
+++ b/internal/namespace/typesystem.go
@@ -265,7 +265,7 @@ func (nts *TypeSystem) referencesWildcardType(ctx context.Context, relationName 
 }
 
 func (nts *TypeSystem) computeReferencesWildcardType(ctx context.Context, relationName string, encountered map[string]bool) (*WildcardTypeReference, error) {
-	relString := nts.nsDef.Name + "#" + relationName
+	relString := tuple.JoinRelRef(nts.nsDef.Name, relationName)
 	if _, ok := encountered[relString]; ok {
 		return nil, nil
 	}
@@ -497,7 +497,7 @@ func (nts *TypeSystem) Validate(ctx context.Context) (*ValidatedNamespaceTypeSys
 								tuple.StringRR(referencedWildcard.ReferencingRelation),
 							),
 							allowedRelation,
-							allowedRelation.GetNamespace()+"#"+allowedRelation.GetRelation(),
+							tuple.JoinRelRef(allowedRelation.GetNamespace(), allowedRelation.GetRelation()),
 						)
 					}
 				}
@@ -529,11 +529,11 @@ func SourceForAllowedRelation(allowedRelation *core.AllowedRelation) string {
 	}
 
 	if allowedRelation.GetPublicWildcard() != nil {
-		return allowedRelation.Namespace + ":*" + caveatStr
+		return tuple.JoinObjectRef(allowedRelation.Namespace, "*") + caveatStr
 	}
 
 	if rel := allowedRelation.GetRelation(); rel != tuple.Ellipsis {
-		return allowedRelation.Namespace + "#" + rel + caveatStr
+		return tuple.JoinRelRef(allowedRelation.Namespace, rel) + caveatStr
 	}
 
 	return allowedRelation.Namespace + caveatStr

--- a/internal/services/v1/debug.go
+++ b/internal/services/v1/debug.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 
@@ -203,5 +202,5 @@ func (a sortByResource) Less(i, j int) bool {
 }
 
 func stringRes(resource *v1.ObjectReference) string {
-	return fmt.Sprintf("%s:%s", resource.ObjectType, resource.ObjectId)
+	return resource.ObjectType + ":" + resource.ObjectId
 }

--- a/internal/services/v1/debug.go
+++ b/internal/services/v1/debug.go
@@ -198,9 +198,5 @@ type sortByResource []*v1.CheckDebugTrace
 func (a sortByResource) Len() int      { return len(a) }
 func (a sortByResource) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a sortByResource) Less(i, j int) bool {
-	return strings.Compare(stringRes(a[i].Resource), stringRes(a[j].Resource)) < 0
-}
-
-func stringRes(resource *v1.ObjectReference) string {
-	return resource.ObjectType + ":" + resource.ObjectId
+	return strings.Compare(tuple.StringObjectRef(a[i].Resource), tuple.StringObjectRef(a[j].Resource)) < 0
 }

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"time"
 
 	"github.com/jzelinskie/cobrautil/v2"
@@ -55,7 +56,7 @@ func RegisterTelemetryCollector(datastoreEngine string, ds datastore.Datastore) 
 				"os":         runtime.GOOS,
 				"arch":       runtime.GOARCH,
 				"go":         buildInfo.GoVersion,
-				"vcpu":       fmt.Sprintf("%d", runtime.NumCPU()),
+				"vcpu":       strconv.Itoa(runtime.NumCPU()),
 				"ds_engine":  datastoreEngine,
 			},
 		),

--- a/pkg/caveats/types/types.go
+++ b/pkg/caveats/types/types.go
@@ -29,7 +29,7 @@ func (vt VariableType) String() string {
 			childTypeStrings = append(childTypeStrings, childType.String())
 		}
 
-		return fmt.Sprintf("%s<%s>", vt.localName, strings.Join(childTypeStrings, ", "))
+		return vt.localName + "<" + strings.Join(childTypeStrings, ", ") + ">"
 	}
 
 	return vt.localName

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -104,7 +104,7 @@ func RegisterDatastoreFlagsWithPrefix(flagSet *pflag.FlagSet, prefix string, opt
 		prefix = prefix + "-"
 	}
 	flagName := func(flag string) string {
-		return fmt.Sprintf("%s%s", prefix, flag)
+		return prefix + flag
 	}
 	defaults := DefaultDatastoreConfig()
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -167,7 +168,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 				return nil, fmt.Errorf("preshared key #%d is empty", index+1)
 			}
 
-			log.Ctx(ctx).Trace().Int(fmt.Sprintf("preshared-key-%d-length", index+1), len(presharedKey)).Msg("preshared key configured")
+			log.Ctx(ctx).Trace().Int("preshared-key-"+strconv.Itoa(index+1)+"-length", len(presharedKey)).Msg("preshared key configured")
 		}
 
 		c.GRPCAuthFunc = auth.MustRequirePresharedKey(c.PresharedKey)

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -30,7 +30,7 @@ func EngineOptions() string {
 	ids := SortedEngineIDs()
 	quoted := make([]string, 0, len(ids))
 	for _, id := range ids {
-		quoted = append(quoted, fmt.Sprintf("%q", id))
+		quoted = append(quoted, `"`+id+`"`)
 	}
 	return strings.Join(quoted, ", ")
 }

--- a/pkg/development/validation.go
+++ b/pkg/development/validation.go
@@ -72,7 +72,7 @@ func RunValidation(devContext *DevContext, validation *blocks.ParsedExpectedRela
 func wrapRelationships(onrStrings []string) []string {
 	wrapped := make([]string, 0, len(onrStrings))
 	for _, str := range onrStrings {
-		wrapped = append(wrapped, fmt.Sprintf("<%s>", str))
+		wrapped = append(wrapped, "<"+str+">")
 	}
 
 	// Sort to ensure stability.
@@ -250,7 +250,7 @@ func toExpectedRelationshipsStrings(subs []blocks.SubjectAndCaveat) []string {
 	mapped := make([]string, 0, len(subs))
 	for _, sub := range subs {
 		if sub.IsCaveated {
-			mapped = append(mapped, fmt.Sprintf("%s[...]", tuple.StringONR(sub.Subject)))
+			mapped = append(mapped, tuple.StringONR(sub.Subject)+"[...]")
 		} else {
 			mapped = append(mapped, tuple.StringONR(sub.Subject))
 		}

--- a/pkg/proto/dispatch/v1/00_zerolog.go
+++ b/pkg/proto/dispatch/v1/00_zerolog.go
@@ -9,7 +9,7 @@ import (
 // MarshalZerologObject implements zerolog object marshalling.
 func (cr *DispatchCheckRequest) MarshalZerologObject(e *zerolog.Event) {
 	e.Object("metadata", cr.Metadata)
-	e.Str("resource-type", cr.ResourceRelation.Namespace+"#"+cr.ResourceRelation.Relation)
+	e.Str("resource-type", tuple.StringRR(cr.ResourceRelation))
 	e.Str("subject", tuple.StringONR(cr.Subject))
 	e.Array("resource-ids", strArray(cr.ResourceIds))
 }
@@ -40,7 +40,7 @@ func (cr *DispatchExpandResponse) MarshalZerologObject(e *zerolog.Event) {
 // MarshalZerologObject implements zerolog object marshalling.
 func (lr *DispatchLookupRequest) MarshalZerologObject(e *zerolog.Event) {
 	e.Object("metadata", lr.Metadata)
-	e.Str("object", lr.ObjectRelation.Namespace+"#"+lr.ObjectRelation.Relation)
+	e.Str("object", tuple.StringRR(lr.ObjectRelation))
 	e.Str("subject", tuple.StringONR(lr.Subject))
 	e.Interface("context", lr.Context)
 	e.Uint32("limit", lr.Limit)
@@ -49,16 +49,16 @@ func (lr *DispatchLookupRequest) MarshalZerologObject(e *zerolog.Event) {
 // MarshalZerologObject implements zerolog object marshalling.
 func (lr *DispatchReachableResourcesRequest) MarshalZerologObject(e *zerolog.Event) {
 	e.Object("metadata", lr.Metadata)
-	e.Str("resource-type", lr.ResourceRelation.Namespace+"#"+lr.ResourceRelation.Relation)
-	e.Str("subject-type", lr.SubjectRelation.Namespace+"#"+lr.SubjectRelation.Relation)
+	e.Str("resource-type", tuple.StringRR(lr.ResourceRelation))
+	e.Str("subject-type", tuple.StringRR(lr.SubjectRelation))
 	e.Array("subject-ids", strArray(lr.SubjectIds))
 }
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (ls *DispatchLookupSubjectsRequest) MarshalZerologObject(e *zerolog.Event) {
 	e.Object("metadata", ls.Metadata)
-	e.Str("resource-type", ls.ResourceRelation.Namespace+"#"+ls.ResourceRelation.Relation)
-	e.Str("subject-type", ls.SubjectRelation.Namespace+"#"+ls.SubjectRelation.Relation)
+	e.Str("resource-type", tuple.StringRR(ls.ResourceRelation))
+	e.Str("subject-type", tuple.StringRR(ls.SubjectRelation))
 	e.Array("resource-ids", strArray(ls.ResourceIds))
 }
 

--- a/pkg/proto/dispatch/v1/00_zerolog.go
+++ b/pkg/proto/dispatch/v1/00_zerolog.go
@@ -1,8 +1,6 @@
 package dispatchv1
 
 import (
-	"fmt"
-
 	"github.com/rs/zerolog"
 
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -11,7 +9,7 @@ import (
 // MarshalZerologObject implements zerolog object marshalling.
 func (cr *DispatchCheckRequest) MarshalZerologObject(e *zerolog.Event) {
 	e.Object("metadata", cr.Metadata)
-	e.Str("resource-type", fmt.Sprintf("%s#%s", cr.ResourceRelation.Namespace, cr.ResourceRelation.Relation))
+	e.Str("resource-type", cr.ResourceRelation.Namespace+"#"+cr.ResourceRelation.Relation)
 	e.Str("subject", tuple.StringONR(cr.Subject))
 	e.Array("resource-ids", strArray(cr.ResourceIds))
 }
@@ -42,7 +40,7 @@ func (cr *DispatchExpandResponse) MarshalZerologObject(e *zerolog.Event) {
 // MarshalZerologObject implements zerolog object marshalling.
 func (lr *DispatchLookupRequest) MarshalZerologObject(e *zerolog.Event) {
 	e.Object("metadata", lr.Metadata)
-	e.Str("object", fmt.Sprintf("%s#%s", lr.ObjectRelation.Namespace, lr.ObjectRelation.Relation))
+	e.Str("object", lr.ObjectRelation.Namespace+"#"+lr.ObjectRelation.Relation)
 	e.Str("subject", tuple.StringONR(lr.Subject))
 	e.Interface("context", lr.Context)
 	e.Uint32("limit", lr.Limit)
@@ -51,16 +49,16 @@ func (lr *DispatchLookupRequest) MarshalZerologObject(e *zerolog.Event) {
 // MarshalZerologObject implements zerolog object marshalling.
 func (lr *DispatchReachableResourcesRequest) MarshalZerologObject(e *zerolog.Event) {
 	e.Object("metadata", lr.Metadata)
-	e.Str("resource-type", fmt.Sprintf("%s#%s", lr.ResourceRelation.Namespace, lr.ResourceRelation.Relation))
-	e.Str("subject-type", fmt.Sprintf("%s#%s", lr.SubjectRelation.Namespace, lr.SubjectRelation.Relation))
+	e.Str("resource-type", lr.ResourceRelation.Namespace+"#"+lr.ResourceRelation.Relation)
+	e.Str("subject-type", lr.SubjectRelation.Namespace+"#"+lr.SubjectRelation.Relation)
 	e.Array("subject-ids", strArray(lr.SubjectIds))
 }
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (ls *DispatchLookupSubjectsRequest) MarshalZerologObject(e *zerolog.Event) {
 	e.Object("metadata", ls.Metadata)
-	e.Str("resource-type", fmt.Sprintf("%s#%s", ls.ResourceRelation.Namespace, ls.ResourceRelation.Relation))
-	e.Str("subject-type", fmt.Sprintf("%s#%s", ls.SubjectRelation.Namespace, ls.SubjectRelation.Relation))
+	e.Str("resource-type", ls.ResourceRelation.Namespace+"#"+ls.ResourceRelation.Relation)
+	e.Str("subject-type", ls.SubjectRelation.Namespace+"#"+ls.SubjectRelation.Relation)
 	e.Array("resource-ids", strArray(ls.ResourceIds))
 }
 

--- a/pkg/schemadsl/parser/parser.go
+++ b/pkg/schemadsl/parser/parser.go
@@ -2,8 +2,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/authzed/spicedb/pkg/schemadsl/dslshape"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
 	"github.com/authzed/spicedb/pkg/schemadsl/lexer"
@@ -405,7 +403,7 @@ func (p *sourceParser) consumeTypePath() (string, bool) {
 		return "", false
 	}
 
-	return fmt.Sprintf("%s/%s", typeNameOrNamespace, typeName), true
+	return typeNameOrNamespace + "/" + typeName, true
 }
 
 // consumePermission consumes a permission.

--- a/pkg/tuple/onr.go
+++ b/pkg/tuple/onr.go
@@ -93,13 +93,10 @@ func StringONR(onr *core.ObjectAndRelation) string {
 	if onr == nil {
 		return ""
 	}
-
-	// Implicit subject relation
 	if onr.Relation == Ellipsis {
-		return onr.Namespace + ":" + onr.ObjectId
+		return JoinObjectRef(onr.Namespace, onr.ObjectId)
 	}
-
-	return onr.Namespace + ":" + onr.ObjectId + "#" + onr.Relation
+	return JoinRelRef(JoinObjectRef(onr.Namespace, onr.ObjectId), onr.Relation)
 }
 
 // StringsONRs converts ONR objects to a string slice, sorted.

--- a/pkg/tuple/onr.go
+++ b/pkg/tuple/onr.go
@@ -2,6 +2,7 @@ package tuple
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/jzelinskie/stringz"
 
@@ -63,13 +64,28 @@ func ParseONR(onr string) *core.ObjectAndRelation {
 	}
 }
 
+// JoinRelRef joins the namespace and relation together into the same
+// format as `StringRR()`.
+func JoinRelRef(namespace, relation string) string { return namespace + "#" + relation }
+
+// MustSplitRelRef splits a string produced by `JoinRelRef()` and panics if
+// it fails.
+func MustSplitRelRef(relRef string) (namespace, relation string) {
+	var ok bool
+	namespace, relation, ok = strings.Cut(relRef, "#")
+	if !ok {
+		panic("improperly formatted relation reference")
+	}
+	return
+}
+
 // StringRR converts a RR object to a string.
 func StringRR(rr *core.RelationReference) string {
 	if rr == nil {
 		return ""
 	}
 
-	return rr.Namespace + "#" + rr.Relation
+	return JoinRelRef(rr.Namespace, rr.Relation)
 }
 
 // StringONR converts an ONR object to a string.

--- a/pkg/tuple/onr.go
+++ b/pkg/tuple/onr.go
@@ -1,18 +1,11 @@
 package tuple
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/jzelinskie/stringz"
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-)
-
-const (
-	// Format is the serialized form of the tuple
-	formatWithRel            = "%s:%s#%s"
-	formatImplicitSubjectRel = "%s:%s"
 )
 
 // ObjectAndRelation creates an ONR from string pieces.
@@ -76,7 +69,7 @@ func StringRR(rr *core.RelationReference) string {
 		return ""
 	}
 
-	return fmt.Sprintf("%s#%s", rr.Namespace, rr.Relation)
+	return rr.Namespace + "#" + rr.Relation
 }
 
 // StringONR converts an ONR object to a string.
@@ -85,11 +78,12 @@ func StringONR(onr *core.ObjectAndRelation) string {
 		return ""
 	}
 
+	// Implicit subject relation
 	if onr.Relation == Ellipsis {
-		return fmt.Sprintf(formatImplicitSubjectRel, onr.Namespace, onr.ObjectId)
+		return onr.Namespace + ":" + onr.ObjectId
 	}
 
-	return fmt.Sprintf(formatWithRel, onr.Namespace, onr.ObjectId, onr.Relation)
+	return onr.Namespace + ":" + onr.ObjectId + "#" + onr.Relation
 }
 
 // StringsONRs converts ONR objects to a string slice, sorted.

--- a/pkg/tuple/onrbytypeset.go
+++ b/pkg/tuple/onrbytypeset.go
@@ -54,7 +54,7 @@ func (s *ONRByTypeSet) Map(mapper func(rr *core.RelationReference) (*core.Relati
 		if updatedType == nil {
 			continue
 		}
-		mapped.byType[JoinRelRef(ns, rel)] = objectIds
+		mapped.byType[JoinRelRef(updatedType.Namespace, updatedType.Relation)] = objectIds
 	}
 	return mapped, nil
 }

--- a/pkg/tuple/onrbytypeset.go
+++ b/pkg/tuple/onrbytypeset.go
@@ -1,7 +1,6 @@
 package tuple
 
 import (
-	"fmt"
 	"strings"
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -21,7 +20,7 @@ func NewONRByTypeSet() *ONRByTypeSet {
 
 // Add adds the specified ObjectAndRelation to the set.
 func (s *ONRByTypeSet) Add(onr *core.ObjectAndRelation) {
-	typeKey := fmt.Sprintf("%s#%s", onr.Namespace, onr.Relation)
+	typeKey := onr.Namespace + "#" + onr.Relation
 	if _, ok := s.byType[typeKey]; !ok {
 		s.byType[typeKey] = []string{}
 	}
@@ -57,7 +56,7 @@ func (s *ONRByTypeSet) Map(mapper func(rr *core.RelationReference) (*core.Relati
 		if updatedType == nil {
 			continue
 		}
-		updatedTypeKey := fmt.Sprintf("%s#%s", updatedType.Namespace, updatedType.Relation)
+		updatedTypeKey := updatedType.Namespace + "#" + updatedType.Relation
 		mapped.byType[updatedTypeKey] = objectIds
 	}
 	return mapped, nil

--- a/pkg/tuple/onrbytypeset_test.go
+++ b/pkg/tuple/onrbytypeset_test.go
@@ -20,7 +20,7 @@ func TestONRByTypeSet(t *testing.T) {
 	assertHasObjectIds := func(s *ONRByTypeSet, rr *core.RelationReference, expected []string) {
 		wasFound := false
 		s.ForEachType(func(foundRR *core.RelationReference, objectIds []string) {
-			if rr.Namespace == foundRR.Namespace && rr.Relation == foundRR.Relation {
+			if rr.EqualVT(foundRR) {
 				sort.Strings(objectIds)
 				require.Equal(t, expected, objectIds)
 				wasFound = true

--- a/pkg/tuple/relationship.go
+++ b/pkg/tuple/relationship.go
@@ -4,17 +4,21 @@ import (
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 )
 
+// JoinObject joins the namespace and the objectId together into the standard
+// format.
+func JoinObjectRef(namespace, objectID string) string { return namespace + ":" + objectID }
+
 // StringObjectRef marshals a *v1.ObjectReference into a string.
 func StringObjectRef(ref *v1.ObjectReference) string {
-	return ref.ObjectType + ":" + ref.ObjectId
+	return JoinObjectRef(ref.ObjectType, ref.ObjectId)
 }
 
 // StringSubjectRef marshals a *v1.SubjectReference into a string.
 func StringSubjectRef(ref *v1.SubjectReference) string {
-	if ref.OptionalRelation != "" {
-		return ref.Object.ObjectType + ":" + ref.Object.ObjectId + "#" + ref.OptionalRelation
+	if ref.OptionalRelation == "" {
+		return StringObjectRef(ref.Object)
 	}
-	return ref.Object.ObjectType + ":" + ref.Object.ObjectId
+	return JoinRelRef(StringObjectRef(ref.Object), ref.OptionalRelation)
 }
 
 // MustStringRelationship converts a v1.Relationship to a string.

--- a/pkg/tuple/relationship.go
+++ b/pkg/tuple/relationship.go
@@ -1,8 +1,6 @@
 package tuple
 
 import (
-	"fmt"
-
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 )
 
@@ -66,5 +64,5 @@ func StringCaveatRef(caveat *v1.ContextualizedCaveat) (string, error) {
 		contextString = ":" + contextString
 	}
 
-	return fmt.Sprintf("[%s%s]", caveat.CaveatName, contextString), nil
+	return "[" + caveat.CaveatName + contextString + "]", nil
 }

--- a/pkg/tuple/relationship.go
+++ b/pkg/tuple/relationship.go
@@ -6,14 +6,20 @@ import (
 
 // JoinObject joins the namespace and the objectId together into the standard
 // format.
+//
+// This function assumes that the provided values have already been validated.
 func JoinObjectRef(namespace, objectID string) string { return namespace + ":" + objectID }
 
 // StringObjectRef marshals a *v1.ObjectReference into a string.
+//
+// This function assumes that the provided values have already been validated.
 func StringObjectRef(ref *v1.ObjectReference) string {
 	return JoinObjectRef(ref.ObjectType, ref.ObjectId)
 }
 
 // StringSubjectRef marshals a *v1.SubjectReference into a string.
+//
+// This function assumes that the provided values have already been validated.
 func StringSubjectRef(ref *v1.SubjectReference) string {
 	if ref.OptionalRelation == "" {
 		return StringObjectRef(ref.Object)

--- a/pkg/tuple/relationship_test.go
+++ b/pkg/tuple/relationship_test.go
@@ -1,0 +1,46 @@
+package tuple
+
+import (
+	"testing"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func objRef(typ, id string) *v1.ObjectReference {
+	return &v1.ObjectReference{ObjectType: typ, ObjectId: id}
+}
+
+func subRef(typ, id, rel string) *v1.SubjectReference {
+	return &v1.SubjectReference{Object: objRef(typ, id), OptionalRelation: rel}
+}
+
+func TestStringObjectRef(t *testing.T) {
+	table := []struct {
+		ref      *v1.ObjectReference
+		expected string
+	}{
+		// This code assumes input has already been validated.
+		{objRef("document", "1"), "document:1"},
+		{objRef("", ""), ":"},
+		{objRef(":", ":"), ":::"},
+	}
+	for _, tt := range table {
+		require.Equal(t, tt.expected, StringObjectRef(tt.ref))
+		require.Equal(t, tt.expected, StringSubjectRef(subRef(tt.ref.ObjectType, tt.ref.ObjectId, "")))
+	}
+}
+
+func TestJoinSubjectRef(t *testing.T) {
+	table := []struct {
+		ref      *v1.SubjectReference
+		expected string
+	}{
+		// This code assumes input has already been validated.
+		{subRef("document", "1", ""), "document:1"},
+		{subRef("document", "1", "reader"), "document:1#reader"},
+	}
+	for _, tt := range table {
+		require.Equal(t, tt.expected, StringSubjectRef(tt.ref))
+	}
+}

--- a/pkg/validationfile/blocks/errors.go
+++ b/pkg/validationfile/blocks/errors.go
@@ -29,7 +29,7 @@ func convertYamlError(err error) error {
 		if len(unmarshalPieces) == 2 {
 			source = unmarshalPieces[1]
 			if strings.Contains(source, " ") {
-				source = strings.Split(source, " ")[0]
+				source, _, _ = strings.Cut(source, " ")
 			}
 
 			message = fmt.Sprintf("unexpected value `%s`", source)

--- a/pkg/validationfile/blocks/expectedrelations.go
+++ b/pkg/validationfile/blocks/expectedrelations.go
@@ -175,7 +175,7 @@ func (vs ValidationString) Subject() (*SubjectWithExceptions, *spiceerrors.Error
 	subjectStr = strings.TrimSpace(subjectStr)
 	groups := vsSubjectWithExceptionsOrCaveatRegex.FindStringSubmatch(subjectStr)
 	if len(groups) == 0 {
-		bracketedSubjectString := fmt.Sprintf("[%s]", subjectStr)
+		bracketedSubjectString := "[" + subjectStr + "]"
 		return nil, spiceerrors.NewErrorWithSource(fmt.Errorf("invalid subject: `%s`", subjectStr), bracketedSubjectString, 0, 0)
 	}
 


### PR DESCRIPTION
An allocs profile showed that we're making lots of allocations from `fmt.Sprintf` (nearly half as many as allocations from allocation protos!). I removed many of the simple usages from the critical path to save allocations.

The second commit also adopts `strings.Cut` where it makes sense for further optimization.