### PR TITLE
improve CRDB GC error message

### DIFF
--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -112,14 +112,14 @@ func newCRDBDatastore(url string, options ...Option) (datastore.Datastore, error
 
 	clusterTTLNanos, err := readClusterTTLNanos(initCtx, pool)
 	if err != nil {
-		return nil, fmt.Errorf(errUnableToInstantiate, err)
+		return nil, fmt.Errorf("unable to read cluster gc window: %w", err)
 	}
 
 	gcWindowNanos := config.gcWindow.Nanoseconds()
 	if clusterTTLNanos < gcWindowNanos {
 		return nil, fmt.Errorf(
 			errUnableToInstantiate,
-			fmt.Errorf("cluster gc window is less than requested gc window %d < %d",
+			fmt.Errorf("configured cluster gc window is %d, less than configured SpiceDB gc window %d - see https://spicedb.dev/d/crdb-gc-window-warning",
 				clusterTTLNanos,
 				gcWindowNanos,
 			),


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb/issues/1158

unfortunately we cannot change the default CRDB GC value as that would be a breaking change for deployments relying heavily on `at_exact_snapshot` request consistency and `Watch` API.

- For users of Cockroach dedicated, the value won't change automatically. Newly created clusters will have a GC of 4 hours, but users can change it 
- For users of Cockroach serverless the value will be automatically updated by the control plane to 1h15m - see [release notes](https://www.cockroachlabs.com/docs/releases/cloud.html#general-changes) 