### PR TITLE
Move to Go 1.20.4 to fix a reported vuln in Go

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -32,7 +32,7 @@ on:  # yamllint disable-line rule:truthy
       - "internal/**"
       - "proto/**"
 env:
-  GO_VERSION: "~1.20.3"
+  GO_VERSION: "~1.20.4"
 jobs:
   build:
     name: "Build Binary"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Lint"
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - "!dependabot/*"
@@ -8,7 +8,7 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     branches: ["*"]
 env:
-  GO_VERSION: "~1.20.3"
+  GO_VERSION: "~1.20.4"
 jobs:
   go-lint:
     name: "Lint Go"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: "write"
   packages: "write"
 env:
-  GO_VERSION: "~1.20.3"
+  GO_VERSION: "~1.20.4"
 jobs:
   goreleaser:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: "write"
   packages: "write"
 env:
-  GO_VERSION: "~1.20.3"
+  GO_VERSION: "~1.20.4"
 jobs:
   goreleaser:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -6,7 +6,7 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: "write"
 env:
-  GO_VERSION: "~1.20.3"
+  GO_VERSION: "~1.20.4"
 jobs:
   build:
     name: "Build WASM"


### PR DESCRIPTION
See: https://pkg.go.dev/vuln/GO-2023-1753