### PR TITLE
[PoC] add executed sql to trace event in mysql datastore

### DIFF
--- a/internal/datastore/common/sql.go
+++ b/internal/datastore/common/sql.go
@@ -2,8 +2,10 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"runtime"
+	"strings"
 
 	sq "github.com/Masterminds/squirrel"
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
@@ -376,6 +378,20 @@ func (tqs TupleQuerySplitter) SplitAndExecuteQuery(
 	iter := datastore.NewSliceRelationshipIterator(tuples)
 	runtime.SetFinalizer(iter, datastore.MustIteratorBeClosed)
 	return iter, nil
+}
+
+func InlineSqlArgs(sqlQuery string, args []interface{}) string {
+	for _, arg := range args {
+		var formattedArg string
+		switch arg.(type) {
+		case string:
+			formattedArg = fmt.Sprintf("'%v'", arg)
+		default:
+			formattedArg = fmt.Sprint(arg)
+		}
+		sqlQuery = strings.Replace(sqlQuery, "?", formattedArg, 1)
+	}
+	return sqlQuery
 }
 
 // ExecuteQueryFunc is a function that can be used to execute a single rendered SQL query.

--- a/internal/datastore/common/sql_test.go
+++ b/internal/datastore/common/sql_test.go
@@ -375,3 +375,8 @@ func TestSchemaQueryFilterer(t *testing.T) {
 		})
 	}
 }
+
+func TestInlineSqlArgs(t *testing.T) {
+	query := InlineSqlArgs("select * from foo where id = ?", []interface{}{"a"})
+	require.Equal(t, "select * from foo where id = 'a'", query)
+}

