### PR TITLE
pkg/cache: default TTL of 2x quantization window

### DIFF
--- a/pkg/cmd/server/cacheconfig.go
+++ b/pkg/cmd/server/cacheconfig.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/jzelinskie/stringz"
@@ -31,6 +32,14 @@ type CacheConfig struct {
 	NumCounters int64
 	Metrics     bool
 	Enabled     bool
+	defaultTTL  time.Duration
+}
+
+// WithQuantization configures a cache such that all entries are given a TTL
+// that will expire safely outside of the quantization window.
+func (cc *CacheConfig) WithQuantization(window time.Duration) *CacheConfig {
+	cc.defaultTTL = window * 2
+	return cc
 }
 
 // Complete translates the CLI cache config into a cache config.
@@ -56,6 +65,7 @@ func (cc *CacheConfig) Complete() (cache.Cache, error) {
 	return cache.NewCache(&cache.Config{
 		MaxCost:     int64(maxCost),
 		NumCounters: cc.NumCounters,
+		DefaultTTL:  cc.defaultTTL,
 		Metrics:     cc.Metrics,
 	})
 }

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -200,7 +200,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 
 	dispatcher := c.Dispatcher
 	if dispatcher == nil {
-		cc, err := c.DispatchCacheConfig.Complete()
+		cc, err := c.DispatchCacheConfig.WithQuantization(c.DatastoreConfig.RevisionQuantization).Complete()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create dispatcher: %w", err)
 		}
@@ -244,7 +244,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 
 	var cachingClusterDispatch dispatch.Dispatcher
 	if c.DispatchServer.Enabled {
-		cdcc, err := c.ClusterDispatchCacheConfig.Complete()
+		cdcc, err := c.ClusterDispatchCacheConfig.WithQuantization(c.DatastoreConfig.RevisionQuantization).Complete()
 		if err != nil {
 			return nil, fmt.Errorf("failed to configure cluster dispatch: %w", err)
 		}


### PR DESCRIPTION
This should help reduce memory usage as it'll more eagerly expire keys that we know won't ever be queried again.