### PR TITLE
makes the request caveat context size configurable

### DIFF
--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -1370,3 +1370,19 @@ func randString(length int) string {
 	}
 	return string(b)
 }
+
+func TestGetCaveatContext(t *testing.T) {
+	strct, err := structpb.NewStruct(map[string]any{"foo": "bar"})
+	require.NoError(t, err)
+
+	_, err = v1svc.GetCaveatContext(context.Background(), strct, 1)
+	require.ErrorContains(t, err, "request caveat context should have less than 1 bytes")
+
+	caveatMap, err := v1svc.GetCaveatContext(context.Background(), strct, 0)
+	require.NoError(t, err)
+	require.Contains(t, caveatMap, "foo")
+
+	caveatMap, err = v1svc.GetCaveatContext(context.Background(), strct, -1)
+	require.NoError(t, err)
+	require.Contains(t, caveatMap, "foo")
+}

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -44,6 +44,9 @@ type PermissionsServerConfig struct {
 	// StreamingAPITimeout is the timeout for streaming APIs when no response has been
 	// recently received.
 	StreamingAPITimeout time.Duration
+
+	// MaxCaveatContextSize defines the maximum length of the request caveat context in bytes
+	MaxCaveatContextSize int
 }
 
 // NewPermissionsServer creates a PermissionsServiceServer instance.
