### PR TITLE
use cgr.dev/chainguard/busybox as base instead of distroless.dev/busybox

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,7 +81,7 @@ dockers:
     use: "buildx"
     build_flag_templates:
       - "--platform=linux/amd64"
-      - "--build-arg=BASE=distroless.dev/busybox"
+      - "--build-arg=BASE=cgr.dev/chainguard/busybox"
   # ARM64
   - image_templates:
       - &arm_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64"
@@ -104,7 +104,7 @@ dockers:
     use: "buildx"
     build_flag_templates:
       - "--platform=linux/arm64"
-      - "--build-arg=BASE=distroless.dev/busybox"
+      - "--build-arg=BASE=cgr.dev/chainguard/busybox"
 docker_manifests:
   # Quay
   - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"

--- a/nightly.goreleaser.yml
+++ b/nightly.goreleaser.yml
@@ -35,7 +35,7 @@ dockers:
     use: "buildx"
     build_flag_templates:
       - "--platform=linux/amd64"
-      - "--build-arg=BASE=distroless.dev/busybox"
+      - "--build-arg=BASE=cgr.dev/chainguard/busybox"
   # ARM64
   - image_templates:
       - &arm_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64"
@@ -58,7 +58,7 @@ dockers:
     use: "buildx"
     build_flag_templates:
       - "--platform=linux/arm64"
-      - "--build-arg=BASE=distroless.dev/busybox"
+      - "--build-arg=BASE=cgr.dev/chainguard/busybox"
 docker_manifests:
   # Quay
   - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"


### PR DESCRIPTION
tl;dr: `cgr.dev/chainguard/busybox` is equivalent in every way to `distroless.dev/busybox`, and will have better availability going forward.

---

https://github.com/authzed/spicedb/pull/750 switched the base image to `distroless.dev/busybox` in August of last year. Since then we've supported both `distroless.dev/busybox` and `cgr.dev/chainguard/busybox` as totally equivalent paths to the same image hosted on GHCR, via a redirecting façade.

We've since started to move off of relying on GHCR for our hosting for a number of reasons (reliability, visibility, rate limits, etc). Today we publish to both GHCR, available via the distroless.dev redirector, and to cgr.dev directly -- cgr.dev is no longer redirecting to GHCR. We plan to publish to both for a while, and relatively soon point distroless.dev to cgr.dev backed by our own infra, so that distroless.dev continues to operate without disruption.

However, distroless.dev is not the recommended path to these images going forward. This redirector path will be available on a best-effort basis indefinitely, while cgr.dev will be actively monitored, backed by an oncall rotation with pagers. distroless.dev will redirect to cgr.dev and as such will necessarily be slower.