### PR TITLE
propagate option to disable stats in spanner datastore

### DIFF
--- a/internal/datastore/spanner/options.go
+++ b/internal/datastore/spanner/options.go
@@ -15,6 +15,7 @@ type spannerOptions struct {
 	gcEnabled                   bool
 	credentialsFilePath         string
 	emulatorHost                string
+	disableStats                bool
 }
 
 const (
@@ -27,6 +28,7 @@ const (
 	defaultGCWindow                    = 60 * time.Minute
 	defaultGCInterval                  = 3 * time.Minute
 	defaultGCEnabled                   = true
+	defaultDisableStats                = false
 )
 
 // Option provides the facility to configure how clients within the Spanner
@@ -42,6 +44,7 @@ func generateConfig(options []Option) (spannerOptions, error) {
 		revisionQuantization:        defaultRevisionQuantization,
 		followerReadDelay:           defaultFollowerReadDelay,
 		maxRevisionStalenessPercent: defaultMaxRevisionStalenessPercent,
+		disableStats:                defaultDisableStats,
 	}
 
 	for _, option := range options {
@@ -141,5 +144,12 @@ func EmulatorHost(uri string) Option {
 func GCEnabled(isGCEnabled bool) Option {
 	return func(so *spannerOptions) {
 		so.gcEnabled = isGCEnabled
+	}
+}
+
+// DisableStats disables recording counts to the stats table
+func DisableStats(disable bool) Option {
+	return func(po *spannerOptions) {
+		po.disableStats = disable
 	}
 }

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -148,7 +148,11 @@ func (sd spannerDatastore) ReadWriteTx(
 			Executor:         queryExecutor(txSource),
 			UsersetBatchSize: usersetBatchsize,
 		}
-		rwt := spannerReadWriteTXN{spannerReader{querySplitter, txSource}, spannerRWT}
+		rwt := spannerReadWriteTXN{
+			spannerReader{querySplitter, txSource},
+			spannerRWT,
+			sd.config.disableStats,
+		}
 		return fn(rwt)
 	})
 	if err != nil {

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -382,6 +382,7 @@ func newSpannerDatastore(opts Config) (datastore.Datastore, error) {
 		spanner.CredentialsFile(opts.SpannerCredentialsFile),
 		spanner.WatchBufferLength(opts.WatchBufferLength),
 		spanner.EmulatorHost(opts.SpannerEmulatorHost),
+		spanner.DisableStats(opts.DisableStats),
 	)
 }
 


### PR DESCRIPTION
Spanner's datastore implementation does not honor the `datastoreDisableStats` flag. This PR introduces and propagates the CLI option to the datastore initialization.