### PR TITLE
introduces a flag to define the maximum relationship context size

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -3,7 +3,7 @@ module github.com/authzed/spicedb/e2e
 go 1.19
 
 require (
-	github.com/authzed/authzed-go v0.8.1-0.20230530210519-9a8359f06b96
+	github.com/authzed/authzed-go v0.8.1-0.20230601141426-d411c3f66256
 	github.com/authzed/grpcutil v0.0.0-20230509155820-7a6fedb71dbc
 	github.com/authzed/spicedb v1.21.0
 	github.com/brianvoe/gofakeit/v6 v6.15.0

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -394,8 +394,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 h1:yL7+Jz0jTC6yykIK/Wh74gnTJnrGr5AyrNMXuA0gves=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
-github.com/authzed/authzed-go v0.8.1-0.20230530210519-9a8359f06b96 h1:R4rPgXOn/H/SDUauXtlsjhjKJeVqWcgus235qunZ2xE=
-github.com/authzed/authzed-go v0.8.1-0.20230530210519-9a8359f06b96/go.mod h1:maZpwm2z27V95NnEq8CDHIbrrDDP7WJ3ODk98b9fzJ0=
+github.com/authzed/authzed-go v0.8.1-0.20230601141426-d411c3f66256 h1:fu0vsI/+dxpQpdWihrI219piaL2GbXOTrLAMM8ZjanM=
+github.com/authzed/authzed-go v0.8.1-0.20230601141426-d411c3f66256/go.mod h1:qn4HCG0DQcLybaRePpVFW/Gvgz9UgkvobzyBoA5a49c=
 github.com/authzed/grpcutil v0.0.0-20230509155820-7a6fedb71dbc h1:FzQP1mljgX15vawHVHlPXQrB6F6wnR/6CftpED+2cvg=
 github.com/authzed/grpcutil v0.0.0-20230509155820-7a6fedb71dbc/go.mod h1:erPFLN0tntt2V4PAxoUTwqtinm3UhFGzJrcxYKKzGUM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/IBM/pgxpoolprometheus v1.1.1
 	github.com/Masterminds/squirrel v1.5.3
 	github.com/agnivade/wasmbrowsertest v0.7.0
-	github.com/authzed/authzed-go v0.8.1-0.20230530210519-9a8359f06b96
+	github.com/authzed/authzed-go v0.8.1-0.20230601141426-d411c3f66256
 	github.com/authzed/grpcutil v0.0.0-20230509155820-7a6fedb71dbc
 	github.com/aws/aws-sdk-go v1.44.110
 	github.com/benbjohnson/clock v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/ashanbrown/forbidigo v1.5.1 h1:WXhzLjOlnuDYPYQo/eFlcFMi8X/kLfvWLYu6CS
 github.com/ashanbrown/forbidigo v1.5.1/go.mod h1:Y8j9jy9ZYAEHXdu723cUlraTqbzjKF1MUyfOKL+AjcU=
 github.com/ashanbrown/makezero v1.1.1 h1:iCQ87C0V0vSyO+M9E/FZYbu65auqH0lnsOkf5FcB28s=
 github.com/ashanbrown/makezero v1.1.1/go.mod h1:i1bJLCRSCHOcOa9Y6MyF2FTfMZMFdHvxKHxgO5Z1axI=
-github.com/authzed/authzed-go v0.8.1-0.20230530210519-9a8359f06b96 h1:R4rPgXOn/H/SDUauXtlsjhjKJeVqWcgus235qunZ2xE=
-github.com/authzed/authzed-go v0.8.1-0.20230530210519-9a8359f06b96/go.mod h1:maZpwm2z27V95NnEq8CDHIbrrDDP7WJ3ODk98b9fzJ0=
+github.com/authzed/authzed-go v0.8.1-0.20230601141426-d411c3f66256 h1:fu0vsI/+dxpQpdWihrI219piaL2GbXOTrLAMM8ZjanM=
+github.com/authzed/authzed-go v0.8.1-0.20230601141426-d411c3f66256/go.mod h1:qn4HCG0DQcLybaRePpVFW/Gvgz9UgkvobzyBoA5a49c=
 github.com/authzed/grpcutil v0.0.0-20230509155820-7a6fedb71dbc h1:FzQP1mljgX15vawHVHlPXQrB6F6wnR/6CftpED+2cvg=
 github.com/authzed/grpcutil v0.0.0-20230509155820-7a6fedb71dbc/go.mod h1:erPFLN0tntt2V4PAxoUTwqtinm3UhFGzJrcxYKKzGUM=
 github.com/aws/aws-sdk-go v1.17.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/internal/dispatch/combined/combined.go
+++ b/internal/dispatch/combined/combined.go
@@ -3,7 +3,6 @@
 package combined
 
 import (
-	"os"
 	"time"
 
 	"github.com/authzed/grpcutil"
@@ -125,15 +124,11 @@ func NewDispatcher(options ...Option) (dispatch.Dispatcher, error) {
 	// If an upstream is specified, create a cluster dispatcher.
 	if opts.upstreamAddr != "" {
 		if opts.upstreamCAPath != "" {
-			// Ensure that the CA path exists.
-			if _, err := os.Stat(opts.upstreamCAPath); err != nil {
-				return nil, err
-			}
-			certsOpt, err := grpcutil.WithCustomCerts(grpcutil.VerifyCA, opts.upstreamCAPath)
+			customCertOpt, err := grpcutil.WithCustomCerts(grpcutil.VerifyCA, opts.upstreamCAPath)
 			if err != nil {
 				return nil, err
 			}
-			opts.grpcDialOpts = append(opts.grpcDialOpts, certsOpt)
+			opts.grpcDialOpts = append(opts.grpcDialOpts, customCertOpt)
 			opts.grpcDialOpts = append(opts.grpcDialOpts, grpcutil.WithBearerToken(opts.grpcPresharedKey))
 		} else {
 			opts.grpcDialOpts = append(opts.grpcDialOpts, grpcutil.WithInsecureBearerToken(opts.grpcPresharedKey))

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -199,6 +199,7 @@ func TestClusterWithDispatchAndCacheConfig(t testing.TB, size uint, ds datastore
 				Network: util.BufferedNetwork,
 				Enabled: true,
 			}),
+			server.WithMaxRelationshipContextSize(25000),
 			server.WithSchemaPrefixesRequired(false),
 			server.WithGRPCAuthFunc(func(ctx context.Context) (context.Context, error) {
 				return ctx, nil

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -21,9 +21,10 @@ import (
 
 // ServerConfig is configuration for the test server.
 type ServerConfig struct {
-	MaxUpdatesPerWrite    uint16
-	MaxPreconditionsCount uint16
-	StreamingAPITimeout   time.Duration
+	MaxUpdatesPerWrite         uint16
+	MaxPreconditionsCount      uint16
+	MaxRelationshipContextSize int
+	StreamingAPITimeout        time.Duration
 }
 
 // NewTestServer creates a new test server, using defaults for the config.
@@ -35,9 +36,10 @@ func NewTestServer(require *require.Assertions,
 ) (*grpc.ClientConn, func(), datastore.Datastore, datastore.Revision) {
 	return NewTestServerWithConfig(require, revisionQuantization, gcWindow, schemaPrefixRequired,
 		ServerConfig{
-			MaxUpdatesPerWrite:    1000,
-			MaxPreconditionsCount: 1000,
-			StreamingAPITimeout:   30 * time.Second,
+			MaxUpdatesPerWrite:         1000,
+			MaxPreconditionsCount:      1000,
+			StreamingAPITimeout:        30 * time.Second,
+			MaxRelationshipContextSize: 25000,
 		},
 		dsInitFunc)
 }
@@ -62,6 +64,7 @@ func NewTestServerWithConfig(require *require.Assertions,
 		server.WithMaximumUpdatesPerWrite(config.MaxUpdatesPerWrite),
 		server.WithStreamingAPITimeout(config.StreamingAPITimeout),
 		server.WithMaxCaveatContextSize(4096),
+		server.WithMaxRelationshipContextSize(config.MaxRelationshipContextSize),
 		server.WithGRPCServer(util.GRPCServerConfig{
 			Network: util.BufferedNetwork,
 			Enabled: true,

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -118,6 +118,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	cmd.Flags().Uint16Var(&config.MaximumUpdatesPerWrite, "write-relationships-max-updates-per-call", 1000, "maximum number of updates allowed for WriteRelationships calls")
 	cmd.Flags().Uint16Var(&config.MaximumPreconditionCount, "update-relationships-max-preconditions-per-call", 1000, "maximum number of preconditions allowed for WriteRelationships and DeleteRelationships calls")
 	cmd.Flags().IntVar(&config.MaxCaveatContextSize, "max-caveat-context-size", 4096, "maximum allowed size of request caveat context in bytes. A value of zero or less means no limit")
+	cmd.Flags().IntVar(&config.MaxRelationshipContextSize, "max-relationship-context-size", 25000, "maximum allowed size of the context to be stored in a relationship")
 	cmd.Flags().DurationVar(&config.StreamingAPITimeout, "streaming-api-response-delay-timeout", 30*time.Second, "max duration time elapsed between messages sent by the server-side to the client (responses) before the stream times out")
 
 	cmd.Flags().BoolVar(&config.V1SchemaAdditiveOnly, "testing-only-schema-additive-writes", false, "append new definitions to the existing schema, rather than overwriting it")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -72,7 +72,8 @@ type Config struct {
 	Datastore       datastore.Datastore `debugmap:"visible"`
 
 	// Datastore usage
-	MaxCaveatContextSize int `debugmap:"visible"`
+	MaxCaveatContextSize       int `debugmap:"visible"`
+	MaxRelationshipContextSize int `debugmap:"visible"`
 
 	// Namespace cache
 	NamespaceCacheConfig CacheConfig `debugmap:"visible"`
@@ -345,12 +346,13 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 	}
 
 	permSysConfig := v1svc.PermissionsServerConfig{
-		MaxPreconditionsCount:    c.MaximumPreconditionCount,
-		MaxUpdatesPerWrite:       c.MaximumUpdatesPerWrite,
-		MaximumAPIDepth:          c.DispatchMaxDepth,
-		MaxCaveatContextSize:     c.MaxCaveatContextSize,
-		MaxDatastoreReadPageSize: c.MaxDatastoreReadPageSize,
-		StreamingAPITimeout:      c.StreamingAPITimeout,
+		MaxPreconditionsCount:      c.MaximumPreconditionCount,
+		MaxUpdatesPerWrite:         c.MaximumUpdatesPerWrite,
+		MaximumAPIDepth:            c.DispatchMaxDepth,
+		MaxCaveatContextSize:       c.MaxCaveatContextSize,
+		MaxRelationshipContextSize: c.MaxRelationshipContextSize,
+		MaxDatastoreReadPageSize:   c.MaxDatastoreReadPageSize,
+		StreamingAPITimeout:        c.StreamingAPITimeout,
 	}
 
 	healthManager := health.NewHealthManager(dispatcher, ds)

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -51,6 +51,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.DatastoreConfig = c.DatastoreConfig
 		to.Datastore = c.Datastore
 		to.MaxCaveatContextSize = c.MaxCaveatContextSize
+		to.MaxRelationshipContextSize = c.MaxRelationshipContextSize
 		to.NamespaceCacheConfig = c.NamespaceCacheConfig
 		to.SchemaPrefixesRequired = c.SchemaPrefixesRequired
 		to.DispatchServer = c.DispatchServer
@@ -103,6 +104,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["DatastoreConfig"] = helpers.DebugValue(c.DatastoreConfig, false)
 	debugMap["Datastore"] = helpers.DebugValue(c.Datastore, false)
 	debugMap["MaxCaveatContextSize"] = helpers.DebugValue(c.MaxCaveatContextSize, false)
+	debugMap["MaxRelationshipContextSize"] = helpers.DebugValue(c.MaxRelationshipContextSize, false)
 	debugMap["NamespaceCacheConfig"] = helpers.DebugValue(c.NamespaceCacheConfig, false)
 	debugMap["SchemaPrefixesRequired"] = helpers.DebugValue(c.SchemaPrefixesRequired, false)
 	debugMap["DispatchServer"] = helpers.DebugValue(c.DispatchServer, false)
@@ -254,6 +256,13 @@ func WithDatastore(datastore datastore1.Datastore) ConfigOption {
 func WithMaxCaveatContextSize(maxCaveatContextSize int) ConfigOption {
 	return func(c *Config) {
 		c.MaxCaveatContextSize = maxCaveatContextSize
+	}
+}
+
+// WithMaxRelationshipContextSize returns an option that can set MaxRelationshipContextSize on a Config
+func WithMaxRelationshipContextSize(maxRelationshipContextSize int) ConfigOption {
+	return func(c *Config) {
+		c.MaxRelationshipContextSize = maxRelationshipContextSize
 	}
 }
 

--- a/pkg/cmd/testing.go
+++ b/pkg/cmd/testing.go
@@ -23,6 +23,7 @@ func RegisterTestingFlags(cmd *cobra.Command, config *testserver.Config) {
 	cmd.Flags().Uint16Var(&config.MaximumUpdatesPerWrite, "write-relationships-max-updates-per-call", 1000, "maximum number of updates allowed for WriteRelationships calls")
 	cmd.Flags().Uint16Var(&config.MaximumPreconditionCount, "update-relationships-max-preconditions-per-call", 1000, "maximum number of preconditions allowed for WriteRelationships and DeleteRelationships calls")
 	cmd.Flags().IntVar(&config.MaxCaveatContextSize, "max-caveat-context-size", 4096, "maximum allowed size of request caveat context in bytes. A value of zero or less means no limit")
+	cmd.Flags().IntVar(&config.MaxRelationshipContextSize, "max-relationship-context-size", 25000, "maximum allowed size of the context to be stored in a relationship")
 }
 
 func NewTestingCommand(programName string, config *testserver.Config) *cobra.Command {

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -27,14 +27,15 @@ const maxDepth = 50
 
 //go:generate go run github.com/ecordell/optgen -output zz_generated.options.go . Config
 type Config struct {
-	GRPCServer               util.GRPCServerConfig `debugmap:"visible"`
-	ReadOnlyGRPCServer       util.GRPCServerConfig `debugmap:"visible"`
-	HTTPGateway              util.HTTPServerConfig `debugmap:"visible"`
-	ReadOnlyHTTPGateway      util.HTTPServerConfig `debugmap:"visible"`
-	LoadConfigs              []string              `debugmap:"visible"`
-	MaximumUpdatesPerWrite   uint16                `debugmap:"visible"`
-	MaximumPreconditionCount uint16                `debugmap:"visible"`
-	MaxCaveatContextSize     int                   `debugmap:"visible"`
+	GRPCServer                 util.GRPCServerConfig `debugmap:"visible"`
+	ReadOnlyGRPCServer         util.GRPCServerConfig `debugmap:"visible"`
+	HTTPGateway                util.HTTPServerConfig `debugmap:"visible"`
+	ReadOnlyHTTPGateway        util.HTTPServerConfig `debugmap:"visible"`
+	LoadConfigs                []string              `debugmap:"visible"`
+	MaximumUpdatesPerWrite     uint16                `debugmap:"visible"`
+	MaximumPreconditionCount   uint16                `debugmap:"visible"`
+	MaxCaveatContextSize       int                   `debugmap:"visible"`
+	MaxRelationshipContextSize int                   `debugmap:"visible"`
 }
 
 type RunnableTestServer interface {

--- a/pkg/cmd/testserver/zz_generated.options.go
+++ b/pkg/cmd/testserver/zz_generated.options.go
@@ -39,6 +39,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.MaximumUpdatesPerWrite = c.MaximumUpdatesPerWrite
 		to.MaximumPreconditionCount = c.MaximumPreconditionCount
 		to.MaxCaveatContextSize = c.MaxCaveatContextSize
+		to.MaxRelationshipContextSize = c.MaxRelationshipContextSize
 	}
 }
 
@@ -53,6 +54,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["MaximumUpdatesPerWrite"] = helpers.DebugValue(c.MaximumUpdatesPerWrite, false)
 	debugMap["MaximumPreconditionCount"] = helpers.DebugValue(c.MaximumPreconditionCount, false)
 	debugMap["MaxCaveatContextSize"] = helpers.DebugValue(c.MaxCaveatContextSize, false)
+	debugMap["MaxRelationshipContextSize"] = helpers.DebugValue(c.MaxRelationshipContextSize, false)
 	return debugMap
 }
 
@@ -132,5 +134,12 @@ func WithMaximumPreconditionCount(maximumPreconditionCount uint16) ConfigOption 
 func WithMaxCaveatContextSize(maxCaveatContextSize int) ConfigOption {
 	return func(c *Config) {
 		c.MaxCaveatContextSize = maxCaveatContextSize
+	}
+}
+
+// WithMaxRelationshipContextSize returns an option that can set MaxRelationshipContextSize on a Config
+func WithMaxRelationshipContextSize(maxRelationshipContextSize int) ConfigOption {
+	return func(c *Config) {
+		c.MaxRelationshipContextSize = maxRelationshipContextSize
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/authzed/spicedb/issues/1355

depends on https://github.com/authzed/api/pull/66
depends on https://github.com/authzed/authzed-go/pull/118

A new max-relationship-context-size flag is introduced with a default of 25KB. The gRPC RPC controller will fail to perform a WriteRelationship request if any of the relationships contained in the payload exceed the configured maximum size.

The API will return an InvalidArgument error with metadata:
- "relationship" that failed the condition
- "max_allowed_size" returns the configured limit by the server
- "relationship_size" returns the actual size of the relationship that failed the condition