### PR TITLE
Add various timeouts and small fixes to hopefully address the LookupResources memory leak

### DIFF
--- a/internal/dispatch/cluster/cluster.go
+++ b/internal/dispatch/cluster/cluster.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"time"
+
 	"github.com/authzed/spicedb/internal/dispatch"
 	"github.com/authzed/spicedb/internal/dispatch/caching"
 	"github.com/authzed/spicedb/internal/dispatch/graph"
@@ -12,9 +14,10 @@ import (
 type Option func(*optionState)
 
 type optionState struct {
-	prometheusSubsystem string
-	cache               cache.Cache
-	concurrencyLimits   graph.ConcurrencyLimits
+	prometheusSubsystem   string
+	cache                 cache.Cache
+	concurrencyLimits     graph.ConcurrencyLimits
+	remoteDispatchTimeout time.Duration
 }
 
 // PrometheusSubsystem sets the subsystem name for the prometheus metrics
@@ -35,6 +38,14 @@ func Cache(c cache.Cache) Option {
 func ConcurrencyLimits(limits graph.ConcurrencyLimits) Option {
 	return func(state *optionState) {
 		state.concurrencyLimits = limits
+	}
+}
+
+// RemoteDispatchTimeout sets the maximum timeout for a remote dispatch.
+// Defaults to 60s (as defined in the remote dispatcher).
+func RemoteDispatchTimeout(remoteDispatchTimeout time.Duration) Option {
+	return func(state *optionState) {
+		state.remoteDispatchTimeout = remoteDispatchTimeout
 	}
 }
 

--- a/internal/dispatch/remote/cluster.go
+++ b/internal/dispatch/remote/cluster.go
@@ -163,9 +163,7 @@ func (cr *clusterDispatcher) DispatchReachableResources(
 			result, err := client.Recv()
 			if errors.Is(err, io.EOF) {
 				return nil
-			}
-
-			if err != nil {
+			} else if err != nil {
 				return err
 			}
 
@@ -210,9 +208,7 @@ func (cr *clusterDispatcher) DispatchLookupSubjects(
 			result, err := client.Recv()
 			if errors.Is(err, io.EOF) {
 				return nil
-			}
-
-			if err != nil {
+			} else if err != nil {
 				return err
 			}
 

--- a/internal/dispatch/remote/cluster.go
+++ b/internal/dispatch/remote/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -23,20 +24,41 @@ type clusterClient interface {
 	DispatchLookupSubjects(ctx context.Context, in *v1.DispatchLookupSubjectsRequest, opts ...grpc.CallOption) (v1.DispatchService_DispatchLookupSubjectsClient, error)
 }
 
+type ClusterDispatcherConfig struct {
+	// KeyHandler is then handler to use for generating dispatch hash ring keys.
+	KeyHandler keys.Handler
+
+	// DispatchOverallTimeout is the maximum duration of a dispatched request
+	// before it should timeout.
+	DispatchOverallTimeout time.Duration
+}
+
 // NewClusterDispatcher creates a dispatcher implementation that uses the provided client
 // to dispatch requests to peer nodes in the cluster.
-func NewClusterDispatcher(client clusterClient, conn *grpc.ClientConn, keyHandler keys.Handler) dispatch.Dispatcher {
+func NewClusterDispatcher(client clusterClient, conn *grpc.ClientConn, config ClusterDispatcherConfig) dispatch.Dispatcher {
+	keyHandler := config.KeyHandler
 	if keyHandler == nil {
 		keyHandler = &keys.DirectKeyHandler{}
 	}
 
-	return &clusterDispatcher{clusterClient: client, conn: conn, keyHandler: keyHandler}
+	dispatchOverallTimeout := config.DispatchOverallTimeout
+	if dispatchOverallTimeout <= 0 {
+		dispatchOverallTimeout = 60 * time.Second
+	}
+
+	return &clusterDispatcher{
+		clusterClient:          client,
+		conn:                   conn,
+		keyHandler:             keyHandler,
+		dispatchOverallTimeout: dispatchOverallTimeout,
+	}
 }
 
 type clusterDispatcher struct {
-	clusterClient clusterClient
-	conn          *grpc.ClientConn
-	keyHandler    keys.Handler
+	clusterClient          clusterClient
+	conn                   *grpc.ClientConn
+	keyHandler             keys.Handler
+	dispatchOverallTimeout time.Duration
 }
 
 func (cr *clusterDispatcher) DispatchCheck(ctx context.Context, req *v1.DispatchCheckRequest) (*v1.DispatchCheckResponse, error) {
@@ -50,7 +72,11 @@ func (cr *clusterDispatcher) DispatchCheck(ctx context.Context, req *v1.Dispatch
 	}
 
 	ctx = context.WithValue(ctx, balancer.CtxKey, requestKey)
-	resp, err := cr.clusterClient.DispatchCheck(ctx, req)
+
+	withTimeout, cancelFn := context.WithTimeout(ctx, cr.dispatchOverallTimeout)
+	defer cancelFn()
+
+	resp, err := cr.clusterClient.DispatchCheck(withTimeout, req)
 	if err != nil {
 		return &v1.DispatchCheckResponse{Metadata: requestFailureMetadata}, err
 	}
@@ -69,7 +95,11 @@ func (cr *clusterDispatcher) DispatchExpand(ctx context.Context, req *v1.Dispatc
 	}
 
 	ctx = context.WithValue(ctx, balancer.CtxKey, requestKey)
-	resp, err := cr.clusterClient.DispatchExpand(ctx, req)
+
+	withTimeout, cancelFn := context.WithTimeout(ctx, cr.dispatchOverallTimeout)
+	defer cancelFn()
+
+	resp, err := cr.clusterClient.DispatchExpand(withTimeout, req)
 	if err != nil {
 		return &v1.DispatchExpandResponse{Metadata: requestFailureMetadata}, err
 	}
@@ -88,7 +118,11 @@ func (cr *clusterDispatcher) DispatchLookup(ctx context.Context, req *v1.Dispatc
 	}
 
 	ctx = context.WithValue(ctx, balancer.CtxKey, requestKey)
-	resp, err := cr.clusterClient.DispatchLookup(ctx, req)
+
+	withTimeout, cancelFn := context.WithTimeout(ctx, cr.dispatchOverallTimeout)
+	defer cancelFn()
+
+	resp, err := cr.clusterClient.DispatchLookup(withTimeout, req)
 	if err != nil {
 		return &v1.DispatchLookupResponse{Metadata: requestFailureMetadata}, err
 	}
@@ -112,28 +146,35 @@ func (cr *clusterDispatcher) DispatchReachableResources(
 		return err
 	}
 
-	client, err := cr.clusterClient.DispatchReachableResources(ctx, req)
+	withTimeout, cancelFn := context.WithTimeout(ctx, cr.dispatchOverallTimeout)
+	defer cancelFn()
+
+	client, err := cr.clusterClient.DispatchReachableResources(withTimeout, req)
 	if err != nil {
 		return err
 	}
 
 	for {
-		result, err := client.Recv()
-		if errors.Is(err, io.EOF) {
-			break
-		}
+		select {
+		case <-withTimeout.Done():
+			return withTimeout.Err()
 
-		if err != nil {
-			return err
-		}
+		default:
+			result, err := client.Recv()
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
 
-		serr := stream.Publish(result)
-		if serr != nil {
-			return serr
+			if err != nil {
+				return err
+			}
+
+			serr := stream.Publish(result)
+			if serr != nil {
+				return serr
+			}
 		}
 	}
-
-	return nil
 }
 
 func (cr *clusterDispatcher) DispatchLookupSubjects(
@@ -152,28 +193,35 @@ func (cr *clusterDispatcher) DispatchLookupSubjects(
 		return err
 	}
 
-	client, err := cr.clusterClient.DispatchLookupSubjects(ctx, req)
+	withTimeout, cancelFn := context.WithTimeout(ctx, cr.dispatchOverallTimeout)
+	defer cancelFn()
+
+	client, err := cr.clusterClient.DispatchLookupSubjects(withTimeout, req)
 	if err != nil {
 		return err
 	}
 
 	for {
-		result, err := client.Recv()
-		if errors.Is(err, io.EOF) {
-			break
-		}
+		select {
+		case <-withTimeout.Done():
+			return withTimeout.Err()
 
-		if err != nil {
-			return err
-		}
+		default:
+			result, err := client.Recv()
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
 
-		serr := stream.Publish(result)
-		if serr != nil {
-			return serr
+			if err != nil {
+				return err
+			}
+
+			serr := stream.Publish(result)
+			if serr != nil {
+				return serr
+			}
 		}
 	}
-
-	return nil
 }
 
 func (cr *clusterDispatcher) Close() error {

--- a/internal/dispatch/remote/cluster_test.go
+++ b/internal/dispatch/remote/cluster_test.go
@@ -1,0 +1,124 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/authzed/spicedb/internal/dispatch"
+
+	humanize "github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/authzed/spicedb/internal/dispatch/keys"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+)
+
+type fakeDispatchSvc struct {
+	v1.UnimplementedDispatchServiceServer
+
+	sleepTime time.Duration
+}
+
+func (fds *fakeDispatchSvc) DispatchCheck(context.Context, *v1.DispatchCheckRequest) (*v1.DispatchCheckResponse, error) {
+	time.Sleep(fds.sleepTime)
+	return &v1.DispatchCheckResponse{}, nil
+}
+
+func (fds *fakeDispatchSvc) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsRequest, srv v1.DispatchService_DispatchLookupSubjectsServer) error {
+	time.Sleep(fds.sleepTime)
+	return srv.Send(&v1.DispatchLookupSubjectsResponse{})
+}
+
+func TestDispatchTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		timeout   time.Duration
+		sleepTime time.Duration
+	}{
+		{
+			10 * time.Millisecond,
+			20 * time.Millisecond,
+		},
+		{
+			100 * time.Millisecond,
+			20 * time.Millisecond,
+		},
+	} {
+		t.Run(fmt.Sprintf("%v", tc.timeout > tc.sleepTime), func(t *testing.T) {
+			// Configure a fake dispatcher service and an associated buffconn-based
+			// connection to it.
+			listener := bufconn.Listen(humanize.MiByte)
+			s := grpc.NewServer()
+
+			fakeDispatch := &fakeDispatchSvc{sleepTime: tc.sleepTime}
+			v1.RegisterDispatchServiceServer(s, fakeDispatch)
+
+			go func() {
+				// Ignore any errors
+				_ = s.Serve(listener)
+			}()
+
+			conn, err := grpc.DialContext(
+				context.Background(),
+				"",
+				grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+					return listener.Dial()
+				}),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithBlock(),
+			)
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				conn.Close()
+				listener.Close()
+				s.Stop()
+			})
+
+			// Configure a dispatcher with a very low timeout.
+			dispatcher := NewClusterDispatcher(v1.NewDispatchServiceClient(conn), conn, ClusterDispatcherConfig{
+				KeyHandler:             &keys.DirectKeyHandler{},
+				DispatchOverallTimeout: tc.timeout,
+			})
+			require.True(t, dispatcher.IsReady())
+
+			// Invoke a dispatched "check" and ensure it times out, as the fake dispatch will wait
+			// longer than the configured timeout.
+			resp, err := dispatcher.DispatchCheck(context.Background(), &v1.DispatchCheckRequest{
+				ResourceRelation: &core.RelationReference{Namespace: "sometype", Relation: "somerel"},
+				ResourceIds:      []string{"foo"},
+				Metadata:         &v1.ResolverMeta{DepthRemaining: 50},
+				Subject:          &core.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
+			})
+			if tc.sleepTime > tc.timeout {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "context deadline exceeded")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			}
+
+			// Invoke a dispatched "LookupSubjects" and test as well.
+			stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupSubjectsResponse](context.Background())
+			err = dispatcher.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{
+				ResourceRelation: &core.RelationReference{Namespace: "sometype", Relation: "somerel"},
+				ResourceIds:      []string{"foo"},
+				Metadata:         &v1.ResolverMeta{DepthRemaining: 50},
+				SubjectRelation:  &core.RelationReference{Namespace: "sometype", Relation: "somerel"},
+			}, stream)
+			if tc.sleepTime > tc.timeout {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "context deadline exceeded")
+			} else {
+				require.NoError(t, err)
+				require.NotEmpty(t, stream.Results())
+			}
+		})
+	}
+}

