### PR TITLE
Parallelize the entrypoint computation in ReachableResources

### DIFF
--- a/internal/dispatch/graph/reachableresources_test.go
+++ b/internal/dispatch/graph/reachableresources_test.go
@@ -896,8 +896,9 @@ func TestReachableResourcesPaginationWithLimit(t *testing.T) {
 				defer cancel()
 
 				newFound := 0
+				existingCursor := cursor
 				for _, result := range stream.Results() {
-					require.True(t, foundResources.Add(result.Resource.ResourceId))
+					require.True(t, foundResources.Add(result.Resource.ResourceId), "found duplicate %s for iteration %d with cursor %s", result.Resource.ResourceId, i, existingCursor)
 					newFound++
 
 					cursor = result.AfterResponseCursor

--- a/internal/graph/limits_test.go
+++ b/internal/graph/limits_test.go
@@ -27,3 +27,17 @@ func TestLimitsPrepareForPublishing(t *testing.T) {
 
 	require.False(t, result)
 }
+
+func TestLimitsMarkAlreadyPublished(t *testing.T) {
+	limits, _ := newLimitTracker(context.Background(), 10)
+
+	_, err := limits.markAlreadyPublished(5)
+	require.Nil(t, err)
+
+	_, err = limits.markAlreadyPublished(5)
+	require.Nil(t, err)
+
+	require.Panics(t, func() {
+		_, _ = limits.markAlreadyPublished(1)
+	})
+}

--- a/internal/graph/lookupresources.go
+++ b/internal/graph/lookupresources.go
@@ -57,7 +57,7 @@ func (cl *CursoredLookupResources) LookupResources(
 
 		// Create a new handling stream that consumes the reachable resources results and publishes them
 		// as found resources if they are properly checked.
-		rrStream := dispatch.NewHandlingDispatchStream(ctx, func(result *v1.DispatchReachableResourcesResponse) error {
+		rrStream := dispatch.NewHandlingDispatchStream(withCancel, func(result *v1.DispatchReachableResourcesResponse) error {
 			reachableResourcesCursor = result.AfterResponseCursor
 			reachableResourcesFound++
 

--- a/internal/graph/reachableresources.go
+++ b/internal/graph/reachableresources.go
@@ -95,7 +95,7 @@ func (crr *CursoredReachableResources) afterSameType(
 	ctx context.Context,
 	ci cursorInformation,
 	req ValidatedReachableResourcesRequest,
-	stream dispatch.ReachableResourcesStream,
+	parentStream dispatch.ReachableResourcesStream,
 ) error {
 	dispatched := &syncONRSet{}
 
@@ -117,8 +117,8 @@ func (crr *CursoredReachableResources) afterSameType(
 	}
 
 	// For each entrypoint, load the necessary data and re-dispatch if a subproblem was found.
-	return withIterableInCursor(ci, "entrypoint", entrypoints,
-		func(ci cursorInformation, entrypoint namespace.ReachabilityEntrypoint) error {
+	return withParallelizedStreamingIterableInCursor(ctx, ci, "entrypoint", entrypoints, parentStream, crr.concurrencyLimit,
+		func(ctx context.Context, ci cursorInformation, entrypoint namespace.ReachabilityEntrypoint, stream dispatch.ReachableResourcesStream) error {
 			switch entrypoint.EntrypointKind() {
 			case core.ReachabilityEntrypoint_RELATION_ENTRYPOINT:
 				err := crr.lookupRelationEntrypoint(ctx, ci, entrypoint, rg, reader, req, stream, dispatched)

--- a/internal/graph/taskrunner.go
+++ b/internal/graph/taskrunner.go
@@ -37,6 +37,10 @@ type TaskFunc func(ctx context.Context) error
 // started after that point will also be canceled and the error returned. If
 // a task returns an error, the context provided to all tasks is also canceled.
 func NewTaskRunner(ctx context.Context, concurrencyLimit uint16) *TaskRunner {
+	if concurrencyLimit < 1 {
+		concurrencyLimit = 1
+	}
+
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 	return &TaskRunner{
 		ctx:    ctxWithCancel,

--- a/internal/namespace/reachabilitygraph.go
+++ b/internal/namespace/reachabilitygraph.go
@@ -65,6 +65,10 @@ func (re ReachabilityEntrypoint) IsDirectResult() bool {
 	return re.re.ResultStatus == core.ReachabilityEntrypoint_DIRECT_OPERATION_RESULT
 }
 
+func (re ReachabilityEntrypoint) String() string {
+	return re.MustDebugString()
+}
+
 func (re ReachabilityEntrypoint) MustDebugString() string {
 	switch re.EntrypointKind() {
 	case core.ReachabilityEntrypoint_RELATION_ENTRYPOINT:


### PR DESCRIPTION
This brings some parallelism back that was lost during the switch to support cursors

We run each entrypoint in parallel, with the later branches being streamed to in-memory collections that are published in the correct order