### PR TITLE
Fix issue where Watch in Postgres was looping endlessly

### DIFF
--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -247,6 +247,10 @@ func (pr postgresRevision) LessThan(rhsRaw datastore.Revision) bool {
 	return ok && pr.snapshot.LessThan(rhs.snapshot)
 }
 
+func (pr postgresRevision) DebugString() string {
+	return pr.snapshot.String()
+}
+
 func (pr postgresRevision) String() string {
 	return base64.StdEncoding.EncodeToString(pr.mustMarshalBinary())
 }


### PR DESCRIPTION
This occurred if there were two exactly overlapping transactions, which caused the watch code to repeatedly "move backwards" when looking up the next revision

The fix is to ensure that all found transactions are accounted in the overall transaction revision passed to the next iteration of the watch loop

Fixes #1272

Thanks to @aberkovsky for the bug report and detailed repro information!