### PR TITLE
Skip logging of serialization errors in pgx

### DIFF
--- a/internal/datastore/postgres/common/errors.go
+++ b/internal/datastore/postgres/common/errors.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	pgUniqueConstraintViolation = "23505"
+	pgSerializationFailure      = "40001"
 )
 
 var createConflictDetailsRegex = regexp.MustCompile(`^Key (.+)=\(([^,]+),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)\) already exists`)


### PR DESCRIPTION
They will be handled by retries and, if that fails, logged at the request level

Fixes #1269