### PR TITLE
Fix spanner telemetry 

### DIFF
--- a/internal/datastore/spanner/stats.go
+++ b/internal/datastore/spanner/stats.go
@@ -43,8 +43,7 @@ func (sd spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, err
 		return datastore.Stats{}, fmt.Errorf("unable to read namespaces: %w", err)
 	}
 
-	var estimate int64
-
+	var estimate spanner.NullInt64
 	countRows := sd.client.Single().Query(ctx, spanner.Statement{SQL: queryRelationshipEstimate})
 	countRow, err := countRows.Next()
 	if err != nil && spanner.ErrCode(err) != codes.NotFound {
@@ -58,7 +57,7 @@ func (sd spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, err
 	return datastore.Stats{
 		UniqueID:                   uniqueID,
 		ObjectTypeStatistics:       datastore.ComputeObjectTypeStats(allNamespaces),
-		EstimatedRelationshipCount: uint64(estimate),
+		EstimatedRelationshipCount: uint64(estimate.Int64),
 	}, nil
 }
 


### PR DESCRIPTION
Noticed an error in the spicedb-operator test logs against spanner:

```json
{"level":"warn","error":"unable to query DB stats: unable to decode row count: spanner: code = \"InvalidArgument\", desc = \"failed to decode column 0, destination *int64 cannot support NULL SQL values\"","time":"2023-01-09T20:21:37Z","message":"unable to initialize telemetry collector"}
```