### PR TITLE
makes default GC window 1h

### DIFF
--- a/internal/datastore/crdb/options.go
+++ b/internal/datastore/crdb/options.go
@@ -192,7 +192,7 @@ func MaxRevisionStalenessPercent(stalenessPercent float64) Option {
 // GCWindow is the maximum age of a passed revision that will be considered
 // valid.
 //
-// This value defaults to 24 hours.
+// This value defaults to 1 hour.
 func GCWindow(window time.Duration) Option {
 	return func(po *crdbOptions) {
 		po.gcWindow = window

--- a/internal/datastore/mysql/options.go
+++ b/internal/datastore/mysql/options.go
@@ -113,7 +113,7 @@ func MaxRevisionStalenessPercent(stalenessPercent float64) Option {
 // GCWindow is the maximum age of a passed revision that will be considered
 // valid.
 //
-// This value defaults to 24 hours.
+// This value defaults to 1 hour.
 func GCWindow(window time.Duration) Option {
 	return func(mo *mysqlOptions) {
 		mo.gcWindow = window

--- a/internal/datastore/postgres/options.go
+++ b/internal/datastore/postgres/options.go
@@ -189,7 +189,7 @@ func MaxRevisionStalenessPercent(stalenessPercent float64) Option {
 // GCWindow is the maximum age of a passed revision that will be considered
 // valid.
 //
-// This value defaults to 24 hours.
+// This value defaults to 1 hour.
 func GCWindow(window time.Duration) Option {
 	return func(po *postgresOptions) {
 		po.gcWindow = window

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -158,7 +158,7 @@ func RegisterDatastoreFlagsWithPrefix(flagSet *pflag.FlagSet, prefix string, opt
 func DefaultDatastoreConfig() *Config {
 	return &Config{
 		Engine:                         MemoryEngine,
-		GCWindow:                       24 * time.Hour,
+		GCWindow:                       1 * time.Hour,
 		LegacyFuzzing:                  -1,
 		RevisionQuantization:           5 * time.Second,
 		MaxLifetime:                    30 * time.Minute,


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb/issues/1158

see https://github.com/authzed/spicedb/issues/1158 see
https://github.com/cockroachdb/cockroach/issues/89233

Cockroach is changing their default to 4h in dedicated and 1.25h in Serverless.

This commit changes the lowest common denominator, sans some padding,
to avoid problems with folks running with CRDB and not being aware of those settings.