--- a/internal/datastore/mysql/caveat.go
+++ b/internal/datastore/mysql/caveat.go
@@ -40,7 +40,7 @@ func (mr *mysqlReader) ReadCaveatByName(ctx context.Context, name string) (*core
 	var serializedDef []byte
 	var rev decimal.Decimal
 	err = tx.QueryRowContext(ctx, sqlStatement, args...).Scan(&serializedDef, &rev)
-	span.AddEvent("sql: " + inlineSqlArgs(sqlStatement, args))
+	span.AddEvent("sql: " + common.InlineSqlArgs(sqlStatement, args))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, datastore.NoRevision, datastore.NewCaveatNameNotFoundErr(name)
@@ -87,7 +87,7 @@ func (mr *mysqlReader) lookupCaveats(ctx context.Context, caveatNames []string) 
 	defer common.LogOnError(ctx, txCleanup)
 
 	rows, err := tx.QueryContext(ctx, listSQL, listArgs...)
-	span.AddEvent("sql: " + inlineSqlArgs(listSQL, listArgs))
+	span.AddEvent("sql: " + common.InlineSqlArgs(listSQL, listArgs))
 	if err != nil {
 		return nil, fmt.Errorf(errListCaveats, err)
 	}

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -370,7 +370,6 @@ func newMySQLExecutor(tx querier) common.ExecuteQueryFunc {
 		}
 		defer common.LogOnError(ctx, rows.Close)
 
-		// TODO(will) sql logging hack
 		span.AddEvent("sql: " + inlineSqlArgs(sqlQuery, args))
 
 		var tuples []*core.RelationTuple

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"strings"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -370,7 +369,7 @@ func newMySQLExecutor(tx querier) common.ExecuteQueryFunc {
 		}
 		defer common.LogOnError(ctx, rows.Close)
 
-		span.AddEvent("sql: " + inlineSqlArgs(sqlQuery, args))
+		span.AddEvent("sql: " + common.InlineSqlArgs(sqlQuery, args))
 
 		var tuples []*core.RelationTuple
 		for rows.Next() {
@@ -408,20 +407,6 @@ func newMySQLExecutor(tx querier) common.ExecuteQueryFunc {
 		span.AddEvent("Tuples loaded", trace.WithAttributes(attribute.Int("tupleCount", len(tuples))))
 		return tuples, nil
 	}
-}
-
-func inlineSqlArgs(sqlQuery string, args []interface{}) string {
-	for _, arg := range args {
-		var formattedArg string
-		switch arg.(type) {
-		case string:
-			formattedArg = fmt.Sprintf("'%v'", arg)
-		default:
-			formattedArg = fmt.Sprint(arg)
-		}
-		sqlQuery = strings.Replace(sqlQuery, "?", formattedArg, 1)
-	}
-	return sqlQuery
 }
 
 // Datastore is a MySQL-based implementation of the datastore.Datastore interface

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
@@ -84,6 +85,11 @@ func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestF
 func TestMySQLDatastoreDSNWithoutParseTime(t *testing.T) {
 	_, err := NewMySQLDatastore("root:password@(localhost:1234)/mysql")
 	require.ErrorContains(t, err, "https://spicedb.dev/d/parse-time-mysql")
+}
+
+func TestInlineSqlArgs(t *testing.T) {
+	query := inlineSqlArgs("select * from foo where id = ?", []interface{}{"a"})
+	assert.Equal(t, "select * from foo where id = 'a'", query)
 }
 
 func TestMySQLDatastore(t *testing.T) {

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
@@ -85,11 +84,6 @@ func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestF
 func TestMySQLDatastoreDSNWithoutParseTime(t *testing.T) {
 	_, err := NewMySQLDatastore("root:password@(localhost:1234)/mysql")
 	require.ErrorContains(t, err, "https://spicedb.dev/d/parse-time-mysql")
-}
-
-func TestInlineSqlArgs(t *testing.T) {
-	query := inlineSqlArgs("select * from foo where id = ?", []interface{}{"a"})
-	assert.Equal(t, "select * from foo where id = 'a'", query)
 }
 
 func TestMySQLDatastore(t *testing.T) {

--- a/internal/datastore/mysql/gc.go
+++ b/internal/datastore/mysql/gc.go
@@ -28,7 +28,7 @@ func (mds *Datastore) Now(ctx context.Context) (time.Time, error) {
 
 	var now time.Time
 	err = mds.db.QueryRowContext(ctx, nowSQL, nowArgs...).Scan(&now)
-	span.AddEvent("sql: " + inlineSqlArgs(nowSQL, nowArgs))
+	span.AddEvent("sql: " + common.InlineSqlArgs(nowSQL, nowArgs))
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -51,7 +51,7 @@ func (mds *Datastore) TxIDBefore(ctx context.Context, before time.Time) (datasto
 
 	var value sql.NullInt64
 	err = mds.db.QueryRowContext(ctx, query, args...).Scan(&value)
-	span.AddEvent("sql: " + inlineSqlArgs(query, args))
+	span.AddEvent("sql: " + common.InlineSqlArgs(query, args))
 	if err != nil {
 		return datastore.NoRevision, err
 	}

--- a/internal/datastore/mysql/reader.go
+++ b/internal/datastore/mysql/reader.go
@@ -109,7 +109,7 @@ func (mr *mysqlReader) ReadNamespaceByName(ctx context.Context, nsName string) (
 
 func loadNamespace(ctx context.Context, namespace string, tx *sql.Tx, baseQuery sq.SelectBuilder) (*core.NamespaceDefinition, datastore.Revision, error) {
 	// TODO (@vroldanbet) dupe from postgres datastore - need to refactor
-	ctx, span := tracer.Start(ctx, "loadNamespace")
+	ctx, span := tracer.Start(ctx, fmt.Sprintf("loadNamespace %v", namespace))
 	defer span.End()
 
 	query, args, err := baseQuery.Where(sq.Eq{colNamespace: namespace}).ToSql()

--- a/internal/datastore/mysql/reader.go
+++ b/internal/datastore/mysql/reader.go
@@ -120,7 +120,7 @@ func loadNamespace(ctx context.Context, namespace string, tx *sql.Tx, baseQuery 
 	var config []byte
 	var version decimal.Decimal
 	err = tx.QueryRowContext(ctx, query, args...).Scan(&config, &version)
-	span.AddEvent("sql: " + inlineSqlArgs(query, args))
+	span.AddEvent("sql: " + common.InlineSqlArgs(query, args))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = datastore.NewNamespaceNotFoundErr(namespace)
@@ -193,7 +193,7 @@ func loadAllNamespaces(ctx context.Context, tx *sql.Tx, queryBuilder sq.SelectBu
 	var nsDefs []datastore.RevisionedNamespace
 
 	rows, err := tx.QueryContext(ctx, query, args...)
-	span.AddEvent("sql: " + inlineSqlArgs(query, args))
+	span.AddEvent("sql: " + common.InlineSqlArgs(query, args))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datastore/mysql/revisions.go
+++ b/internal/datastore/mysql/revisions.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/authzed/spicedb/internal/datastore/common"
 	"math/big"
 	"time"
 
@@ -121,7 +122,7 @@ func (mds *Datastore) loadRevision(ctx context.Context) (uint64, error) {
 
 	var revision *uint64
 	err = mds.db.QueryRowContext(ctx, query, args...).Scan(&revision)
-	span.AddEvent("sql: " + inlineSqlArgs(query, args))
+	span.AddEvent("sql: " + common.InlineSqlArgs(query, args))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil

--- a/internal/datastore/mysql/revisions.go
+++ b/internal/datastore/mysql/revisions.go
@@ -121,6 +121,7 @@ func (mds *Datastore) loadRevision(ctx context.Context) (uint64, error) {
 
 	var revision *uint64
 	err = mds.db.QueryRowContext(ctx, query, args...).Scan(&revision)
+	span.AddEvent("sql: " + inlineSqlArgs(query, args))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil

--- a/internal/datastore/postgres/common/pgx.go
+++ b/internal/datastore/postgres/common/pgx.go
@@ -43,7 +43,7 @@ func queryTuples(ctx context.Context, sqlStatement string, args []any, span trac
 	}
 	defer rows.Close()
 
-	span.AddEvent("Query issued to database")
+	span.AddEvent("sql: " + common.InlineSqlArgs(sqlStatement, args))
 
 	var tuples []*corev1.RelationTuple
 	for rows.Next() {


### PR DESCRIPTION
Not intended to merge: just a placeholder for hacking executed SQL into the mysql datastore to help understand what actually happens during check requests. Perhaps useful to others trying to understand what check does. Perhaps useful to enable this behaviour behind a flag.

Eg: 

<img width="1711" alt="image" src="https://user-images.githubusercontent.com/2050920/218441068-2d5eaaae-45b7-4025-b90d-4593ac715ad3.png">

Running with mysql and jaeger based on [this](https://github.com/authzed/examples/blob/main/datastores/mysql.yml) example:
```yaml
---
# This runs SpiceDB, using MySQL as the storage engine. SpiceDB will not have
# any schema written to it.
#
# Once the database service is running, the migrate service executes, running
# "spicedb migrate head" to migrate MySQL to the most current revision. After
# MySQL is migrated, the migrate service will stop.
#
# SpiceDB settings:
#   pre-shared key: foobar
#   dashboard address: http://localhost:8080
#   metrics address: http://localhost:9090
#   grpc address: http://localhost:50051
#
# MySQL settings:
#   user: root
#   password: secret
#   port: 3306

version: "3"

services:
  spicedb:
    # local build with tracing hack to include sql
    image: "7605cb00063266272110179212410142fce9736d428a6b2da3f9f5e15c0479c8"
    # image: "authzed/spicedb:v1.16.2"
    command: "serve --otel-sample-ratio=1.0"
    restart: "always"
    ports:
      - "8080:8080"
      - "9090:9090"
      - "50051:50051"
    environment:
      - "SPICEDB_GRPC_PRESHARED_KEY=insecure-shared-key"
      - "SPICEDB_DATASTORE_ENGINE=mysql"
      - "SPICEDB_DATASTORE_CONN_URI=root:secret@tcp(database:3306)/spicedb?parseTime=true"
      - "SPICEDB_EXPERIMENT_ENABLE_CAVEATS=true"
      - "SPICEDB_LOG_LEVEL=trace"
      - "OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317"
      - "OTEL_SAMPLE_RATIO=1.0"
      - "SPICEDB_OTEL_PROVIDER=otlpgrpc"
    depends_on:
      - "migrate"
      - "jaeger"

  migrate:
    image: "authzed/spicedb"
    command: "migrate head"
    restart: "on-failure"
    environment:
      - "SPICEDB_DATASTORE_ENGINE=mysql"
      - "SPICEDB_DATASTORE_CONN_URI=root:secret@tcp(database:3306)/spicedb?parseTime=true"
    depends_on:
      - "database"

  database:
    image: "mysql"
    # enable sql logging
    # https://stackoverflow.com/questions/32938120/how-to-log-queries-to-stdout-on-mysql
    command:
      - /usr/local/bin/mysqld.sh
    ports:
      - "3306:3306"
    environment:
      - "MYSQL_ROOT_PASSWORD=secret"
      - "MYSQL_DATABASE=spicedb"
    volumes:
      # enabling logging, can be commented out
      - ./my.cnf:/etc/mysql/conf.d/my.cnf:ro
      - ./mysqld.sh:/usr/local/bin/mysqld.sh:ro

  jaeger:
    image: "jaegertracing/all-in-one:1.41"
    environment:
      - "COLLECTOR_ZIPKIN_HOST_PORT=:9411"
      - "COLLECTOR_OTLP_ENABLED=true"
    ports:
      # see https://www.jaegertracing.io/docs/1.42/getting-started/#all-in-one
      - "6831:6831/udp"
      - "6832:6832/udp"
      - "5778:5778"
      - "16686:16686" # jaeger web interface http://localhost:16686/
      - "4317:4317"
      - "4318:4318"
      - "14250:14250"
      - "14268:14268"
      - "14269:14269"
      - "9411:9411"
```