### PR TITLE
Change release notes update mode

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -151,7 +151,7 @@ nightly:
 release:
   draft: true
   prerelease: "auto"
-  mode: replace
+  mode: "replace"
   footer: |
     ## Docker Images
     This release is available at `authzed/spicedb:v{{ .Version }}`, `quay.io/authzed/spicedb:v{{ .Version }}`, `ghcr.io/authzed/spicedb:v{{ .Version }}`

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -151,6 +151,7 @@ nightly:
 release:
   draft: true
   prerelease: "auto"
+  mode: replace
   footer: |
     ## Docker Images
     This release is available at `authzed/spicedb:v{{ .Version }}`, `quay.io/authzed/spicedb:v{{ .Version }}`, `ghcr.io/authzed/spicedb:v{{ .Version }}`


### PR DESCRIPTION
This *should* make it so that we can make releases directly in GH ui, and have goreleaser update it with the generated notes when it's done building.

From https://goreleaser.com/customization/release/: 

```yaml
  # What to do with the release notes in case there the release already exists.
  #
  # Valid options are:
  # - `keep-existing`: keep the existing notes
  # - `append`: append the current release notes to the existing notes
  # - `prepend`: prepend the current release notes to the existing notes
  # - `replace`: replace existing notes
  #
  # Default is `keep-existing`.
  mode: replace
```

Since we use the github-native release note generator, this should just replace the generated notes with the generate notes + our extra notes at the end.