### PR TITLE
goreleaser: publish PRs to brew and not commits

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,8 @@ brews:
     description: "SpiceDB is a Zanzibar-inspired database that stores, computes, and validates application permissions."
     license: "Apache-2.0"
     folder: "Formula"
+    pull_request:
+      enabled: true
     custom_block: |
       head "https://github.com/authzed/spicedb.git", :branch => "main"
     dependencies:


### PR DESCRIPTION
This will let us selectively merge releases into brew so that HEAD doesn't accidentally try to move homebrew users into running an backport instead of the latest version of SpiceDB.