--- a/internal/middleware/streamtimeout/streamtimeout.go
+++ b/internal/middleware/streamtimeout/streamtimeout.go
@@ -1,0 +1,47 @@
+package streamtimeout
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// MustStreamServerInterceptor returns a new stream server interceptor that cancels the context
+// after a timeout if no new data has been received.
+func MustStreamServerInterceptor(timeout time.Duration) grpc.StreamServerInterceptor {
+	if timeout <= 0 {
+		panic("timeout must be >= 0 for streaming timeout interceptor")
+	}
+
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := stream.Context()
+		withCancel, cancelFn := context.WithCancel(ctx)
+		timer := time.AfterFunc(timeout, cancelFn)
+		wrapper := &recvWrapper{stream, withCancel, cancelFn, timer, timeout}
+		return handler(srv, wrapper)
+	}
+}
+
+type recvWrapper struct {
+	grpc.ServerStream
+
+	ctx      context.Context
+	cancelFn func()
+	timer    *time.Timer
+	timeout  time.Duration
+}
+
+func (s *recvWrapper) Context() context.Context {
+	return s.ctx
+}
+
+func (s *recvWrapper) RecvMsg(m interface{}) error {
+	err := s.ServerStream.RecvMsg(m)
+	if err != nil {
+		s.timer.Stop()
+	} else {
+		s.timer.Reset(s.timeout)
+	}
+	return err
+}

