### PR TITLE
make cache collector unregister on close

### DIFF
--- a/pkg/cache/metrics.go
+++ b/pkg/cache/metrics.go
@@ -54,6 +54,10 @@ func mustRegisterCache(name string, c Cache) {
 	}
 }
 
+func unregisterCache(name string) {
+	caches.Delete(name)
+}
+
 var (
 	defaultCollector collector
 


### PR DESCRIPTION
in cases where we need to test instantiating servers using `RunnableServer`, we have no control to unregister cache metrics, so global state is left behind, potentially causing failures in other tests