### PR TITLE
Determine connection drain status async

### DIFF
--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -332,6 +332,12 @@ type Feature struct {
 	Reason  string
 }
 
+// ConnHealthChecker is an interface that datastores may implement if they
+// require a background process to manage connection pool health.
+type ConnHealthChecker interface {
+	StartConnectionHealthCheck(ctx context.Context) error
+}
+
 // Features holds values that represent what features a database can support.
 type Features struct {
 	// Watch is enabled if the underlying datastore can support the Watch api.


### PR DESCRIPTION
Note: haven't seen this survive node drains as expected, not ready for review yet. See https://github.com/authzed/spicedb/pull/1283

This starts a worker that periodically (or on any connection error) asks Cockroach if any of its nodes are draining. If draining nodes are found, a shared `draining` flag is set, and only then do we check if connections are draining on acquire. 

The goal is to remove the roundtrip from the common case, while still being able to make use of it when nodes are draining.