### PR TITLE
Skip loading of head revision on write calls

### DIFF
--- a/internal/middleware/consistency/consistency_test.go
+++ b/internal/middleware/consistency/consistency_test.go
@@ -3,19 +3,13 @@ package consistency
 import (
 	"context"
 	"errors"
-	"io"
 	"testing"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/shopspring/decimal"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-	"google.golang.org/grpc"
 
 	"github.com/authzed/spicedb/internal/datastore/proxy/proxy_test"
-	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/revision"
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
@@ -36,7 +30,11 @@ func TestAddRevisionToContextNoneSupplied(t *testing.T) {
 	updated := ContextWithHandle(context.Background())
 	err := AddRevisionToContext(updated, &v1.ReadRelationshipsRequest{}, ds)
 	require.NoError(err)
-	require.True(optimized.Equal(RevisionFromContext(updated)))
+
+	rev, _, err := RevisionFromContext(updated)
+	require.NoError(err)
+
+	require.True(optimized.Equal(rev))
 	ds.AssertExpectations(t)
 }
 
@@ -55,7 +53,11 @@ func TestAddRevisionToContextMinimizeLatency(t *testing.T) {
 		},
 	}, ds)
 	require.NoError(err)
-	require.True(optimized.Equal(RevisionFromContext(updated)))
+
+	rev, _, err := RevisionFromContext(updated)
+	require.NoError(err)
+
+	require.True(optimized.Equal(rev))
 	ds.AssertExpectations(t)
 }
 
@@ -74,7 +76,11 @@ func TestAddRevisionToContextFullyConsistent(t *testing.T) {
 		},
 	}, ds)
 	require.NoError(err)
-	require.True(head.Equal(RevisionFromContext(updated)))
+
+	rev, _, err := RevisionFromContext(updated)
+	require.NoError(err)
+
+	require.True(head.Equal(rev))
 	ds.AssertExpectations(t)
 }
 
@@ -94,7 +100,11 @@ func TestAddRevisionToContextAtLeastAsFresh(t *testing.T) {
 		},
 	}, ds)
 	require.NoError(err)
-	require.True(exact.Equal(RevisionFromContext(updated)))
+
+	rev, _, err := RevisionFromContext(updated)
+	require.NoError(err)
+
+	require.True(exact.Equal(rev))
 	ds.AssertExpectations(t)
 }
 
@@ -114,7 +124,11 @@ func TestAddRevisionToContextAtValidExactSnapshot(t *testing.T) {
 		},
 	}, ds)
 	require.NoError(err)
-	require.True(exact.Equal(RevisionFromContext(updated)))
+
+	rev, _, err := RevisionFromContext(updated)
+	require.NoError(err)
+
+	require.True(exact.Equal(rev))
 	ds.AssertExpectations(t)
 }
 
@@ -137,65 +151,11 @@ func TestAddRevisionToContextAtInvalidExactSnapshot(t *testing.T) {
 	ds.AssertExpectations(t)
 }
 
-func TestAddRevisionToContextAPIAlwaysFullyConsistent(t *testing.T) {
+func TestAddRevisionToContextNoConsistencyAPI(t *testing.T) {
 	require := require.New(t)
 
-	ds := &proxy_test.MockDatastore{}
-	ds.On("HeadRevision").Return(head, nil).Once()
-
 	updated := ContextWithHandle(context.Background())
-	err := AddRevisionToContext(updated, &v1.WriteSchemaRequest{}, ds)
-	require.NoError(err)
-	require.True(head.Equal(RevisionFromContext(updated)))
-	ds.AssertExpectations(t)
-}
 
-func TestMiddlewareConsistencyTestSuite(t *testing.T) {
-	ds := &proxy_test.MockDatastore{}
-	ds.On("HeadRevision").Return(head, nil)
-
-	s := &ConsistencyTestSuite{
-		InterceptorTestSuite: &testpb.InterceptorTestSuite{
-			ServerOpts: []grpc.ServerOption{
-				grpc.ChainStreamInterceptor(
-					datastoremw.StreamServerInterceptor(ds),
-					StreamServerInterceptor(),
-				),
-				grpc.ChainUnaryInterceptor(
-					datastoremw.UnaryServerInterceptor(ds),
-					UnaryServerInterceptor(),
-				),
-			},
-		},
-	}
-	suite.Run(t, s)
-	ds.AssertExpectations(t)
-}
-
-var (
-	goodPing = &testpb.PingRequest{Value: "something"}
-	goodList = &testpb.PingListRequest{Value: "something"}
-)
-
-type ConsistencyTestSuite struct {
-	*testpb.InterceptorTestSuite
-}
-
-func (s *ConsistencyTestSuite) TestValidPasses_Unary() {
-	require := require.New(s.T())
-	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
-	require.NoError(err)
-}
-
-func (s *ConsistencyTestSuite) TestValidPasses_ServerStream() {
-	require := require.New(s.T())
-	stream, err := s.Client.PingList(s.SimpleCtx(), goodList)
-	require.NoError(err)
-	for {
-		_, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		assert.NoError(s.T(), err, "no error on messages sent occurred")
-	}
+	_, _, err := RevisionFromContext(updated)
+	require.Error(err)
 }

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -111,7 +111,11 @@ func (ps *permissionServer) checkFilterNamespaces(ctx context.Context, filter *v
 
 func (ps *permissionServer) ReadRelationships(req *v1.ReadRelationshipsRequest, resp v1.PermissionsService_ReadRelationshipsServer) error {
 	ctx := resp.Context()
-	atRevision, revisionReadAt := consistency.MustRevisionFromContext(ctx)
+	atRevision, revisionReadAt, err := consistency.RevisionFromContext(ctx)
+	if err != nil {
+		return rewriteError(ctx, err)
+	}
+
 	ds := datastoremw.MustFromContext(ctx).SnapshotReader(atRevision)
 
 	if err := ps.checkFilterNamespaces(ctx, req.RelationshipFilter, ds); err != nil {

--- a/pkg/middleware/consistency/consistency.go
+++ b/pkg/middleware/consistency/consistency.go
@@ -7,22 +7,10 @@ import (
 
 	"github.com/authzed/spicedb/internal/middleware/consistency"
 	"github.com/authzed/spicedb/pkg/datastore"
-	"github.com/authzed/spicedb/pkg/zedtoken"
 )
 
-// RevisionFromContext reads the selected revision out of a context.Context and returns nil if it
-// does not exist.
-func RevisionFromContext(ctx context.Context) datastore.Revision {
+// RevisionFromContext reads the selected revision out of a context.Context, computes a zedtoken
+// from it, and returns an internal error if it has not been set on the context.
+func RevisionFromContext(ctx context.Context) (datastore.Revision, *v1.ZedToken, error) {
 	return consistency.RevisionFromContext(ctx)
-}
-
-// MustRevisionFromContext reads the selected revision out of a context.Context, computes a zedtoken
-// from it, and panics if it has not been set on the context.
-func MustRevisionFromContext(ctx context.Context) (datastore.Revision, *v1.ZedToken) {
-	rev := consistency.RevisionFromContext(ctx)
-	if rev == nil {
-		panic("consistency middleware did not inject revision")
-	}
-
-	return rev, zedtoken.MustNewFromRevision(rev)
 }


### PR DESCRIPTION
These APIs do not use consistency blocks, so there is no need to load the head revision outside of their transactions