### PR TITLE
Use correct error type for duplicate relationships

### DIFF
--- a/internal/services/v1/errors.go
+++ b/internal/services/v1/errors.go
@@ -168,7 +168,7 @@ func (err ErrDuplicateRelationshipError) GRPCStatus() *status.Status {
 		err,
 		codes.InvalidArgument,
 		spiceerrors.ForReason(
-			v1.ErrorReason_ERROR_REASON_INVALID_SUBJECT_TYPE,
+			v1.ErrorReason_ERROR_REASON_UPDATES_ON_SAME_RELATIONSHIP,
 			map[string]string{
 				"definition_name": err.update.Relationship.Resource.ObjectType,
 				"relationship":    tuple.MustRelString(err.update.Relationship),


### PR DESCRIPTION
Fixes #1366 
Duplicates #1368 

## Description
We noticed this when looking at error output for a duplicate relationship issue - it wasn't returning the correct error reason out of the enum.

## Changes
* Use the correct error type
## Testing
I suppose it would be good to write a test for this, but I'm not familiar with Go. If you'd like to see some tests I'll dig into it.