### PR TITLE
Move to Go version 1.20.3 to fix reported vulns in Go 1.20.2

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -32,7 +32,7 @@ on:  # yamllint disable-line rule:truthy
       - "internal/**"
       - "proto/**"
 env:
-  GO_VERSION: "~1.20.2"
+  GO_VERSION: "~1.20.3"
 jobs:
   build:
     name: "Build Binary"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     branches: ["*"]
 env:
-  GO_VERSION: "~1.20.2"
+  GO_VERSION: "~1.20.3"
 jobs:
   go-lint:
     name: "Lint Go"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: "write"
   packages: "write"
 env:
-  GO_VERSION: "~1.20.2"
+  GO_VERSION: "~1.20.3"
 jobs:
   goreleaser:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: "write"
   packages: "write"
 env:
-  GO_VERSION: "~1.20.2"
+  GO_VERSION: "~1.20.3"
 jobs:
   goreleaser:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -6,7 +6,7 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: "write"
 env:
-  GO_VERSION: "~1.20.2"
+  GO_VERSION: "~1.20.3"
 jobs:
   build:
     name: "Build WASM"


### PR DESCRIPTION
See: https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8