### PR TITLE
fix CRDB ReadRelationships throughput regression with new paginated approach 

### DIFF
--- a/internal/datastore/common/sql.go
+++ b/internal/datastore/common/sql.go
@@ -58,9 +58,10 @@ const (
 	// which is not compatible with all datastores.
 	TupleComparison PaginationFilterType = iota
 
-	// SpannerCompatible comparison uses a nested tree of ANDs and ORs to properly
-	// filter out already received relationships.
-	SpannerCompatible
+	// ExpandedLogicComparison comparison uses a nested tree of ANDs and ORs to properly
+	// filter out already received relationships. Useful for databases that do not support
+	// tuple comparison, or do not execute it efficiently
+	ExpandedLogicComparison
 )
 
 // SchemaInformation holds the schema information from the SQL datastore implementation.
@@ -152,7 +153,7 @@ func (sqf SchemaQueryFilterer) After(cursor *core.RelationTuple, order options.S
 			)
 		}
 
-	case SpannerCompatible:
+	case ExpandedLogicComparison:
 		switch order {
 		case options.ByResource:
 			sqf.queryBuilder = sqf.queryBuilder.Where(

--- a/internal/datastore/crdb/reader.go
+++ b/internal/datastore/crdb/reader.go
@@ -43,7 +43,7 @@ var (
 		colUsersetObjectID,
 		colUsersetRelation,
 		colCaveatContextName,
-		common.TupleComparison,
+		common.ExpandedLogicComparison,
 	)
 )
 

--- a/internal/datastore/spanner/reader.go
+++ b/internal/datastore/spanner/reader.go
@@ -236,7 +236,7 @@ var schema = common.NewSchemaInformation(
 	colUsersetObjectID,
 	colUsersetRelation,
 	colCaveatName,
-	common.SpannerCompatible,
+	common.ExpandedLogicComparison,
 )
 
 var _ datastore.Reader = spannerReader{}


### PR DESCRIPTION
CRDB shows abysmal performance with the query pattern used by default, leading to full table scans
for the latter pages.

`grpc_time` for test `ReadRelationships`. Test with 153295 relationships in a relation, 3 node local machine CRDB cluster and SpiceDB.

```bash
zed relationship read authzed/resource reader authzed/user --consistency-full | wc -l
153295
```

|  spicedb | time |
|---|---|
| pre datastore pagination |  1.5s |
| datastore pagination with tuple comparison |  40s | 
| datastore pagination with expanded tuple comparison |  2.5s | 

```bash
zed relationship read authzed/resource reader --consistency-full | wc -l
153295
```

|  spicedb | time |
|---|---|
| pre datastore pagination |  1.5s |
| datastore pagination with tuple comparison | 30s |
| datastore pagination with expanded tuple comparison |  13.5s |

```bash
zed relationship read authzed/resource --consistency-full | wc -l
153295
```

|  spicedb | time |
|---|---|
| pre datastore pagination |  1.5s |
| datastore pagination with tuple comparison | 1.7s |
| datastore pagination with expanded tuple comparison | 2.5s |

We observe the query latency is a mixed-bag for pagination, but overall the expanded tuple-comparison offers good query latency for 2 out of 3 request patterns, versus 1 out of 3 for the tuple comparison approach.

Even though it's a regression from non-paginated, we consider it preferable as it scales. The original approach eagerly loaded in memory, adding pressure to the process in runtime, and also issuing a very expensive operation to the database that can also add pressure to it.

EXPLAIN ANALYZE with tuple comparison
```
"info"
"planning time: 942µs"
"execution time: 181ms"
"distribution: local"
"vectorized: true"
"rows read from KV: 60,345 (8.2 MiB, 3 gRPC calls)"
"cumulative time spent in KV: 150ms"
"maximum memory usage: 22 MiB"
"network usage: 0 B (0 messages)"
""
"• limit"
"│ count: 1000"
"│"
"└── • filter"
"    │ nodes: n1"
"    │ actual row count: 1,000"
"    │ estimated row count: 51,098"
"    │ filter: ((relation = 'reader') AND (userset_namespace = 'authzed/user')) AND (('authzed/resource', object_id, 'reader', 'authzed/user', userset_object_id, userset_relation) > ('authzed/resource', '1', 'reader', 'authzed/user', '62c8ff7f-6538-4491-ad16-f91930cd04db', '...'))"
"    │"
"    └── • scan"
"          nodes: n1"
"          actual row count: 60,345"
"          KV time: 150ms"
"          KV contention time: 0µs"
"          KV rows read: 60,345"
"          KV bytes read: 8.2 MiB"
"          KV gRPC calls: 3"
"          estimated max memory allocated: 10 MiB"
"          estimated row count: 3,001 - 153,295 (100% of the table; stats collected 10 seconds ago; using stats forecast for 3 hours in the future)"
"          table: relation_tuple@pk_relation_tuple"
"          spans: [/'authzed/resource' - /'authzed/resource']"
```

EXPLAIN ANALYZE expanded tuple comparison

```
"info"
"planning time: 373µs"
"execution time: 6ms"
"distribution: local"
"vectorized: true"
"rows read from KV: 1,024 (158 KiB, 2 gRPC calls)"
"cumulative time spent in KV: 4ms"
"maximum memory usage: 1010 KiB"
"network usage: 0 B (0 messages)"
""
"• limit"
"│ count: 1000"
"│"
"└── • distinct"
"    │ nodes: n1"
"    │ actual row count: 1,000"
"    │ estimated max memory allocated: 320 KiB"
"    │ estimated max sql temp disk usage: 0 B"
"    │ estimated row count: 51,098"
"    │ distinct on: namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation"
"    │ order key: object_id, userset_object_id, userset_relation"
"    │"
"    └── • union all"
"        │ nodes: n1"
"        │ actual row count: 1,023"
"        │ estimated row count: 17,033"
"        │"
"        ├── • filter"
"        │   │ nodes: n1"
"        │   │ actual row count: 0"
"        │   │ estimated row count: 0"
"        │   │ filter: (relation = 'reader') AND (userset_namespace = 'authzed/user')"
"        │   │"
"        │   └── • scan"
"        │         nodes: n1"
"        │         actual row count: 0"
"        │         KV time: 1ms"
"        │         KV contention time: 0µs"
"        │         KV rows read: 0"
"        │         KV bytes read: 0 B"
"        │         KV gRPC calls: 1"
"        │         estimated max memory allocated: 20 KiB"
"        │         estimated row count: 0 (<0.01% of the table; stats collected 6 minutes ago; using stats forecast for 2 minutes in the future)"
"        │         table: relation_tuple@pk_relation_tuple"
"        │         spans: [/'authzed/resource'/e'1\x00'/'reader'/'authzed/user' - /'authzed/resource']"
"        │"
"        └── • scan"
"              nodes: n1"
"              actual row count: 1,024"
"              KV time: 3ms"
"              KV contention time: 0µs"
"              KV rows read: 1,024"
"              KV bytes read: 158 KiB"
"              KV gRPC calls: 1"
"              estimated max memory allocated: 500 KiB"
"              estimated row count: 1,215 - 17,033 (11% of the table; stats collected 6 minutes ago; using stats forecast for 2 minutes in the future)"
"              table: relation_tuple@pk_relation_tuple"
"              spans: [/'authzed/resource'/'1'/'reader'/'authzed/user'/'a0cbdd9d-887e-4653-a72d-f1e184ebef6a'/e'...\x00' - /'authzed/resource'/'1'/'reader'/'authzed/user']"
```