### PR TITLE
add support for termination log and custom exit codes

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -13,8 +13,8 @@ import (
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/cmd"
 	cmdutil "github.com/authzed/spicedb/pkg/cmd/server"
-	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/cmd/testserver"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
 var errParsing = errors.New("parsing error")
@@ -81,7 +81,7 @@ func main() {
 		if !errors.Is(err, errParsing) {
 			log.Err(err).Msg("terminated with errors")
 		}
-		var termErr termination.Error
+		var termErr spiceerrors.TerminationError
 		if errors.As(err, &termErr) {
 			os.Exit(termErr.ExitCode())
 		}

--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/cmd"
 	cmdutil "github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/cmd/testserver"
 )
 
@@ -79,6 +80,10 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		if !errors.Is(err, errParsing) {
 			log.Err(err).Msg("terminated with errors")
+		}
+		var termErr termination.Error
+		if errors.As(err, &termErr) {
+			os.Exit(termErr.ExitCode())
 		}
 		os.Exit(1)
 	}

--- a/e2e/cockroach/cockroach.go
+++ b/e2e/cockroach/cockroach.go
@@ -67,7 +67,7 @@ func (c *Node) ConnectionString(dbName string) string {
 }
 
 // Connect connects directly to the cockroach instance and caches the connection
-func (c *Node) Connect(ctx context.Context, out io.Writer, dbName string) error {
+func (c *Node) Connect(ctx context.Context, _ io.Writer, dbName string) error {
 	if c.pid < 1 {
 		return fmt.Errorf("can't connect to unstarted cockroach")
 	}

--- a/go.mod
+++ b/go.mod
@@ -288,6 +288,7 @@ require (
 	github.com/sanposhiho/wastedassign/v2 v2.0.7 // indirect
 	github.com/sashamelentyev/interfacebloat v1.1.0 // indirect
 	github.com/sashamelentyev/usestdlibvars v1.23.0 // indirect
+	github.com/sean-/sysexits v1.0.0 // indirect
 	github.com/securego/gosec/v2 v2.15.0 // indirect
 	github.com/shabbyrobe/gocovmerge v0.0.0-20190829150210-3e036491d500 // indirect
 	github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1203,6 +1203,8 @@ github.com/sashamelentyev/usestdlibvars v1.23.0 h1:01h+/2Kd+NblNItNeux0veSL5cBF1
 github.com/sashamelentyev/usestdlibvars v1.23.0/go.mod h1:YPwr/Y1LATzHI93CqoPUN/2BzGQ/6N/cl/KwgR0B/aU=
 github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
+github.com/sean-/sysexits v1.0.0 h1:FLf1xcUTBzTqUI1Nc77UwYPcoWgDM09lyMTt8+QCpbE=
+github.com/sean-/sysexits v1.0.0/go.mod h1:yRz1mwglmPHOlAm3+WGr40EV8qFg4hn8GE9MoNwoecg=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/securego/gosec/v2 v2.15.0 h1:v4Ym7FF58/jlykYmmhZ7mTm7FQvN/setNm++0fgIAtw=
 github.com/securego/gosec/v2 v2.15.0/go.mod h1:VOjTrZOkUtSDt2QLSJmQBMWnvwiQPEjg0l+5juIqGk8=

--- a/pkg/cmd/datastore.go
+++ b/pkg/cmd/datastore.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/cmd/datastore"
 	"github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/cmd/termination"
 	dspkg "github.com/authzed/spicedb/pkg/datastore"
 )
 
@@ -45,7 +46,7 @@ func NewGCDatastoreCommand(programName string, cfg *datastore.Config) *cobra.Com
 		Short:   "executes garbage collection",
 		Long:    "Executes garbage collection against the datastore",
 		PreRunE: server.DefaultPreRunE(programName),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: termination.PublishError(func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
 			// Disable background GC and hedging.
@@ -77,6 +78,6 @@ func NewGCDatastoreCommand(programName string, cfg *datastore.Config) *cobra.Com
 			}
 			log.Ctx(ctx).Info().Msg("Garbage collection completed")
 			return nil
-		},
+		}),
 	}
 }