@@ -56,6 +59,7 @@ func NewPermissionsServer(
 		MaxUpdatesPerWrite:    defaultIfZero(config.MaxUpdatesPerWrite, 1000),
 		MaximumAPIDepth:       defaultIfZero(config.MaximumAPIDepth, 50),
 		StreamingAPITimeout:   defaultIfZero(config.StreamingAPITimeout, 30*time.Second),
+		MaxCaveatContextSize:  config.MaxCaveatContextSize,
 	}
 
 	return &permissionServer{

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -58,6 +58,7 @@ func NewTestServerWithConfig(require *require.Assertions,
 		server.WithDispatchMaxDepth(50),
 		server.WithMaximumPreconditionCount(config.MaxPreconditionsCount),
 		server.WithMaximumUpdatesPerWrite(config.MaxUpdatesPerWrite),
+		server.WithMaxCaveatContextSize(4096),
 		server.WithGRPCServer(util.GRPCServerConfig{
 			Network: util.BufferedNetwork,
 			Enabled: true,

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -111,6 +111,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	cmd.Flags().BoolVar(&config.DisableVersionResponse, "disable-version-response", false, "disables version response support in the API")
 	cmd.Flags().Uint16Var(&config.MaximumUpdatesPerWrite, "write-relationships-max-updates-per-call", 1000, "maximum number of updates allowed for WriteRelationships calls")
 	cmd.Flags().Uint16Var(&config.MaximumPreconditionCount, "update-relationships-max-preconditions-per-call", 1000, "maximum number of preconditions allowed for WriteRelationships and DeleteRelationships calls")
+	cmd.Flags().IntVar(&config.MaxCaveatContextSize, "max-caveat-context-size", 4096, "maximum allowed size of request caveat context in bytes. A value of zero or less means no limit")
 
 	cmd.Flags().BoolVar(&config.V1SchemaAdditiveOnly, "testing-only-schema-additive-writes", false, "append new definitions to the existing schema, rather than overwriting it")
 	if err := cmd.Flags().MarkHidden("testing-only-schema-additive-writes"); err != nil {

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -88,6 +88,7 @@ type Config struct {
 	V1SchemaAdditiveOnly     bool
 	MaximumUpdatesPerWrite   uint16
 	MaximumPreconditionCount uint16
+	MaxCaveatContextSize     int
 
 	// Additional Services
 	DashboardAPI util.HTTPServerConfig
@@ -311,6 +312,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		MaxPreconditionsCount: c.MaximumPreconditionCount,
 		MaxUpdatesPerWrite:    c.MaximumUpdatesPerWrite,
 		MaximumAPIDepth:       c.DispatchMaxDepth,
+		MaxCaveatContextSize:  c.MaxCaveatContextSize,
 	}
 
 	healthManager := health.NewHealthManager(dispatcher, ds)

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -58,6 +58,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.V1SchemaAdditiveOnly = c.V1SchemaAdditiveOnly
 		to.MaximumUpdatesPerWrite = c.MaximumUpdatesPerWrite
 		to.MaximumPreconditionCount = c.MaximumPreconditionCount
+		to.MaxCaveatContextSize = c.MaxCaveatContextSize
 		to.DashboardAPI = c.DashboardAPI
 		to.MetricsAPI = c.MetricsAPI
 		to.MiddlewareModification = c.MiddlewareModification
@@ -313,6 +314,13 @@ func WithMaximumUpdatesPerWrite(maximumUpdatesPerWrite uint16) ConfigOption {
 func WithMaximumPreconditionCount(maximumPreconditionCount uint16) ConfigOption {
 	return func(c *Config) {
 		c.MaximumPreconditionCount = maximumPreconditionCount
+	}
+}
+
+// WithMaxCaveatContextSize returns an option that can set MaxCaveatContextSize on a Config
+func WithMaxCaveatContextSize(maxCaveatContextSize int) ConfigOption {
+	return func(c *Config) {
+		c.MaxCaveatContextSize = maxCaveatContextSize
 	}
 }
 

--- a/pkg/cmd/testing.go
+++ b/pkg/cmd/testing.go
@@ -22,6 +22,7 @@ func RegisterTestingFlags(cmd *cobra.Command, config *testserver.Config) {
 	// Flags for API behavior
 	cmd.Flags().Uint16Var(&config.MaximumUpdatesPerWrite, "write-relationships-max-updates-per-call", 1000, "maximum number of updates allowed for WriteRelationships calls")
 	cmd.Flags().Uint16Var(&config.MaximumPreconditionCount, "update-relationships-max-preconditions-per-call", 1000, "maximum number of preconditions allowed for WriteRelationships and DeleteRelationships calls")
+	cmd.Flags().IntVar(&config.MaxCaveatContextSize, "max-caveat-context-size", 4096, "maximum allowed size of request caveat context in bytes. A value of zero or less means no limit")
 }
 
 func NewTestingCommand(programName string, config *testserver.Config) *cobra.Command {

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -33,6 +33,7 @@ type Config struct {
 	LoadConfigs              []string
 	MaximumUpdatesPerWrite   uint16
 	MaximumPreconditionCount uint16
+	MaxCaveatContextSize     int
 }
 
 type RunnableTestServer interface {
@@ -65,6 +66,7 @@ func (c *Config) Complete() (RunnableTestServer, error) {
 				MaxPreconditionsCount: c.MaximumPreconditionCount,
 				MaxUpdatesPerWrite:    c.MaximumUpdatesPerWrite,
 				MaximumAPIDepth:       maxDepth,
+				MaxCaveatContextSize:  c.MaxCaveatContextSize,
 			},
 		)
 	}

--- a/pkg/cmd/testserver/zz_generated.options.go
+++ b/pkg/cmd/testserver/zz_generated.options.go
@@ -24,6 +24,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.LoadConfigs = c.LoadConfigs
 		to.MaximumUpdatesPerWrite = c.MaximumUpdatesPerWrite
 		to.MaximumPreconditionCount = c.MaximumPreconditionCount
+		to.MaxCaveatContextSize = c.MaxCaveatContextSize
 	}
 }
 
@@ -88,5 +89,12 @@ func WithMaximumUpdatesPerWrite(maximumUpdatesPerWrite uint16) ConfigOption {
 func WithMaximumPreconditionCount(maximumPreconditionCount uint16) ConfigOption {
 	return func(c *Config) {
 		c.MaximumPreconditionCount = maximumPreconditionCount
+	}
+}
+
+// WithMaxCaveatContextSize returns an option that can set MaxCaveatContextSize on a Config
+func WithMaxCaveatContextSize(maxCaveatContextSize int) ConfigOption {
+	return func(c *Config) {
+		c.MaxCaveatContextSize = maxCaveatContextSize
 	}
 }

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -134,6 +134,7 @@ func (dc *DevContext) RunV1InMemoryService() (*grpc.ClientConn, func(), error) {
 		MaxUpdatesPerWrite:    50,
 		MaxPreconditionsCount: 50,
 		MaximumAPIDepth:       50,
+		MaxCaveatContextSize:  0,
 	})
 	ss := v1svc.NewSchemaServer(false)
 


### PR DESCRIPTION
makes it possible to configure the caveat context
size enforcement. This is useful when some
schemas may end up hitting this limit easily, but
we still need to have a limit in place to prevent abuse.