### PR TITLE
Fix serialization of custom types in caveat context

### DIFF
--- a/internal/services/v1/debug_test.go
+++ b/internal/services/v1/debug_test.go
@@ -304,6 +304,37 @@ func TestCheckPermissionWithDebug(t *testing.T) {
 			},
 		},
 		{
+			"ip address caveat",
+			`definition user {}
+
+			caveat has_valid_ip(user_ip ipaddress, allowed_range string) {
+				user_ip.in_cidr(allowed_range)
+			}
+			
+			definition resource {
+				relation viewer: user | user with has_valid_ip
+			}`,
+			[]*core.RelationTuple{
+				tuple.MustParse(`resource:first#viewer@user:sarah[has_valid_ip:{"allowed_range":"192.168.0.0/16"}]`),
+			},
+			[]debugCheckInfo{
+				{
+					"sarah as viewer",
+					debugCheckRequest{
+						obj("resource", "first"),
+						"viewer",
+						sub("user", "sarah", ""),
+						map[string]any{
+							"user_ip": "192.168.1.100",
+						},
+					},
+					v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION,
+					0,
+					nil,
+				},
+			},
+		},
+		{
 			"multiple caveated debug",
 			`definition user {}
 			

--- a/pkg/caveats/context.go
+++ b/pkg/caveats/context.go
@@ -5,6 +5,8 @@ import (
 
 	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/authzed/spicedb/pkg/caveats/types"
 )
 
 // ConvertContextToStruct converts the given context values into a context struct.
@@ -33,6 +35,9 @@ func convertCustomValues(value any) any {
 
 	case time.Duration:
 		return v.String()
+
+	case types.CustomType:
+		return v.SerializedString()
 
 	default:
 		return v

--- a/pkg/caveats/context_test.go
+++ b/pkg/caveats/context_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/testutil"
 )
 
@@ -95,6 +96,15 @@ func TestConvertContextToStruct(t *testing.T) {
 			mustNewStruct(map[string]any{
 				"another_field": 1234,
 				"some_time":     "2h45m0s",
+			}),
+		},
+		{
+			"converts ip address",
+			map[string]any{
+				"user_ip": types.MustParseIPAddress("192.168.1.100"),
+			},
+			mustNewStruct(map[string]any{
+				"user_ip": "192.168.1.100",
 			}),
 		},
 	}

--- a/pkg/caveats/types/custom.go
+++ b/pkg/caveats/types/custom.go
@@ -1,0 +1,8 @@
+package types
+
+// CustomType is the interface for custom-defined types.
+type CustomType interface {
+	// SerializedString returns the serialized string form of the data within
+	// this instance of the type.
+	SerializedString() string
+}

--- a/pkg/caveats/types/ipaddress.go
+++ b/pkg/caveats/types/ipaddress.go
@@ -33,6 +33,10 @@ type IPAddress struct {
 	ip netip.Addr
 }
 
+func (ipa IPAddress) SerializedString() string {
+	return ipa.ip.String()
+}
+
 func (ipa IPAddress) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc {
 	case reflect.TypeOf(""):
@@ -67,7 +71,7 @@ func (ipa IPAddress) Value() interface{} {
 	return ipa
 }
 
-var IPAddressType = registerCustomType(
+var IPAddressType = registerCustomType[IPAddress](
 	"ipaddress",
 	cel.ObjectType("IPAddress"),
 	func(value any) (any, error) {

--- a/pkg/caveats/types/registration.go
+++ b/pkg/caveats/types/registration.go
@@ -80,7 +80,7 @@ func registerGenericType(
 }
 
 // registerCustomType registers a custom type that wraps a base CEL type.
-func registerCustomType(keyword string, baseCelType *cel.Type, converter typedValueConverter, opts ...cel.EnvOption) VariableType {
+func registerCustomType[T CustomType](keyword string, baseCelType *cel.Type, converter typedValueConverter, opts ...cel.EnvOption) VariableType {
 	CustomTypes[keyword] = opts
 	return registerBasicType(keyword, baseCelType, converter)
 }


### PR DESCRIPTION
We need to have another method on a shared interface to enable this to be generic and be enforced

Also adds some tests

Fixed #1299