--- a/pkg/cmd/devtools.go
+++ b/pkg/cmd/devtools.go
@@ -29,6 +29,7 @@ import (
 	log "github.com/authzed/spicedb/internal/logging"
 	v0svc "github.com/authzed/spicedb/internal/services/v0"
 	"github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/cmd/termination"
 )
 
 func RegisterDevtoolsFlags(cmd *cobra.Command) {
@@ -51,7 +52,7 @@ func NewDevtoolsCommand(programName string) *cobra.Command {
 		Short:   "runs the developer tools service",
 		Long:    "Serves the authzed.api.v0.DeveloperService which is used for development tooling such as the Authzed Playground",
 		PreRunE: server.DefaultPreRunE(programName),
-		RunE:    runfunc,
+		RunE:    termination.PublishError(runfunc),
 		Args:    cobra.ExactArgs(0),
 	}
 }

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -15,6 +15,7 @@ import (
 	spannermigrations "github.com/authzed/spicedb/internal/datastore/spanner/migrations"
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/migrate"
 )
@@ -35,7 +36,7 @@ func NewMigrateCommand(programName string) *cobra.Command {
 		Short:   "execute datastore schema migrations",
 		Long:    fmt.Sprintf("Executes datastore schema migrations for the datastore.\nThe special value \"%s\" can be used to migrate to the latest revision.", color.YellowString(migrate.Head)),
 		PreRunE: server.DefaultPreRunE(programName),
-		RunE:    migrateRun,
+		RunE:    termination.PublishError(migrateRun),
 		Args:    cobra.ExactArgs(1),
 	}
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/releases"
 )
 
@@ -13,6 +14,7 @@ func RegisterRootFlags(cmd *cobra.Command) {
 	cobrazerolog.New().RegisterFlags(cmd.PersistentFlags())
 	cobraotel.New(cmd.Use).RegisterFlags(cmd.PersistentFlags())
 	releases.RegisterFlags(cmd.PersistentFlags())
+	termination.RegisterFlags(cmd.PersistentFlags())
 }
 
 func NewRootCommand(programName string) *cobra.Command {

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -10,6 +10,7 @@ import (
 	"github.com/authzed/spicedb/internal/telemetry"
 	"github.com/authzed/spicedb/pkg/cmd/datastore"
 	"github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/cmd/util"
 )
 
@@ -142,7 +143,7 @@ func NewServeCommand(programName string, config *server.Config) *cobra.Command {
 		Short:   "serve the permissions database",
 		Long:    "A database that stores, computes, and validates application permissions",
 		PreRunE: server.DefaultPreRunE(programName),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: termination.PublishError(func(cmd *cobra.Command, args []string) error {
 			server, err := config.Complete(cmd.Context())
 			if err != nil {
 				return err
@@ -152,7 +153,7 @@ func NewServeCommand(programName string, config *server.Config) *cobra.Command {
 				config.ShutdownGracePeriod,
 			)
 			return server.Run(signalctx)
-		},
+		}),
 		Example: server.ServeExample(programName),
 	}
 }

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -10,14 +10,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/authzed/grpcutil"
 	"github.com/cespare/xxhash/v2"
 	"github.com/ecordell/optgen/helpers"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	grpcprom "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/hashicorp/go-multierror"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
 	"github.com/rs/zerolog"
 	"github.com/sean-/sysexits"
