### PR TITLE
fixes positional argument errors failing silently

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/rs/zerolog"
 	"github.com/sercand/kuberesolver/v3"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/balancer"
@@ -39,6 +40,8 @@ func main() {
 		hashringReplicationFactor,
 		backendsPerKey,
 	))
+
+	log.SetGlobalLogger(zerolog.New(os.Stdout))
 
 	// Create a root command
 	rootCmd := cmd.NewRootCommand("spicedb")


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb/issues/1100

unfortunately cobra positional arguments are not governed by the same logic as flag parsing, and as a consequence, we are not logging them out.

This is also compounded by the fact the global logger is not initialized until it's injected via
pkg/cmd/server/defaults.go/DefaultPreRunE. We recently moved to use our own global logger instead of ZeroLog's, and we've set it to Noop by default. As a consequence, the positional argument error was being printed by a noop logger.

ideally, we would invert the control via `main.go` and let `DefaultPreRunE` (which sets the global logger in the command stack) receive a logger instance, instead of it creating it and injecting it back.

In the meanwhile, and as a workaround, we set a default global logger so that errors before positional argument parsing are logged out. This default logger will be overwritten once the cobra `PreRunE` is executed, invoking `cobrautil.CommandStack`