### PR TITLE
Add additional option to CEL to compile caveat macro expressions

### DIFF
--- a/internal/services/integrationtesting/testconfigs/caveatlist.yaml
+++ b/internal/services/integrationtesting/testconfigs/caveatlist.yaml
@@ -1,0 +1,29 @@
+---
+schema: |+
+  definition user {}
+
+  caveat some_caveat(somelist list<int>) {
+    somelist.all(i, i >= 42)
+  }
+
+  definition document {
+    relation viewer: user with some_caveat
+    permission view = viewer
+  }
+
+relationships: >-
+  document:firstdoc#viewer@user:tom[some_caveat:{"somelist": [42, 43]}]
+
+  document:firstdoc#viewer@user:sarah[some_caveat]
+
+  document:firstdoc#viewer@user:fred[some_caveat:{"somelist": [42, 41]}]
+assertions:
+  assertTrue:
+    - 'document:firstdoc#view@user:tom'
+    - 'document:firstdoc#view@user:sarah with {"somelist":[]}'
+    - 'document:firstdoc#view@user:sarah with {"somelist":[56]}'
+  assertCaveated:
+    - 'document:firstdoc#view@user:sarah'
+  assertFalse:
+    - 'document:firstdoc#view@user:fred'
+    - 'document:firstdoc#view@user:sarah with {"somelist":[12]}'

--- a/pkg/caveats/compile_test.go
+++ b/pkg/caveats/compile_test.go
@@ -214,13 +214,14 @@ func TestDeserializeEmpty(t *testing.T) {
 }
 
 func TestSerialization(t *testing.T) {
-	exprs := []string{"a == 1", "a + b == 2", "b - a == 4"}
+	exprs := []string{"a == 1", "a + b == 2", "b - a == 4", "l.all(i, i > 42)"}
 
 	for _, expr := range exprs {
 		t.Run(expr, func(t *testing.T) {
 			env := MustEnvForVariables(map[string]types.VariableType{
 				"a": types.IntType,
 				"b": types.IntType,
+				"l": types.MustListType(types.IntType),
 			})
 			compiled, err := compileCaveat(env, expr)
 			require.NoError(t, err)

--- a/pkg/caveats/env.go
+++ b/pkg/caveats/env.go
@@ -72,6 +72,11 @@ func (e *Environment) asCelEnvironment() (*cel.Env, error) {
 	// DefaultUTCTimeZone: ensure all timestamps are evaluated at UTC
 	opts = append(opts, cel.DefaultUTCTimeZone(true))
 
+	// EnableMacroCallTracking: enables tracking of call macros so when we call AstToString we get
+	// back out the expected expressions.
+	// See: https://github.com/google/cel-go/issues/474
+	opts = append(opts, cel.EnableMacroCallTracking())
+
 	for name, varType := range e.variables {
 		opts = append(opts, cel.Variable(name, varType.CelType()))
 	}


### PR DESCRIPTION
See https://github.com/google/cel-go/issues/474 for why this is necessary

Also adds a consistency test