@@ -42,9 +41,9 @@ import (
 	"github.com/authzed/spicedb/internal/telemetry"
 	"github.com/authzed/spicedb/pkg/balancer"
 	datastorecfg "github.com/authzed/spicedb/pkg/cmd/datastore"
-	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/cmd/util"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
 // ConsistentHashringBuilder is a balancer Builder that uses xxhash as the
@@ -205,7 +204,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		var err error
 		ds, err = datastorecfg.NewDatastore(context.Background(), c.DatastoreConfig.ToOption())
 		if err != nil {
-			return nil, termination.New(fmt.Errorf("failed to create datastore: %w", err)).
+			return nil, spiceerrors.NewTerminationErrorBuilder(fmt.Errorf("failed to create datastore: %w", err)).
 				Component("datastore").
 				ExitCode(sysexits.Config).
 				Error()

--- a/pkg/cmd/termination/termination.go
+++ b/pkg/cmd/termination/termination.go
@@ -1,0 +1,136 @@
+package termination
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	log "github.com/authzed/spicedb/internal/logging"
+
+	"github.com/jzelinskie/cobrautil/v2"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	defaultTerminationLogPath = "/dev/termination-log"
+	terminationLogFlagName    = "termination-log-path"
+	kubeTerminationLogLimit   = 4096
+)
+
+// Error represents an error that captures contextual information to make
+// available on process termination. The error will be marshalled as JSON and
+// serialized into a file-path specified via CLI arguments
+type Error struct {
+	error
+	Component   string            `json:"component"`
+	Timestamp   time.Time         `json:"timestamp"`
+	ErrorString string            `json:"error"`
+	Metadata    map[string]string `json:"metadata"`
+	exitCode    int
+}
+
+// ExitCode returns the exit code to be returned on process termination
+func (e Error) ExitCode() int {
+	return e.exitCode
+}
+
+// ErrorBuilder is a fluent-style builder for Error
+type ErrorBuilder struct {
+	terminationErr Error
+}
+
+// Error returns the built termination Error
+func (eb *ErrorBuilder) Error() Error {
+	return eb.terminationErr
+}
+
+// Component specifies the component in SpiceDB that
+func (eb *ErrorBuilder) Component(component string) *ErrorBuilder {
+	eb.terminationErr.Component = component
+	return eb
+}
+
+// Metadata adds a new key-value pair of metadata to the termination Error being built
+func (eb *ErrorBuilder) Metadata(key, value string) *ErrorBuilder {
+	eb.terminationErr.Metadata[key] = value
+	return eb
+}
+
+// ExitCode defines the ExitCode to be used upon process termination. Defaults to 1 if not specified.
+func (eb *ErrorBuilder) ExitCode(exitCode int) *ErrorBuilder {
+	eb.terminationErr.exitCode = exitCode
+	return eb
+}
+
+// Timestamp defines the time of the error. Defaults to time.Now().UTC() if not specified.
+func (eb *ErrorBuilder) Timestamp(timestamp time.Time) *ErrorBuilder {
+	eb.terminationErr.Timestamp = timestamp
+	return eb
+}
+
+// New returns a new ErrorBuilder for a termination.Error.
+func New(err error) *ErrorBuilder {
+	return &ErrorBuilder{terminationErr: Error{
+		error:       err,
+		Component:   "unspecified",
+		Timestamp:   time.Now().UTC(),
+		ErrorString: err.Error(),
+		Metadata:    make(map[string]string, 0),
+		exitCode:    1,
+	}}
+}
+
+// PublishError returns a new wrapping cobra run function that executes the provided argument runFunc, and
+// writes to disk an error returned by the latter if it is of type termination.Error.
+func PublishError(runFunc cobrautil.CobraRunFunc) cobrautil.CobraRunFunc {
+	return func(cmd *cobra.Command, args []string) error {
+		runFuncErr := runFunc(cmd, args)
+		var termErr Error
+		if runFuncErr != nil && errors.As(runFuncErr, &termErr) {
+			ctx := context.Background()
+			if cmd.Context() != nil {
+				ctx = cmd.Context()
+			}
+			terminationLogPath := cobrautil.MustGetString(cmd, terminationLogFlagName)
+			bytes, err := json.Marshal(termErr)
+			if err != nil {
+				log.Ctx(ctx).Error().Err(fmt.Errorf("unable to marshall termination log: %w", err)).Msg("failed to report termination log")
+				return runFuncErr
+			}
+
+			if len(bytes) > kubeTerminationLogLimit {
+				log.Ctx(ctx).Warn().Msg("termination log exceeds 4096 bytes limit, metadata will be truncated")
+				termErr.Metadata = nil
+				bytes, err = json.Marshal(termErr)
+				if err != nil {
+					return runFuncErr
+				}
+			}
+
+			if _, err := os.Stat(path.Dir(terminationLogPath)); os.IsNotExist(err) {
+				mkdirErr := os.MkdirAll(path.Dir(terminationLogPath), 0o700) // Create your file
+				if mkdirErr != nil {
+					log.Ctx(ctx).Error().Err(fmt.Errorf("unable to create directory for termination log: %w", err)).Msg("failed to report termination log")
+					return runFuncErr
+				}
+			}
+			if err := os.WriteFile(terminationLogPath, bytes, 0o600); err != nil {
+				log.Ctx(ctx).Error().Err(fmt.Errorf("unable to write terminationlog file: %w", err)).Msg("failed to report termination log")
+			}
+		}
+		return runFuncErr
+	}
+}
+
+// RegisterFlags registers the termination log flag
+func RegisterFlags(flagset *flag.FlagSet) {
+	flagset.String(terminationLogFlagName,
+		defaultTerminationLogPath,
+		"define the path to the termination log file, which contains a JSON payload to surface as reason for termination",
+	)
+}

--- a/pkg/cmd/termination/termination_test.go
+++ b/pkg/cmd/termination/termination_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/authzed/spicedb/pkg/spiceerrors"
+
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
@@ -19,16 +21,16 @@ func TestPublishError(t *testing.T) {
 	require.NoError(t, err)
 	filePath := f.Name()
 	cmd.Flag(terminationLogFlagName).Value = newStringValue(filePath, &filePath)
-	publishedError := New(errors.New("hi")).Metadata("k", "v").Component("test").Error()
+	publishedError := spiceerrors.NewTerminationErrorBuilder(errors.New("hi")).Metadata("k", "v").Component("test").Error()
 	err = PublishError(func(cmd *cobra.Command, args []string) error {
 		return publishedError
 	})(&cmd, nil)
-	var termErr Error
+	var termErr spiceerrors.TerminationError
 	require.ErrorAs(t, err, &termErr)
 
 	jsonBytes, err := os.ReadFile(f.Name())
 	require.NoError(t, err)
-	var readErr Error
+	var readErr spiceerrors.TerminationError
 	err = json.Unmarshal(jsonBytes, &readErr)
 	require.NoError(t, err)
 

--- a/pkg/cmd/termination/termination_test.go
+++ b/pkg/cmd/termination/termination_test.go
@@ -1,0 +1,77 @@
+package termination
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishError(t *testing.T) {
+	cmd := cobra.Command{}
+	RegisterFlags(cmd.Flags())
+
+	f, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	filePath := f.Name()
+	cmd.Flag(terminationLogFlagName).Value = newStringValue(filePath, &filePath)
+	publishedError := New(errors.New("hi")).Metadata("k", "v").Component("test").Error()
+	err = PublishError(func(cmd *cobra.Command, args []string) error {
+		return publishedError
+	})(&cmd, nil)
+	var termErr Error
+	require.ErrorAs(t, err, &termErr)
+
+	jsonBytes, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	var readErr Error
+	err = json.Unmarshal(jsonBytes, &readErr)
+	require.NoError(t, err)
+
+	require.Equal(t, "hi", readErr.ErrorString)
+	require.Equal(t, "test", readErr.Component)
+	require.NotEmpty(t, readErr.Timestamp)
+	require.Equal(t, publishedError.Timestamp, readErr.Timestamp)
+	require.Len(t, readErr.Metadata, 1)
+	require.Equal(t, readErr.Metadata["k"], "v")
+
+	// test error metadata is truncated when too large
+	var builder strings.Builder
+	for i := 0; i < kubeTerminationLogLimit; i++ {
+		builder.WriteString("a")
+	}
+	publishedError.Metadata["large_value"] = builder.String()
+	_ = PublishError(func(cmd *cobra.Command, args []string) error {
+		return publishedError
+	})(&cmd, nil)
+
+	jsonBytes, err = os.ReadFile(f.Name())
+	require.NoError(t, err)
+	err = json.Unmarshal(jsonBytes, &readErr)
+	require.NoError(t, err)
+	require.Len(t, readErr.Metadata, 0)
+}
+
+type testValue string
+
+func newStringValue(val string, p *string) *testValue {
+	*p = val
+	return (*testValue)(p)
+}
+
+func (s *testValue) Set(val string) error {
+	*s = testValue(val)
+	return nil
+}
+
+func (s *testValue) Type() string {
+	return "string"
+}
+
+func (s *testValue) String() string {
+	return string(*s)
+}

--- a/pkg/cmd/testing.go
+++ b/pkg/cmd/testing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/cmd/testserver"
 	"github.com/authzed/spicedb/pkg/cmd/util"
 )
@@ -31,7 +32,7 @@ func NewTestingCommand(programName string, config *testserver.Config) *cobra.Com
 		Short:   "test server with an in-memory datastore",
 		Long:    "An in-memory spicedb server which serves completely isolated datastores per client-supplied auth token used.",
 		PreRunE: server.DefaultPreRunE(programName),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: termination.PublishError(func(cmd *cobra.Command, args []string) error {
 			signalctx := SignalContextWithGracePeriod(
 				context.Background(),
 				0,
@@ -41,6 +42,6 @@ func NewTestingCommand(programName string, config *testserver.Config) *cobra.Com
 				return err
 			}
 			return srv.Run(signalctx)
-		},
+		}),
 	}
 }

