### PR TITLE
Make sure to bind vars in table driven tests

### DIFF
--- a/cmd/spicedb/serve_integration_test.go
+++ b/cmd/spicedb/serve_integration_test.go
@@ -41,6 +41,7 @@ func TestServe(t *testing.T) {
 		"secondkey":  true,
 		"anotherkey": false,
 	} {
+		key := key
 		t.Run(key, func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -53,6 +53,8 @@ func TestConsistency(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, filePath := range consistencyTestFiles {
+		filePath := filePath
+
 		t.Run(path.Base(filePath), func(t *testing.T) {
 			for _, dispatcherKind := range []string{"local", "caching"} {
 				dispatcherKind := dispatcherKind


### PR DESCRIPTION
Ensures that the parallel test runners get the correct values