### PR TITLE
spanner: close row iterators when done

### DIFF
--- a/internal/datastore/spanner/revisions.go
+++ b/internal/datastore/spanner/revisions.go
@@ -29,16 +29,10 @@ func (sd spannerDatastore) now(ctx context.Context) (time.Time, error) {
 	ctx, span := tracer.Start(ctx, "now")
 	defer span.End()
 
-	iter := sd.client.Single().Query(ctx, spanner.NewStatement("SELECT CURRENT_TIMESTAMP()"))
-	defer iter.Stop()
-
-	row, err := iter.Next()
-	if err != nil {
-		return time.Time{}, err
-	}
-
 	var timestamp time.Time
-	if err := row.Columns(&timestamp); err != nil {
+	if err := sd.client.Single().Query(ctx, spanner.NewStatement("SELECT CURRENT_TIMESTAMP()")).Do(func(r *spanner.Row) error {
+		return r.Columns(&timestamp)
+	}); err != nil {
 		return time.Time{}, err
 	}
 


### PR DESCRIPTION
There were a couple of places where we build an iterator but then don't use the `Do` consumer. All of the places where we did that made sense to use `Do` anyway, since we only read one row.

This should fix #1196, but we'll want to some testing to confirm.

From Spanner Docs:

> Read returns a RowIterator. You can call the Do method on the iterator and pass a callback:
>```go
>err := iter.Do(func(row *Row) error {
>   // TODO: use row
>   return nil
>})
>```
>RowIterator also follows the standard pattern for the Google Cloud Client Libraries:
>
>```go
>defer iter.Stop()
>for {
>    row, err := iter.Next()
>    if err == iterator.Done {
>        break
>    }
>    if err != nil {
>        // TODO: Handle error.
>    }
>    // TODO: use row
>}
>```
>Always call Stop when you finish using an iterator this way, whether or not you iterate to the end. **(Failing to call Stop could lead you to exhaust the database's session quota.)**

