### PR TITLE
Add caching of caveats in caching proxy for datastore

### DIFF
--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -140,7 +140,7 @@ func NewHandler(grpcAddr string, grpcTLSEnabled bool, datastoreEngine string, ds
 				return
 			}
 
-			nsDefs, err := ds.SnapshotReader(headRevision).ListNamespaces(r.Context())
+			nsDefs, err := ds.SnapshotReader(headRevision).ListAllNamespaces(r.Context())
 			if err != nil {
 				log.Ctx(r.Context()).Error().AnErr("datastoreError", err).Msg("Got error when trying to load namespaces")
 				fmt.Fprintf(w, "Internal Error")

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -148,7 +148,7 @@ func NewHandler(grpcAddr string, grpcTLSEnabled bool, datastoreEngine string, ds
 			}
 
 			for _, nsDef := range nsDefs {
-				objectDef, _, err := generator.GenerateSource(nsDef)
+				objectDef, _, err := generator.GenerateSource(nsDef.Definition)
 				if err != nil {
 					log.Ctx(r.Context()).Error().Err(err).Msg("Got error when trying to generate namespace")
 					fmt.Fprintf(w, "Internal Error")
@@ -157,10 +157,10 @@ func NewHandler(grpcAddr string, grpcTLSEnabled bool, datastoreEngine string, ds
 
 				objectDefs = append(objectDefs, objectDef)
 
-				if nsDef.Name == "user" {
+				if nsDef.Definition.Name == "user" {
 					userFound = true
 				}
-				if nsDef.Name == "resource" {
+				if nsDef.Definition.Name == "resource" {
 					resourceFound = true
 				}
 			}

--- a/internal/datastore/crdb/caveat.go
+++ b/internal/datastore/crdb/caveat.go
@@ -62,7 +62,18 @@ func (cr *crdbReader) ReadCaveatByName(ctx context.Context, name string) (*core.
 	return loaded, revisionFromTimestamp(timestamp), nil
 }
 
-func (cr *crdbReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
+func (cr *crdbReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+	if len(caveatNames) == 0 {
+		return nil, nil
+	}
+	return cr.lookupCaveats(ctx, caveatNames)
+}
+
+func (cr *crdbReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+	return cr.lookupCaveats(ctx, nil)
+}
+
+func (cr *crdbReader) lookupCaveats(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
 	caveatsWithNames := listCaveat
 	if len(caveatNames) > 0 {
 		caveatsWithNames = caveatsWithNames.Where(sq.Eq{colCaveatName: caveatNames})

--- a/internal/datastore/crdb/caveat.go
+++ b/internal/datastore/crdb/caveat.go
@@ -22,7 +22,7 @@ var (
 	)
 	writeCaveat  = psql.Insert(tableCaveat).Columns(colCaveatName, colCaveatDefinition).Suffix(upsertCaveatSuffix)
 	readCaveat   = psql.Select(colCaveatDefinition, colTimestamp).From(tableCaveat)
-	listCaveat   = psql.Select(colCaveatName, colCaveatDefinition).From(tableCaveat).OrderBy(colCaveatName)
+	listCaveat   = psql.Select(colCaveatName, colCaveatDefinition, colTimestamp).From(tableCaveat).OrderBy(colCaveatName)
 	deleteCaveat = psql.Delete(tableCaveat)
 )
 
@@ -62,18 +62,23 @@ func (cr *crdbReader) ReadCaveatByName(ctx context.Context, name string) (*core.
 	return loaded, revisionFromTimestamp(timestamp), nil
 }
 
-func (cr *crdbReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+func (cr *crdbReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
 	if len(caveatNames) == 0 {
 		return nil, nil
 	}
 	return cr.lookupCaveats(ctx, caveatNames)
 }
 
-func (cr *crdbReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (cr *crdbReader) ListAllCaveats(ctx context.Context) ([]datastore.RevisionedCaveat, error) {
 	return cr.lookupCaveats(ctx, nil)
 }
 
-func (cr *crdbReader) lookupCaveats(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+type bytesAndTimestamp struct {
+	bytes     []byte
+	timestamp time.Time
+}
+
+func (cr *crdbReader) lookupCaveats(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
 	caveatsWithNames := listCaveat
 	if len(caveatNames) > 0 {
 		caveatsWithNames = caveatsWithNames.Where(sq.Eq{colCaveatName: caveatNames})
@@ -83,7 +88,8 @@ func (cr *crdbReader) lookupCaveats(ctx context.Context, caveatNames []string) (
 	if err != nil {
 		return nil, fmt.Errorf(errListCaveats, err)
 	}
-	var allDefinitionBytes [][]byte
+	var allDefinitionBytes []bytesAndTimestamp
+
 	err = cr.executeWithTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, sql, args...)
 		if err != nil {
@@ -94,11 +100,12 @@ func (cr *crdbReader) lookupCaveats(ctx context.Context, caveatNames []string) (
 		for rows.Next() {
 			var defBytes []byte
 			var name string
-			err = rows.Scan(&name, &defBytes)
+			var timestamp time.Time
+			err = rows.Scan(&name, &defBytes, &timestamp)
 			if err != nil {
 				return err
 			}
-			allDefinitionBytes = append(allDefinitionBytes, defBytes)
+			allDefinitionBytes = append(allDefinitionBytes, bytesAndTimestamp{bytes: defBytes, timestamp: timestamp})
 			cr.addOverlapKey(name)
 		}
 		return nil
@@ -107,13 +114,16 @@ func (cr *crdbReader) lookupCaveats(ctx context.Context, caveatNames []string) (
 		return nil, fmt.Errorf(errListCaveats, err)
 	}
 
-	caveats := make([]*core.CaveatDefinition, 0, len(allDefinitionBytes))
-	for _, defBytes := range allDefinitionBytes {
+	caveats := make([]datastore.RevisionedCaveat, 0, len(allDefinitionBytes))
+	for _, bat := range allDefinitionBytes {
 		loaded := &core.CaveatDefinition{}
-		if err := loaded.UnmarshalVT(defBytes); err != nil {
+		if err := loaded.UnmarshalVT(bat.bytes); err != nil {
 			return nil, fmt.Errorf(errListCaveats, err)
 		}
-		caveats = append(caveats, loaded)
+		caveats = append(caveats, datastore.RevisionedCaveat{
+			Definition:          loaded,
+			LastWrittenRevision: revisionFromTimestamp(bat.timestamp),
+		})
 	}
 
 	return caveats, nil

--- a/internal/datastore/crdb/reader.go
+++ b/internal/datastore/crdb/reader.go
@@ -85,7 +85,7 @@ func (cr *crdbReader) ReadNamespaceByName(
 	return config, revisionFromTimestamp(timestamp), nil
 }
 
-func (cr *crdbReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (cr *crdbReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
 	var nsDefs []*core.NamespaceDefinition
 	if err := cr.execute(ctx, func(ctx context.Context) error {
 		tx, txCleanup, err := cr.txSource(ctx)
@@ -110,7 +110,7 @@ func (cr *crdbReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefi
 	return nsDefs, nil
 }
 
-func (cr *crdbReader) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (cr *crdbReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
 	if len(nsNames) == 0 {
 		return nil, nil
 	}

--- a/internal/datastore/crdb/reader.go
+++ b/internal/datastore/crdb/reader.go
@@ -54,7 +54,7 @@ type crdbReader struct {
 	execute       executeTxRetryFunc
 }
 
-func (cr *crdbReader) ReadNamespace(
+func (cr *crdbReader) ReadNamespaceByName(
 	ctx context.Context,
 	nsName string,
 ) (*core.NamespaceDefinition, datastore.Revision, error) {

--- a/internal/datastore/crdb/stats.go
+++ b/internal/datastore/crdb/stats.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/revision"
-	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
 const (
@@ -39,7 +38,7 @@ func (cds *crdbDatastore) Statistics(ctx context.Context) (datastore.Stats, erro
 	}
 
 	var uniqueID string
-	var nsDefs []*corev1.NamespaceDefinition
+	var nsDefs []datastore.RevisionedNamespace
 	var relCount uint64
 	if err := cds.pool.BeginTxFunc(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly}, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(ctx, sql, args...).Scan(&uniqueID); err != nil {

--- a/internal/datastore/memdb/readonly.go
+++ b/internal/datastore/memdb/readonly.go
@@ -132,7 +132,7 @@ func (r *memdbReader) ReverseQueryRelationships(
 
 // ReadNamespace reads a namespace definition and version and returns it, and the revision at
 // which it was created or last written, if found.
-func (r *memdbReader) ReadNamespace(ctx context.Context, nsName string) (ns *core.NamespaceDefinition, lastWritten datastore.Revision, err error) {
+func (r *memdbReader) ReadNamespaceByName(ctx context.Context, nsName string) (ns *core.NamespaceDefinition, lastWritten datastore.Revision, err error) {
 	if r.initErr != nil {
 		return nil, datastore.NoRevision, r.initErr
 	}

--- a/internal/datastore/memdb/readonly.go
+++ b/internal/datastore/memdb/readonly.go
@@ -165,7 +165,7 @@ func (r *memdbReader) ReadNamespaceByName(ctx context.Context, nsName string) (n
 }
 
 // ListNamespaces lists all namespaces defined.
-func (r *memdbReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (r *memdbReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
 	if r.initErr != nil {
 		return nil, r.initErr
 	}
@@ -199,7 +199,7 @@ func (r *memdbReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefi
 	return nsDefs, nil
 }
 
-func (r *memdbReader) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (r *memdbReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
 	if r.initErr != nil {
 		return nil, r.initErr
 	}

--- a/internal/datastore/memdb/stats.go
+++ b/internal/datastore/memdb/stats.go
@@ -18,7 +18,7 @@ func (mdb *memdbDatastore) Statistics(ctx context.Context) (datastore.Stats, err
 		return datastore.Stats{}, fmt.Errorf("unable to count relationships: %w", err)
 	}
 
-	objTypes, err := mdb.SnapshotReader(head).ListNamespaces(ctx)
+	objTypes, err := mdb.SnapshotReader(head).ListAllNamespaces(ctx)
 	if err != nil {
 		return datastore.Stats{}, fmt.Errorf("unable to list object types: %w", err)
 	}

--- a/internal/datastore/mysql/caveat.go
+++ b/internal/datastore/mysql/caveat.go
@@ -52,7 +52,18 @@ func (mr *mysqlReader) ReadCaveatByName(ctx context.Context, name string) (*core
 	return &def, revision.NewFromDecimal(rev), nil
 }
 
-func (mr *mysqlReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
+func (mr *mysqlReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+	if len(caveatNames) == 0 {
+		return nil, nil
+	}
+	return mr.lookupCaveats(ctx, caveatNames)
+}
+
+func (mr *mysqlReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+	return mr.lookupCaveats(ctx, nil)
+}
+
+func (mr *mysqlReader) lookupCaveats(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
 	caveatsWithNames := mr.ListCaveatsQuery
 	if len(caveatNames) > 0 {
 		caveatsWithNames = caveatsWithNames.Where(sq.Eq{colName: caveatNames})

--- a/internal/datastore/mysql/caveat.go
+++ b/internal/datastore/mysql/caveat.go
@@ -52,18 +52,18 @@ func (mr *mysqlReader) ReadCaveatByName(ctx context.Context, name string) (*core
 	return &def, revision.NewFromDecimal(rev), nil
 }
 
-func (mr *mysqlReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+func (mr *mysqlReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
 	if len(caveatNames) == 0 {
 		return nil, nil
 	}
 	return mr.lookupCaveats(ctx, caveatNames)
 }
 
-func (mr *mysqlReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (mr *mysqlReader) ListAllCaveats(ctx context.Context) ([]datastore.RevisionedCaveat, error) {
 	return mr.lookupCaveats(ctx, nil)
 }
 
-func (mr *mysqlReader) lookupCaveats(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+func (mr *mysqlReader) lookupCaveats(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
 	caveatsWithNames := mr.ListCaveatsQuery
 	if len(caveatNames) > 0 {
 		caveatsWithNames = caveatsWithNames.Where(sq.Eq{colName: caveatNames})
@@ -87,10 +87,12 @@ func (mr *mysqlReader) lookupCaveats(ctx context.Context, caveatNames []string) 
 	}
 	defer common.LogOnError(ctx, rows.Close)
 
-	var caveats []*core.CaveatDefinition
+	var caveats []datastore.RevisionedCaveat
 	for rows.Next() {
 		var defBytes []byte
-		err = rows.Scan(&defBytes)
+		var version decimal.Decimal
+
+		err = rows.Scan(&defBytes, &version)
 		if err != nil {
 			return nil, fmt.Errorf(errListCaveats, err)
 		}
@@ -99,7 +101,10 @@ func (mr *mysqlReader) lookupCaveats(ctx context.Context, caveatNames []string) 
 		if err != nil {
 			return nil, fmt.Errorf(errListCaveats, err)
 		}
-		caveats = append(caveats, &c)
+		caveats = append(caveats, datastore.RevisionedCaveat{
+			Definition:          &c,
+			LastWrittenRevision: revision.NewFromDecimal(version),
+		})
 	}
 	if rows.Err() != nil {
 		return nil, fmt.Errorf(errListCaveats, rows.Err())

--- a/internal/datastore/mysql/query_builder.go
+++ b/internal/datastore/mysql/query_builder.go
@@ -65,7 +65,7 @@ func NewQueryBuilder(driver *migrations.MySQLDriver) *QueryBuilder {
 }
 
 func listCaveats(tableCaveat string) sq.SelectBuilder {
-	return sb.Select(colCaveatDefinition).From(tableCaveat).OrderBy(colName)
+	return sb.Select(colCaveatDefinition, colCreatedTxn).From(tableCaveat).OrderBy(colName)
 }
 
 func deleteCaveat(tableCaveat string) sq.UpdateBuilder {

--- a/internal/datastore/mysql/reader.go
+++ b/internal/datastore/mysql/reader.go
@@ -88,7 +88,7 @@ func (mr *mysqlReader) ReverseQueryRelationships(
 	)
 }
 
-func (mr *mysqlReader) ReadNamespace(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {
+func (mr *mysqlReader) ReadNamespaceByName(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {
 	// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
 	tx, txCleanup, err := mr.txSource(ctx)
 	if err != nil {

--- a/internal/datastore/mysql/reader.go
+++ b/internal/datastore/mysql/reader.go
@@ -135,7 +135,7 @@ func loadNamespace(ctx context.Context, namespace string, tx *sql.Tx, baseQuery 
 	return loaded, revision.NewFromDecimal(version), nil
 }
 
-func (mr *mysqlReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (mr *mysqlReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
 	// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
 	tx, txCleanup, err := mr.txSource(ctx)
 	if err != nil {
@@ -153,7 +153,7 @@ func (mr *mysqlReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDef
 	return nsDefs, err
 }
 
-func (mr *mysqlReader) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (mr *mysqlReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
 	if len(nsNames) == 0 {
 		return nil, nil
 	}

--- a/internal/datastore/mysql/stats.go
+++ b/internal/datastore/mysql/stats.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authzed/spicedb/internal/datastore/common"
-
-	"github.com/authzed/spicedb/pkg/datastore"
-
 	"github.com/Masterminds/squirrel"
+
+	"github.com/authzed/spicedb/internal/datastore/common"
+	"github.com/authzed/spicedb/pkg/datastore"
 )
 
 const (

--- a/internal/datastore/postgres/caveat.go
+++ b/internal/datastore/postgres/caveat.go
@@ -58,7 +58,18 @@ func (r *pgReader) ReadCaveatByName(ctx context.Context, name string) (*core.Cav
 	return &def, rev, nil
 }
 
-func (r *pgReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
+func (r *pgReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+	if len(caveatNames) == 0 {
+		return nil, nil
+	}
+	return r.lookupCaveats(ctx, caveatNames)
+}
+
+func (r *pgReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+	return r.lookupCaveats(ctx, nil)
+}
+
+func (r *pgReader) lookupCaveats(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
 	caveatsWithNames := listCaveat
 	if len(caveatNames) > 0 {
 		caveatsWithNames = caveatsWithNames.Where(sq.Eq{colCaveatName: caveatNames})

--- a/internal/datastore/postgres/reader.go
+++ b/internal/datastore/postgres/reader.go
@@ -91,7 +91,7 @@ func (r *pgReader) ReverseQueryRelationships(
 	)
 }
 
-func (r *pgReader) ReadNamespace(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {
+func (r *pgReader) ReadNamespaceByName(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {
 	tx, txCleanup, err := r.txSource(ctx)
 	if err != nil {
 		return nil, datastore.NoRevision, fmt.Errorf(errUnableToReadConfig, err)

--- a/internal/datastore/postgres/reader.go
+++ b/internal/datastore/postgres/reader.go
@@ -127,7 +127,7 @@ func (r *pgReader) loadNamespace(ctx context.Context, namespace string, tx pgx.T
 	return defs[0].nsDef, defs[0].revision, nil
 }
 
-func (r *pgReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (r *pgReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
 	tx, txCleanup, err := r.txSource(ctx)
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (r *pgReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinit
 	return stripRevisions(nsDefsWithRevisions), err
 }
 
-func (r *pgReader) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (r *pgReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
 	if len(nsNames) == 0 {
 		return nil, nil
 	}

--- a/internal/datastore/postgres/stats.go
+++ b/internal/datastore/postgres/stats.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jackc/pgx/v4"
 
 	"github.com/authzed/spicedb/pkg/datastore"
-	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
 const (
@@ -44,7 +43,7 @@ func (pgd *pgDatastore) Statistics(ctx context.Context) (datastore.Stats, error)
 	}
 
 	var uniqueID string
-	var nsDefs []*corev1.NamespaceDefinition
+	var nsDefs []datastore.RevisionedNamespace
 	var relCount int64
 	if err := pgd.dbpool.BeginTxFunc(ctx, pgd.readTxOptions, func(tx pgx.Tx) error {
 		if pgd.analyzeBeforeStatistics {
@@ -62,7 +61,7 @@ func (pgd *pgDatastore) Statistics(ctx context.Context) (datastore.Stats, error)
 			return fmt.Errorf("unable to load namespaces: %w", err)
 		}
 
-		nsDefs = stripRevisions(nsDefsWithRevisions)
+		nsDefs = nsDefsWithRevisions
 
 		if err := tx.QueryRow(ctx, rowCountSQL, rowCountArgs...).Scan(&relCount); err != nil {
 			return fmt.Errorf("unable to read relationship count: %w", err)

--- a/internal/datastore/proxy/caching.go
+++ b/internal/datastore/proxy/caching.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/authzed/spicedb/pkg/util"
+
+	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
+
 	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/singleflight"
@@ -16,14 +20,17 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
-// namespaceDefinitionSizeVTMultiplier is the mulitiplier to be used for
-// estimating the in-memory cost of a NamespaceDefinition based on its
+// *DefinitionSizeVTMultiplier are the mulitipliers to be used for
+// estimating the in-memory cost of a SchemaDefinition based on its
 // on-wire size, as returned by SizeVT. This was determined by testing
-// all existing namespace definitions found in consistency tests and is
-// enforced via the estimatednssize_test.
+// all existing definitions found in consistency tests and is
+// enforced via the estimatedsize_test.
 const (
 	namespaceDefinitionSizeVTMultiplier = 10
 	namespaceDefinitionMinimumSize      = 150
+
+	caveatDefinitionSizeVTMultiplier = 10
+	caveatDefinitionMinimumSize      = 150
 )
 
 // DatastoreProxyTestCache returns a cache used for testing.
@@ -36,72 +43,186 @@ func DatastoreProxyTestCache(t testing.TB) cache.Cache {
 	return cache
 }
 
-// NewCachingDatastoreProxy creates a new datastore proxy which caches namespace definitions that
+// NewCachingDatastoreProxy creates a new datastore proxy which caches definitions that
 // are loaded at specific datastore revisions.
 func NewCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache) datastore.Datastore {
 	if c == nil {
 		c = cache.NoopCache()
 	}
-	return &nsCachingProxy{
+	return &definitionCachingProxy{
 		Datastore: delegate,
 		c:         c,
 	}
 }
 
-type nsCachingProxy struct {
-	datastore.Datastore
-	c           cache.Cache
-	readNsGroup singleflight.Group
+type schemaDefinition interface {
+	compiler.SchemaDefinition
+	SizeVT() int
 }
 
-func (p *nsCachingProxy) Close() error {
+type definitionCachingProxy struct {
+	datastore.Datastore
+	c         cache.Cache
+	readGroup singleflight.Group
+}
+
+func (p *definitionCachingProxy) Close() error {
 	p.c.Close()
 	return p.Datastore.Close()
 }
 
-func (p *nsCachingProxy) SnapshotReader(rev datastore.Revision) datastore.Reader {
+func (p *definitionCachingProxy) SnapshotReader(rev datastore.Revision) datastore.Reader {
 	delegateReader := p.Datastore.SnapshotReader(rev)
-	return &nsCachingReader{delegateReader, rev, p}
+	return &definitionCachingReader{delegateReader, rev, p}
 }
 
-func (p *nsCachingProxy) ReadWriteTx(
+func (p *definitionCachingProxy) ReadWriteTx(
 	ctx context.Context,
 	f datastore.TxUserFunc,
 ) (datastore.Revision, error) {
 	return p.Datastore.ReadWriteTx(ctx, func(delegateRWT datastore.ReadWriteTransaction) error {
-		rwt := &nsCachingRWT{delegateRWT, &sync.Map{}}
+		rwt := &definitionCachingRWT{delegateRWT, &sync.Map{}}
 		return f(rwt)
 	})
 }
 
-type nsCachingReader struct {
+const (
+	namespaceCacheKeyPrefix = "n"
+	caveatCacheKeyPrefix    = "c"
+)
+
+type definitionCachingReader struct {
 	datastore.Reader
 	rev datastore.Revision
-	p   *nsCachingProxy
+	p   *definitionCachingProxy
 }
 
-func (r *nsCachingReader) ReadNamespaceByName(
+func (r *definitionCachingReader) ReadNamespaceByName(
 	ctx context.Context,
-	nsName string,
+	name string,
 ) (*core.NamespaceDefinition, datastore.Revision, error) {
-	// Check the nsCache.
-	nsRevisionKey := nsName + "@" + r.rev.String()
+	return readAndCache[*core.NamespaceDefinition](ctx, r, namespaceCacheKeyPrefix, name,
+		func(ctx context.Context, name string) (*core.NamespaceDefinition, datastore.Revision, error) {
+			return r.Reader.ReadNamespaceByName(ctx, name)
+		},
+		estimatedNamespaceDefinitionSize)
+}
 
-	loadedRaw, found := r.p.c.Get(nsRevisionKey)
+func (r *definitionCachingReader) LookupNamespacesWithNames(
+	ctx context.Context,
+	nsNames []string,
+) ([]datastore.RevisionedNamespace, error) {
+	return listAndCache[*core.NamespaceDefinition](ctx, r, namespaceCacheKeyPrefix, nsNames,
+		func(ctx context.Context, names []string) ([]datastore.RevisionedNamespace, error) {
+			return r.Reader.LookupNamespacesWithNames(ctx, names)
+		},
+		estimatedNamespaceDefinitionSize)
+}
+
+func (r *definitionCachingReader) ReadCaveatByName(
+	ctx context.Context,
+	name string,
+) (*core.CaveatDefinition, datastore.Revision, error) {
+	return readAndCache[*core.CaveatDefinition](ctx, r, caveatCacheKeyPrefix, name,
+		func(ctx context.Context, name string) (*core.CaveatDefinition, datastore.Revision, error) {
+			return r.Reader.ReadCaveatByName(ctx, name)
+		},
+		estimatedCaveatDefinitionSize)
+}
+
+func (r *definitionCachingReader) LookupCaveatsWithNames(
+	ctx context.Context,
+	caveatNames []string,
+) ([]datastore.RevisionedCaveat, error) {
+	return listAndCache[*core.CaveatDefinition](ctx, r, caveatCacheKeyPrefix, caveatNames,
+		func(ctx context.Context, names []string) ([]datastore.RevisionedCaveat, error) {
+			return r.Reader.LookupCaveatsWithNames(ctx, names)
+		},
+		estimatedCaveatDefinitionSize)
+}
+
+func listAndCache[T schemaDefinition](
+	ctx context.Context,
+	r *definitionCachingReader,
+	prefix string,
+	names []string,
+	reader func(ctx context.Context, names []string) ([]datastore.RevisionedDefinition[T], error),
+	estimator func(sizeVT int) int64,
+) ([]datastore.RevisionedDefinition[T], error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	// Check the cache for each entry.
+	remainingToLoad := util.NewSet[string]()
+	remainingToLoad.Extend(names)
+
+	foundDefs := make([]datastore.RevisionedDefinition[T], 0, len(names))
+	for _, name := range names {
+		cacheRevisionKey := prefix + ":" + name + "@" + r.rev.String()
+		loadedRaw, found := r.p.c.Get(cacheRevisionKey)
+		if !found {
+			continue
+		}
+
+		remainingToLoad.Remove(name)
+		loaded := loadedRaw.(*cacheEntry)
+		foundDefs = append(foundDefs, datastore.RevisionedDefinition[T]{
+			Definition:          loaded.definition.(T),
+			LastWrittenRevision: loaded.updated,
+		})
+	}
+
+	if !remainingToLoad.IsEmpty() {
+		// Load and cache the remaining names.
+		loadedDefs, err := reader(ctx, remainingToLoad.AsSlice())
+		if err != nil {
+			return nil, err
+		}
+
+		for _, def := range loadedDefs {
+			foundDefs = append(foundDefs, def)
+
+			cacheRevisionKey := prefix + ":" + def.Definition.GetName() + "@" + r.rev.String()
+			estimatedDefinitionSize := estimator(def.Definition.SizeVT())
+			entry := &cacheEntry{def.Definition, def.LastWrittenRevision, estimatedDefinitionSize, err}
+			r.p.c.Set(cacheRevisionKey, entry, entry.Size())
+		}
+
+		// We have to call wait here or else Ristretto may not have the key(s)
+		// available to a subsequent caller.
+		r.p.c.Wait()
+	}
+
+	return foundDefs, nil
+}
+
+func readAndCache[T schemaDefinition](
+	ctx context.Context,
+	r *definitionCachingReader,
+	prefix string,
+	name string,
+	reader func(ctx context.Context, name string) (T, datastore.Revision, error),
+	estimator func(sizeVT int) int64,
+) (T, datastore.Revision, error) {
+	// Check the cache.
+	cacheRevisionKey := prefix + ":" + name + "@" + r.rev.String()
+	loadedRaw, found := r.p.c.Get(cacheRevisionKey)
 	if !found {
 		// We couldn't use the cached entry, load one
 		var err error
-		loadedRaw, err, _ = r.p.readNsGroup.Do(nsRevisionKey, func() (any, error) {
+		loadedRaw, err, _ = r.p.readGroup.Do(cacheRevisionKey, func() (any, error) {
 			// sever the context so that another branch doesn't cancel the
-			// single-flighted namespace read
-			loaded, updatedRev, err := r.Reader.ReadNamespaceByName(SeparateContextWithTracing(ctx), nsName)
-			if err != nil && !errors.Is(err, &datastore.ErrNamespaceNotFound{}) {
+			// single-flighted read
+			loaded, updatedRev, err := reader(SeparateContextWithTracing(ctx), name)
+			if err != nil && !errors.Is(err, &datastore.ErrNamespaceNotFound{}) && !errors.Is(err, &datastore.ErrCaveatNameNotFound{}) {
 				// Propagate this error to the caller
 				return nil, err
 			}
 
-			entry := &cacheEntry{loaded, updatedRev, err}
-			r.p.c.Set(nsRevisionKey, entry, entry.Size())
+			estimatedDefinitionSize := estimator(loaded.SizeVT())
+			entry := &cacheEntry{loaded, updatedRev, estimatedDefinitionSize, err}
+			r.p.c.Set(cacheRevisionKey, entry, entry.Size())
 
 			// We have to call wait here or else Ristretto may not have the key
 			// available to a subsequent caller.
@@ -110,79 +231,124 @@ func (r *nsCachingReader) ReadNamespaceByName(
 			return entry, nil
 		})
 		if err != nil {
-			return nil, datastore.NoRevision, err
+			return *new(T), datastore.NoRevision, err
 		}
 	}
 
 	loaded := loadedRaw.(*cacheEntry)
-	return loaded.namespaceDefinition, loaded.updated, loaded.notFound
+	return loaded.definition.(T), loaded.updated, loaded.notFound
 }
 
-type nsCachingRWT struct {
+type definitionCachingRWT struct {
 	datastore.ReadWriteTransaction
-	namespaceCache *sync.Map
+	definitionCache *sync.Map
 }
 
 type rwtCacheEntry struct {
-	loaded   *core.NamespaceDefinition
+	loaded   schemaDefinition
 	updated  datastore.Revision
 	notFound error
 }
 
-func (rwt *nsCachingRWT) ReadNamespaceByName(
+func (rwt *definitionCachingRWT) ReadNamespaceByName(
 	ctx context.Context,
 	nsName string,
 ) (*core.NamespaceDefinition, datastore.Revision, error) {
-	untypedEntry, ok := rwt.namespaceCache.Load(nsName)
+	return readAndCacheInTransaction[*core.NamespaceDefinition](
+		ctx, rwt, "namespace", nsName, func(ctx context.Context, name string) (*core.NamespaceDefinition, datastore.Revision, error) {
+			return rwt.ReadWriteTransaction.ReadNamespaceByName(ctx, name)
+		})
+}
+
+func (rwt *definitionCachingRWT) ReadCaveatByName(
+	ctx context.Context,
+	nsName string,
+) (*core.CaveatDefinition, datastore.Revision, error) {
+	return readAndCacheInTransaction[*core.CaveatDefinition](
+		ctx, rwt, "caveat", nsName, func(ctx context.Context, name string) (*core.CaveatDefinition, datastore.Revision, error) {
+			return rwt.ReadWriteTransaction.ReadCaveatByName(ctx, name)
+		})
+}
+
+func readAndCacheInTransaction[T schemaDefinition](
+	ctx context.Context,
+	rwt *definitionCachingRWT,
+	prefix string,
+	name string,
+	reader func(ctx context.Context, name string) (T, datastore.Revision, error),
+) (T, datastore.Revision, error) {
+	key := prefix + ":" + name
+	untypedEntry, ok := rwt.definitionCache.Load(key)
 
 	var entry rwtCacheEntry
 	if ok {
 		entry = untypedEntry.(rwtCacheEntry)
 	} else {
-		loaded, updatedRev, err := rwt.ReadWriteTransaction.ReadNamespaceByName(ctx, nsName)
-		if err != nil && !errors.As(err, &datastore.ErrNamespaceNotFound{}) {
+		loaded, updatedRev, err := reader(ctx, name)
+		if err != nil && !errors.As(err, &datastore.ErrNamespaceNotFound{}) && !errors.As(err, &datastore.ErrCaveatNameNotFound{}) {
 			// Propagate this error to the caller
-			return nil, datastore.NoRevision, err
+			return *new(T), datastore.NoRevision, err
 		}
 
 		entry = rwtCacheEntry{loaded, updatedRev, err}
-		rwt.namespaceCache.Store(nsName, entry)
+		rwt.definitionCache.Store(key, entry)
 	}
 
-	return entry.loaded, entry.updated, entry.notFound
+	return entry.loaded.(T), entry.updated, entry.notFound
 }
 
-func (rwt *nsCachingRWT) WriteNamespaces(ctx context.Context, newConfigs ...*core.NamespaceDefinition) error {
+func (rwt *definitionCachingRWT) WriteNamespaces(ctx context.Context, newConfigs ...*core.NamespaceDefinition) error {
 	if err := rwt.ReadWriteTransaction.WriteNamespaces(ctx, newConfigs...); err != nil {
 		return err
 	}
 
 	for _, nsDef := range newConfigs {
-		rwt.namespaceCache.Delete(nsDef.Name)
+		rwt.definitionCache.Delete("namespace:" + nsDef.Name)
+	}
+
+	return nil
+}
+
+func (rwt *definitionCachingRWT) WriteCaveats(ctx context.Context, newConfigs []*core.CaveatDefinition) error {
+	if err := rwt.ReadWriteTransaction.WriteCaveats(ctx, newConfigs); err != nil {
+		return err
+	}
+
+	for _, caveatDef := range newConfigs {
+		rwt.definitionCache.Delete("caveat:" + caveatDef.Name)
 	}
 
 	return nil
 }
 
 type cacheEntry struct {
-	namespaceDefinition *core.NamespaceDefinition
-	updated             datastore.Revision
-	notFound            error
+	definition              schemaDefinition
+	updated                 datastore.Revision
+	estimatedDefinitionSize int64
+	notFound                error
 }
 
 func (c *cacheEntry) Size() int64 {
-	return estimatedNamespaceDefinitionSize(c.namespaceDefinition.SizeVT()) + int64(unsafe.Sizeof(c))
+	return c.estimatedDefinitionSize + int64(unsafe.Sizeof(c))
 }
 
 var (
-	_ datastore.Datastore = &nsCachingProxy{}
-	_ datastore.Reader    = &nsCachingReader{}
+	_ datastore.Datastore = &definitionCachingProxy{}
+	_ datastore.Reader    = &definitionCachingReader{}
 )
 
 func estimatedNamespaceDefinitionSize(sizevt int) int64 {
 	size := int64(sizevt * namespaceDefinitionSizeVTMultiplier)
 	if size < namespaceDefinitionMinimumSize {
 		return namespaceDefinitionMinimumSize
+	}
+	return size
+}
+
+func estimatedCaveatDefinitionSize(sizevt int) int64 {
+	size := int64(sizevt * caveatDefinitionSizeVTMultiplier)
+	if size < caveatDefinitionMinimumSize {
+		return caveatDefinitionMinimumSize
 	}
 	return size
 }

--- a/internal/datastore/proxy/caching.go
+++ b/internal/datastore/proxy/caching.go
@@ -80,7 +80,7 @@ type nsCachingReader struct {
 	p   *nsCachingProxy
 }
 
-func (r *nsCachingReader) ReadNamespace(
+func (r *nsCachingReader) ReadNamespaceByName(
 	ctx context.Context,
 	nsName string,
 ) (*core.NamespaceDefinition, datastore.Revision, error) {
@@ -94,7 +94,7 @@ func (r *nsCachingReader) ReadNamespace(
 		loadedRaw, err, _ = r.p.readNsGroup.Do(nsRevisionKey, func() (any, error) {
 			// sever the context so that another branch doesn't cancel the
 			// single-flighted namespace read
-			loaded, updatedRev, err := r.Reader.ReadNamespace(SeparateContextWithTracing(ctx), nsName)
+			loaded, updatedRev, err := r.Reader.ReadNamespaceByName(SeparateContextWithTracing(ctx), nsName)
 			if err != nil && !errors.Is(err, &datastore.ErrNamespaceNotFound{}) {
 				// Propagate this error to the caller
 				return nil, err
@@ -129,7 +129,7 @@ type rwtCacheEntry struct {
 	notFound error
 }
 
-func (rwt *nsCachingRWT) ReadNamespace(
+func (rwt *nsCachingRWT) ReadNamespaceByName(
 	ctx context.Context,
 	nsName string,
 ) (*core.NamespaceDefinition, datastore.Revision, error) {
@@ -139,7 +139,7 @@ func (rwt *nsCachingRWT) ReadNamespace(
 	if ok {
 		entry = untypedEntry.(rwtCacheEntry)
 	} else {
-		loaded, updatedRev, err := rwt.ReadWriteTransaction.ReadNamespace(ctx, nsName)
+		loaded, updatedRev, err := rwt.ReadWriteTransaction.ReadNamespaceByName(ctx, nsName)
 		if err != nil && !errors.As(err, &datastore.ErrNamespaceNotFound{}) {
 			// Propagate this error to the caller
 			return nil, datastore.NoRevision, err

--- a/internal/datastore/proxy/caching_test.go
+++ b/internal/datastore/proxy/caching_test.go
@@ -14,11 +14,14 @@ import (
 
 	"github.com/authzed/spicedb/internal/datastore/memdb"
 	"github.com/authzed/spicedb/internal/datastore/proxy/proxy_test"
+	"github.com/authzed/spicedb/pkg/caveats"
+	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/revision"
 	ns "github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/testutil"
+	"github.com/authzed/spicedb/pkg/util"
 )
 
 var (
@@ -47,184 +50,292 @@ func TestNilUnmarshal(t *testing.T) {
 	require.Equal(t, nsDef, newDef)
 }
 
-func TestSnapshotNamespaceCaching(t *testing.T) {
-	dsMock := &proxy_test.MockDatastore{}
+type testerDef struct {
+	name                   string
+	readSingleFunctionName string
+	readSingleFunc         func(ctx context.Context, reader datastore.Reader, name string) (datastore.SchemaDefinition, datastore.Revision, error)
 
-	oneReader := &proxy_test.MockReader{}
-	dsMock.On("SnapshotReader", one).Return(oneReader)
-	oneReader.On("ReadNamespaceByName", nsA).Return(nil, old, nil).Once()
-	oneReader.On("ReadNamespaceByName", nsB).Return(nil, zero, nil).Once()
+	lookupFunctionName string
+	lookupFunc         func(ctx context.Context, reader datastore.Reader, names []string) ([]datastore.SchemaDefinition, error)
 
-	twoReader := &proxy_test.MockReader{}
-	dsMock.On("SnapshotReader", two).Return(twoReader)
-	twoReader.On("ReadNamespaceByName", nsA).Return(nil, zero, nil).Once()
-	twoReader.On("ReadNamespaceByName", nsB).Return(nil, one, nil).Once()
+	notFoundErr error
 
-	require := require.New(t)
-	ctx := context.Background()
+	writeFunctionName string
+	writeFunc         func(rwt datastore.ReadWriteTransaction, def datastore.SchemaDefinition) error
 
-	ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
-
-	_, updatedOneA, err := ds.SnapshotReader(one).ReadNamespaceByName(ctx, nsA)
-	require.NoError(err)
-	require.True(old.Equal(updatedOneA))
-
-	_, updatedOneAAgain, err := ds.SnapshotReader(one).ReadNamespaceByName(ctx, nsA)
-	require.NoError(err)
-	require.True(old.Equal(updatedOneAAgain))
-
-	_, updatedOneB, err := ds.SnapshotReader(one).ReadNamespaceByName(ctx, nsB)
-	require.NoError(err)
-	require.True(zero.Equal(updatedOneB))
-
-	_, updatedOneBAgain, err := ds.SnapshotReader(one).ReadNamespaceByName(ctx, nsB)
-	require.NoError(err)
-	require.True(zero.Equal(updatedOneBAgain))
-
-	_, updatedTwoA, err := ds.SnapshotReader(two).ReadNamespaceByName(ctx, nsA)
-	require.NoError(err)
-	require.True(zero.Equal(updatedTwoA))
-
-	_, updatedTwoAAgain, err := ds.SnapshotReader(two).ReadNamespaceByName(ctx, nsA)
-	require.NoError(err)
-	require.True(zero.Equal(updatedTwoAAgain))
-
-	_, updatedTwoB, err := ds.SnapshotReader(two).ReadNamespaceByName(ctx, nsB)
-	require.NoError(err)
-	require.True(one.Equal(updatedTwoB))
-
-	_, updatedTwoBAgain, err := ds.SnapshotReader(two).ReadNamespaceByName(ctx, nsB)
-	require.NoError(err)
-	require.True(one.Equal(updatedTwoBAgain))
-
-	dsMock.AssertExpectations(t)
-	oneReader.AssertExpectations(t)
-	twoReader.AssertExpectations(t)
+	createDef      func(name string) datastore.SchemaDefinition
+	wrap           func(def datastore.SchemaDefinition) any
+	wrapRevisioned func(def datastore.SchemaDefinition) any
 }
 
-func TestRWTNamespaceCaching(t *testing.T) {
-	dsMock := &proxy_test.MockDatastore{}
-	rwtMock := &proxy_test.MockReadWriteTransaction{}
+var testers = []testerDef{
+	{
+		"namespace",
 
-	require := require.New(t)
+		"ReadNamespaceByName",
+		func(ctx context.Context, reader datastore.Reader, name string) (datastore.SchemaDefinition, datastore.Revision, error) {
+			return reader.ReadNamespaceByName(ctx, name)
+		},
 
-	dsMock.On("ReadWriteTx").Return(rwtMock, one, nil).Once()
-	rwtMock.On("ReadNamespaceByName", nsA).Return(nil, zero, nil).Once()
+		"LookupNamespacesWithNames",
+		func(ctx context.Context, reader datastore.Reader, names []string) ([]datastore.SchemaDefinition, error) {
+			defs, err := reader.LookupNamespacesWithNames(ctx, names)
+			if err != nil {
+				return nil, err
+			}
+			schemaDefs := []datastore.SchemaDefinition{}
+			for _, def := range defs {
+				schemaDefs = append(schemaDefs, def.Definition)
+			}
+			return schemaDefs, nil
+		},
 
-	ctx := context.Background()
+		datastore.ErrNamespaceNotFound{},
 
-	ds := NewCachingDatastoreProxy(dsMock, nil)
+		"WriteNamespaces",
+		func(rwt datastore.ReadWriteTransaction, def datastore.SchemaDefinition) error {
+			return rwt.WriteNamespaces(context.Background(), def.(*core.NamespaceDefinition))
+		},
 
-	rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
-		_, updatedA, err := rwt.ReadNamespaceByName(ctx, nsA)
-		require.NoError(err)
-		require.True(zero.Equal(updatedA))
+		func(name string) datastore.SchemaDefinition { return &core.NamespaceDefinition{Name: name} },
+		func(def datastore.SchemaDefinition) any {
+			return []*core.NamespaceDefinition{def.(*core.NamespaceDefinition)}
+		},
+		func(def datastore.SchemaDefinition) any {
+			return []datastore.RevisionedNamespace{{Definition: def.(*core.NamespaceDefinition)}}
+		},
+	},
+	{
+		"caveat",
+		"ReadCaveatByName",
+		func(ctx context.Context, reader datastore.Reader, name string) (datastore.SchemaDefinition, datastore.Revision, error) {
+			return reader.ReadCaveatByName(ctx, name)
+		},
 
-		// This will not call out the mock RWT again, the mock will panic if it does.
-		_, updatedA, err = rwt.ReadNamespaceByName(ctx, nsA)
-		require.NoError(err)
-		require.True(zero.Equal(updatedA))
+		"LookupCaveatsWithNames",
+		func(ctx context.Context, reader datastore.Reader, names []string) ([]datastore.SchemaDefinition, error) {
+			defs, err := reader.LookupCaveatsWithNames(ctx, names)
+			if err != nil {
+				return nil, err
+			}
+			schemaDefs := []datastore.SchemaDefinition{}
+			for _, def := range defs {
+				schemaDefs = append(schemaDefs, def.Definition)
+			}
+			return schemaDefs, nil
+		},
 
-		return nil
-	})
-	require.True(one.Equal(rev))
-	require.NoError(err)
+		datastore.ErrCaveatNameNotFound{},
 
-	dsMock.AssertExpectations(t)
-	rwtMock.AssertExpectations(t)
+		"WriteCaveats",
+		func(rwt datastore.ReadWriteTransaction, def datastore.SchemaDefinition) error {
+			return rwt.WriteCaveats(context.Background(), []*core.CaveatDefinition{def.(*core.CaveatDefinition)})
+		},
+
+		func(name string) datastore.SchemaDefinition { return &core.CaveatDefinition{Name: name} },
+		func(def datastore.SchemaDefinition) any {
+			return []*core.CaveatDefinition{def.(*core.CaveatDefinition)}
+		},
+		func(def datastore.SchemaDefinition) any {
+			return []datastore.RevisionedCaveat{{Definition: def.(*core.CaveatDefinition)}}
+		},
+	},
 }
 
-func TestRWTNamespaceCacheWithWrites(t *testing.T) {
-	dsMock := &proxy_test.MockDatastore{}
-	rwtMock := &proxy_test.MockReadWriteTransaction{}
+func TestSnapshotCaching(t *testing.T) {
+	for _, tester := range testers {
+		t.Run(tester.name, func(t *testing.T) {
+			dsMock := &proxy_test.MockDatastore{}
 
-	require := require.New(t)
+			oneReader := &proxy_test.MockReader{}
+			dsMock.On("SnapshotReader", one).Return(oneReader)
+			oneReader.On(tester.readSingleFunctionName, nsA).Return(nil, old, nil).Once()
+			oneReader.On(tester.readSingleFunctionName, nsB).Return(nil, zero, nil).Once()
 
-	dsMock.On("ReadWriteTx").Return(rwtMock, one, nil).Once()
-	notFoundErr := datastore.NewNamespaceNotFoundErr(nsA)
-	rwtMock.On("ReadNamespaceByName", nsA).Return(nil, zero, notFoundErr).Once()
+			twoReader := &proxy_test.MockReader{}
+			dsMock.On("SnapshotReader", two).Return(twoReader)
+			twoReader.On(tester.readSingleFunctionName, nsA).Return(nil, zero, nil).Once()
+			twoReader.On(tester.readSingleFunctionName, nsB).Return(nil, one, nil).Once()
 
-	ctx := context.Background()
+			require := require.New(t)
+			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
 
-	ds := NewCachingDatastoreProxy(dsMock, nil)
+			_, updatedOneA, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsA)
+			require.NoError(err)
+			require.True(old.Equal(updatedOneA))
 
-	rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
-		// Cache the 404
-		_, _, err := rwt.ReadNamespaceByName(ctx, nsA)
-		require.ErrorIs(err, notFoundErr)
+			_, updatedOneAAgain, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsA)
+			require.NoError(err)
+			require.True(old.Equal(updatedOneAAgain))
 
-		// This will not call out the mock RWT again, the mock will panic if it does.
-		_, _, err = rwt.ReadNamespaceByName(ctx, nsA)
-		require.Error(err, notFoundErr)
+			_, updatedOneB, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsB)
+			require.NoError(err)
+			require.True(zero.Equal(updatedOneB))
 
-		// Write nsA
-		nsADef := &core.NamespaceDefinition{Name: nsA}
-		rwtMock.On("WriteNamespaces", []*core.NamespaceDefinition{nsADef}).Return(nil).Once()
-		require.NoError(rwt.WriteNamespaces(ctx, nsADef))
+			_, updatedOneBAgain, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsB)
+			require.NoError(err)
+			require.True(zero.Equal(updatedOneBAgain))
 
-		// Call ReadNamespace on nsA and we should flow through to the mock
-		rwtMock.On("ReadNamespaceByName", nsA).Return(nsADef, zero, nil).Once()
-		def, updatedA, err := rwt.ReadNamespaceByName(ctx, nsA)
+			_, updatedTwoA, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(two), nsA)
+			require.NoError(err)
+			require.True(zero.Equal(updatedTwoA))
 
-		require.True(updatedA.Equal(zero))
-		require.NotNil(def)
-		require.NoError(err)
+			_, updatedTwoAAgain, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(two), nsA)
+			require.NoError(err)
+			require.True(zero.Equal(updatedTwoAAgain))
 
-		return nil
-	})
-	require.True(one.Equal(rev))
-	require.NoError(err)
+			_, updatedTwoB, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(two), nsB)
+			require.NoError(err)
+			require.True(one.Equal(updatedTwoB))
 
-	dsMock.AssertExpectations(t)
-	rwtMock.AssertExpectations(t)
+			_, updatedTwoBAgain, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(two), nsB)
+			require.NoError(err)
+			require.True(one.Equal(updatedTwoBAgain))
+
+			dsMock.AssertExpectations(t)
+			oneReader.AssertExpectations(t)
+			twoReader.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRWTCaching(t *testing.T) {
+	for _, tester := range testers {
+		t.Run(tester.name, func(t *testing.T) {
+			dsMock := &proxy_test.MockDatastore{}
+			rwtMock := &proxy_test.MockReadWriteTransaction{}
+
+			require := require.New(t)
+
+			dsMock.On("ReadWriteTx").Return(rwtMock, one, nil).Once()
+			rwtMock.On(tester.readSingleFunctionName, nsA).Return(nil, zero, nil).Once()
+
+			ctx := context.Background()
+
+			ds := NewCachingDatastoreProxy(dsMock, nil)
+
+			rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
+				_, updatedA, err := tester.readSingleFunc(ctx, rwt, nsA)
+				require.NoError(err)
+				require.True(zero.Equal(updatedA))
+
+				// This will not call out the mock RWT again, the mock will panic if it does.
+				_, updatedA, err = tester.readSingleFunc(ctx, rwt, nsA)
+				require.NoError(err)
+				require.True(zero.Equal(updatedA))
+
+				return nil
+			})
+			require.True(one.Equal(rev))
+			require.NoError(err)
+
+			dsMock.AssertExpectations(t)
+			rwtMock.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRWTCacheWithWrites(t *testing.T) {
+	for _, tester := range testers {
+		t.Run(tester.name, func(t *testing.T) {
+			dsMock := &proxy_test.MockDatastore{}
+			rwtMock := &proxy_test.MockReadWriteTransaction{}
+
+			require := require.New(t)
+
+			dsMock.On("ReadWriteTx").Return(rwtMock, one, nil).Once()
+			rwtMock.On(tester.readSingleFunctionName, nsA).Return(nil, zero, tester.notFoundErr).Once()
+
+			ctx := context.Background()
+
+			ds := NewCachingDatastoreProxy(dsMock, nil)
+
+			rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
+				// Cache the 404
+				_, _, err := tester.readSingleFunc(ctx, rwt, nsA)
+				require.Error(err, tester.notFoundErr)
+
+				// This will not call out the mock RWT again, the mock will panic if it does.
+				_, _, err = tester.readSingleFunc(ctx, rwt, nsA)
+				require.Error(err, tester.notFoundErr)
+
+				// Write nsA
+				def := tester.createDef(nsA)
+				rwtMock.On(tester.writeFunctionName, tester.wrap(def)).Return(nil).Once()
+				require.NoError(tester.writeFunc(rwt, def))
+
+				// Call Read* on nsA and we should flow through to the mock
+				rwtMock.On(tester.readSingleFunctionName, nsA).Return(def, zero, nil).Once()
+				def, updatedA, err := tester.readSingleFunc(ctx, rwt, nsA)
+
+				require.True(updatedA.Equal(zero))
+				require.NotNil(def)
+				require.NoError(err)
+
+				return nil
+			})
+			require.True(one.Equal(rev))
+			require.NoError(err)
+
+			dsMock.AssertExpectations(t)
+			rwtMock.AssertExpectations(t)
+		})
+	}
 }
 
 func TestSingleFlight(t *testing.T) {
-	dsMock := &proxy_test.MockDatastore{}
+	for _, tester := range testers {
+		t.Run(tester.name, func(t *testing.T) {
+			dsMock := &proxy_test.MockDatastore{}
 
-	ctx := context.Background()
-	oneReader := &proxy_test.MockReader{}
-	dsMock.On("SnapshotReader", one).Return(oneReader)
-	oneReader.
-		On("ReadNamespaceByName", nsA).
-		WaitUntil(time.After(10*time.Millisecond)).
-		Return(nil, old, nil).
-		Once()
+			oneReader := &proxy_test.MockReader{}
+			dsMock.On("SnapshotReader", one).Return(oneReader)
+			oneReader.
+				On(tester.readSingleFunctionName, nsA).
+				WaitUntil(time.After(10*time.Millisecond)).
+				Return(nil, old, nil).
+				Once()
 
-	require := require.New(t)
+			require := require.New(t)
 
-	ds := NewCachingDatastoreProxy(dsMock, nil)
+			ds := NewCachingDatastoreProxy(dsMock, nil)
 
-	readNamespace := func() error {
-		_, updatedAt, err := ds.SnapshotReader(one).ReadNamespaceByName(ctx, nsA)
-		require.NoError(err)
-		require.True(old.Equal(updatedAt))
-		return err
+			readNamespace := func() error {
+				_, updatedAt, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsA)
+				require.NoError(err)
+				require.True(old.Equal(updatedAt))
+				return err
+			}
+
+			g := errgroup.Group{}
+			g.Go(readNamespace)
+			g.Go(readNamespace)
+
+			require.NoError(g.Wait())
+
+			dsMock.AssertExpectations(t)
+			oneReader.AssertExpectations(t)
+		})
 	}
-
-	g := errgroup.Group{}
-	g.Go(readNamespace)
-	g.Go(readNamespace)
-
-	require.NoError(g.Wait())
-
-	dsMock.AssertExpectations(t)
-	oneReader.AssertExpectations(t)
 }
 
-func TestSnapshotNamespaceCachingRealDatastore(t *testing.T) {
+func TestSnapshotCachingRealDatastore(t *testing.T) {
 	tcs := []struct {
 		name          string
 		nsDef         *core.NamespaceDefinition
 		namespaceName string
+		caveatDef     *core.CaveatDefinition
+		caveatName    string
 	}{
 		{
-			"missing namespace",
+			"missing",
 			nil,
 			"somenamespace",
+			nil,
+			"somecaveat",
 		},
 		{
-			"defined namespace",
+			"defined",
 			ns.Namespace(
 				"document",
 				ns.MustRelation("owner",
@@ -237,6 +348,12 @@ func TestSnapshotNamespaceCachingRealDatastore(t *testing.T) {
 				),
 			),
 			"document",
+			ns.MustCaveatDefinition(caveats.MustEnvForVariables(
+				map[string]caveattypes.VariableType{
+					"somevar": caveattypes.IntType,
+				},
+			), "somecaveat", "somevar < 42"),
+			"somecaveat",
 		},
 	}
 
@@ -250,7 +367,12 @@ func TestSnapshotNamespaceCachingRealDatastore(t *testing.T) {
 
 			if tc.nsDef != nil {
 				_, err = ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
-					return rwt.WriteNamespaces(ctx, tc.nsDef)
+					err := rwt.WriteNamespaces(ctx, tc.nsDef)
+					if err != nil {
+						return err
+					}
+
+					return rwt.WriteCaveats(ctx, []*core.CaveatDefinition{tc.caveatDef})
 				})
 				require.NoError(t, err)
 			}
@@ -264,6 +386,12 @@ func TestSnapshotNamespaceCachingRealDatastore(t *testing.T) {
 
 			ns2, _, _ := reader.ReadNamespaceByName(ctx, tc.namespaceName)
 			testutil.RequireProtoEqual(t, tc.nsDef, ns2, "found different namespaces")
+
+			c1, _, _ := reader.ReadCaveatByName(ctx, tc.caveatName)
+			testutil.RequireProtoEqual(t, tc.caveatDef, c1, "found different caveats")
+
+			c2, _, _ := reader.ReadCaveatByName(ctx, tc.caveatName)
+			testutil.RequireProtoEqual(t, tc.caveatDef, c2, "found different caveats")
 		})
 	}
 }
@@ -280,34 +408,101 @@ func (r *reader) ReadNamespaceByName(ctx context.Context, namespace string) (ns 
 	return &core.NamespaceDefinition{Name: namespace}, old, nil
 }
 
+func (r *reader) ReadCaveatByName(ctx context.Context, name string) (*core.CaveatDefinition, datastore.Revision, error) {
+	time.Sleep(10 * time.Millisecond)
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return nil, old, fmt.Errorf("error")
+	}
+	return &core.CaveatDefinition{Name: name}, old, nil
+}
+
 func TestSingleFlightCancelled(t *testing.T) {
-	dsMock := &proxy_test.MockDatastore{}
-	ctx1, cancel1 := context.WithCancel(context.Background())
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel2()
-	defer cancel1()
+	for _, tester := range testers {
+		t.Run(tester.name, func(t *testing.T) {
+			dsMock := &proxy_test.MockDatastore{}
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+			defer cancel1()
 
-	dsMock.On("SnapshotReader", one).Return(&reader{MockReader: proxy_test.MockReader{}})
+			dsMock.On("SnapshotReader", one).Return(&reader{MockReader: proxy_test.MockReader{}})
 
-	ds := NewCachingDatastoreProxy(dsMock, nil)
+			ds := NewCachingDatastoreProxy(dsMock, nil)
 
-	g := sync.WaitGroup{}
-	var ns2 *core.NamespaceDefinition
-	g.Add(2)
-	go func() {
-		_, _, _ = ds.SnapshotReader(one).ReadNamespaceByName(ctx1, nsA)
-		g.Done()
-	}()
-	go func() {
-		time.Sleep(5 * time.Millisecond)
-		ns2, _, _ = ds.SnapshotReader(one).ReadNamespaceByName(ctx2, nsA)
-		g.Done()
-	}()
-	cancel1()
+			g := sync.WaitGroup{}
+			var d2 datastore.SchemaDefinition
+			g.Add(2)
+			go func() {
+				_, _, _ = tester.readSingleFunc(ctx1, ds.SnapshotReader(one), nsA)
+				g.Done()
+			}()
+			go func() {
+				time.Sleep(5 * time.Millisecond)
+				d2, _, _ = tester.readSingleFunc(ctx2, ds.SnapshotReader(one), nsA)
+				g.Done()
+			}()
+			cancel1()
 
-	g.Wait()
-	require.NotNil(t, ns2)
-	require.Equal(t, nsA, ns2.Name)
+			g.Wait()
+			require.NotNil(t, d2)
+			require.Equal(t, nsA, d2.GetName())
 
-	dsMock.AssertExpectations(t)
+			dsMock.AssertExpectations(t)
+		})
+	}
+}
+
+func TestMixedCaching(t *testing.T) {
+	for _, tester := range testers {
+		t.Run(tester.name, func(t *testing.T) {
+			dsMock := &proxy_test.MockDatastore{}
+
+			defA := tester.createDef(nsA)
+			defB := tester.createDef(nsB)
+
+			reader := &proxy_test.MockReader{}
+			reader.On(tester.readSingleFunctionName, nsA).Return(defA, old, nil).Once()
+			reader.On(tester.lookupFunctionName, []string{nsB}).Return(tester.wrapRevisioned(defB), nil).Once()
+
+			dsMock.On("SnapshotReader", one).Return(reader)
+
+			require := require.New(t)
+			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
+
+			dsReader := ds.SnapshotReader(one)
+
+			// Lookup name A
+			_, _, err := tester.readSingleFunc(context.Background(), dsReader, nsA)
+			require.NoError(err)
+
+			// Lookup A and B, which should only lookup B and use A from cache.
+			found, err := tester.lookupFunc(context.Background(), dsReader, []string{nsA, nsB})
+			require.NoError(err)
+			require.Equal(2, len(found))
+
+			names := util.NewSet[string]()
+			for _, d := range found {
+				names.Add(d.GetName())
+			}
+
+			require.True(names.Has(nsA))
+			require.True(names.Has(nsB))
+
+			// Lookup A and B, which should use both from cache.
+			foundAgain, err := tester.lookupFunc(context.Background(), dsReader, []string{nsA, nsB})
+			require.NoError(err)
+			require.Equal(2, len(foundAgain))
+
+			namesAgain := util.NewSet[string]()
+			for _, d := range foundAgain {
+				namesAgain.Add(d.GetName())
+			}
+
+			require.True(namesAgain.Has(nsA))
+			require.True(namesAgain.Has(nsB))
+
+			dsMock.AssertExpectations(t)
+			reader.AssertExpectations(t)
+		})
+	}
 }

--- a/internal/datastore/proxy/caching_test.go
+++ b/internal/datastore/proxy/caching_test.go
@@ -52,48 +52,48 @@ func TestSnapshotNamespaceCaching(t *testing.T) {
 
 	oneReader := &proxy_test.MockReader{}
 	dsMock.On("SnapshotReader", one).Return(oneReader)
-	oneReader.On("ReadNamespace", nsA).Return(nil, old, nil).Once()
-	oneReader.On("ReadNamespace", nsB).Return(nil, zero, nil).Once()
+	oneReader.On("ReadNamespaceByName", nsA).Return(nil, old, nil).Once()
+	oneReader.On("ReadNamespaceByName", nsB).Return(nil, zero, nil).Once()
 
 	twoReader := &proxy_test.MockReader{}
 	dsMock.On("SnapshotReader", two).Return(twoReader)
-	twoReader.On("ReadNamespace", nsA).Return(nil, zero, nil).Once()
-	twoReader.On("ReadNamespace", nsB).Return(nil, one, nil).Once()
+	twoReader.On("ReadNamespaceByName", nsA).Return(nil, zero, nil).Once()
+	twoReader.On("ReadNamespaceByName", nsB).Return(nil, one, nil).Once()
 
 	require := require.New(t)
 	ctx := context.Background()
 
 	ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
 
-	_, updatedOneA, err := ds.SnapshotReader(one).ReadNamespace(ctx, nsA)
+	_, updatedOneA, err := ds.SnapshotReader(one).ReadNamespaceByName(ctx, nsA)
 	require.NoError(err)
 	require.True(old.Equal(updatedOneA))
 
-	_, updatedOneAAgain, err := ds.SnapshotReader(one).ReadNamespace(ctx, nsA)
+	_, updatedOneAAgain, err := ds.SnapshotReader(one).ReadNamespaceByName(ctx, nsA)
 	require.NoError(err)
 	require.True(old.Equal(updatedOneAAgain))
 
-	_, updatedOneB, err := ds.SnapshotReader(one).ReadNamespace(ctx, nsB)
+	_, updatedOneB, err := ds.SnapshotReader(one).ReadNamespaceByName(ctx, nsB)
 	require.NoError(err)
 	require.True(zero.Equal(updatedOneB))
 
-	_, updatedOneBAgain, err := ds.SnapshotReader(one).ReadNamespace(ctx, nsB)
+	_, updatedOneBAgain, err := ds.SnapshotReader(one).ReadNamespaceByName(ctx, nsB)
 	require.NoError(err)
 	require.True(zero.Equal(updatedOneBAgain))
 
-	_, updatedTwoA, err := ds.SnapshotReader(two).ReadNamespace(ctx, nsA)
+	_, updatedTwoA, err := ds.SnapshotReader(two).ReadNamespaceByName(ctx, nsA)
 	require.NoError(err)
 	require.True(zero.Equal(updatedTwoA))
 
-	_, updatedTwoAAgain, err := ds.SnapshotReader(two).ReadNamespace(ctx, nsA)
+	_, updatedTwoAAgain, err := ds.SnapshotReader(two).ReadNamespaceByName(ctx, nsA)
 	require.NoError(err)
 	require.True(zero.Equal(updatedTwoAAgain))
 
-	_, updatedTwoB, err := ds.SnapshotReader(two).ReadNamespace(ctx, nsB)
+	_, updatedTwoB, err := ds.SnapshotReader(two).ReadNamespaceByName(ctx, nsB)
 	require.NoError(err)
 	require.True(one.Equal(updatedTwoB))
 
-	_, updatedTwoBAgain, err := ds.SnapshotReader(two).ReadNamespace(ctx, nsB)
+	_, updatedTwoBAgain, err := ds.SnapshotReader(two).ReadNamespaceByName(ctx, nsB)
 	require.NoError(err)
 	require.True(one.Equal(updatedTwoBAgain))
 
@@ -109,19 +109,19 @@ func TestRWTNamespaceCaching(t *testing.T) {
 	require := require.New(t)
 
 	dsMock.On("ReadWriteTx").Return(rwtMock, one, nil).Once()
-	rwtMock.On("ReadNamespace", nsA).Return(nil, zero, nil).Once()
+	rwtMock.On("ReadNamespaceByName", nsA).Return(nil, zero, nil).Once()
 
 	ctx := context.Background()
 
 	ds := NewCachingDatastoreProxy(dsMock, nil)
 
 	rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
-		_, updatedA, err := rwt.ReadNamespace(ctx, nsA)
+		_, updatedA, err := rwt.ReadNamespaceByName(ctx, nsA)
 		require.NoError(err)
 		require.True(zero.Equal(updatedA))
 
 		// This will not call out the mock RWT again, the mock will panic if it does.
-		_, updatedA, err = rwt.ReadNamespace(ctx, nsA)
+		_, updatedA, err = rwt.ReadNamespaceByName(ctx, nsA)
 		require.NoError(err)
 		require.True(zero.Equal(updatedA))
 
@@ -142,7 +142,7 @@ func TestRWTNamespaceCacheWithWrites(t *testing.T) {
 
 	dsMock.On("ReadWriteTx").Return(rwtMock, one, nil).Once()
 	notFoundErr := datastore.NewNamespaceNotFoundErr(nsA)
-	rwtMock.On("ReadNamespace", nsA).Return(nil, zero, notFoundErr).Once()
+	rwtMock.On("ReadNamespaceByName", nsA).Return(nil, zero, notFoundErr).Once()
 
 	ctx := context.Background()
 
@@ -150,11 +150,11 @@ func TestRWTNamespaceCacheWithWrites(t *testing.T) {
 
 	rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 		// Cache the 404
-		_, _, err := rwt.ReadNamespace(ctx, nsA)
+		_, _, err := rwt.ReadNamespaceByName(ctx, nsA)
 		require.ErrorIs(err, notFoundErr)
 
 		// This will not call out the mock RWT again, the mock will panic if it does.
-		_, _, err = rwt.ReadNamespace(ctx, nsA)
+		_, _, err = rwt.ReadNamespaceByName(ctx, nsA)
 		require.Error(err, notFoundErr)
 
 		// Write nsA
@@ -163,8 +163,8 @@ func TestRWTNamespaceCacheWithWrites(t *testing.T) {
 		require.NoError(rwt.WriteNamespaces(ctx, nsADef))
 
 		// Call ReadNamespace on nsA and we should flow through to the mock
-		rwtMock.On("ReadNamespace", nsA).Return(nsADef, zero, nil).Once()
-		def, updatedA, err := rwt.ReadNamespace(ctx, nsA)
+		rwtMock.On("ReadNamespaceByName", nsA).Return(nsADef, zero, nil).Once()
+		def, updatedA, err := rwt.ReadNamespaceByName(ctx, nsA)
 
 		require.True(updatedA.Equal(zero))
 		require.NotNil(def)
@@ -186,7 +186,7 @@ func TestSingleFlight(t *testing.T) {
 	oneReader := &proxy_test.MockReader{}
 	dsMock.On("SnapshotReader", one).Return(oneReader)
 	oneReader.
-		On("ReadNamespace", nsA).
+		On("ReadNamespaceByName", nsA).
 		WaitUntil(time.After(10*time.Millisecond)).
 		Return(nil, old, nil).
 		Once()
@@ -196,7 +196,7 @@ func TestSingleFlight(t *testing.T) {
 	ds := NewCachingDatastoreProxy(dsMock, nil)
 
 	readNamespace := func() error {
-		_, updatedAt, err := ds.SnapshotReader(one).ReadNamespace(ctx, nsA)
+		_, updatedAt, err := ds.SnapshotReader(one).ReadNamespaceByName(ctx, nsA)
 		require.NoError(err)
 		require.True(old.Equal(updatedAt))
 		return err
@@ -259,10 +259,10 @@ func TestSnapshotNamespaceCachingRealDatastore(t *testing.T) {
 			require.NoError(t, err)
 
 			reader := ds.SnapshotReader(headRev)
-			ns, _, _ := reader.ReadNamespace(ctx, tc.namespaceName)
+			ns, _, _ := reader.ReadNamespaceByName(ctx, tc.namespaceName)
 			testutil.RequireProtoEqual(t, tc.nsDef, ns, "found different namespaces")
 
-			ns2, _, _ := reader.ReadNamespace(ctx, tc.namespaceName)
+			ns2, _, _ := reader.ReadNamespaceByName(ctx, tc.namespaceName)
 			testutil.RequireProtoEqual(t, tc.nsDef, ns2, "found different namespaces")
 		})
 	}
@@ -272,7 +272,7 @@ type reader struct {
 	proxy_test.MockReader
 }
 
-func (r *reader) ReadNamespace(ctx context.Context, namespace string) (ns *core.NamespaceDefinition, lastWritten datastore.Revision, err error) {
+func (r *reader) ReadNamespaceByName(ctx context.Context, namespace string) (ns *core.NamespaceDefinition, lastWritten datastore.Revision, err error) {
 	time.Sleep(10 * time.Millisecond)
 	if errors.Is(ctx.Err(), context.Canceled) {
 		return nil, old, fmt.Errorf("error")
@@ -295,12 +295,12 @@ func TestSingleFlightCancelled(t *testing.T) {
 	var ns2 *core.NamespaceDefinition
 	g.Add(2)
 	go func() {
-		_, _, _ = ds.SnapshotReader(one).ReadNamespace(ctx1, nsA)
+		_, _, _ = ds.SnapshotReader(one).ReadNamespaceByName(ctx1, nsA)
 		g.Done()
 	}()
 	go func() {
 		time.Sleep(5 * time.Millisecond)
-		ns2, _, _ = ds.SnapshotReader(one).ReadNamespace(ctx2, nsA)
+		ns2, _, _ = ds.SnapshotReader(one).ReadNamespaceByName(ctx2, nsA)
 		g.Done()
 	}()
 	cancel1()

--- a/internal/datastore/proxy/context.go
+++ b/internal/datastore/proxy/context.go
@@ -95,12 +95,12 @@ func (r *ctxReader) ListCaveats(ctx context.Context, caveatNamesForFiltering ...
 	return r.delegate.ListCaveats(SeparateContextWithTracing(ctx), caveatNamesForFiltering...)
 }
 
-func (r *ctxReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
-	return r.delegate.ListNamespaces(SeparateContextWithTracing(ctx))
+func (r *ctxReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+	return r.delegate.ListAllNamespaces(SeparateContextWithTracing(ctx))
 }
 
-func (r *ctxReader) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
-	return r.delegate.LookupNamespaces(SeparateContextWithTracing(ctx), nsNames)
+func (r *ctxReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+	return r.delegate.LookupNamespacesWithNames(SeparateContextWithTracing(ctx), nsNames)
 }
 
 func (r *ctxReader) ReadNamespaceByName(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {

--- a/internal/datastore/proxy/context.go
+++ b/internal/datastore/proxy/context.go
@@ -91,19 +91,19 @@ func (r *ctxReader) ReadCaveatByName(ctx context.Context, name string) (*core.Ca
 	return r.delegate.ReadCaveatByName(SeparateContextWithTracing(ctx), name)
 }
 
-func (r *ctxReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (r *ctxReader) ListAllCaveats(ctx context.Context) ([]datastore.RevisionedCaveat, error) {
 	return r.delegate.ListAllCaveats(SeparateContextWithTracing(ctx))
 }
 
-func (r *ctxReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+func (r *ctxReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
 	return r.delegate.LookupCaveatsWithNames(SeparateContextWithTracing(ctx), caveatNames)
 }
 
-func (r *ctxReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (r *ctxReader) ListAllNamespaces(ctx context.Context) ([]datastore.RevisionedNamespace, error) {
 	return r.delegate.ListAllNamespaces(SeparateContextWithTracing(ctx))
 }
 
-func (r *ctxReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (r *ctxReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]datastore.RevisionedNamespace, error) {
 	return r.delegate.LookupNamespacesWithNames(SeparateContextWithTracing(ctx), nsNames)
 }
 

--- a/internal/datastore/proxy/context.go
+++ b/internal/datastore/proxy/context.go
@@ -91,8 +91,12 @@ func (r *ctxReader) ReadCaveatByName(ctx context.Context, name string) (*core.Ca
 	return r.delegate.ReadCaveatByName(SeparateContextWithTracing(ctx), name)
 }
 
-func (r *ctxReader) ListCaveats(ctx context.Context, caveatNamesForFiltering ...string) ([]*core.CaveatDefinition, error) {
-	return r.delegate.ListCaveats(SeparateContextWithTracing(ctx), caveatNamesForFiltering...)
+func (r *ctxReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+	return r.delegate.ListAllCaveats(SeparateContextWithTracing(ctx))
+}
+
+func (r *ctxReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+	return r.delegate.LookupCaveatsWithNames(SeparateContextWithTracing(ctx), caveatNames)
 }
 
 func (r *ctxReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {

--- a/internal/datastore/proxy/context.go
+++ b/internal/datastore/proxy/context.go
@@ -103,8 +103,8 @@ func (r *ctxReader) LookupNamespaces(ctx context.Context, nsNames []string) ([]*
 	return r.delegate.LookupNamespaces(SeparateContextWithTracing(ctx), nsNames)
 }
 
-func (r *ctxReader) ReadNamespace(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {
-	return r.delegate.ReadNamespace(SeparateContextWithTracing(ctx), nsName)
+func (r *ctxReader) ReadNamespaceByName(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {
+	return r.delegate.ReadNamespaceByName(SeparateContextWithTracing(ctx), nsName)
 }
 
 func (r *ctxReader) QueryRelationships(ctx context.Context, filter datastore.RelationshipsFilter, options ...options.QueryOptionsOption) (datastore.RelationshipIterator, error) {

--- a/internal/datastore/proxy/hedging.go
+++ b/internal/datastore/proxy/hedging.go
@@ -214,13 +214,13 @@ type hedgingReader struct {
 	p hedgingProxy
 }
 
-func (hp hedgingReader) ReadNamespace(
+func (hp hedgingReader) ReadNamespaceByName(
 	ctx context.Context,
 	nsName string,
 ) (ns *core.NamespaceDefinition, createdAt datastore.Revision, err error) {
 	var once sync.Once
 	subreq := func(ctx context.Context, responseReady chan<- struct{}) {
-		delegatedNs, delegatedRev, delegatedErr := hp.Reader.ReadNamespace(ctx, nsName)
+		delegatedNs, delegatedRev, delegatedErr := hp.Reader.ReadNamespaceByName(ctx, nsName)
 		once.Do(func() {
 			ns = delegatedNs
 			createdAt = delegatedRev

--- a/internal/datastore/proxy/hedging_test.go
+++ b/internal/datastore/proxy/hedging_test.go
@@ -45,14 +45,14 @@ func TestDatastoreRequestHedging(t *testing.T) {
 		f                 testFunc
 	}{
 		{
-			"ReadNamespace",
+			"ReadNamespaceByName",
 			true,
 			[]interface{}{nsKnown},
 			[]interface{}{&core.NamespaceDefinition{}, revisionKnown, errKnown},
 			[]interface{}{&core.NamespaceDefinition{}, anotherRevisionKnown, errKnown},
 			func(t *testing.T, proxy datastore.Datastore, expectFirst bool) {
 				require := require.New(t)
-				_, rev, err := proxy.SnapshotReader(datastore.NoRevision).ReadNamespace(context.Background(), nsKnown)
+				_, rev, err := proxy.SnapshotReader(datastore.NoRevision).ReadNamespaceByName(context.Background(), nsKnown)
 				require.ErrorIs(errKnown, err)
 				if expectFirst {
 					require.Equal(revisionKnown, rev)

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -152,20 +152,20 @@ func (r *observableReader) ListCaveats(ctx context.Context, caveatNamesForFilter
 	return r.delegate.ListCaveats(ctx, caveatNamesForFiltering...)
 }
 
-func (r *observableReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
-	ctx, closer := observe(ctx, "ListNamespaces")
+func (r *observableReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+	ctx, closer := observe(ctx, "ListAllNamespaces")
 	defer closer()
 
-	return r.delegate.ListNamespaces(ctx)
+	return r.delegate.ListAllNamespaces(ctx)
 }
 
-func (r *observableReader) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
-	ctx, closer := observe(ctx, "LookupNamespaces", trace.WithAttributes(
+func (r *observableReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+	ctx, closer := observe(ctx, "LookupNamespacesWithNames", trace.WithAttributes(
 		attribute.StringSlice("names", nsNames),
 	))
 	defer closer()
 
-	return r.delegate.LookupNamespaces(ctx, nsNames)
+	return r.delegate.LookupNamespacesWithNames(ctx, nsNames)
 }
 
 func (r *observableReader) ReadNamespaceByName(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -168,13 +168,13 @@ func (r *observableReader) LookupNamespaces(ctx context.Context, nsNames []strin
 	return r.delegate.LookupNamespaces(ctx, nsNames)
 }
 
-func (r *observableReader) ReadNamespace(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {
-	ctx, closer := observe(ctx, "ReadNamespace", trace.WithAttributes(
+func (r *observableReader) ReadNamespaceByName(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {
+	ctx, closer := observe(ctx, "ReadNamespaceByName", trace.WithAttributes(
 		attribute.String("name", nsName),
 	))
 	defer closer()
 
-	return r.delegate.ReadNamespace(ctx, nsName)
+	return r.delegate.ReadNamespaceByName(ctx, nsName)
 }
 
 func (r *observableReader) QueryRelationships(ctx context.Context, filter datastore.RelationshipsFilter, options ...options.QueryOptionsOption) (datastore.RelationshipIterator, error) {

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -143,13 +143,20 @@ func (r *observableReader) ReadCaveatByName(ctx context.Context, name string) (*
 	return r.delegate.ReadCaveatByName(ctx, name)
 }
 
-func (r *observableReader) ListCaveats(ctx context.Context, caveatNamesForFiltering ...string) ([]*core.CaveatDefinition, error) {
-	ctx, closer := observe(ctx, "ListCaveats", trace.WithAttributes(
-		attribute.StringSlice("names", caveatNamesForFiltering),
+func (r *observableReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+	ctx, closer := observe(ctx, "LookupCaveatsWithNames", trace.WithAttributes(
+		attribute.StringSlice("names", caveatNames),
 	))
 	defer closer()
 
-	return r.delegate.ListCaveats(ctx, caveatNamesForFiltering...)
+	return r.delegate.LookupCaveatsWithNames(ctx, caveatNames)
+}
+
+func (r *observableReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+	ctx, closer := observe(ctx, "ListAllCaveats")
+	defer closer()
+
+	return r.delegate.ListAllCaveats(ctx)
 }
 
 func (r *observableReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -143,7 +143,7 @@ func (r *observableReader) ReadCaveatByName(ctx context.Context, name string) (*
 	return r.delegate.ReadCaveatByName(ctx, name)
 }
 
-func (r *observableReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+func (r *observableReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
 	ctx, closer := observe(ctx, "LookupCaveatsWithNames", trace.WithAttributes(
 		attribute.StringSlice("names", caveatNames),
 	))
@@ -152,21 +152,21 @@ func (r *observableReader) LookupCaveatsWithNames(ctx context.Context, caveatNam
 	return r.delegate.LookupCaveatsWithNames(ctx, caveatNames)
 }
 
-func (r *observableReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (r *observableReader) ListAllCaveats(ctx context.Context) ([]datastore.RevisionedCaveat, error) {
 	ctx, closer := observe(ctx, "ListAllCaveats")
 	defer closer()
 
 	return r.delegate.ListAllCaveats(ctx)
 }
 
-func (r *observableReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (r *observableReader) ListAllNamespaces(ctx context.Context) ([]datastore.RevisionedNamespace, error) {
 	ctx, closer := observe(ctx, "ListAllNamespaces")
 	defer closer()
 
 	return r.delegate.ListAllNamespaces(ctx)
 }
 
-func (r *observableReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (r *observableReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]datastore.RevisionedNamespace, error) {
 	ctx, closer := observe(ctx, "LookupNamespacesWithNames", trace.WithAttributes(
 		attribute.StringSlice("names", nsNames),
 	))

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -137,12 +137,12 @@ func (dm *MockReader) ReverseQueryRelationships(
 	return results, args.Error(1)
 }
 
-func (dm *MockReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (dm *MockReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
 	args := dm.Called()
 	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
 }
 
-func (dm *MockReader) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (dm *MockReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
 	args := dm.Called()
 	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
 }
@@ -215,12 +215,12 @@ func (dm *MockReadWriteTransaction) ReverseQueryRelationships(
 	return results, args.Error(1)
 }
 
-func (dm *MockReadWriteTransaction) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (dm *MockReadWriteTransaction) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
 	args := dm.Called()
 	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
 }
 
-func (dm *MockReadWriteTransaction) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (dm *MockReadWriteTransaction) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
 	args := dm.Called()
 	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
 }

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -137,14 +137,14 @@ func (dm *MockReader) ReverseQueryRelationships(
 	return results, args.Error(1)
 }
 
-func (dm *MockReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (dm *MockReader) ListAllNamespaces(ctx context.Context) ([]datastore.RevisionedNamespace, error) {
 	args := dm.Called()
-	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
+	return args.Get(0).([]datastore.RevisionedNamespace), args.Error(1)
 }
 
-func (dm *MockReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (dm *MockReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]datastore.RevisionedNamespace, error) {
 	args := dm.Called()
-	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
+	return args.Get(0).([]datastore.RevisionedNamespace), args.Error(1)
 }
 
 func (dm *MockReader) ReadCaveatByName(ctx context.Context, name string) (*core.CaveatDefinition, datastore.Revision, error) {
@@ -152,12 +152,12 @@ func (dm *MockReader) ReadCaveatByName(ctx context.Context, name string) (*core.
 	panic("implement me")
 }
 
-func (dm *MockReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+func (dm *MockReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
 	// TODO implement me
 	panic("implement me")
 }
 
-func (dm *MockReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (dm *MockReader) ListAllCaveats(ctx context.Context) ([]datastore.RevisionedCaveat, error) {
 	// TODO implement me
 	panic("implement me")
 }
@@ -220,14 +220,14 @@ func (dm *MockReadWriteTransaction) ReverseQueryRelationships(
 	return results, args.Error(1)
 }
 
-func (dm *MockReadWriteTransaction) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (dm *MockReadWriteTransaction) ListAllNamespaces(ctx context.Context) ([]datastore.RevisionedNamespace, error) {
 	args := dm.Called()
-	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
+	return args.Get(0).([]datastore.RevisionedNamespace), args.Error(1)
 }
 
-func (dm *MockReadWriteTransaction) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (dm *MockReadWriteTransaction) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]datastore.RevisionedNamespace, error) {
 	args := dm.Called()
-	return args.Get(0).([]*core.NamespaceDefinition), args.Error(1)
+	return args.Get(0).([]datastore.RevisionedNamespace), args.Error(1)
 }
 
 func (dm *MockReadWriteTransaction) WriteRelationships(ctx context.Context, mutations []*core.RelationTupleUpdate) error {
@@ -260,12 +260,12 @@ func (dm *MockReadWriteTransaction) ReadCaveatByName(ctx context.Context, name s
 	panic("implement me")
 }
 
-func (dm *MockReadWriteTransaction) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+func (dm *MockReadWriteTransaction) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
 	// TODO implement me
 	panic("implement me")
 }
 
-func (dm *MockReadWriteTransaction) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (dm *MockReadWriteTransaction) ListAllCaveats(ctx context.Context) ([]datastore.RevisionedCaveat, error) {
 	// TODO implement me
 	panic("implement me")
 }

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -143,23 +143,29 @@ func (dm *MockReader) ListAllNamespaces(ctx context.Context) ([]datastore.Revisi
 }
 
 func (dm *MockReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]datastore.RevisionedNamespace, error) {
-	args := dm.Called()
+	args := dm.Called(nsNames)
 	return args.Get(0).([]datastore.RevisionedNamespace), args.Error(1)
 }
 
 func (dm *MockReader) ReadCaveatByName(ctx context.Context, name string) (*core.CaveatDefinition, datastore.Revision, error) {
-	// TODO implement me
-	panic("implement me")
+	args := dm.Called(name)
+
+	var def *core.CaveatDefinition
+	if args.Get(0) != nil {
+		def = args.Get(0).(*core.CaveatDefinition)
+	}
+
+	return def, args.Get(1).(datastore.Revision), args.Error(2)
 }
 
 func (dm *MockReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
-	// TODO implement me
-	panic("implement me")
+	args := dm.Called(caveatNames)
+	return args.Get(0).([]datastore.RevisionedCaveat), args.Error(1)
 }
 
 func (dm *MockReader) ListAllCaveats(ctx context.Context) ([]datastore.RevisionedCaveat, error) {
-	// TODO implement me
-	panic("implement me")
+	args := dm.Called()
+	return args.Get(0).([]datastore.RevisionedCaveat), args.Error(1)
 }
 
 type MockReadWriteTransaction struct {
@@ -226,7 +232,7 @@ func (dm *MockReadWriteTransaction) ListAllNamespaces(ctx context.Context) ([]da
 }
 
 func (dm *MockReadWriteTransaction) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]datastore.RevisionedNamespace, error) {
-	args := dm.Called()
+	args := dm.Called(nsNames)
 	return args.Get(0).([]datastore.RevisionedNamespace), args.Error(1)
 }
 
@@ -256,28 +262,33 @@ func (dm *MockReadWriteTransaction) DeleteNamespaces(ctx context.Context, nsName
 }
 
 func (dm *MockReadWriteTransaction) ReadCaveatByName(ctx context.Context, name string) (*core.CaveatDefinition, datastore.Revision, error) {
-	// TODO implement me
-	panic("implement me")
+	args := dm.Called(name)
+
+	var def *core.CaveatDefinition
+	if args.Get(0) != nil {
+		def = args.Get(0).(*core.CaveatDefinition)
+	}
+
+	return def, args.Get(1).(datastore.Revision), args.Error(2)
 }
 
 func (dm *MockReadWriteTransaction) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
-	// TODO implement me
-	panic("implement me")
+	args := dm.Called(caveatNames)
+	return args.Get(0).([]datastore.RevisionedCaveat), args.Error(1)
 }
 
 func (dm *MockReadWriteTransaction) ListAllCaveats(ctx context.Context) ([]datastore.RevisionedCaveat, error) {
-	// TODO implement me
-	panic("implement me")
+	args := dm.Called()
+	return args.Get(0).([]datastore.RevisionedCaveat), args.Error(1)
 }
 
 func (dm *MockReadWriteTransaction) WriteCaveats(ctx context.Context, caveats []*core.CaveatDefinition) error {
-	// TODO implement me
-	panic("implement me")
+	args := dm.Called(caveats)
+	return args.Error(0)
 }
 
 func (dm *MockReadWriteTransaction) DeleteCaveats(ctx context.Context, names []string) error {
-	// TODO implement me
-	panic("implement me")
+	panic("not used")
 }
 
 var (

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -152,7 +152,12 @@ func (dm *MockReader) ReadCaveatByName(ctx context.Context, name string) (*core.
 	panic("implement me")
 }
 
-func (dm *MockReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
+func (dm *MockReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (dm *MockReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
 	// TODO implement me
 	panic("implement me")
 }
@@ -255,7 +260,12 @@ func (dm *MockReadWriteTransaction) ReadCaveatByName(ctx context.Context, name s
 	panic("implement me")
 }
 
-func (dm *MockReadWriteTransaction) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
+func (dm *MockReadWriteTransaction) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (dm *MockReadWriteTransaction) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
 	// TODO implement me
 	panic("implement me")
 }

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -83,7 +83,7 @@ type MockReader struct {
 	mock.Mock
 }
 
-func (dm *MockReader) ReadNamespace(
+func (dm *MockReader) ReadNamespaceByName(
 	ctx context.Context,
 	nsName string,
 ) (*core.NamespaceDefinition, datastore.Revision, error) {
@@ -161,7 +161,7 @@ type MockReadWriteTransaction struct {
 	mock.Mock
 }
 
-func (dm *MockReadWriteTransaction) ReadNamespace(
+func (dm *MockReadWriteTransaction) ReadNamespaceByName(
 	ctx context.Context,
 	nsName string,
 ) (*core.NamespaceDefinition, datastore.Revision, error) {

--- a/internal/datastore/proxy/readonly_test.go
+++ b/internal/datastore/proxy/readonly_test.go
@@ -133,9 +133,9 @@ func TestSnapshotReaderPassthrough(t *testing.T) {
 	ds := NewReadonlyDatastore(delegate)
 	ctx := context.Background()
 
-	reader.On("ReadNamespace", "fake").Return(nil, expectedRevision, nil).Times(1)
+	reader.On("ReadNamespaceByName", "fake").Return(nil, expectedRevision, nil).Times(1)
 
-	_, rev, err := ds.SnapshotReader(expectedRevision).ReadNamespace(ctx, "fake")
+	_, rev, err := ds.SnapshotReader(expectedRevision).ReadNamespaceByName(ctx, "fake")
 	require.NoError(err)
 	require.True(expectedRevision.Equal(rev))
 	delegate.AssertExpectations(t)

--- a/internal/datastore/spanner/caveat.go
+++ b/internal/datastore/spanner/caveat.go
@@ -35,7 +35,18 @@ func (sr spannerReader) ReadCaveatByName(ctx context.Context, name string) (*cor
 	return loaded, revisionFromTimestamp(updated), nil
 }
 
-func (sr spannerReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
+func (sr spannerReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+	return sr.listCaveats(ctx, nil)
+}
+
+func (sr spannerReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+	if len(caveatNames) == 0 {
+		return nil, nil
+	}
+	return sr.listCaveats(ctx, caveatNames)
+}
+
+func (sr spannerReader) listCaveats(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
 	keyset := spanner.AllKeys()
 	if len(caveatNames) > 0 {
 		keys := make([]spanner.Key, 0, len(caveatNames))

--- a/internal/datastore/spanner/reader.go
+++ b/internal/datastore/spanner/reader.go
@@ -120,7 +120,7 @@ func queryExecutor(txSource txFactory) common.ExecuteQueryFunc {
 	}
 }
 
-func (sr spannerReader) ReadNamespace(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {
+func (sr spannerReader) ReadNamespaceByName(ctx context.Context, nsName string) (*core.NamespaceDefinition, datastore.Revision, error) {
 	nsKey := spanner.Key{nsName}
 	row, err := sr.txSource().ReadRow(
 		ctx,

--- a/internal/datastore/spanner/reader.go
+++ b/internal/datastore/spanner/reader.go
@@ -149,7 +149,7 @@ func (sr spannerReader) ReadNamespaceByName(ctx context.Context, nsName string) 
 	return ns, revisionFromTimestamp(updated), nil
 }
 
-func (sr spannerReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
+func (sr spannerReader) ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error) {
 	iter := sr.txSource().Read(
 		ctx,
 		tableNamespace,
@@ -165,7 +165,7 @@ func (sr spannerReader) ListNamespaces(ctx context.Context) ([]*core.NamespaceDe
 	return allNamespaces, nil
 }
 
-func (sr spannerReader) LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
+func (sr spannerReader) LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error) {
 	if len(nsNames) == 0 {
 		return nil, nil
 	}

--- a/internal/datastore/spanner/stats.go
+++ b/internal/datastore/spanner/stats.go
@@ -35,7 +35,7 @@ func (sd spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, err
 		ctx,
 		tableNamespace,
 		spanner.AllKeys(),
-		[]string{colNamespaceConfig},
+		[]string{colNamespaceConfig, colNamespaceTS},
 	)
 
 	allNamespaces, err := readAllNamespaces(iter)

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -125,7 +125,7 @@ func (ld *localDispatcher) loadNamespace(ctx context.Context, nsName string, rev
 	ds := datastoremw.MustFromContext(ctx).SnapshotReader(revision)
 
 	// Load namespace and relation from the datastore
-	ns, _, err := ds.ReadNamespace(ctx, nsName)
+	ns, _, err := ds.ReadNamespaceByName(ctx, nsName)
 	if err != nil {
 		return nil, rewriteError(err)
 	}

--- a/internal/namespace/resolver.go
+++ b/internal/namespace/resolver.go
@@ -69,7 +69,7 @@ func (r *resolver) LookupNamespace(ctx context.Context, name string) (*core.Name
 		return nil, asTypeError(NewNamespaceNotFoundErr(name))
 	}
 
-	ns, _, err := r.ds.ReadNamespace(ctx, name)
+	ns, _, err := r.ds.ReadNamespaceByName(ctx, name)
 	return ns, err
 }
 

--- a/internal/namespace/util.go
+++ b/internal/namespace/util.go
@@ -21,7 +21,7 @@ func ReadNamespaceAndRelation(
 	relation string,
 	ds datastore.Reader,
 ) (*core.NamespaceDefinition, *core.Relation, error) {
-	config, _, err := ds.ReadNamespace(ctx, namespace)
+	config, _, err := ds.ReadNamespaceByName(ctx, namespace)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -48,7 +48,7 @@ func CheckNamespaceAndRelation(
 	allowEllipsis bool,
 	ds datastore.Reader,
 ) error {
-	config, _, err := ds.ReadNamespace(ctx, namespace)
+	config, _, err := ds.ReadNamespaceByName(ctx, namespace)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func ReadNamespaceAndTypes(
 	nsName string,
 	ds datastore.Reader,
 ) (*core.NamespaceDefinition, *TypeSystem, error) {
-	nsDef, _, err := ds.ReadNamespace(ctx, nsName)
+	nsDef, _, err := ds.ReadNamespaceByName(ctx, nsName)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/relationships/validation.go
+++ b/internal/relationships/validation.go
@@ -37,7 +37,7 @@ func ValidateRelationshipUpdates(
 
 		referencedCaveatMap = make(map[string]*core.CaveatDefinition, len(foundCaveats))
 		for _, caveatDef := range foundCaveats {
-			referencedCaveatMap[caveatDef.Name] = caveatDef
+			referencedCaveatMap[caveatDef.Definition.Name] = caveatDef.Definition
 		}
 	}
 

--- a/internal/relationships/validation.go
+++ b/internal/relationships/validation.go
@@ -30,7 +30,7 @@ func ValidateRelationshipUpdates(
 	}
 
 	if !referencedCaveatNamesWithContext.IsEmpty() {
-		foundCaveats, err := rwt.ListCaveats(ctx, referencedCaveatNamesWithContext.AsSlice()...)
+		foundCaveats, err := rwt.LookupCaveatsWithNames(ctx, referencedCaveatNamesWithContext.AsSlice())
 		if err != nil {
 			return err
 		}

--- a/internal/services/shared/schema.go
+++ b/internal/services/shared/schema.go
@@ -88,7 +88,7 @@ func ApplySchemaChanges(ctx context.Context, rwt datastore.ReadWriteTransaction,
 		return nil, err
 	}
 
-	existingObjectDefs, err := rwt.ListNamespaces(ctx)
+	existingObjectDefs, err := rwt.ListAllNamespaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/shared/schema.go
+++ b/internal/services/shared/schema.go
@@ -93,7 +93,7 @@ func ApplySchemaChanges(ctx context.Context, rwt datastore.ReadWriteTransaction,
 		return nil, err
 	}
 
-	return ApplySchemaChangesOverExisting(ctx, rwt, validated, existingCaveats, existingObjectDefs)
+	return ApplySchemaChangesOverExisting(ctx, rwt, validated, datastore.DefinitionsOf(existingCaveats), datastore.DefinitionsOf(existingObjectDefs))
 }
 
 // ApplySchemaChangesOverExisting applies schema changes found in the validated changes struct, against

--- a/internal/services/shared/schema.go
+++ b/internal/services/shared/schema.go
@@ -83,7 +83,7 @@ type AppliedSchemaChanges struct {
 // ApplySchemaChanges applies schema changes found in the validated changes struct, via the specified
 // ReadWriteTransaction.
 func ApplySchemaChanges(ctx context.Context, rwt datastore.ReadWriteTransaction, validated *ValidatedSchemaChanges) (*AppliedSchemaChanges, error) {
-	existingCaveats, err := rwt.ListCaveats(ctx)
+	existingCaveats, err := rwt.ListAllCaveats(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/v1/debug.go
+++ b/internal/services/v1/debug.go
@@ -29,7 +29,7 @@ func ConvertCheckDispatchDebugInformation(
 		return nil, nil
 	}
 
-	caveats, err := reader.ListCaveats(ctx)
+	caveats, err := reader.ListAllCaveats(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/v1/debug.go
+++ b/internal/services/v1/debug.go
@@ -34,7 +34,7 @@ func ConvertCheckDispatchDebugInformation(
 		return nil, err
 	}
 
-	namespaces, err := reader.ListNamespaces(ctx)
+	namespaces, err := reader.ListAllNamespaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/v1/debug.go
+++ b/internal/services/v1/debug.go
@@ -41,10 +41,10 @@ func ConvertCheckDispatchDebugInformation(
 
 	defs := make([]compiler.SchemaDefinition, 0, len(namespaces)+len(caveats))
 	for _, caveat := range caveats {
-		defs = append(defs, caveat)
+		defs = append(defs, caveat.Definition)
 	}
 	for _, ns := range namespaces {
-		defs = append(defs, ns)
+		defs = append(defs, ns.Definition)
 	}
 
 	schema, _, err := generator.GenerateSchema(defs)

--- a/internal/services/v1/schema.go
+++ b/internal/services/v1/schema.go
@@ -52,7 +52,7 @@ func (ss *schemaServer) ReadSchema(ctx context.Context, in *v1.ReadSchemaRequest
 	readRevision, _ := consistency.MustRevisionFromContext(ctx)
 	ds := datastoremw.MustFromContext(ctx).SnapshotReader(readRevision)
 
-	nsDefs, err := ds.ListNamespaces(ctx)
+	nsDefs, err := ds.ListAllNamespaces(ctx)
 	if err != nil {
 		return nil, rewriteError(ctx, err)
 	}

--- a/internal/services/v1/schema.go
+++ b/internal/services/v1/schema.go
@@ -57,7 +57,7 @@ func (ss *schemaServer) ReadSchema(ctx context.Context, in *v1.ReadSchemaRequest
 		return nil, rewriteError(ctx, err)
 	}
 
-	caveatDefs, err := ds.ListCaveats(ctx)
+	caveatDefs, err := ds.ListAllCaveats(ctx)
 	if err != nil {
 		return nil, rewriteError(ctx, err)
 	}

--- a/internal/services/v1/schema.go
+++ b/internal/services/v1/schema.go
@@ -68,11 +68,11 @@ func (ss *schemaServer) ReadSchema(ctx context.Context, in *v1.ReadSchemaRequest
 
 	schemaDefinitions := make([]compiler.SchemaDefinition, 0, len(nsDefs)+len(caveatDefs))
 	for _, caveatDef := range caveatDefs {
-		schemaDefinitions = append(schemaDefinitions, caveatDef)
+		schemaDefinitions = append(schemaDefinitions, caveatDef.Definition)
 	}
 
 	for _, nsDef := range nsDefs {
-		schemaDefinitions = append(schemaDefinitions, nsDef)
+		schemaDefinitions = append(schemaDefinitions, nsDef.Definition)
 	}
 
 	schemaText, _, err := generator.GenerateSchema(schemaDefinitions)

--- a/internal/services/v1/schema_test.go
+++ b/internal/services/v1/schema_test.go
@@ -541,10 +541,10 @@ func TestSchemaUnchangedNamespaces(t *testing.T) {
 
 	reader := ds.SnapshotReader(rev)
 
-	_, userRevision, err := reader.ReadNamespace(context.Background(), "user")
+	_, userRevision, err := reader.ReadNamespaceByName(context.Background(), "user")
 	require.NoError(t, err)
 
-	_, docRevision, err := reader.ReadNamespace(context.Background(), "document")
+	_, docRevision, err := reader.ReadNamespaceByName(context.Background(), "document")
 	require.NoError(t, err)
 
 	require.True(t, docRevision.GreaterThan(userRevision))

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -46,10 +46,10 @@ type validatingSnapshotReader struct {
 	delegate datastore.Reader
 }
 
-func (vsr validatingSnapshotReader) ListNamespaces(
+func (vsr validatingSnapshotReader) ListAllNamespaces(
 	ctx context.Context,
 ) ([]*core.NamespaceDefinition, error) {
-	read, err := vsr.delegate.ListNamespaces(ctx)
+	read, err := vsr.delegate.ListAllNamespaces(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -64,11 +64,11 @@ func (vsr validatingSnapshotReader) ListNamespaces(
 	return read, err
 }
 
-func (vsr validatingSnapshotReader) LookupNamespaces(
+func (vsr validatingSnapshotReader) LookupNamespacesWithNames(
 	ctx context.Context,
 	nsNames []string,
 ) ([]*core.NamespaceDefinition, error) {
-	read, err := vsr.delegate.LookupNamespaces(ctx, nsNames)
+	read, err := vsr.delegate.LookupNamespacesWithNames(ctx, nsNames)
 	if err != nil {
 		return read, err
 	}

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -97,11 +97,11 @@ func (vsr validatingSnapshotReader) QueryRelationships(ctx context.Context,
 	return vsr.delegate.QueryRelationships(ctx, filter, opts...)
 }
 
-func (vsr validatingSnapshotReader) ReadNamespace(
+func (vsr validatingSnapshotReader) ReadNamespaceByName(
 	ctx context.Context,
 	nsName string,
 ) (*core.NamespaceDefinition, datastore.Revision, error) {
-	read, createdAt, err := vsr.delegate.ReadNamespace(ctx, nsName)
+	read, createdAt, err := vsr.delegate.ReadNamespaceByName(ctx, nsName)
 	if err != nil {
 		return read, createdAt, err
 	}

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -137,8 +137,24 @@ func (vsr validatingSnapshotReader) ReadCaveatByName(ctx context.Context, name s
 	return read, createdAt, err
 }
 
-func (vsr validatingSnapshotReader) ListCaveats(ctx context.Context, caveatNames ...string) ([]*core.CaveatDefinition, error) {
-	read, err := vsr.delegate.ListCaveats(ctx, caveatNames...)
+func (vsr validatingSnapshotReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+	read, err := vsr.delegate.LookupCaveatsWithNames(ctx, caveatNames)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, caveatDef := range read {
+		err := caveatDef.Validate()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return read, err
+}
+
+func (vsr validatingSnapshotReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+	read, err := vsr.delegate.ListAllCaveats(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -48,14 +48,14 @@ type validatingSnapshotReader struct {
 
 func (vsr validatingSnapshotReader) ListAllNamespaces(
 	ctx context.Context,
-) ([]*core.NamespaceDefinition, error) {
+) ([]datastore.RevisionedNamespace, error) {
 	read, err := vsr.delegate.ListAllNamespaces(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, nsDef := range read {
-		err := nsDef.Validate()
+	for _, ns := range read {
+		err := ns.Definition.Validate()
 		if err != nil {
 			return nil, err
 		}
@@ -67,14 +67,14 @@ func (vsr validatingSnapshotReader) ListAllNamespaces(
 func (vsr validatingSnapshotReader) LookupNamespacesWithNames(
 	ctx context.Context,
 	nsNames []string,
-) ([]*core.NamespaceDefinition, error) {
+) ([]datastore.RevisionedNamespace, error) {
 	read, err := vsr.delegate.LookupNamespacesWithNames(ctx, nsNames)
 	if err != nil {
 		return read, err
 	}
 
-	for _, nsDef := range read {
-		err := nsDef.Validate()
+	for _, ns := range read {
+		err := ns.Definition.Validate()
 		if err != nil {
 			return nil, err
 		}
@@ -137,14 +137,14 @@ func (vsr validatingSnapshotReader) ReadCaveatByName(ctx context.Context, name s
 	return read, createdAt, err
 }
 
-func (vsr validatingSnapshotReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]*core.CaveatDefinition, error) {
+func (vsr validatingSnapshotReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []string) ([]datastore.RevisionedCaveat, error) {
 	read, err := vsr.delegate.LookupCaveatsWithNames(ctx, caveatNames)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, caveatDef := range read {
-		err := caveatDef.Validate()
+	for _, caveat := range read {
+		err := caveat.Definition.Validate()
 		if err != nil {
 			return nil, err
 		}
@@ -153,14 +153,14 @@ func (vsr validatingSnapshotReader) LookupCaveatsWithNames(ctx context.Context, 
 	return read, err
 }
 
-func (vsr validatingSnapshotReader) ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error) {
+func (vsr validatingSnapshotReader) ListAllCaveats(ctx context.Context) ([]datastore.RevisionedCaveat, error) {
 	read, err := vsr.delegate.ListAllCaveats(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, caveatDef := range read {
-		err := caveatDef.Validate()
+	for _, caveat := range read {
+		err := caveat.Definition.Validate()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -223,7 +223,7 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 			return nil, fmt.Errorf("unable to determine datastore state before applying bootstrap data: %w", err)
 		}
 
-		nsDefs, err := ds.SnapshotReader(revision).ListNamespaces(ctx)
+		nsDefs, err := ds.SnapshotReader(revision).ListAllNamespaces(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine datastore state before applying bootstrap data: %w", err)
 		}

--- a/pkg/cmd/datastore/datastore_test.go
+++ b/pkg/cmd/datastore/datastore_test.go
@@ -27,10 +27,11 @@ func TestLoadDatastoreFromFileContents(t *testing.T) {
 
 	revision, err := ds.HeadRevision(ctx)
 	require.NoError(t, err)
-	namespaces, err := ds.SnapshotReader(revision).ListNamespaces(ctx)
+
+	namespaces, err := ds.SnapshotReader(revision).ListAllNamespaces(ctx)
 	require.NoError(t, err)
 	require.Len(t, namespaces, 1)
-	require.Equal(t, "user", namespaces[0].Name)
+	require.Equal(t, "user", namespaces[0].Definition.Name)
 }
 
 func TestLoadDatastoreFromFile(t *testing.T) {
@@ -47,10 +48,11 @@ func TestLoadDatastoreFromFile(t *testing.T) {
 
 	revision, err := ds.HeadRevision(ctx)
 	require.NoError(t, err)
-	namespaces, err := ds.SnapshotReader(revision).ListNamespaces(ctx)
+
+	namespaces, err := ds.SnapshotReader(revision).ListAllNamespaces(ctx)
 	require.NoError(t, err)
 	require.Len(t, namespaces, 1)
-	require.Equal(t, "user", namespaces[0].Name)
+	require.Equal(t, "user", namespaces[0].Definition.Name)
 }
 
 func TestLoadDatastoreFromFileAndContents(t *testing.T) {
@@ -68,10 +70,11 @@ func TestLoadDatastoreFromFileAndContents(t *testing.T) {
 
 	revision, err := ds.HeadRevision(ctx)
 	require.NoError(t, err)
-	namespaces, err := ds.SnapshotReader(revision).ListNamespaces(ctx)
+
+	namespaces, err := ds.SnapshotReader(revision).ListAllNamespaces(ctx)
 	require.NoError(t, err)
 	require.Len(t, namespaces, 2)
-	namespaceNames := []string{namespaces[0].Name, namespaces[1].Name}
+	namespaceNames := []string{namespaces[0].Definition.Name, namespaces[1].Definition.Name}
 	require.Contains(t, namespaceNames, "user")
 	require.Contains(t, namespaceNames, "repository")
 }

--- a/pkg/datastore/caveat.go
+++ b/pkg/datastore/caveat.go
@@ -12,9 +12,11 @@ type CaveatReader interface {
 	// It returns an instance of ErrCaveatNotFound if not found.
 	ReadCaveatByName(ctx context.Context, name string) (*core.CaveatDefinition, Revision, error)
 
-	// ListCaveats returns all caveats stored in the system. If caveatNames are provided
-	// the result will be filtered to the provided caveat names
-	ListCaveats(ctx context.Context, caveatNamesForFiltering ...string) ([]*core.CaveatDefinition, error)
+	// ListAllCaveats returns all caveats stored in the system.
+	ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error)
+
+	// LookupCaveatsWithNames finds all caveats with the matching names.
+	LookupCaveatsWithNames(ctx context.Context, names []string) ([]*core.CaveatDefinition, error)
 }
 
 // CaveatStorer offers both read and write operations for Caveats

--- a/pkg/datastore/caveat.go
+++ b/pkg/datastore/caveat.go
@@ -8,7 +8,8 @@ import (
 
 // CaveatReader offers read operations for caveats
 type CaveatReader interface {
-	// ReadCaveatByName returns a caveat with the provided name
+	// ReadCaveatByName returns a caveat with the provided name.
+	// It returns an instance of ErrCaveatNotFound if not found.
 	ReadCaveatByName(ctx context.Context, name string) (*core.CaveatDefinition, Revision, error)
 
 	// ListCaveats returns all caveats stored in the system. If caveatNames are provided

--- a/pkg/datastore/caveat.go
+++ b/pkg/datastore/caveat.go
@@ -6,17 +6,20 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
+// RevisionedCaveat is a revisioned version of a caveat definition.
+type RevisionedCaveat = RevisionedDefinition[*core.CaveatDefinition]
+
 // CaveatReader offers read operations for caveats
 type CaveatReader interface {
 	// ReadCaveatByName returns a caveat with the provided name.
 	// It returns an instance of ErrCaveatNotFound if not found.
-	ReadCaveatByName(ctx context.Context, name string) (*core.CaveatDefinition, Revision, error)
+	ReadCaveatByName(ctx context.Context, name string) (caveat *core.CaveatDefinition, lastWritten Revision, err error)
 
 	// ListAllCaveats returns all caveats stored in the system.
-	ListAllCaveats(ctx context.Context) ([]*core.CaveatDefinition, error)
+	ListAllCaveats(ctx context.Context) ([]RevisionedCaveat, error)
 
 	// LookupCaveatsWithNames finds all caveats with the matching names.
-	LookupCaveatsWithNames(ctx context.Context, names []string) ([]*core.CaveatDefinition, error)
+	LookupCaveatsWithNames(ctx context.Context, names []string) ([]RevisionedCaveat, error)
 }
 
 // CaveatStorer offers both read and write operations for Caveats

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -196,6 +196,23 @@ func (sf SubjectsFilter) AsSelector() SubjectsSelector {
 	}
 }
 
+// SchemaDefinition represents a namespace or caveat definition under a schema.
+type SchemaDefinition interface {
+	GetName() string
+}
+
+// RevisionedDefinition holds a schema definition and its last updated revision.
+type RevisionedDefinition[T SchemaDefinition] struct {
+	// Definition is the namespace or caveat definition.
+	Definition T
+
+	// LastWrittenRevision is the revision at which the namespace or caveat was last updated.
+	LastWrittenRevision Revision
+}
+
+// RevisionedNamespace is a revisioned version of a namespace definition.
+type RevisionedNamespace = RevisionedDefinition[*core.NamespaceDefinition]
+
 // Reader is an interface for reading relationships from the datastore.
 type Reader interface {
 	CaveatReader
@@ -219,10 +236,10 @@ type Reader interface {
 	ReadNamespaceByName(ctx context.Context, nsName string) (ns *core.NamespaceDefinition, lastWritten Revision, err error)
 
 	// ListAllNamespaces lists all namespaces defined.
-	ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error)
+	ListAllNamespaces(ctx context.Context) ([]RevisionedNamespace, error)
 
 	// LookupNamespacesWithNames finds all namespaces with the matching names.
-	LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error)
+	LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]RevisionedNamespace, error)
 }
 
 type ReadWriteTransaction interface {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -218,11 +218,11 @@ type Reader interface {
 	// last written. It returns an instance of ErrNamespaceNotFound if not found.
 	ReadNamespaceByName(ctx context.Context, nsName string) (ns *core.NamespaceDefinition, lastWritten Revision, err error)
 
-	// ListNamespaces lists all namespaces defined.
-	ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error)
+	// ListAllNamespaces lists all namespaces defined.
+	ListAllNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error)
 
-	// LookupNamespaces finds all namespaces with the matching names.
-	LookupNamespaces(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error)
+	// LookupNamespacesWithNames finds all namespaces with the matching names.
+	LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]*core.NamespaceDefinition, error)
 }
 
 type ReadWriteTransaction interface {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -214,9 +214,9 @@ type Reader interface {
 		options ...options.ReverseQueryOptionsOption,
 	) (RelationshipIterator, error)
 
-	// ReadNamespace reads a namespace definition and the revision at which it was created or
+	// ReadNamespaceByName reads a namespace definition and the revision at which it was created or
 	// last written. It returns an instance of ErrNamespaceNotFound if not found.
-	ReadNamespace(ctx context.Context, nsName string) (ns *core.NamespaceDefinition, lastWritten Revision, err error)
+	ReadNamespaceByName(ctx context.Context, nsName string) (ns *core.NamespaceDefinition, lastWritten Revision, err error)
 
 	// ListNamespaces lists all namespaces defined.
 	ListNamespaces(ctx context.Context) ([]*core.NamespaceDefinition, error)

--- a/pkg/datastore/errors.go
+++ b/pkg/datastore/errors.go
@@ -6,10 +6,21 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// ErrNotFound is a shared interface for not found errors.
+type ErrNotFound interface {
+	IsNotFoundError() bool
+}
+
 // ErrNamespaceNotFound occurs when a namespace was not found.
 type ErrNamespaceNotFound struct {
 	error
 	namespaceName string
+}
+
+var _ ErrNotFound = ErrNamespaceNotFound{}
+
+func (err ErrNamespaceNotFound) IsNotFoundError() bool {
+	return true
 }
 
 // NotFoundNamespaceName is the name of the namespace not found.
@@ -145,6 +156,12 @@ func NewInvalidRevisionErr(revision Revision, reason InvalidRevisionReason) erro
 type ErrCaveatNameNotFound struct {
 	error
 	name string
+}
+
+var _ ErrNotFound = ErrCaveatNameNotFound{}
+
+func (err ErrCaveatNameNotFound) IsNotFoundError() bool {
+	return true
 }
 
 // CaveatName returns the name of the caveat that couldn't be found

--- a/pkg/datastore/stats.go
+++ b/pkg/datastore/stats.go
@@ -2,19 +2,18 @@ package datastore
 
 import (
 	"github.com/authzed/spicedb/pkg/namespace"
-	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	iv1 "github.com/authzed/spicedb/pkg/proto/impl/v1"
 )
 
 // ComputeObjectTypeStats creates a list of object type stats from an input list of
 // parsed object types.
-func ComputeObjectTypeStats(objTypes []*core.NamespaceDefinition) []ObjectTypeStat {
+func ComputeObjectTypeStats(objTypes []RevisionedNamespace) []ObjectTypeStat {
 	stats := make([]ObjectTypeStat, 0, len(objTypes))
 
 	for _, objType := range objTypes {
 		var relations, permissions uint32
 
-		for _, rel := range objType.Relation {
+		for _, rel := range objType.Definition.Relation {
 			if namespace.GetRelationKind(rel) == iv1.RelationMetadata_PERMISSION {
 				permissions++
 			} else {

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -86,9 +86,9 @@ func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 	req.NoError(err)
 	req.Len(cvs, 2)
 
-	foundDiff = cmp.Diff(coreCaveat, cvs[0], protocmp.Transform())
+	foundDiff = cmp.Diff(coreCaveat, cvs[0].Definition, protocmp.Transform())
 	req.Empty(foundDiff)
-	foundDiff = cmp.Diff(anotherCoreCaveat, cvs[1], protocmp.Transform())
+	foundDiff = cmp.Diff(anotherCoreCaveat, cvs[1].Definition, protocmp.Transform())
 	req.Empty(foundDiff)
 
 	// Caveats can be found by names
@@ -96,7 +96,7 @@ func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 	req.NoError(err)
 	req.Len(cvs, 1)
 
-	foundDiff = cmp.Diff(coreCaveat, cvs[0], protocmp.Transform())
+	foundDiff = cmp.Diff(coreCaveat, cvs[0].Definition, protocmp.Transform())
 	req.Empty(foundDiff)
 
 	// Non-existing names returns no caveat

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -22,6 +22,24 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// CaveatNotFound tests to ensure that an unknown caveat returns the expected
+// error.
+func CaveatNotFoundTest(t *testing.T, tester DatastoreTester) {
+	require := require.New(t)
+
+	ds, err := tester.New(0, veryLargeGCWindow, 1)
+	require.NoError(err)
+
+	ctx := context.Background()
+
+	startRevision, err := ds.HeadRevision(ctx)
+	require.NoError(err)
+	require.True(startRevision.GreaterThan(datastore.NoRevision))
+
+	_, _, err = ds.SnapshotReader(startRevision).ReadCaveatByName(ctx, "unknown")
+	require.True(errors.As(err, &datastore.ErrCaveatNameNotFound{}))
+}
+
 func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
 	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 1)

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -82,7 +82,7 @@ func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 	req.Equal("bytes", cv.ParameterTypes["bar"].ChildTypes[0].TypeName)
 
 	// All caveats can be listed
-	cvs, err := cr.ListCaveats(ctx)
+	cvs, err := cr.ListAllCaveats(ctx)
 	req.NoError(err)
 	req.Len(cvs, 2)
 
@@ -91,8 +91,8 @@ func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 	foundDiff = cmp.Diff(anotherCoreCaveat, cvs[1], protocmp.Transform())
 	req.Empty(foundDiff)
 
-	// All caveats can be filtered by names
-	cvs, err = cr.ListCaveats(ctx, coreCaveat.Name)
+	// Caveats can be found by names
+	cvs, err = cr.LookupCaveatsWithNames(ctx, []string{coreCaveat.Name})
 	req.NoError(err)
 	req.Len(cvs, 1)
 
@@ -100,9 +100,19 @@ func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 	req.Empty(foundDiff)
 
 	// Non-existing names returns no caveat
-	cvs, err = cr.ListCaveats(ctx, "doesnotexist")
+	cvs, err = cr.LookupCaveatsWithNames(ctx, []string{"doesnotexist"})
 	req.NoError(err)
 	req.Empty(cvs)
+
+	// Empty lookup returns no values.
+	cvs, err = cr.LookupCaveatsWithNames(ctx, []string{})
+	req.NoError(err)
+	req.Len(cvs, 0)
+
+	// nil lookup returns no values.
+	cvs, err = cr.LookupCaveatsWithNames(ctx, nil)
+	req.NoError(err)
+	req.Len(cvs, 0)
 
 	// Delete Caveat
 	rev, err = ds.ReadWriteTx(ctx, func(tx datastore.ReadWriteTransaction) error {

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -33,6 +33,7 @@ func (f DatastoreTesterFunc) New(revisionQuantization, gcWindow time.Duration, w
 // AllExceptWatch runs all generic datastore tests on a DatastoreTester, except
 // those invoking the watch API.
 func AllExceptWatch(t *testing.T, tester DatastoreTester) {
+	t.Run("TestNamespaceNotFound", func(t *testing.T) { NamespaceNotFoundTest(t, tester) })
 	t.Run("TestNamespaceWrite", func(t *testing.T) { NamespaceWriteTest(t, tester) })
 	t.Run("TestNamespaceDelete", func(t *testing.T) { NamespaceDeleteTest(t, tester) })
 	t.Run("TestNamespaceMultiDelete", func(t *testing.T) { NamespaceMultiDeleteTest(t, tester) })
@@ -56,6 +57,7 @@ func AllExceptWatch(t *testing.T, tester DatastoreTester) {
 
 	t.Run("TestStats", func(t *testing.T) { StatsTest(t, tester) })
 
+	t.Run("TestCaveatNotFound", func(t *testing.T) { CaveatNotFoundTest(t, tester) })
 	t.Run("TestWriteReadDeleteCaveat", func(t *testing.T) { WriteReadDeleteCaveatTest(t, tester) })
 	t.Run("TestWriteCaveatedRelationship", func(t *testing.T) { WriteCaveatedRelationshipTest(t, tester) })
 	t.Run("TestCaveatedRelationshipFilter", func(t *testing.T) { CaveatedRelationshipFilterTest(t, tester) })

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -62,7 +62,7 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 	require.True(startRevision.GreaterThan(datastore.NoRevision))
 
-	nsDefs, err := ds.SnapshotReader(startRevision).ListNamespaces(ctx)
+	nsDefs, err := ds.SnapshotReader(startRevision).ListAllNamespaces(ctx)
 	require.NoError(err)
 	require.Equal(0, len(nsDefs))
 
@@ -72,7 +72,7 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 	require.True(writtenRev.GreaterThan(startRevision))
 
-	nsDefs, err = ds.SnapshotReader(writtenRev).ListNamespaces(ctx)
+	nsDefs, err = ds.SnapshotReader(writtenRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	require.Equal(1, len(nsDefs))
 	require.Equal(testUserNS.Name, nsDefs[0].Name)
@@ -83,14 +83,14 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 	require.True(secondWritten.GreaterThan(writtenRev))
 
-	nsDefs, err = ds.SnapshotReader(secondWritten).ListNamespaces(ctx)
+	nsDefs, err = ds.SnapshotReader(secondWritten).ListAllNamespaces(ctx)
 	require.NoError(err)
 	require.Equal(2, len(nsDefs))
 
 	_, _, err = ds.SnapshotReader(writtenRev).ReadNamespaceByName(ctx, testNamespace.Name)
 	require.Error(err)
 
-	nsDefs, err = ds.SnapshotReader(writtenRev).ListNamespaces(ctx)
+	nsDefs, err = ds.SnapshotReader(writtenRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	require.Equal(1, len(nsDefs))
 
@@ -119,23 +119,23 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	require.True(createdRev.GreaterThan(startRevision))
 	require.Empty(cmp.Diff(testUserNS, checkOld, protocmp.Transform()))
 
-	checkOldList, err := ds.SnapshotReader(writtenRev).ListNamespaces(ctx)
+	checkOldList, err := ds.SnapshotReader(writtenRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	require.Equal(1, len(checkOldList))
 	require.Equal(testUserNS.Name, checkOldList[0].Name)
 	require.Empty(cmp.Diff(testUserNS, checkOldList[0], protocmp.Transform()))
 
-	checkLookup, err := ds.SnapshotReader(secondWritten).LookupNamespaces(ctx, []string{testNamespace.Name})
+	checkLookup, err := ds.SnapshotReader(secondWritten).LookupNamespacesWithNames(ctx, []string{testNamespace.Name})
 	require.NoError(err)
 	require.Equal(1, len(checkLookup))
 	require.Equal(testNamespace.Name, checkLookup[0].Name)
 	require.Empty(cmp.Diff(testNamespace, checkLookup[0], protocmp.Transform()))
 
-	checkLookupMultiple, err := ds.SnapshotReader(secondWritten).LookupNamespaces(ctx, []string{testNamespace.Name, testUserNS.Name})
+	checkLookupMultiple, err := ds.SnapshotReader(secondWritten).LookupNamespacesWithNames(ctx, []string{testNamespace.Name, testUserNS.Name})
 	require.NoError(err)
 	require.Equal(2, len(checkLookupMultiple))
 
-	emptyLookup, err := ds.SnapshotReader(secondWritten).LookupNamespaces(ctx, []string{"anothername"})
+	emptyLookup, err := ds.SnapshotReader(secondWritten).LookupNamespacesWithNames(ctx, []string{"anothername"})
 	require.NoError(err)
 	require.Equal(0, len(emptyLookup))
 }
@@ -174,7 +174,7 @@ func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	require.True(nsCreatedRev.LessThan(deletedRev))
 	require.NoError(err)
 
-	allNamespaces, err := ds.SnapshotReader(deletedRev).ListNamespaces(ctx)
+	allNamespaces, err := ds.SnapshotReader(deletedRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	for _, ns := range allNamespaces {
 		require.NotEqual(testfixtures.DocumentNS.Name, ns.Name, "deleted namespace '%s' should not be in namespace list", ns.Name)
@@ -199,7 +199,7 @@ func NamespaceMultiDeleteTest(t *testing.T, tester DatastoreTester) {
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
 	ctx := context.Background()
 
-	namespaces, err := ds.SnapshotReader(revision).ListNamespaces(ctx)
+	namespaces, err := ds.SnapshotReader(revision).ListAllNamespaces(ctx)
 	require.NoError(t, err)
 
 	nsNames := make([]string, 0, len(namespaces))
@@ -212,7 +212,7 @@ func NamespaceMultiDeleteTest(t *testing.T, tester DatastoreTester) {
 	})
 	require.NoError(t, err)
 
-	namespacesAfterDel, err := ds.SnapshotReader(deletedRev).ListNamespaces(ctx)
+	namespacesAfterDel, err := ds.SnapshotReader(deletedRev).ListAllNamespaces(ctx)
 	require.NoError(t, err)
 	require.Len(t, namespacesAfterDel, 0)
 }

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -30,6 +30,24 @@ var (
 	)
 )
 
+// NamespaceNotFoundTest tests to ensure that an unknown namespace returns the expected
+// error.
+func NamespaceNotFoundTest(t *testing.T, tester DatastoreTester) {
+	require := require.New(t)
+
+	ds, err := tester.New(0, veryLargeGCWindow, 1)
+	require.NoError(err)
+
+	ctx := context.Background()
+
+	startRevision, err := ds.HeadRevision(ctx)
+	require.NoError(err)
+	require.True(startRevision.GreaterThan(datastore.NoRevision))
+
+	_, _, err = ds.SnapshotReader(startRevision).ReadNamespace(ctx, "unknown")
+	require.True(errors.As(err, &datastore.ErrNamespaceNotFound{}))
+}
+
 // NamespaceWriteTest tests whether or not the requirements for writing
 // namespaces hold for a particular datastore.
 func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -75,7 +75,7 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	nsDefs, err = ds.SnapshotReader(writtenRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	require.Equal(1, len(nsDefs))
-	require.Equal(testUserNS.Name, nsDefs[0].Name)
+	require.Equal(testUserNS.Name, nsDefs[0].Definition.Name)
 
 	secondWritten, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 		return rwt.WriteNamespaces(ctx, testNamespace)
@@ -122,14 +122,14 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	checkOldList, err := ds.SnapshotReader(writtenRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	require.Equal(1, len(checkOldList))
-	require.Equal(testUserNS.Name, checkOldList[0].Name)
-	require.Empty(cmp.Diff(testUserNS, checkOldList[0], protocmp.Transform()))
+	require.Equal(testUserNS.Name, checkOldList[0].Definition.Name)
+	require.Empty(cmp.Diff(testUserNS, checkOldList[0].Definition, protocmp.Transform()))
 
 	checkLookup, err := ds.SnapshotReader(secondWritten).LookupNamespacesWithNames(ctx, []string{testNamespace.Name})
 	require.NoError(err)
 	require.Equal(1, len(checkLookup))
-	require.Equal(testNamespace.Name, checkLookup[0].Name)
-	require.Empty(cmp.Diff(testNamespace, checkLookup[0], protocmp.Transform()))
+	require.Equal(testNamespace.Name, checkLookup[0].Definition.Name)
+	require.Empty(cmp.Diff(testNamespace, checkLookup[0].Definition, protocmp.Transform()))
 
 	checkLookupMultiple, err := ds.SnapshotReader(secondWritten).LookupNamespacesWithNames(ctx, []string{testNamespace.Name, testUserNS.Name})
 	require.NoError(err)
@@ -177,7 +177,7 @@ func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	allNamespaces, err := ds.SnapshotReader(deletedRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	for _, ns := range allNamespaces {
-		require.NotEqual(testfixtures.DocumentNS.Name, ns.Name, "deleted namespace '%s' should not be in namespace list", ns.Name)
+		require.NotEqual(testfixtures.DocumentNS.Name, ns.Definition.Name, "deleted namespace '%s' should not be in namespace list", ns.Definition.Name)
 	}
 
 	deletedRevision, err := ds.HeadRevision(ctx)
@@ -204,7 +204,7 @@ func NamespaceMultiDeleteTest(t *testing.T, tester DatastoreTester) {
 
 	nsNames := make([]string, 0, len(namespaces))
 	for _, ns := range namespaces {
-		nsNames = append(nsNames, ns.Name)
+		nsNames = append(nsNames, ns.Definition.Name)
 	}
 
 	deletedRev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -44,7 +44,7 @@ func NamespaceNotFoundTest(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 	require.True(startRevision.GreaterThan(datastore.NoRevision))
 
-	_, _, err = ds.SnapshotReader(startRevision).ReadNamespace(ctx, "unknown")
+	_, _, err = ds.SnapshotReader(startRevision).ReadNamespaceByName(ctx, "unknown")
 	require.True(errors.As(err, &datastore.ErrNamespaceNotFound{}))
 }
 
@@ -87,14 +87,14 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 	require.Equal(2, len(nsDefs))
 
-	_, _, err = ds.SnapshotReader(writtenRev).ReadNamespace(ctx, testNamespace.Name)
+	_, _, err = ds.SnapshotReader(writtenRev).ReadNamespaceByName(ctx, testNamespace.Name)
 	require.Error(err)
 
 	nsDefs, err = ds.SnapshotReader(writtenRev).ListNamespaces(ctx)
 	require.NoError(err)
 	require.Equal(1, len(nsDefs))
 
-	found, createdRev, err := ds.SnapshotReader(secondWritten).ReadNamespace(ctx, testNamespace.Name)
+	found, createdRev, err := ds.SnapshotReader(secondWritten).ReadNamespaceByName(ctx, testNamespace.Name)
 	require.NoError(err)
 	require.False(createdRev.GreaterThan(secondWritten))
 	require.True(createdRev.GreaterThan(startRevision))
@@ -106,14 +106,14 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	})
 	require.NoError(err)
 
-	checkUpdated, createdRev, err := ds.SnapshotReader(updatedRevision).ReadNamespace(ctx, testNamespace.Name)
+	checkUpdated, createdRev, err := ds.SnapshotReader(updatedRevision).ReadNamespaceByName(ctx, testNamespace.Name)
 	require.NoError(err)
 	require.False(createdRev.GreaterThan(updatedRevision))
 	require.True(createdRev.GreaterThan(startRevision))
 	foundUpdated := cmp.Diff(updatedNamespace, checkUpdated, protocmp.Transform())
 	require.Empty(foundUpdated)
 
-	checkOld, createdRev, err := ds.SnapshotReader(writtenRev).ReadNamespace(ctx, testUserNamespace)
+	checkOld, createdRev, err := ds.SnapshotReader(writtenRev).ReadNamespaceByName(ctx, testUserNamespace)
 	require.NoError(err)
 	require.False(createdRev.GreaterThan(writtenRev))
 	require.True(createdRev.GreaterThan(startRevision))
@@ -166,10 +166,10 @@ func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 	require.True(deletedRev.GreaterThan(revision))
 
-	_, _, err = ds.SnapshotReader(deletedRev).ReadNamespace(ctx, testfixtures.DocumentNS.Name)
+	_, _, err = ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.DocumentNS.Name)
 	require.True(errors.As(err, &datastore.ErrNamespaceNotFound{}))
 
-	found, nsCreatedRev, err := ds.SnapshotReader(deletedRev).ReadNamespace(ctx, testfixtures.FolderNS.Name)
+	found, nsCreatedRev, err := ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.FolderNS.Name)
 	require.NotNil(found)
 	require.True(nsCreatedRev.LessThan(deletedRev))
 	require.NoError(err)
@@ -233,7 +233,7 @@ func EmptyNamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 	require.True(deletedRev.GreaterThan(revision))
 
-	_, _, err = ds.SnapshotReader(deletedRev).ReadNamespace(ctx, testfixtures.UserNS.Name)
+	_, _, err = ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.UserNS.Name)
 	require.True(errors.As(err, &datastore.ErrNamespaceNotFound{}))
 }
 
@@ -283,7 +283,7 @@ definition document {
 
 	// Read the namespace definition back from the datastore and compare.
 	nsConfig := compiled.ObjectDefinitions[0]
-	readNsDef, _, err := ds.SnapshotReader(updatedRevision).ReadNamespace(ctx, nsConfig.Name)
+	readNsDef, _, err := ds.SnapshotReader(updatedRevision).ReadNamespaceByName(ctx, nsConfig.Name)
 	require.NoError(err)
 	testutil.RequireProtoEqual(t, nsConfig, readNsDef, "found changed namespace definition")
 

--- a/pkg/datastore/util.go
+++ b/pkg/datastore/util.go
@@ -1,0 +1,11 @@
+package datastore
+
+// DefinitionsOf returns just the schema definitions found in the list of revisioned
+// definitions.
+func DefinitionsOf[T SchemaDefinition](revisionedDefinitions []RevisionedDefinition[T]) []T {
+	definitions := make([]T, 0, len(revisionedDefinitions))
+	for _, revDef := range revisionedDefinitions {
+		definitions = append(definitions, revDef.Definition)
+	}
+	return definitions
+}

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -25,6 +25,10 @@ type PopulatedValidationFile struct {
 	// direct or compiled from schema form.
 	NamespaceDefinitions []*core.NamespaceDefinition
 
+	// CaveatDefinitions are the caveats defined in the validation file, in either
+	// direct or compiled from schema form.
+	CaveatDefinitions []*core.CaveatDefinition
+
 	// Tuples are the relation tuples defined in the validation file, either directly
 	// or in the relationships block.
 	Tuples []*core.RelationTuple
@@ -158,5 +162,5 @@ func PopulateFromFilesContents(ctx context.Context, ds datastore.Datastore, file
 		return nil, nil, err
 	}
 
-	return &PopulatedValidationFile{schema, objectDefs, tuples, files}, revision, err
+	return &PopulatedValidationFile{schema, objectDefs, caveatDefs, tuples, files}, revision, err
 }


### PR DESCRIPTION
This PR adds support for caching caveats alongside namespaces in the datastore caching proxy and also adds support for having calls to the methods`Lookup{Caveats,Namespaces}WithNames` automatically be cached and use the cache when available.

As part of this PR, I also standardized the naming of the Lookup and List methods in the datastore for namespaces and caveats

Fixes #892