--- a/pkg/spiceerrors/termination.go
+++ b/pkg/spiceerrors/termination.go
@@ -1,0 +1,66 @@
+package spiceerrors
+
+import "time"
+
+// TerminationError represents an error that captures contextual information to make
+// available on process termination. The error will be marshalled as JSON and
+// serialized into a file-path specified via CLI arguments
+type TerminationError struct {
+	error
+	Component   string            `json:"component"`
+	Timestamp   time.Time         `json:"timestamp"`
+	ErrorString string            `json:"error"`
+	Metadata    map[string]string `json:"metadata"`
+	exitCode    int
+}
+
+// ExitCode returns the exit code to be returned on process termination
+func (e TerminationError) ExitCode() int {
+	return e.exitCode
+}
+
+// ErrorBuilder is a fluent-style builder for TerminationError
+type ErrorBuilder struct {
+	terminationErr TerminationError
+}
+
+// TerminationError returns the built termination TerminationError
+func (eb *ErrorBuilder) Error() TerminationError {
+	return eb.terminationErr
+}
+
+// Component specifies the component in SpiceDB that
+func (eb *ErrorBuilder) Component(component string) *ErrorBuilder {
+	eb.terminationErr.Component = component
+	return eb
+}
+
+// Metadata adds a new key-value pair of metadata to the termination TerminationError being built
+func (eb *ErrorBuilder) Metadata(key, value string) *ErrorBuilder {
+	eb.terminationErr.Metadata[key] = value
+	return eb
+}
+
+// ExitCode defines the ExitCode to be used upon process termination. Defaults to 1 if not specified.
+func (eb *ErrorBuilder) ExitCode(exitCode int) *ErrorBuilder {
+	eb.terminationErr.exitCode = exitCode
+	return eb
+}
+
+// Timestamp defines the time of the error. Defaults to time.Now().UTC() if not specified.
+func (eb *ErrorBuilder) Timestamp(timestamp time.Time) *ErrorBuilder {
+	eb.terminationErr.Timestamp = timestamp
+	return eb
+}
+
+// NewTerminationErrorBuilder returns a new ErrorBuilder for a termination.TerminationError.
+func NewTerminationErrorBuilder(err error) *ErrorBuilder {
+	return &ErrorBuilder{terminationErr: TerminationError{
+		error:       err,
+		Component:   "unspecified",
+		Timestamp:   time.Now().UTC(),
+		ErrorString: err.Error(),
+		Metadata:    make(map[string]string, 0),
+		exitCode:    1,
+	}}
+}


### PR DESCRIPTION
[termination log](https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/#customizing-the-termination-message) is a concept in Kubernetes that
allows applications providing information
upon termination that will be surfaced as part
of the status of a Pod. This is useful for troubleshooting
purposes but also can be used by the control plane.

The `termination.Error` also includes an `ExitCode` which will emit on process termination.