### PR TITLE
Add release process for dev builds (nightlies)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,14 +1,9 @@
 ---
-name: "Release"
+name: "Devel (nightly) Release"
 on:  # yamllint disable-line rule:truthy
   push:
-    tags:
-      - "*"
-permissions:
-  contents: "write"
-  packages: "write"
-env:
-  GO_VERSION: "~1.19.4"
+    branches:
+      - "main"
 jobs:
   goreleaser:
     runs-on: "ubuntu-latest"
@@ -31,9 +26,7 @@ jobs:
         with:
           distribution: "goreleaser-pro"
           version: "latest"
-          args: "release --clean"
+          args: "release --clean --nightly"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          HOMEBREW_TAP_GITHUB_TOKEN: "${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}"
           GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"
-          GEMFURY_PUSH_TOKEN: "${{ secrets.GEMFURY_PUSH_TOKEN }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,6 @@ nfpms:
 furies:
   - account: "authzed"
     secret_name: "GEMFURY_PUSH_TOKEN"
-
 brews:
   - tap:
       owner: "authzed"
@@ -62,9 +61,9 @@ brews:
 dockers:
   # AMD64
   - image_templates:
-      - &amd_image_quay "quay.io/authzed/spicedb:v{{ .Version }}-amd64"
-      - &amd_image_gh "ghcr.io/authzed/spicedb:v{{ .Version }}-amd64"
-      - &amd_image_dh "authzed/spicedb:v{{ .Version }}-amd64"
+      - &amd_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64"
+      - &amd_image_gh "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64"
+      - &amd_image_dh "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64"
     dockerfile: &dockerfile "Dockerfile.release"
     goos: "linux"
     goarch: "amd64"
@@ -73,9 +72,9 @@ dockers:
       - "--platform=linux/amd64"
   # AMD64 (debug)
   - image_templates:
-      - &amd_debug_image_quay "quay.io/authzed/spicedb:v{{ .Version }}-amd64-debug"
-      - &amd_debug_image_gh "ghcr.io/authzed/spicedb:v{{ .Version }}-amd64-debug"
-      - &amd_debug_image_dh "authzed/spicedb:v{{ .Version }}-amd64-debug"
+      - &amd_debug_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64-debug"
+      - &amd_debug_image_gh "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64-debug"
+      - &amd_debug_image_dh "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64-debug"
     dockerfile: &dockerfile "Dockerfile.release"
     goos: "linux"
     goarch: "amd64"
@@ -85,9 +84,9 @@ dockers:
       - "--build-arg=BASE=distroless.dev/busybox"
   # ARM64
   - image_templates:
-      - &arm_image_quay "quay.io/authzed/spicedb:v{{ .Version }}-arm64"
-      - &arm_image_gh "ghcr.io/authzed/spicedb:v{{ .Version }}-arm64"
-      - &arm_image_dh "authzed/spicedb:v{{ .Version }}-arm64"
+      - &arm_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64"
+      - &arm_image_gh "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64"
+      - &arm_image_dh "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64"
     dockerfile: *dockerfile
     goos: "linux"
     goarch: "arm64"
@@ -96,9 +95,9 @@ dockers:
       - "--platform=linux/arm64"
   # ARM64 (debug)
   - image_templates:
-      - &arm_debug_image_quay "quay.io/authzed/spicedb:v{{ .Version }}-arm64-debug"
-      - &arm_debug_image_gh "ghcr.io/authzed/spicedb:v{{ .Version }}-arm64-debug"
-      - &arm_debug_image_dh "authzed/spicedb:v{{ .Version }}-arm64-debug"
+      - &arm_debug_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64-debug"
+      - &arm_debug_image_gh "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64-debug"
+      - &arm_debug_image_dh "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64-debug"
     dockerfile: *dockerfile
     goos: "linux"
     goarch: "arm64"
@@ -108,37 +107,37 @@ dockers:
       - "--build-arg=BASE=distroless.dev/busybox"
 docker_manifests:
   # Quay
-  - name_template: "quay.io/authzed/spicedb:v{{ .Version }}"
+  - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"
     image_templates: [*amd_image_quay, *arm_image_quay]
-  - name_template: "quay.io/authzed/spicedb:latest"
+  - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest"
     image_templates: [*amd_image_quay, *arm_image_quay]
   # GitHub Registry
-  - name_template: "ghcr.io/authzed/spicedb:v{{ .Version }}"
+  - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"
     image_templates: [*amd_image_gh, *arm_image_gh]
-  - name_template: "ghcr.io/authzed/spicedb:latest"
+  - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest"
     image_templates: [*amd_image_gh, *arm_image_gh]
   # Docker Hub
-  - name_template: "authzed/spicedb:v{{ .Version }}"
+  - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"
     image_templates: [*amd_image_dh, *arm_image_dh]
-  - name_template: "authzed/spicedb:latest"
+  - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest"
     image_templates: [*amd_image_dh, *arm_image_dh]
 
   # Debug Images:
 
   # Quay (debug)
-  - name_template: "quay.io/authzed/spicedb:v{{ .Version }}-debug"
+  - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
     image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
-  - name_template: "quay.io/authzed/spicedb:latest-debug"
+  - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
     image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
   # GitHub Registry
-  - name_template: "ghcr.io/authzed/spicedb:v{{ .Version }}-debug"
+  - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
     image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
-  - name_template: "ghcr.io/authzed/spicedb:latest-debug"
+  - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
     image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
   # Docker Hub
-  - name_template: "authzed/spicedb:v{{ .Version }}-debug"
+  - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
     image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
-  - name_template: "authzed/spicedb:latest-debug"
+  - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
     image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
 checksum:
   name_template: "checksums.txt"
@@ -147,6 +146,8 @@ snapshot:
 changelog:
   use: "github-native"
   sort: "asc"
+nightly:
+  name_template: "{{ incpatch .Version }}-{{ .ShortCommit }}"
 release:
   draft: true
   prerelease: "auto"


### PR DESCRIPTION
This will build spicedb images on every push to main. 

Images will be pushed to `authzed/spicedb-git` repos with tags like `v<currentVersion + 0.0.1>-<shortsha>`

For example, running against main would publish:

```
ghcr.io/authzed/spicedb-git:v1.16.2-a3424cda
ghcr.io/authzed/spicedb-git:v1.16.2-a3424cda-debug
ghcr.io/authzed/spicedb-git:latest
ghcr.io/authzed/spicedb-git:latest-debug
```
(and equivalents in quay and docker hub)
