### PR TITLE
skips namespace cache proxy if cache disabled

### DIFF
--- a/internal/datastore/proxy/caching.go
+++ b/internal/datastore/proxy/caching.go
@@ -43,9 +43,9 @@ func DatastoreProxyTestCache(t testing.TB) cache.Cache {
 	return cache
 }
 
-// NewCachingDatastoreProxy creates a new datastore proxy which caches definitions that
+// NewNamespaceCachingDatastoreProxy creates a new datastore proxy which caches namespace definitions that
 // are loaded at specific datastore revisions.
-func NewCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache) datastore.Datastore {
+func NewNamespaceCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache) datastore.Datastore {
 	if c == nil {
 		c = cache.NoopCache()
 	}

--- a/internal/datastore/proxy/caching_test.go
+++ b/internal/datastore/proxy/caching_test.go
@@ -158,7 +158,7 @@ func TestSnapshotCaching(t *testing.T) {
 			twoReader.On(tester.readSingleFunctionName, nsB).Return(nil, one, nil).Once()
 
 			require := require.New(t)
-			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
+			ds := NewNamespaceCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
 
 			_, updatedOneA, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsA)
 			require.NoError(err)
@@ -212,7 +212,7 @@ func TestRWTCaching(t *testing.T) {
 
 			ctx := context.Background()
 
-			ds := NewCachingDatastoreProxy(dsMock, nil)
+			ds := NewNamespaceCachingDatastoreProxy(dsMock, nil)
 
 			rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 				_, updatedA, err := tester.readSingleFunc(ctx, rwt, nsA)
@@ -248,7 +248,7 @@ func TestRWTCacheWithWrites(t *testing.T) {
 
 			ctx := context.Background()
 
-			ds := NewCachingDatastoreProxy(dsMock, nil)
+			ds := NewNamespaceCachingDatastoreProxy(dsMock, nil)
 
 			rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 				// Cache the 404
@@ -298,7 +298,7 @@ func TestSingleFlight(t *testing.T) {
 
 			require := require.New(t)
 
-			ds := NewCachingDatastoreProxy(dsMock, nil)
+			ds := NewNamespaceCachingDatastoreProxy(dsMock, nil)
 
 			readNamespace := func() error {
 				_, updatedAt, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsA)
@@ -363,7 +363,7 @@ func TestSnapshotCachingRealDatastore(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			ds := NewCachingDatastoreProxy(rawDS, nil)
+			ds := NewNamespaceCachingDatastoreProxy(rawDS, nil)
 
 			if tc.nsDef != nil {
 				_, err = ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
@@ -427,7 +427,7 @@ func TestSingleFlightCancelled(t *testing.T) {
 
 			dsMock.On("SnapshotReader", one).Return(&reader{MockReader: proxy_test.MockReader{}})
 
-			ds := NewCachingDatastoreProxy(dsMock, nil)
+			ds := NewNamespaceCachingDatastoreProxy(dsMock, nil)
 
 			g := sync.WaitGroup{}
 			var d2 datastore.SchemaDefinition
@@ -467,7 +467,7 @@ func TestMixedCaching(t *testing.T) {
 			dsMock.On("SnapshotReader", one).Return(reader)
 
 			require := require.New(t)
-			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
+			ds := NewNamespaceCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
 
 			dsReader := ds.SnapshotReader(one)
 


### PR DESCRIPTION
in situations where we are using the memory datastore and caching is disabled, adding the proxy does not help at all, and just adds an unnecessary singleflight in front.

This change skips wrapping the datastore with the proxy if the cache is disabled.