### PR TITLE
fixes regression of revision precision problem in MacOS for MemDB

### DIFF
--- a/internal/datastore/memdb/revisions.go
+++ b/internal/datastore/memdb/revisions.go
@@ -45,7 +45,7 @@ func (mdb *memdbDatastore) HeadRevision(ctx context.Context) (datastore.Revision
 }
 
 func (mdb *memdbDatastore) headRevisionNoLock() decimal.Decimal {
-	return revisionFromTimestamp(time.Now().UTC()).Decimal
+	return mdb.revisions[len(mdb.revisions)-1].revision
 }
 
 func (mdb *memdbDatastore) OptimizedRevision(ctx context.Context) (datastore.Revision, error) {


### PR DESCRIPTION
Fixes https://github.com/authzed/spicedb/issues/1206

we recently changed how MemDB handles head revisions that are outside of the window. We iterated
on the fix, but the final solution was the result
of merging 2 solutions, by accident.

- one option was to change HeadRevision to return now
- another option was to handle in CheckRevision and make an exception if the revision is the last known revision, even if outside of GC window

Both fixes work fine together, but the first option resurfaced problems with time resolution in MacOS
that leads to test flakes. This happens because
a call to very close calls to HeadRevision and
ReadWriteTx could lead to the same revision, due to the microsecond resolution.

The proposed solution is to rollback the changes
to HeadRevision. While we want to converge to time-based revisions, we already have other datastores doing this anyway, so addressing this would be part of a bigger initiative.