### PR TITLE
some follow ups to paginated datastore

### DIFF
--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -297,6 +297,36 @@ func ToRelationship(tpl *core.RelationTuple) *v1.Relationship {
 	}
 }
 
+// NewRelationship creates a new Relationship value with all its required child structures allocated
+func NewRelationship() *v1.Relationship {
+	return &v1.Relationship{
+		Resource: &v1.ObjectReference{},
+		Subject: &v1.SubjectReference{
+			Object: &v1.ObjectReference{},
+		},
+	}
+}
+
+// MustToRelationshipMutating sets target relationship to all the values provided in the source tuple.
+func MustToRelationshipMutating(source *core.RelationTuple, targetRel *v1.Relationship, targetCaveat *v1.ContextualizedCaveat) {
+	targetRel.Resource.ObjectType = source.ResourceAndRelation.Namespace
+	targetRel.Resource.ObjectId = source.ResourceAndRelation.ObjectId
+	targetRel.Relation = source.ResourceAndRelation.Relation
+	targetRel.Subject.Object.ObjectType = source.Subject.Namespace
+	targetRel.Subject.Object.ObjectId = source.Subject.ObjectId
+	targetRel.Subject.OptionalRelation = stringz.Default(source.Subject.Relation, "", Ellipsis)
+	targetRel.OptionalCaveat = nil
+
+	if source.Caveat != nil {
+		if targetCaveat == nil {
+			panic("expected a provided target caveat")
+		}
+		targetCaveat.CaveatName = source.Caveat.CaveatName
+		targetCaveat.Context = source.Caveat.Context
+		targetRel.OptionalCaveat = targetCaveat
+	}
+}
+
 // MustToFilter converts a RelationTuple into a RelationshipFilter. Will panic if
 // the RelationTuple does not validate.
 func MustToFilter(tpl *core.RelationTuple) *v1.RelationshipFilter {


### PR DESCRIPTION
Based on top of https://github.com/authzed/spicedb/pull/1265

Some follow up fixes I didn't want to commit directly to the parent PR:
- [correctly return gRPC code on cancellation](https://github.com/authzed/spicedb/pull/1271/commits/af3bee68d1b8ef18ed5b8e2e7f3a33c008f76ce2)
- [remove 2 allocations from ReadRelationships streaming loop](https://github.com/authzed/spicedb/pull/1271/commits/6a31be9d341413b36c98b26c6298d39b287e59e2). This proved to reduce the allocations generated for a test with 2M tuples in 25% (800MB)

```
A call to ReadRelationships using "zed relationship read resource reader user --consistency-full | wc -l"
test with postgres and a relation with 2,272,303 tuples

Jakes branch, fetchSize=1K, grpc.time_ms=16864.852
before starting iteration          Alloc = 8.9 MB. TotalAlloc = 18 MB      Sys = 39 MB     NumGC = 7
after closing iteration            Alloc = 12 MB   TotalAlloc = 3.4 GB     Sys = 48 MB     NumGC = 317

Jakes branch, fetchSize=10K, grpc.time_ms=16614.432
before starting iteration          Alloc = 8.8 MB TotalAlloc = 18 MB       Sys = 39 MB     NumGC = 7 
after closing iteration            Alloc = 19 MB  TotalAlloc = 3.4 GB      Sys = 48 MB     NumGC = 323

Jakes branch+fix, fetchSize=1K, grpc.time_ms=16606.984
before starting iteration.         Alloc = 12 MB   TotalAlloc = 18 MB      Sys = 40 MB     NumGC = 6
after closing iteration            Alloc = 22 MB   TotalAlloc = 2.6 GB     Sys = 52 MB     NumGC = 235

Jakes branch+fix, fetchSize=10K, grpc.time_ms=16606.984
before starting iteration         Alloc = 10 MB    TotalAlloc = 18 MB      Sys = 35 MB     NumGC = 7
after closing iteration           Alloc = 18 MB    TotalAlloc = 2.6 GB     Sys = 52 MB     NumGC = 235
```