### PR TITLE
Fix flakiness of bootstrap file in serve-testing by squashing all memdb revisions

### DIFF
--- a/cmd/spicedb/restgateway_integration_test.go
+++ b/cmd/spicedb/restgateway_integration_test.go
@@ -25,6 +25,7 @@ func TestRESTGateway(t *testing.T) {
 			ExposedPorts: []string{"50051/tcp", "8443/tcp"},
 		},
 		"somerandomkeyhere",
+		false,
 	)
 	require.NoError(err)
 	defer tester.cleanup()

--- a/cmd/spicedb/serve_integration_test.go
+++ b/cmd/spicedb/serve_integration_test.go
@@ -31,6 +31,7 @@ func TestServe(t *testing.T) {
 			ExposedPorts: []string{"50051/tcp"},
 		},
 		"firstkey",
+		false,
 	)
 	requireParent.NoError(err)
 	defer tester.cleanup()

--- a/cmd/spicedb/servetesting_race_test.go
+++ b/cmd/spicedb/servetesting_race_test.go
@@ -1,0 +1,64 @@
+//go:build docker && image
+// +build docker,image
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Based on a test originally written by https://github.com/wscalf
+func TestCheckPermissionOnTesterNoFlakes(t *testing.T) {
+	_, b, _, _ := runtime.Caller(0)
+	basepath := filepath.Dir(b)
+	tester, err := newTester(t,
+		&dockertest.RunOptions{
+			Repository:   "authzed/spicedb",
+			Tag:          "ci",
+			Cmd:          []string{"serve-testing", "--load-configs", "/mnt/spicedb_bootstrap.yaml"},
+			Mounts:       []string{path.Join(basepath, "testdata/bootstrap.yaml") + ":/mnt/spicedb_bootstrap.yaml"},
+			ExposedPorts: []string{"50051/tcp", "50052/tcp", "8443/tcp", "8444/tcp"},
+		},
+		"",
+		true,
+	)
+	require.NoError(t, err)
+	defer tester.cleanup()
+
+	for i := 0; i < 1000; i++ {
+		conn, err := grpc.Dial(fmt.Sprintf("localhost:%s", tester.port), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := v1.NewPermissionsServiceClient(conn)
+
+		result, err := client.CheckPermission(context.Background(), &v1.CheckPermissionRequest{
+			Resource: &v1.ObjectReference{
+				ObjectType: "access",
+				ObjectId:   "blue",
+			},
+			Permission: "assigned",
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: "user",
+					ObjectId:   "alice",
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, result.Permissionship, "Error on attempt #%d", i)
+	}
+}

--- a/cmd/spicedb/testdata/bootstrap.yaml
+++ b/cmd/spicedb/testdata/bootstrap.yaml
@@ -1,0 +1,8 @@
+---
+schema: |
+  definition user {}
+
+  definition access {
+      relation assigned: user
+  }
+relationships: "access:blue#assigned@user:alice"

--- a/internal/datastore/memdb/revisions.go
+++ b/internal/datastore/memdb/revisions.go
@@ -44,6 +44,15 @@ func (mdb *memdbDatastore) HeadRevision(ctx context.Context) (datastore.Revision
 	return revision.NewFromDecimal(mdb.headRevisionNoLock()), nil
 }
 
+func (mdb *memdbDatastore) SquashRevisionsForTesting() {
+	mdb.revisions = []snapshot{
+		{
+			revision: revisionFromTimestamp(time.Now().UTC()).Decimal,
+			db:       mdb.db,
+		},
+	}
+}
+
 func (mdb *memdbDatastore) headRevisionNoLock() decimal.Decimal {
 	return mdb.revisions[len(mdb.revisions)-1].revision
 }


### PR DESCRIPTION
Also adds an integration test

Thanks to https://github.com/wscalf for the bug report and basis of the test case

Original bug report: https://discord.com/channels/844600078504951838/844600078948630559/1095721051020873779

wscalf — 12/04/2023, 7:44 AM
Hey there,

We're doing some integration tests with SpiceDB using the serve-testing command and using --load-configs and a YAML file containing schema and relationships, and we're noticing that sometimes (between 2% and 20% of the time), our tests fail- the schema appears to be there, but the relationships may not have been loaded yet- all test failures are due to missing relationships, and it looks like in the SpiceDB logs, the log message for serving comes before the log message for loading relationships:
{"level":"info","addr":":50051","network":"tcp","service":"grpc","workers":0,"insecure":true,"time":"2023-04-12T14:43:05Z","message":"grpc server started serving"}
{"level":"info","addr":":50052","network":"tcp","service":"readonly-grpc","workers":0,"insecure":true,"time":"2023-04-12T14:43:05Z","message":"grpc server started serving"}
{"level":"info","filePath":"/mnt/spicedb_bootstrap.yaml","schemaDefinitionCount":7,"time":"2023-04-12T14:43:06Z","message":"adding schema definitions"}


Should we be doing something differently? And as a side question, is --load-configs different from --datastore-bootstrap-files in some significant way?