### PR TITLE
pkg/cache: implement a central collector

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -36,20 +36,13 @@ type Config struct {
 	// DefaultTTL configures a default deadline on the lifetime of any keys set
 	// to the cache.
 	DefaultTTL time.Duration
-
-	// Metrics determines whether cache statistics are kept during the cache's
-	// lifetime. There *is* some overhead to keeping statistics, so you should
-	// only set this flag to true when testing or throughput performance isn't a
-	// major factor.
-	Metrics bool
 }
 
 func (c *Config) MarshalZerologObject(e *zerolog.Event) {
 	e.
 		Str("maxCost", humanize.IBytes(uint64(c.MaxCost))).
 		Int64("numCounters", c.NumCounters).
-		Dur("defaultTTL", c.DefaultTTL).
-		Bool("metrics", c.Metrics)
+		Dur("defaultTTL", c.DefaultTTL)
 }
 
 // Cache defines an interface for a generic cache.
@@ -88,9 +81,7 @@ type Metrics interface {
 }
 
 // NoopCache returns a cache that does nothing.
-func NoopCache() Cache {
-	return &noopCache{}
-}
+func NoopCache() Cache { return &noopCache{} }
 
 type noopCache struct{}
 

--- a/pkg/cache/cache_ristretto.go
+++ b/pkg/cache/cache_ristretto.go
@@ -13,25 +13,41 @@ import (
 	"github.com/authzed/spicedb/internal/dispatch/keys"
 )
 
-// NewCache creates a new ristretto cache from the given config.
-func NewCache(config *Config) (Cache, error) {
-	cache, err := ristretto.NewCache(&ristretto.Config{
+func ristrettoConfig(config *Config) *ristretto.Config {
+	return &ristretto.Config{
 		NumCounters: config.NumCounters,
 		MaxCost:     config.MaxCost,
 		BufferItems: 64, // Recommended constant by Ristretto authors.
-		Metrics:     config.Metrics,
-		KeyToHash: func(key interface{}) (uint64, uint64) {
+		KeyToHash: func(key any) (uint64, uint64) {
 			dispatchCacheKey, ok := key.(keys.DispatchCacheKey)
 			if !ok {
 				return z.KeyToHash(key)
 			}
 			return dispatchCacheKey.AsUInt64s()
 		},
-	})
+	}
+}
+
+// NewCacheWithMetrics creates a new ristretto cache from the given config
+// that also reports metrics to the default Prometheus registry.
+func NewCacheWithMetrics(name string, config *Config) (Cache, error) {
+	cfg := ristrettoConfig(config)
+	cfg.Metrics = true
+
+	rcache, err := ristretto.NewCache(cfg)
 	if err != nil {
 		return nil, err
 	}
-	return wrapped{config, config.DefaultTTL, cache}, nil
+
+	cache := wrapped{config, config.DefaultTTL, rcache}
+	mustRegisterCache(name, cache)
+	return cache, nil
+}
+
+// NewCache creates a new ristretto cache from the given config.
+func NewCache(config *Config) (Cache, error) {
+	rcache, err := ristretto.NewCache(ristrettoConfig(config))
+	return wrapped{config, config.DefaultTTL, rcache}, err
 }
 
 type wrapped struct {

--- a/pkg/cache/metrics.go
+++ b/pkg/cache/metrics.go
@@ -1,0 +1,79 @@
+package cache
+
+import (
+	"sync"
+
+	"github.com/jzelinskie/stringz"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	prometheus.MustRegister(defaultCollector)
+}
+
+const (
+	promNamespace = "spicedb"
+	promSubsystem = "cache"
+)
+
+var (
+	descCacheHitsTotal = prometheus.NewDesc(
+		stringz.Join("_", promNamespace, promSubsystem, "hits_total"),
+		"Number of cache hits",
+		[]string{"cache"},
+		nil,
+	)
+
+	descCacheMissesTotal = prometheus.NewDesc(
+		stringz.Join("_", promNamespace, promSubsystem, "misses_total"),
+		"Number of cache misses",
+		[]string{"cache"},
+		nil,
+	)
+
+	descCostAddedBytes = prometheus.NewDesc(
+		stringz.Join("_", promNamespace, promSubsystem, "cost_added_bytes"),
+		"Cost of entries added to the cache",
+		[]string{"cache"},
+		nil,
+	)
+
+	descCostEvictedBytes = prometheus.NewDesc(
+		stringz.Join("_", promNamespace, promSubsystem, "cost_evicted_bytes"),
+		"Cost of entries evicted from the cache",
+		[]string{"cache"},
+		nil,
+	)
+)
+
+var caches sync.Map
+
+func mustRegisterCache(name string, c Cache) {
+	if _, loaded := caches.LoadOrStore(name, c); loaded {
+		panic("two caches with the same name")
+	}
+}
+
+var (
+	defaultCollector collector
+
+	_ prometheus.Collector = (*collector)(nil)
+)
+
+type collector struct{}
+
+func (c collector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+func (c collector) Collect(ch chan<- prometheus.Metric) {
+	caches.Range(func(name, cache any) bool {
+		cacheName := name.(string)
+		metrics := cache.(Cache).GetMetrics()
+		ch <- prometheus.MustNewConstMetric(descCacheHitsTotal, prometheus.CounterValue, float64(metrics.Hits()), cacheName)
+		ch <- prometheus.MustNewConstMetric(descCacheMissesTotal, prometheus.CounterValue, float64(metrics.Misses()), cacheName)
+		ch <- prometheus.MustNewConstMetric(descCostAddedBytes, prometheus.CounterValue, float64(metrics.CostAdded()), cacheName)
+		ch <- prometheus.MustNewConstMetric(descCostEvictedBytes, prometheus.CounterValue, float64(metrics.CostEvicted()), cacheName)
+		return true
+	})
+}

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -17,22 +17,25 @@ const PresharedKeyFlag = "grpc-preshared-key"
 
 var (
 	namespaceCacheDefaults = &server.CacheConfig{
+		Name:        "namespace",
 		Enabled:     true,
-		Metrics:     false,
+		Metrics:     true,
 		NumCounters: 1_000,
 		MaxCost:     "16MiB",
 	}
 
 	dispatchCacheDefaults = &server.CacheConfig{
+		Name:        "dispatch",
 		Enabled:     true,
-		Metrics:     false,
+		Metrics:     true,
 		NumCounters: 10_000,
 		MaxCost:     "30%",
 	}
 
 	dispatchClusterCacheDefaults = &server.CacheConfig{
+		Name:        "cluster_dispatch",
 		Enabled:     true,
-		Metrics:     false,
+		Metrics:     true,
 		NumCounters: 100_000,
 		MaxCost:     "70%",
 	}


### PR DESCRIPTION
This commit adds a Prometheus collector that records metrics for all allocated caches.

This fixes a bug where we weren't getting metrics on anything other than the the dispatch because it was manually being recorded in the caching dispatcher.

This changes the default to collect metrics which is the common case as the overhead is typically worth the added observability.