### PR TITLE
makes dispatch metrics toggleable

### DIFF
--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -53,7 +53,7 @@ func DispatchTestCache(t testing.TB) cache.Cache {
 
 // NewCachingDispatcher creates a new dispatch.Dispatcher which delegates
 // dispatch requests and caches the responses when possible and desirable.
-func NewCachingDispatcher(cacheInst cache.Cache, prometheusSubsystem string, keyHandler keys.Handler) (*Dispatcher, error) {
+func NewCachingDispatcher(cacheInst cache.Cache, metricsEnabled bool, prometheusSubsystem string, keyHandler keys.Handler) (*Dispatcher, error) {
 	if cacheInst == nil {
 		cacheInst = cache.NoopCache()
 	}
@@ -102,7 +102,7 @@ func NewCachingDispatcher(cacheInst cache.Cache, prometheusSubsystem string, key
 		Name:      "lookup_subjects_from_cache_total",
 	})
 
-	if prometheusSubsystem != "" {
+	if metricsEnabled && prometheusSubsystem != "" {
 		err := prometheus.Register(checkTotalCounter)
 		if err != nil {
 			return nil, fmt.Errorf(errCachingInitialization, err)

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -116,7 +116,7 @@ func TestMaxDepthCaching(t *testing.T) {
 				}
 			}
 
-			dispatch, err := NewCachingDispatcher(DispatchTestCache(t), "", nil)
+			dispatch, err := NewCachingDispatcher(DispatchTestCache(t), false, "", nil)
 			dispatch.SetDelegate(delegate)
 			require.NoError(err)
 			defer dispatch.Close()

--- a/internal/dispatch/cluster/cluster.go
+++ b/internal/dispatch/cluster/cluster.go
@@ -14,10 +14,18 @@ import (
 type Option func(*optionState)
 
 type optionState struct {
+	metricsEnabled        bool
 	prometheusSubsystem   string
 	cache                 cache.Cache
 	concurrencyLimits     graph.ConcurrencyLimits
 	remoteDispatchTimeout time.Duration
+}
+
+// MetricsEnabled enables issuing prometheus metrics
+func MetricsEnabled(enabled bool) Option {
+	return func(state *optionState) {
+		state.metricsEnabled = enabled
+	}
 }
 
 // PrometheusSubsystem sets the subsystem name for the prometheus metrics
@@ -34,7 +42,7 @@ func Cache(c cache.Cache) Option {
 	}
 }
 
-// ConcurrencyLimit sets the max number of goroutines per operation
+// ConcurrencyLimits sets the max number of goroutines per operation
 func ConcurrencyLimits(limits graph.ConcurrencyLimits) Option {
 	return func(state *optionState) {
 		state.concurrencyLimits = limits
@@ -64,7 +72,7 @@ func NewClusterDispatcher(dispatch dispatch.Dispatcher, options ...Option) (disp
 		opts.prometheusSubsystem = "dispatch"
 	}
 
-	cachingClusterDispatch, err := caching.NewCachingDispatcher(opts.cache, opts.prometheusSubsystem, &keys.CanonicalKeyHandler{})
+	cachingClusterDispatch, err := caching.NewCachingDispatcher(opts.cache, opts.metricsEnabled, opts.prometheusSubsystem, &keys.CanonicalKeyHandler{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dispatch/combined/combined.go
+++ b/internal/dispatch/combined/combined.go
@@ -24,6 +24,7 @@ import (
 type Option func(*optionState)
 
 type optionState struct {
+	metricsEnabled        bool
 	prometheusSubsystem   string
 	upstreamAddr          string
 	upstreamCAPath        string
@@ -32,6 +33,13 @@ type optionState struct {
 	cache                 cache.Cache
 	concurrencyLimits     graph.ConcurrencyLimits
 	remoteDispatchTimeout time.Duration
+}
+
+// MetricsEnabled enables issuing prometheus metrics
+func MetricsEnabled(enabled bool) Option {
+	return func(state *optionState) {
+		state.metricsEnabled = enabled
+	}
 }
 
 // PrometheusSubsystem sets the subsystem name for the prometheus metrics
@@ -107,7 +115,7 @@ func NewDispatcher(options ...Option) (dispatch.Dispatcher, error) {
 		opts.prometheusSubsystem = "dispatch_client"
 	}
 
-	cachingRedispatch, err := caching.NewCachingDispatcher(opts.cache, opts.prometheusSubsystem, &keys.CanonicalKeyHandler{})
+	cachingRedispatch, err := caching.NewCachingDispatcher(opts.cache, opts.metricsEnabled, opts.prometheusSubsystem, &keys.CanonicalKeyHandler{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -411,7 +411,7 @@ func newLocalDispatcherWithConcurrencyLimit(t testing.TB, concurrencyLimit uint1
 
 	dispatch := NewLocalOnlyDispatcher(concurrencyLimit)
 
-	cachingDispatcher, err := caching.NewCachingDispatcher(caching.DispatchTestCache(t), "", &keys.CanonicalKeyHandler{})
+	cachingDispatcher, err := caching.NewCachingDispatcher(caching.DispatchTestCache(t), false, "", &keys.CanonicalKeyHandler{})
 	cachingDispatcher.SetDelegate(dispatch)
 	require.NoError(t, err)
 
@@ -433,7 +433,7 @@ func newLocalDispatcherWithSchemaAndRels(t testing.TB, schema string, rels []*co
 
 	dispatch := NewLocalOnlyDispatcher(10)
 
-	cachingDispatcher, err := caching.NewCachingDispatcher(caching.DispatchTestCache(t), "", &keys.CanonicalKeyHandler{})
+	cachingDispatcher, err := caching.NewCachingDispatcher(caching.DispatchTestCache(t), false, "", &keys.CanonicalKeyHandler{})
 	cachingDispatcher.SetDelegate(dispatch)
 	require.NoError(t, err)
 

--- a/internal/services/integrationtesting/consistencytestutil/clusteranddata.go
+++ b/internal/services/integrationtesting/consistencytestutil/clusteranddata.go
@@ -84,7 +84,7 @@ func CreateDispatcherForTesting(t *testing.T, withCaching bool) dispatch.Dispatc
 	require := require.New(t)
 	dispatcher := graph.NewLocalOnlyDispatcher(defaultConcurrencyLimit)
 	if withCaching {
-		cachingDispatcher, err := caching.NewCachingDispatcher(nil, "", &keys.CanonicalKeyHandler{})
+		cachingDispatcher, err := caching.NewCachingDispatcher(nil, false, "", &keys.CanonicalKeyHandler{})
 		require.NoError(err)
 
 		localDispatcher := graph.NewDispatcher(cachingDispatcher, graph.SharedConcurrencyLimits(10))

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -42,6 +42,10 @@ var (
 )
 
 func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
+	// sets default values, but does not expose it as CLI arguments
+	config.DispatchClusterMetricsEnabled = true
+	config.DispatchClientMetricsEnabled = true
+
 	// Flags for the gRPC API server
 	util.RegisterGRPCServerFlags(cmd.Flags(), &config.GRPCServer, "grpc", "gRPC", ":50051", true)
 	cmd.Flags().StringSliceVar(&config.PresharedKey, PresharedKeyFlag, []string{}, "preshared key(s) to require for authenticated requests")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -74,7 +74,9 @@ type Config struct {
 	DispatchUpstreamAddr           string
 	DispatchUpstreamCAPath         string
 	DispatchUpstreamTimeout        time.Duration
+	DispatchClientMetricsEnabled   bool
 	DispatchClientMetricsPrefix    string
+	DispatchClusterMetricsEnabled  bool
 	DispatchClusterMetricsPrefix   string
 	Dispatcher                     dispatch.Dispatcher
 
@@ -225,6 +227,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 				grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
 				grpc.WithDefaultServiceConfig(balancer.BalancerServiceConfig),
 			),
+			combineddispatch.MetricsEnabled(c.DispatchClientMetricsEnabled),
 			combineddispatch.PrometheusSubsystem(c.DispatchClientMetricsPrefix),
 			combineddispatch.Cache(cc),
 			combineddispatch.ConcurrencyLimits(concurrencyLimits),
@@ -254,6 +257,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 
 		cachingClusterDispatch, err = clusterdispatch.NewClusterDispatcher(
 			dispatcher,
+			clusterdispatch.MetricsEnabled(c.DispatchClusterMetricsEnabled),
 			clusterdispatch.PrometheusSubsystem(c.DispatchClusterMetricsPrefix),
 			clusterdispatch.Cache(cdcc),
 			clusterdispatch.RemoteDispatchTimeout(c.DispatchUpstreamTimeout),

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -47,7 +47,9 @@ func (c *Config) ToOption() ConfigOption {
 		to.DispatchUpstreamAddr = c.DispatchUpstreamAddr
 		to.DispatchUpstreamCAPath = c.DispatchUpstreamCAPath
 		to.DispatchUpstreamTimeout = c.DispatchUpstreamTimeout
+		to.DispatchClientMetricsEnabled = c.DispatchClientMetricsEnabled
 		to.DispatchClientMetricsPrefix = c.DispatchClientMetricsPrefix
+		to.DispatchClusterMetricsEnabled = c.DispatchClusterMetricsEnabled
 		to.DispatchClusterMetricsPrefix = c.DispatchClusterMetricsPrefix
 		to.Dispatcher = c.Dispatcher
 		to.DispatchCacheConfig = c.DispatchCacheConfig
@@ -238,10 +240,24 @@ func WithDispatchUpstreamTimeout(dispatchUpstreamTimeout time.Duration) ConfigOp
 	}
 }
 
+// WithDispatchClientMetricsEnabled returns an option that can set DispatchClientMetricsEnabled on a Config
+func WithDispatchClientMetricsEnabled(dispatchClientMetricsEnabled bool) ConfigOption {
+	return func(c *Config) {
+		c.DispatchClientMetricsEnabled = dispatchClientMetricsEnabled
+	}
+}
+
 // WithDispatchClientMetricsPrefix returns an option that can set DispatchClientMetricsPrefix on a Config
 func WithDispatchClientMetricsPrefix(dispatchClientMetricsPrefix string) ConfigOption {
 	return func(c *Config) {
 		c.DispatchClientMetricsPrefix = dispatchClientMetricsPrefix
+	}
+}
+
+// WithDispatchClusterMetricsEnabled returns an option that can set DispatchClusterMetricsEnabled on a Config
+func WithDispatchClusterMetricsEnabled(dispatchClusterMetricsEnabled bool) ConfigOption {
+	return func(c *Config) {
+		c.DispatchClusterMetricsEnabled = dispatchClusterMetricsEnabled
 	}
 }
 


### PR DESCRIPTION
dispatch metrics tends to cause cryptic errors
in tests when things are not tear down properly
and an instance of the dispatcher isn't Closed.
It also makes difficult running multiple spicedb
in the same process.

This makes those metrics:
- disabled by default when instantiated programmatically
- enabled by default in the serve command (as it currently stands before the change)