### PR TITLE
Fix reachable resource TTU over subject relations

### DIFF
--- a/internal/namespace/reachabilitygraph.go
+++ b/internal/namespace/reachabilitygraph.go
@@ -62,6 +62,22 @@ func (re ReachabilityEntrypoint) IsDirectResult() bool {
 	return re.re.ResultStatus == core.ReachabilityEntrypoint_DIRECT_OPERATION_RESULT
 }
 
+func (re ReachabilityEntrypoint) MustDebugString() string {
+	switch re.EntrypointKind() {
+	case core.ReachabilityEntrypoint_RELATION_ENTRYPOINT:
+		return fmt.Sprintf("relation-entrypoint: %s#%s", re.re.TargetRelation.Namespace, re.re.TargetRelation.Relation)
+
+	case core.ReachabilityEntrypoint_TUPLESET_TO_USERSET_ENTRYPOINT:
+		return fmt.Sprintf("ttu-entrypoint: %s#%s | %s | %s#%s", re.parentRelation.Namespace, re.parentRelation.Relation, re.re.TuplesetRelation, re.re.TargetRelation.Namespace, re.re.TargetRelation.Relation)
+
+	case core.ReachabilityEntrypoint_COMPUTED_USERSET_ENTRYPOINT:
+		return fmt.Sprintf("computed-entrypoint: %s#%s", re.re.TargetRelation.Namespace, re.re.TargetRelation.Relation)
+
+	default:
+		panic("unknown relation entrypoint kind")
+	}
+}
+
 // ReachabilityGraphFor returns a reachability graph for the given namespace.
 func ReachabilityGraphFor(ts *ValidatedNamespaceTypeSystem) *ReachabilityGraph {
 	return &ReachabilityGraph{ts.TypeSystem, sync.Map{}, sync.Map{}}

--- a/internal/services/integrationtesting/testconfigs/lrordering.yaml
+++ b/internal/services/integrationtesting/testconfigs/lrordering.yaml
@@ -1,0 +1,43 @@
+schema: |-
+  definition user {}
+
+  definition organization {
+  	relation entitled : service
+  	permission service = entitled->service
+  }
+
+  definition project {
+  	relation granted : granted_service
+  	permission service = granted->service
+  }
+
+  definition granted_service {
+  	relation arbiter : organization#entitled
+  	relation granted : service
+
+  	permission service1 = arbiter->service & granted->service
+  	permission service2 = granted->service & arbiter->service
+  }
+
+  definition service {
+  	relation servicer: user
+
+  	permission service = servicer
+  }
+
+  definition widget {
+  	relation project: project
+  	permission service = project->service
+  }
+relationships: |-
+  service:s1#servicer@user:u1
+  service:s1#servicer@user:u2
+  organization:o1#entitled@service:s1
+  granted_service:gs1#arbiter@organization:o1#entitled
+  service:just_u1#servicer@user:u1
+  granted_service:gs1#granted@service:just_u1
+  project:p1#granted@granted_service:gs1
+  widget:w1#project@project:p1
+assertions:
+  assertTrue: []
+  assertFalse: []

--- a/internal/services/integrationtesting/testconfigs/lroverrelation.yaml
+++ b/internal/services/integrationtesting/testconfigs/lroverrelation.yaml
@@ -1,0 +1,28 @@
+schema: |-
+  definition user {}
+
+  definition organization {
+  	relation with_container: container
+  	permission entitled_service = with_container->view
+  }
+
+  definition granted_service {
+  	relation arbiter: organization#with_container
+  	permission service1 = arbiter->entitled_service
+  }
+
+  definition container {
+  	relation viewer: user
+  	permission view = viewer
+  }
+
+relationships: |-
+  container:s1#viewer@user:u1
+  container:s1#viewer@user:u2
+  organization:o1#with_container@container:s1
+  granted_service:gs1#arbiter@organization:o1#with_container
+assertions:
+  assertTrue:
+    - "granted_service:gs1#service1@user:u1"
+    - "granted_service:gs1#service1@user:u2"
+  assertFalse: []


### PR DESCRIPTION
We need to walk the subject type *regardless of subject relation* to match the behavior of arrows when walking forward

Fixes #1323

Special thanks to @alechenninger for reporting the issue and producing a repro