### PR TITLE
introduce BootstrapFileContents

### DIFF
--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -57,9 +57,10 @@ type Config struct {
 	DisableStats           bool
 
 	// Bootstrap
-	BootstrapFiles     []string
-	BootstrapOverwrite bool
-	BootstrapTimeout   time.Duration
+	BootstrapFiles        []string
+	BootstrapFileContents map[string][]byte
+	BootstrapOverwrite    bool
+	BootstrapTimeout      time.Duration
 
 	// Hedging
 	RequestHedgingEnabled          bool
@@ -213,7 +214,7 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 		return nil, err
 	}
 
-	if len(opts.BootstrapFiles) > 0 {
+	if len(opts.BootstrapFiles) > 0 || len(opts.BootstrapFileContents) > 0 {
 		ctx, cancel := context.WithTimeout(ctx, opts.BootstrapTimeout)
 		defer cancel()
 
@@ -228,7 +229,11 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 		}
 		if opts.BootstrapOverwrite || len(nsDefs) == 0 {
 			log.Ctx(ctx).Info().Msg("initializing datastore from bootstrap files")
-			_, _, err = validationfile.PopulateFromFiles(ctx, ds, opts.BootstrapFiles)
+			if len(opts.BootstrapFileContents) > 0 {
+				_, _, err = validationfile.PopulateFromFilesContents(ctx, ds, opts.BootstrapFileContents)
+			} else {
+				_, _, err = validationfile.PopulateFromFiles(ctx, ds, opts.BootstrapFiles)
+			}
 			if err != nil {
 				return nil, fmt.Errorf("failed to load bootstrap files: %w", err)
 			}

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -229,13 +229,19 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 		}
 		if opts.BootstrapOverwrite || len(nsDefs) == 0 {
 			log.Ctx(ctx).Info().Msg("initializing datastore from bootstrap files")
+
+			if len(opts.BootstrapFiles) > 0 {
+				_, _, err = validationfile.PopulateFromFiles(ctx, ds, opts.BootstrapFiles)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load bootstrap files: %w", err)
+				}
+			}
+
 			if len(opts.BootstrapFileContents) > 0 {
 				_, _, err = validationfile.PopulateFromFilesContents(ctx, ds, opts.BootstrapFileContents)
-			} else {
-				_, _, err = validationfile.PopulateFromFiles(ctx, ds, opts.BootstrapFiles)
-			}
-			if err != nil {
-				return nil, fmt.Errorf("failed to load bootstrap files: %w", err)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load bootstrap file contents: %w", err)
+				}
 			}
 		} else {
 			return nil, errors.New("cannot apply bootstrap data: schema or tuples already exist in the datastore. Delete existing data or set the flag --datastore-bootstrap-overwrite=true")

--- a/pkg/cmd/datastore/datastore_test.go
+++ b/pkg/cmd/datastore/datastore_test.go
@@ -1,6 +1,8 @@
 package datastore
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -14,4 +16,62 @@ func TestDefaults(t *testing.T) {
 	require.NoError(t, err)
 	received := DefaultDatastoreConfig()
 	require.Equal(t, expected, *received)
+}
+
+func TestLoadDatastoreFromFileContents(t *testing.T) {
+	ctx := context.Background()
+	ds, err := NewDatastore(ctx,
+		SetBootstrapFileContents(map[string][]byte{"test": []byte("schema: definition user{}")}),
+		WithEngine(MemoryEngine))
+	require.NoError(t, err)
+
+	revision, err := ds.HeadRevision(ctx)
+	require.NoError(t, err)
+	namespaces, err := ds.SnapshotReader(revision).ListNamespaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, namespaces, 1)
+	require.Equal(t, "user", namespaces[0].Name)
+}
+
+func TestLoadDatastoreFromFile(t *testing.T) {
+	file, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	_, err = file.Write([]byte("schema: definition user{}"))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ds, err := NewDatastore(ctx,
+		SetBootstrapFiles([]string{file.Name()}),
+		WithEngine(MemoryEngine))
+	require.NoError(t, err)
+
+	revision, err := ds.HeadRevision(ctx)
+	require.NoError(t, err)
+	namespaces, err := ds.SnapshotReader(revision).ListNamespaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, namespaces, 1)
+	require.Equal(t, "user", namespaces[0].Name)
+}
+
+func TestLoadDatastoreFromFileAndContents(t *testing.T) {
+	file, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	_, err = file.Write([]byte("schema: definition repository{}"))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ds, err := NewDatastore(ctx,
+		SetBootstrapFiles([]string{file.Name()}),
+		SetBootstrapFileContents(map[string][]byte{"test": []byte("schema: definition user{}")}),
+		WithEngine(MemoryEngine))
+	require.NoError(t, err)
+
+	revision, err := ds.HeadRevision(ctx)
+	require.NoError(t, err)
+	namespaces, err := ds.SnapshotReader(revision).ListNamespaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, namespaces, 2)
+	namespaceNames := []string{namespaces[0].Name, namespaces[1].Name}
+	require.Contains(t, namespaceNames, "user")
+	require.Contains(t, namespaceNames, "repository")
 }

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -31,6 +31,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.EnableDatastoreMetrics = c.EnableDatastoreMetrics
 		to.DisableStats = c.DisableStats
 		to.BootstrapFiles = c.BootstrapFiles
+		to.BootstrapFileContents = c.BootstrapFileContents
 		to.BootstrapOverwrite = c.BootstrapOverwrite
 		to.BootstrapTimeout = c.BootstrapTimeout
 		to.RequestHedgingEnabled = c.RequestHedgingEnabled
@@ -162,6 +163,20 @@ func WithBootstrapFiles(bootstrapFiles string) ConfigOption {
 func SetBootstrapFiles(bootstrapFiles []string) ConfigOption {
 	return func(c *Config) {
 		c.BootstrapFiles = bootstrapFiles
+	}
+}
+
+// WithBootstrapFileContents returns an option that can append BootstrapFileContentss to Config.BootstrapFileContents
+func WithBootstrapFileContents(key string, value []byte) ConfigOption {
+	return func(c *Config) {
+		c.BootstrapFileContents[key] = value
+	}
+}
+
+// SetBootstrapFileContents returns an option that can set BootstrapFileContents on a Config
+func SetBootstrapFileContents(bootstrapFileContents map[string][]byte) ConfigOption {
+	return func(c *Config) {
+		c.BootstrapFileContents = bootstrapFileContents
 	}
 }
 


### PR DESCRIPTION
allows programatically spinning up a datastore from ValidationFile bytes, instead of a path to a file