--- a/internal/middleware/streamtimeout/streamtimeout_test.go
+++ b/internal/middleware/streamtimeout/streamtimeout_test.go
@@ -1,0 +1,90 @@
+package streamtimeout
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+)
+
+type testServer struct {
+	testpb.UnimplementedTestServiceServer
+}
+
+func (t testServer) PingEmpty(ctx context.Context, empty *testpb.PingEmptyRequest) (*testpb.PingEmptyResponse, error) {
+	return &testpb.PingEmptyResponse{}, nil
+}
+
+func (t testServer) Ping(ctx context.Context, request *testpb.PingRequest) (*testpb.PingResponse, error) {
+	return &testpb.PingResponse{Value: ""}, nil
+}
+
+func (t testServer) PingError(ctx context.Context, request *testpb.PingErrorRequest) (*testpb.PingErrorResponse, error) {
+	return nil, fmt.Errorf("err")
+}
+
+func (t testServer) PingList(request *testpb.PingListRequest, server testpb.TestService_PingListServer) error {
+	var counter int32
+	for {
+		// Produce ping responses until the context is canceled.
+		select {
+		case <-server.Context().Done():
+			return server.Context().Err()
+
+		default:
+			counter++
+			err := server.Send(&testpb.PingListResponse{Counter: counter})
+			if err != nil {
+				return err
+			}
+			time.Sleep(time.Duration(counter*10) * time.Millisecond)
+		}
+	}
+}
+
+func (t testServer) PingStream(stream testpb.TestService_PingStreamServer) error {
+	return fmt.Errorf("unused")
+}
+
+type testSuite struct {
+	*testpb.InterceptorTestSuite
+}
+
+func TestStreamTimeoutMiddleware(t *testing.T) {
+	s := &testSuite{
+		InterceptorTestSuite: &testpb.InterceptorTestSuite{
+			TestService: &testServer{},
+			ServerOpts: []grpc.ServerOption{
+				grpc.StreamInterceptor(MustStreamServerInterceptor(50 * time.Millisecond)),
+			},
+			ClientOpts: []grpc.DialOption{},
+		},
+	}
+	suite.Run(t, s)
+}
+
+func (s *testSuite) TestStreamTimeout() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), &testpb.PingListRequest{Value: "something"})
+	require.NoError(s.T(), err)
+
+	var maxCounter int32
+
+	for {
+		// Ensure if we get an error, it is because the context was canceled.
+		resp, err := stream.Recv()
+		if err != nil {
+			require.ErrorContains(s.T(), err, "context canceled")
+			return
+		}
+
+		// Ensure that we produced a *maximum* of 6 responses (timeout is 50ms and each response
+		// should take 10ms * counter). This ensures that we timed out (roughly) when expected.
+		maxCounter = resp.Counter
+		require.LessOrEqual(s.T(), maxCounter, int32(6), "stream was not properly canceled: %d", maxCounter)
+	}
+}

