### PR TITLE
fixes behaviour of various datastores when HeadRevision is outside GC window

### DIFF
--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestCRDBDatastore(t *testing.T) {
 	b := testdatastore.RunCRDBForTesting(t, "")
-	test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 			ds, err := NewCRDBDatastore(
 				uri,

--- a/internal/datastore/memdb/memdb_test.go
+++ b/internal/datastore/memdb/memdb_test.go
@@ -19,7 +19,7 @@ import (
 
 type memDBTest struct{}
 
-func (mdbt memDBTest) New(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+func (mdbt memDBTest) New(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 	return NewMemdbDatastore(watchBufferLength, revisionQuantization, gcWindow)
 }
 

--- a/internal/datastore/memdb/revisions.go
+++ b/internal/datastore/memdb/revisions.go
@@ -45,7 +45,7 @@ func (mdb *memdbDatastore) HeadRevision(ctx context.Context) (datastore.Revision
 }
 
 func (mdb *memdbDatastore) headRevisionNoLock() decimal.Decimal {
-	return mdb.revisions[len(mdb.revisions)-1].revision
+	return revisionFromTimestamp(time.Now().UTC()).Decimal
 }
 
 func (mdb *memdbDatastore) OptimizedRevision(ctx context.Context) (datastore.Revision, error) {

--- a/internal/datastore/memdb/revisions_test.go
+++ b/internal/datastore/memdb/revisions_test.go
@@ -1,0 +1,27 @@
+package memdb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadRevision(t *testing.T) {
+	ds, err := NewMemdbDatastore(0, 0, 500*time.Millisecond)
+	require.NoError(t, err)
+
+	older, err := ds.HeadRevision(context.Background())
+	require.NoError(t, err)
+	err = ds.CheckRevision(context.Background(), older)
+	require.NoError(t, err)
+
+	time.Sleep(550 * time.Millisecond)
+
+	// GC window elapsed, last revision is returned even if outside GC window
+	newer, err := ds.HeadRevision(context.Background())
+	require.NoError(t, err)
+	err = ds.CheckRevision(context.Background(), newer)
+	require.NoError(t, err)
+}

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -36,11 +36,12 @@ type datastoreTester struct {
 	prefix string
 }
 
-func (dst *datastoreTester) createDatastore(revisionQuantization, gcWindow time.Duration, _ uint16) (datastore.Datastore, error) {
+func (dst *datastoreTester) createDatastore(revisionQuantization, gcInterval, gcWindow time.Duration, _ uint16) (datastore.Datastore, error) {
 	ds := dst.b.NewDatastore(dst.t, func(engine, uri string) datastore.Datastore {
 		ds, err := newMySQLDatastore(uri,
 			RevisionQuantization(revisionQuantization),
 			GCWindow(gcWindow),
+			GCInterval(gcInterval),
 			GCInterval(0*time.Second),
 			TablePrefix(dst.prefix),
 			DebugAnalyzeBeforeStatistics(),

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -42,7 +42,6 @@ func (dst *datastoreTester) createDatastore(revisionQuantization, gcInterval, gc
 			RevisionQuantization(revisionQuantization),
 			GCWindow(gcWindow),
 			GCInterval(gcInterval),
-			GCInterval(0*time.Second),
 			TablePrefix(dst.prefix),
 			DebugAnalyzeBeforeStatistics(),
 			OverrideLockWaitTimeout(1),

--- a/internal/datastore/postgres/gc.go
+++ b/internal/datastore/postgres/gc.go
@@ -70,7 +70,7 @@ func (pgd *pgDatastore) TxIDBefore(ctx context.Context, before time.Time) (datas
 		return datastore.NoRevision, err
 	}
 
-	return postgresRevision{snapshot.markComplete(value.Uint)}, nil
+	return postgresRevision{snapshot}, nil
 }
 
 func (pgd *pgDatastore) DeleteBeforeTx(ctx context.Context, txID datastore.Revision) (removed common.DeletionCounts, err error) {

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -38,11 +38,12 @@ func TestPostgresDatastore(t *testing.T) {
 			t.Parallel()
 			b := testdatastore.RunPostgresForTesting(t, "", config.targetMigration)
 
-			test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+			test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 				ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 					ds, err := newPostgresDatastore(uri,
 						RevisionQuantization(revisionQuantization),
 						GCWindow(gcWindow),
+						GCInterval(gcInterval),
 						WatchBufferLength(watchBufferLength),
 						DebugAnalyzeBeforeStatistics(),
 						MigrationPhase(config.migrationPhase),
@@ -55,11 +56,12 @@ func TestPostgresDatastore(t *testing.T) {
 
 			t.Run("WithSplit", func(t *testing.T) {
 				// Set the split at a VERY small size, to ensure any WithUsersets queries are split.
-				test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+				test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 					ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 						ds, err := newPostgresDatastore(uri,
 							RevisionQuantization(revisionQuantization),
 							GCWindow(gcWindow),
+							GCInterval(gcInterval),
 							WatchBufferLength(watchBufferLength),
 							DebugAnalyzeBeforeStatistics(),
 							SplitAtUsersetCount(1), // 1 userset
@@ -144,11 +146,12 @@ func TestPostgresDatastoreWithoutCommitTimestamps(t *testing.T) {
 	b := testdatastore.RunPostgresForTestingWithCommitTimestamps(t, "", "head", false)
 
 	// NOTE: watch API requires the commit timestamps, so we skip those tests here.
-	test.AllExceptWatch(t, test.DatastoreTesterFunc(func(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	test.AllExceptWatch(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 			ds, err := newPostgresDatastore(uri,
 				RevisionQuantization(revisionQuantization),
 				GCWindow(gcWindow),
+				GCInterval(gcInterval),
 				WatchBufferLength(watchBufferLength),
 				DebugAnalyzeBeforeStatistics(),
 			)

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -56,7 +56,14 @@ const (
 	//   %[5] Name of the snapshot column
 	queryValidTransaction = `
 	WITH minvalid AS (
-		SELECT %[1]s, %[5]s FROM %[2]s WHERE %[3]s >= NOW() - INTERVAL '%[4]f seconds' ORDER BY %[3]s ASC LIMIT 1
+		SELECT %[1]s, %[5]s
+        FROM %[2]s
+        WHERE 
+            %[3]s >= NOW() - INTERVAL '%[4]f seconds'
+          OR
+             %[3]s = (SELECT MAX(%[3]s) FROM %[2]s)
+        ORDER BY %[3]s ASC
+        LIMIT 1
 	)
 	SELECT minvalid.%[1]s, minvalid.%[5]s, pg_current_snapshot() FROM minvalid;`
 

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -16,9 +16,13 @@ import (
 
 func TestSpannerDatastore(t *testing.T) {
 	b := testdatastore.RunSpannerForTesting(t, "")
-	test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
-			ds, err := NewSpannerDatastore(uri, RevisionQuantization(revisionQuantization), GCWindow(gcWindow), WatchBufferLength(watchBufferLength))
+			ds, err := NewSpannerDatastore(uri,
+				RevisionQuantization(revisionQuantization),
+				GCWindow(gcWindow),
+				GCInterval(gcInterval),
+				WatchBufferLength(watchBufferLength))
 			require.NoError(t, err)
 			return ds
 		})

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -27,7 +27,7 @@ import (
 func CaveatNotFoundTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCWindow, 1)
+	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx := context.Background()
@@ -42,7 +42,7 @@ func CaveatNotFoundTest(t *testing.T, tester DatastoreTester) {
 
 func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
-	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 1)
+	ds, err := tester.New(0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
 	req.NoError(err)
 
 	skipIfNotCaveatStorer(t, ds)
@@ -130,7 +130,7 @@ func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 
 func WriteCaveatedRelationshipTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
-	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 1)
+	ds, err := tester.New(0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
 	req.NoError(err)
 
 	skipIfNotCaveatStorer(t, ds)
@@ -203,7 +203,7 @@ func WriteCaveatedRelationshipTest(t *testing.T, tester DatastoreTester) {
 
 func CaveatedRelationshipFilterTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
-	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 1)
+	ds, err := tester.New(0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
 	req.NoError(err)
 
 	skipIfNotCaveatStorer(t, ds)
@@ -245,7 +245,7 @@ func CaveatedRelationshipFilterTest(t *testing.T, tester DatastoreTester) {
 
 func CaveatSnapshotReadsTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
-	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 1)
+	ds, err := tester.New(0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
 	req.NoError(err)
 
 	skipIfNotCaveatStorer(t, ds)
@@ -280,7 +280,7 @@ func CaveatSnapshotReadsTest(t *testing.T, tester DatastoreTester) {
 
 func CaveatedRelationshipWatchTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
-	ds, err := tester.New(0*time.Second, veryLargeGCWindow, 16)
+	ds, err := tester.New(0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 16)
 	req.NoError(err)
 
 	skipIfNotCaveatStorer(t, ds)

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -15,19 +15,22 @@ import (
 
 // veryLargeGCWindow is a very large time duration, which when passed to a constructor should
 // effectively disable garbage collection.
-const veryLargeGCWindow = 90000 * time.Second
+const (
+	veryLargeGCWindow   = 90000 * time.Second
+	veryLargeGCInterval = 90000 * time.Second
+)
 
 // DatastoreTester provides a generic datastore suite a means of initializing
 // a particular datastore.
 type DatastoreTester interface {
 	// New creates a new datastore instance for a single test.
-	New(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error)
+	New(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error)
 }
 
-type DatastoreTesterFunc func(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error)
+type DatastoreTesterFunc func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error)
 
-func (f DatastoreTesterFunc) New(revisionQuantization, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
-	return f(revisionQuantization, gcWindow, watchBufferLength)
+func (f DatastoreTesterFunc) New(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	return f(revisionQuantization, gcInterval, gcWindow, watchBufferLength)
 }
 
 // AllExceptWatch runs all generic datastore tests on a DatastoreTester, except
@@ -54,6 +57,7 @@ func AllExceptWatch(t *testing.T, tester DatastoreTester) {
 
 	t.Run("TestRevisionQuantization", func(t *testing.T) { RevisionQuantizationTest(t, tester) })
 	t.Run("TestRevisionSerialization", func(t *testing.T) { RevisionSerializationTest(t, tester) })
+	t.Run("TestRevisionGC", func(t *testing.T) { RevisionGCTest(t, tester) })
 
 	t.Run("TestStats", func(t *testing.T) { StatsTest(t, tester) })
 

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -35,7 +35,7 @@ var (
 func NamespaceNotFoundTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCWindow, 1)
+	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx := context.Background()
@@ -53,7 +53,7 @@ func NamespaceNotFoundTest(t *testing.T, tester DatastoreTester) {
 func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCWindow, 1)
+	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx := context.Background()
@@ -145,7 +145,7 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -193,7 +193,7 @@ func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 }
 
 func NamespaceMultiDeleteTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
@@ -221,7 +221,7 @@ func NamespaceMultiDeleteTest(t *testing.T, tester DatastoreTester) {
 func EmptyNamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -267,7 +267,7 @@ definition document {
 	require.Equal(2, len(compiled.OrderedDefinitions))
 
 	// Write the namespace definition to the datastore.
-	ds, err := tester.New(0, veryLargeGCWindow, 1)
+	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx := context.Background()

--- a/pkg/datastore/test/revisions.go
+++ b/pkg/datastore/test/revisions.go
@@ -29,7 +29,7 @@ func RevisionQuantizationTest(t *testing.T, tester DatastoreTester) {
 		t.Run(fmt.Sprintf("quantization%s", tc.quantizationRange), func(t *testing.T) {
 			require := require.New(t)
 
-			ds, err := tester.New(tc.quantizationRange, veryLargeGCWindow, 1)
+			ds, err := tester.New(tc.quantizationRange, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(err)
 
 			ctx := context.Background()
@@ -72,7 +72,7 @@ func RevisionQuantizationTest(t *testing.T, tester DatastoreTester) {
 func RevisionSerializationTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCWindow, 1)
+	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -87,4 +87,44 @@ func RevisionSerializationTest(t *testing.T, tester DatastoreTester) {
 		DepthRemaining: 50,
 	}
 	require.NoError(meta.Validate())
+}
+
+// RevisionGCTest makes sure revision GC takes place, revisions out-side of the GC window
+// are invalid, and revisions inside the GC window are valid.
+func RevisionGCTest(t *testing.T, tester DatastoreTester) {
+	require := require.New(t)
+
+	ds, err := tester.New(0, 10*time.Millisecond, 300*time.Millisecond, 1)
+	require.NoError(err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	previousRev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
+		return rwt.WriteNamespaces(ctx, testNamespace)
+	})
+	require.NoError(err)
+	require.NoError(ds.CheckRevision(ctx, previousRev), "expected latest write revision to be within GC window")
+
+	head, err := ds.HeadRevision(ctx)
+	require.NoError(err)
+	require.NoError(ds.CheckRevision(ctx, head), "expected head revision to be valid in GC Window")
+
+	// wait to make sure GC kicks in
+	time.Sleep(400 * time.Millisecond)
+
+	// check freshly fetched head revision is valid after GC window elapsed
+	head, err = ds.HeadRevision(ctx)
+	require.NoError(err)
+
+	_, _, err = ds.SnapshotReader(head).ReadNamespaceByName(ctx, "foo/bar")
+	require.NoError(err, "expected previously written schema to exist at head")
+	require.NoError(ds.CheckRevision(ctx, head), "expected freshly obtained head revision to be valid")
+
+	newerRev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
+		return rwt.WriteNamespaces(ctx, testNamespace)
+	})
+	require.NoError(err)
+	require.NoError(ds.CheckRevision(ctx, newerRev), "expected newer head revision to be within GC Window")
+	require.Error(ds.CheckRevision(ctx, previousRev), "expected revision head-1 to be outside GC Window")
 }

--- a/pkg/datastore/test/stats.go
+++ b/pkg/datastore/test/stats.go
@@ -16,7 +16,7 @@ func StatsTest(t *testing.T, tester DatastoreTester) {
 	ctx := context.Background()
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCWindow, 1)
+	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ = testfixtures.StandardDatastoreWithData(ds, require)

--- a/pkg/datastore/test/tuples.go
+++ b/pkg/datastore/test/tuples.go
@@ -39,7 +39,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 		t.Run(strconv.Itoa(numTuples), func(t *testing.T) {
 			require := require.New(t)
 
-			ds, err := tester.New(0, veryLargeGCWindow, 1)
+			ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(err)
 			defer ds.Close()
 
@@ -391,7 +391,7 @@ func DeleteRelationshipsTest(t *testing.T, tester DatastoreTester) {
 			require := require.New(t)
 			ctx := context.Background()
 
-			ds, err := tester.New(0, veryLargeGCWindow, 1)
+			ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(err)
 			defer ds.Close()
 
@@ -439,7 +439,7 @@ func InvalidReadsTest(t *testing.T, tester DatastoreTester) {
 
 		require := require.New(t)
 
-		ds, err := tester.New(0, testGCDuration, 1)
+		ds, err := tester.New(0, veryLargeGCInterval, testGCDuration, 1)
 		require.NoError(err)
 		defer ds.Close()
 
@@ -483,7 +483,7 @@ func InvalidReadsTest(t *testing.T, tester DatastoreTester) {
 func DeleteNotExistantTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -504,7 +504,7 @@ func DeleteNotExistantTest(t *testing.T, tester DatastoreTester) {
 func DeleteAlreadyDeletedTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -539,7 +539,7 @@ func DeleteAlreadyDeletedTest(t *testing.T, tester DatastoreTester) {
 func WriteDeleteWriteTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -560,7 +560,7 @@ func WriteDeleteWriteTest(t *testing.T, tester DatastoreTester) {
 func CreateAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -580,7 +580,7 @@ func CreateAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 func TouchAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -605,7 +605,7 @@ func UsersetsTest(t *testing.T, tester DatastoreTester) {
 			t.Run(strconv.Itoa(numTuples), func(t *testing.T) {
 				require := require.New(t)
 
-				ds, err := tester.New(0, veryLargeGCWindow, 1)
+				ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 				require.NoError(err)
 				defer ds.Close()
 
@@ -652,7 +652,7 @@ func UsersetsTest(t *testing.T, tester DatastoreTester) {
 func MultipleReadsInRWTTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -681,7 +681,7 @@ func MultipleReadsInRWTTest(t *testing.T, tester DatastoreTester) {
 func ConcurrentWriteSerializationTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)

--- a/pkg/datastore/test/watch.go
+++ b/pkg/datastore/test/watch.go
@@ -47,7 +47,7 @@ func WatchTest(t *testing.T, tester DatastoreTester) {
 		t.Run(strconv.Itoa(tc.numTuples), func(t *testing.T) {
 			require := require.New(t)
 
-			ds, err := tester.New(0, veryLargeGCWindow, 16)
+			ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 16)
 			require.NoError(err)
 
 			setupDatastore(ds, require)
@@ -171,7 +171,7 @@ func setOfChanges(changes []*core.RelationTupleUpdate) *strset.Set {
 func WatchCancelTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCWindow, 1)
+	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	startWatchRevision := setupDatastore(ds, require)


### PR DESCRIPTION
This started as an attempt to fix MemDB's behaviour upon a head revision that is outside GC window. After creating a test-case that run for all datastores, it surfaced MySQL and PostgreSQL had a similar problem, each one with its own flavour.

The problem manifested in the various databases in different ways:
- in MemDB, a request with an out-of-window head revision would return `invalid zedtoken: revision has expired`
- in PostgreSQL, a request with an out-of-window head revision would return that the provided resource type was unknown (because it wasn't able to determine a valid namespace)

The fixes depend on the datastore:
- MemDB: we use the machine timestamp instead of the last valid revision, and consider last revision valid even outside that window
- PostgreSQL: do not GC the most recent transaction (which changed in https://github.com/authzed/spicedb/pull/1153), and update query to consider it valid if it's the most recent TX
- MySQL: update query to consider it valid if it's the most recent TX