### PR TITLE
Set a subdictionary key for pgx logs adaptor

### DIFF
--- a/internal/datastore/postgres/common/pgx.go
+++ b/internal/datastore/postgres/common/pgx.go
@@ -102,7 +102,8 @@ func ConfigurePGXLogger(connConfig *pgx.ConnConfig) {
 			logger.Log(ctx, level, msg, data)
 		}
 	}
-	l := zerologadapter.NewLogger(log.Logger)
+
+	l := zerologadapter.NewLogger(log.Logger, zerologadapter.WithSubDictionary("pgx"))
 	connConfig.Tracer = &tracelog.TraceLog{Logger: levelMappingFn(l), LogLevel: tracelog.LogLevelInfo}
 }
 


### PR DESCRIPTION
This ensures that all pgx supplied log keys are under the `pgx` key, to prevent overlap of the `time` keys

Example:
```
{"level":"debug","module":"pgx","pgx":{"args":[],"commandTag":"COMMIT","pid":110,"sql":"commit","time":0.434708},"time":"2023-01-01T01:01:00-00:00","message":"Query"}
```

Fixes #58