### PR TITLE
mysql: prevents misleading log messages by avoiding Rollback if committed

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"errors"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/rs/zerolog"
@@ -28,9 +26,6 @@ const (
 var errParsing = errors.New("parsing error")
 
 func main() {
-	// Set up a seed for randomness
-	rand.Seed(time.Now().UnixNano())
-
 	// Enable Kubernetes gRPC resolver
 	kuberesolver.RegisterInCluster()
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/authzed/spicedb
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/spanner v1.42.0

--- a/internal/datastore/crdb/stats.go
+++ b/internal/datastore/crdb/stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"time"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/shopspring/decimal"
@@ -29,6 +30,8 @@ var (
 		colID,
 		colCount,
 	).Suffix(fmt.Sprintf("ON CONFLICT (%[1]s) DO UPDATE SET %[2]s = %[3]s.%[2]s + EXCLUDED.%[2]s RETURNING cluster_logical_timestamp()", colID, colCount, tableCounters))
+
+	rng = rand.NewSource(time.Now().UnixNano())
 )
 
 func (cds *crdbDatastore) Statistics(ctx context.Context) (datastore.Stats, error) {
@@ -68,7 +71,7 @@ func (cds *crdbDatastore) Statistics(ctx context.Context) (datastore.Stats, erro
 
 func updateCounter(ctx context.Context, tx pgx.Tx, change int64) (revision.Decimal, error) {
 	counterID := make([]byte, 2)
-	_, err := rand.Read(counterID)
+	_, err := rand.New(rng).Read(counterID)
 	if err != nil {
 		return revision.NoRevision, fmt.Errorf("unable to select random counter: %w", err)
 	}

--- a/internal/datastore/mysql/migrations/driver.go
+++ b/internal/datastore/mysql/migrations/driver.go
@@ -74,7 +74,7 @@ func columnNameToRevision(columnName string) (string, bool) {
 func (driver *MySQLDriver) Version(ctx context.Context) (string, error) {
 	query, args, err := sb.Select("*").From(driver.migrationVersion()).ToSql()
 	if err != nil {
-		return "", fmt.Errorf("unable to load driver migration revision: %w", err)
+		return "", fmt.Errorf("unable to generate query for revision: %w", err)
 	}
 
 	rows, err := driver.db.QueryContext(ctx, query, args...)
@@ -83,15 +83,15 @@ func (driver *MySQLDriver) Version(ctx context.Context) (string, error) {
 		if errors.As(err, &mysqlError) && mysqlError.Number == mysqlMissingTableErrorNumber {
 			return "", nil
 		}
-		return "", fmt.Errorf("unable to load driver migration revision: %w", err)
+		return "", fmt.Errorf("unable to query revision: %w", err)
 	}
 	defer common.LogOnError(ctx, rows.Close)
 	if rows.Err() != nil {
-		return "", fmt.Errorf("unable to load driver migration revision: %w", rows.Err())
+		return "", fmt.Errorf("unable to load revision row: %w", rows.Err())
 	}
 	cols, err := rows.Columns()
 	if err != nil {
-		return "", fmt.Errorf("failed to get columns: %w", err)
+		return "", fmt.Errorf("failed to get columns from revision row: %w", err)
 	}
 
 	for _, col := range cols {
@@ -125,17 +125,12 @@ func BeginTxFunc(ctx context.Context, db *sql.DB, txOptions *sql.TxOptions, f fu
 	if err != nil {
 		return err
 	}
-	defer common.LogOnError(ctx, tx.Rollback)
 
 	if err := f(tx); err != nil {
-		return err
+		return errors.Join(err, tx.Rollback())
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	return nil
+	return tx.Commit()
 }
 
 // WriteVersion overwrites the _meta_version_ column name which encodes the version

--- a/internal/datastore/spanner/stats.go
+++ b/internal/datastore/spanner/stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"time"
 
 	"cloud.google.com/go/spanner"
 	"google.golang.org/grpc/codes"
@@ -12,7 +13,11 @@ import (
 	"github.com/authzed/spicedb/pkg/datastore"
 )
 
-var queryRelationshipEstimate = fmt.Sprintf("SELECT SUM(%s) FROM %s", colCount, tableCounters)
+var (
+	queryRelationshipEstimate = fmt.Sprintf("SELECT SUM(%s) FROM %s", colCount, tableCounters)
+
+	rng = rand.NewSource(time.Now().UnixNano())
+)
 
 func (sd spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, error) {
 	var uniqueID string
@@ -57,7 +62,7 @@ func updateCounter(ctx context.Context, rwt *spanner.ReadWriteTransaction, chang
 	newValue := change
 
 	counterID := make([]byte, 2)
-	_, err := rand.Read(counterID)
+	_, err := rand.New(rng).Read(counterID)
 	if err != nil {
 		return fmt.Errorf("unable to select random counter: %w", err)
 	}

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -102,7 +102,7 @@ func (m *Manager[D, C, T]) Run(ctx context.Context, driver D, throughRevision st
 	requestedRevision := throughRevision
 	starting, err := driver.Version(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to compute target revision: %w", err)
+		return fmt.Errorf("unable to get current revision: %w", err)
 	}
 
 	if strings.ToLower(throughRevision) == Head {


### PR DESCRIPTION
Fixes https://github.com/authzed/spicedb/issues/1131

users reported confusing errors during migrations (and also initial seeding) because MySQL driver's Rollback method is not idempotent and returns an error if the Tx was already committed.