### PR TITLE
Add an explicit error if parseTime is missing from MySQL URIs

### DIFF
--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -107,6 +108,16 @@ func newMySQLDatastore(uri string, options ...Option) (*Datastore, error) {
 	if err != nil {
 		return nil, fmt.Errorf(errUnableToInstantiate, err)
 	}
+
+	parsedURI, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("NewMySQLDatastore: could not parse connection URI `%s`: %w", uri, err)
+	}
+
+	if parsedURI.Query().Get("parseTime") != "true" {
+		return nil, fmt.Errorf("NewMySQLDatastore: connection URI for MySQL datastore must include `parseTime=true` as a query parameter. See https://spicedb.dev/d/parse-time-mysql for more details. Found: `%s`", uri)
+	}
+
 	connector, err := mysql.MySQLDriver{}.OpenConnector(uri)
 	if err != nil {
 		return nil, fmt.Errorf("NewMySQLDatastore: failed to create connector: %w", err)

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -81,6 +81,11 @@ func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestF
 	}
 }
 
+func TestMySQLDatastoreWithoutParseTime(t *testing.T) {
+	_, err := NewMySQLDatastore("foo@bar.com/whatever")
+	require.ErrorContains(t, err, "https://spicedb.dev/d/parse-time-mysql")
+}
+
 func TestMySQLDatastore(t *testing.T) {
 	b := testdatastore.RunMySQLForTesting(t, "")
 	dst := datastoreTester{b: b, t: t}


### PR DESCRIPTION
This is necessary for garbage collection and other time-based work, so make it required on construction

Related: #1126