--- a/internal/services/v1/errors.go
+++ b/internal/services/v1/errors.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
@@ -246,12 +245,9 @@ func rewriteError(ctx context.Context, err error) error {
 	}
 }
 
-type uinteger interface {
-	uint32 | uint16 | time.Duration
-}
-
-func defaultIfZero[T uinteger](value T, defaultValue T) T {
-	if value == 0 {
+func defaultIfZero[T comparable](value T, defaultValue T) T {
+	var zero T
+	if value == zero {
 		return defaultValue
 	}
 	return value

--- a/internal/services/v1/errors.go
+++ b/internal/services/v1/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
@@ -246,7 +247,7 @@ func rewriteError(ctx context.Context, err error) error {
 }
 
 type uinteger interface {
-	uint32 | uint16
+	uint32 | uint16 | time.Duration
 }
 
 func defaultIfZero[T uinteger](value T, defaultValue T) T {

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"time"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	grpcvalidate "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/validator"
@@ -13,6 +14,7 @@ import (
 	"github.com/authzed/spicedb/internal/middleware"
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/internal/middleware/handwrittenvalidation"
+	"github.com/authzed/spicedb/internal/middleware/streamtimeout"
 	"github.com/authzed/spicedb/internal/middleware/usagemetrics"
 	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/internal/relationships"
@@ -38,6 +40,10 @@ type PermissionsServerConfig struct {
 	// MaximumAPIDepth is the default/starting depth remaining for API calls made
 	// to the permissions server.
 	MaximumAPIDepth uint32
+
+	// StreamingAPITimeout is the timeout for streaming APIs when no response has been
+	// recently received.
+	StreamingAPITimeout time.Duration
 }
 
 // NewPermissionsServer creates a PermissionsServiceServer instance.
@@ -50,6 +56,7 @@ func NewPermissionsServer(
 		MaxPreconditionsCount: defaultIfZero(config.MaxPreconditionsCount, 1000),
 		MaxUpdatesPerWrite:    defaultIfZero(config.MaxUpdatesPerWrite, 1000),
 		MaximumAPIDepth:       defaultIfZero(config.MaximumAPIDepth, 50),
+		StreamingAPITimeout:   defaultIfZero(config.StreamingAPITimeout, 30*time.Second),
 	}
 
 	return &permissionServer{
@@ -66,6 +73,7 @@ func NewPermissionsServer(
 				grpcvalidate.StreamServerInterceptor(true),
 				handwrittenvalidation.StreamServerInterceptor,
 				usagemetrics.StreamServerInterceptor(),
+				streamtimeout.MustStreamServerInterceptor(configWithDefaults.StreamingAPITimeout),
 			),
 		},
 	}

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -90,6 +90,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	cmd.Flags().Uint32Var(&config.DispatchMaxDepth, "dispatch-max-depth", 50, "maximum recursion depth for nested calls")
 	cmd.Flags().StringVar(&config.DispatchUpstreamAddr, "dispatch-upstream-addr", "", "upstream grpc address to dispatch to")
 	cmd.Flags().StringVar(&config.DispatchUpstreamCAPath, "dispatch-upstream-ca-path", "", "local path to the TLS CA used when connecting to the dispatch cluster")
+	cmd.Flags().DurationVar(&config.DispatchUpstreamTimeout, "dispatch-upstream-timeout", 60*time.Second, "maximum duration of a dispatch call an upstream cluster before it times out")
 
 	cmd.Flags().Uint16Var(&config.GlobalDispatchConcurrencyLimit, "dispatch-concurrency-limit", 50, "maximum number of parallel goroutines to create for each request or subrequest")
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -73,9 +73,9 @@ type Config struct {
 	DispatchConcurrencyLimits      graph.ConcurrencyLimits
 	DispatchUpstreamAddr           string
 	DispatchUpstreamCAPath         string
+	DispatchUpstreamTimeout        time.Duration
 	DispatchClientMetricsPrefix    string
 	DispatchClusterMetricsPrefix   string
-	DispatchUpstreamTimeout        time.Duration
 	Dispatcher                     dispatch.Dispatcher
 
 	DispatchCacheConfig        CacheConfig

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -75,6 +75,7 @@ type Config struct {
 	DispatchUpstreamCAPath         string
 	DispatchClientMetricsPrefix    string
 	DispatchClusterMetricsPrefix   string
+	DispatchUpstreamTimeout        time.Duration
 	Dispatcher                     dispatch.Dispatcher
 
 	DispatchCacheConfig        CacheConfig
@@ -255,6 +256,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 			dispatcher,
 			clusterdispatch.PrometheusSubsystem(c.DispatchClusterMetricsPrefix),
 			clusterdispatch.Cache(cdcc),
+			clusterdispatch.RemoteDispatchTimeout(c.DispatchUpstreamTimeout),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to configure cluster dispatch: %w", err)

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -46,9 +46,9 @@ func (c *Config) ToOption() ConfigOption {
 		to.DispatchConcurrencyLimits = c.DispatchConcurrencyLimits
 		to.DispatchUpstreamAddr = c.DispatchUpstreamAddr
 		to.DispatchUpstreamCAPath = c.DispatchUpstreamCAPath
+		to.DispatchUpstreamTimeout = c.DispatchUpstreamTimeout
 		to.DispatchClientMetricsPrefix = c.DispatchClientMetricsPrefix
 		to.DispatchClusterMetricsPrefix = c.DispatchClusterMetricsPrefix
-		to.DispatchUpstreamTimeout = c.DispatchUpstreamTimeout
 		to.Dispatcher = c.Dispatcher
 		to.DispatchCacheConfig = c.DispatchCacheConfig
 		to.ClusterDispatchCacheConfig = c.ClusterDispatchCacheConfig
@@ -231,6 +231,13 @@ func WithDispatchUpstreamCAPath(dispatchUpstreamCAPath string) ConfigOption {
 	}
 }
 
+// WithDispatchUpstreamTimeout returns an option that can set DispatchUpstreamTimeout on a Config
+func WithDispatchUpstreamTimeout(dispatchUpstreamTimeout time.Duration) ConfigOption {
+	return func(c *Config) {
+		c.DispatchUpstreamTimeout = dispatchUpstreamTimeout
+	}
+}
+
 // WithDispatchClientMetricsPrefix returns an option that can set DispatchClientMetricsPrefix on a Config
 func WithDispatchClientMetricsPrefix(dispatchClientMetricsPrefix string) ConfigOption {
 	return func(c *Config) {
@@ -242,13 +249,6 @@ func WithDispatchClientMetricsPrefix(dispatchClientMetricsPrefix string) ConfigO
 func WithDispatchClusterMetricsPrefix(dispatchClusterMetricsPrefix string) ConfigOption {
 	return func(c *Config) {
 		c.DispatchClusterMetricsPrefix = dispatchClusterMetricsPrefix
-	}
-}
-
-// WithDispatchUpstreamTimeout returns an option that can set DispatchUpstreamTimeout on a Config
-func WithDispatchUpstreamTimeout(dispatchUpstreamTimeout time.Duration) ConfigOption {
-	return func(c *Config) {
-		c.DispatchUpstreamTimeout = dispatchUpstreamTimeout
 	}
 }
 

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -48,6 +48,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.DispatchUpstreamCAPath = c.DispatchUpstreamCAPath
 		to.DispatchClientMetricsPrefix = c.DispatchClientMetricsPrefix
 		to.DispatchClusterMetricsPrefix = c.DispatchClusterMetricsPrefix
+		to.DispatchUpstreamTimeout = c.DispatchUpstreamTimeout
 		to.Dispatcher = c.Dispatcher
 		to.DispatchCacheConfig = c.DispatchCacheConfig
 		to.ClusterDispatchCacheConfig = c.ClusterDispatchCacheConfig
@@ -241,6 +242,13 @@ func WithDispatchClientMetricsPrefix(dispatchClientMetricsPrefix string) ConfigO
 func WithDispatchClusterMetricsPrefix(dispatchClusterMetricsPrefix string) ConfigOption {
 	return func(c *Config) {
 		c.DispatchClusterMetricsPrefix = dispatchClusterMetricsPrefix
+	}
+}
+
+// WithDispatchUpstreamTimeout returns an option that can set DispatchUpstreamTimeout on a Config
+func WithDispatchUpstreamTimeout(dispatchUpstreamTimeout time.Duration) ConfigOption {
+	return func(c *Config) {
+		c.DispatchUpstreamTimeout = dispatchUpstreamTimeout
 	}
 }
 

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	humanize "github.com/dustin/go-humanize"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -31,7 +32,7 @@ import (
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
-const defaultConnBufferSize = 1024 * 1204
+const defaultConnBufferSize = humanize.MiByte
 
 // DevContext holds the various helper types for running the developer calls.
 type DevContext struct {


### PR DESCRIPTION
Despite changes from errgroup to taskrunner in the previous PR, it appears gRPC is still holding open streams long-term.

This PR adds a number of changes to address this:
1. Add a middleware that automatically cancels the downstream context after a duration of having not received any streamed results and install it in *both* V1 and dispatching
2. Change remote dispatching to have a maximum timeout for upstream calls
3. Change the LookupResources code to use task runner as well