### PR TITLE
Fix deduplication bug in reachable resources

### DIFF
--- a/internal/dispatch/graph/reachableresources_test.go
+++ b/internal/dispatch/graph/reachableresources_test.go
@@ -531,6 +531,7 @@ func TestCaveatedReachableResources(t *testing.T) {
 			ONR("user", "tom", "..."),
 			[]reachableResource{
 				{"document:foo#view", true},
+				{"document:foo#view", true},
 			},
 		},
 		{

--- a/internal/graph/resourcesubjectsmap_test.go
+++ b/internal/graph/resourcesubjectsmap_test.go
@@ -38,10 +38,10 @@ func TestResourcesSubjectsMapBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 4, rsm.len())
 
-	filtered := rsm.filterForDispatch(&syncONRSet{})
-	require.False(t, filtered.isEmpty())
+	locked := rsm.asReadOnly()
+	require.False(t, locked.isEmpty())
 
-	directAsResources := filtered.asReachableResources(true)
+	directAsResources := locked.asReachableResources(true)
 	testutil.RequireProtoSlicesEqual(t, []*v1.ReachableResource{
 		{
 			ResourceId:    "first",
@@ -65,7 +65,7 @@ func TestResourcesSubjectsMapBasic(t *testing.T) {
 		},
 	}, directAsResources, sortByResource, "different resources")
 
-	notDirectAsResources := filtered.asReachableResources(false)
+	notDirectAsResources := locked.asReachableResources(false)
 	testutil.RequireProtoSlicesEqual(t, []*v1.ReachableResource{
 		{
 			ResourceId:    "first",
@@ -201,8 +201,8 @@ func TestResourcesSubjectsMapAsReachableResources(t *testing.T) {
 						expected = append(expected, cloned)
 					}
 
-					filtered := rsm.filterForDispatch(&syncONRSet{})
-					resources := filtered.asReachableResources(isDirectEntrypoint)
+					locked := rsm.asReadOnly()
+					resources := locked.asReachableResources(isDirectEntrypoint)
 					testutil.RequireProtoSlicesEqual(t, expected, resources, sortByResource, "different resources")
 				})
 			}
@@ -418,8 +418,8 @@ func TestResourcesSubjectsMapMapFoundResources(t *testing.T) {
 						expected = append(expected, cloned)
 					}
 
-					filtered := rsm.filterForDispatch(&syncONRSet{})
-					resources, err := filtered.mapFoundResources(tc.foundResources, isDirectEntrypoint)
+					locked := rsm.asReadOnly()
+					resources, err := locked.mapFoundResources(tc.foundResources, isDirectEntrypoint)
 					require.NoError(t, err)
 
 					for _, r := range resources {

--- a/internal/services/integrationtesting/testconfigs/multiplepathssamelookupresult.yaml
+++ b/internal/services/integrationtesting/testconfigs/multiplepathssamelookupresult.yaml
@@ -1,0 +1,28 @@
+---
+schema: |2+
+    definition user {}
+    definition folder {
+      relation parent: folder
+      relation hidden: folder
+
+      relation owner: user
+
+      permission can_read_hidden = owner + parent->can_read_hidden
+      permission can_read = owner + parent->can_read_hidden
+    }
+    definition resource {
+      relation parent: folder
+      relation hidden: folder
+
+      permission can_read_hidden = hidden->can_read_hidden
+      permission can_read = parent->can_read + can_read_hidden
+    }
+
+relationships: |-
+  folder:test#owner@user:tom
+  folder:normal#parent@folder:test
+  resource:normal-1#parent@folder:normal
+  resource:hidden-1#hidden@folder:normal
+  resource:hidden-2#parent@folder:hidden
+assertions: null
+validation: null


### PR DESCRIPTION
We were previously deduplicating dispatching in reachable resources based solely on the subject found, but without being transformed for the parent resource type. This resulted in branches that produced the *same* subject, but with a different relation, being skipped occasionally due to a race in the dispatching.

We now do the duplication check at the dispatch point, to ensure we're checking the exact subject being dispatched.

Also adds a consistency test which reproduces the issue. Thanks to `tr33` from Discord for the bug report and reproduction case!