### PR TITLE
more robust server defaults using optgen defaults

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -62,9 +62,9 @@ func main() {
 	rootCmd.AddCommand(headCmd)
 
 	// Add server commands
-	var serverConfig cmdutil.Config
-	serveCmd := cmd.NewServeCommand(rootCmd.Use, &serverConfig)
-	if err := cmd.RegisterServeFlags(serveCmd, &serverConfig); err != nil {
+	serverConfig := cmdutil.NewConfigWithOptionsAndDefaults()
+	serveCmd := cmd.NewServeCommand(rootCmd.Use, serverConfig)
+	if err := cmd.RegisterServeFlags(serveCmd, serverConfig); err != nil {
 		log.Fatal().Err(err).Msg("failed to register server flags")
 	}
 	rootCmd.AddCommand(serveCmd)

--- a/internal/services/integrationtesting/cert_test.go
+++ b/internal/services/integrationtesting/cert_test.go
@@ -117,7 +117,7 @@ func TestCertRotation(t *testing.T) {
 	require.NoError(t, err)
 	ds, revision := tf.StandardDatastoreWithData(emptyDS, require.New(t))
 	ctx, cancel := context.WithCancel(context.Background())
-	srv, err := server.NewConfigWithOptions(
+	srv, err := server.NewConfigWithOptionsAndDefaults(
 		server.WithDatastore(ds),
 		server.WithDispatcher(graph.NewLocalOnlyDispatcher(1)),
 		server.WithDispatchMaxDepth(50),

--- a/internal/services/v1/errors.go
+++ b/internal/services/v1/errors.go
@@ -190,7 +190,7 @@ type ErrMaxRelationshipContextError struct {
 func NewMaxRelationshipContextError(update *v1.RelationshipUpdate, maxAllowedSize int) ErrMaxRelationshipContextError {
 	return ErrMaxRelationshipContextError{
 		error: fmt.Errorf(
-			"provided relationship `%s` exceeded maximum allowed size of %d",
+			"provided relationship `%s` exceeded maximum allowed caveat size of %d",
 			tuple.StringRelationshipWithoutCaveat(update.Relationship),
 			maxAllowedSize,
 		),

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -81,8 +81,8 @@ func NewPermissionsServer(
 		MaxUpdatesPerWrite:         defaultIfZero(config.MaxUpdatesPerWrite, 1000),
 		MaximumAPIDepth:            defaultIfZero(config.MaximumAPIDepth, 50),
 		StreamingAPITimeout:        defaultIfZero(config.StreamingAPITimeout, 30*time.Second),
-		MaxCaveatContextSize:       config.MaxCaveatContextSize,
-		MaxRelationshipContextSize: config.MaxRelationshipContextSize,
+		MaxCaveatContextSize:       defaultIfZero(config.MaxCaveatContextSize, 4096),
+		MaxRelationshipContextSize: defaultIfZero(config.MaxRelationshipContextSize, 25_000),
 		MaxDatastoreReadPageSize:   defaultIfZero(config.MaxDatastoreReadPageSize, 1_000),
 	}
 

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -1286,7 +1286,7 @@ func TestWriteRelationshipsCaveatExceedsMaxSize(t *testing.T) {
 
 	require.Error(err)
 	grpcutil.RequireStatus(t, codes.InvalidArgument, err)
-	require.ErrorContains(err, "exceeded maximum allowed size of 1")
+	require.ErrorContains(err, "exceeded maximum allowed caveat size of 1")
 }
 
 func TestReadRelationshipsWithTimeout(t *testing.T) {

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -73,8 +73,8 @@ type Config struct {
 	Datastore       datastore.Datastore `debugmap:"visible"`
 
 	// Datastore usage
-	MaxCaveatContextSize       int `debugmap:"visible"`
-	MaxRelationshipContextSize int `debugmap:"visible"`
+	MaxCaveatContextSize       int `debugmap:"visible" default:"4096"`
+	MaxRelationshipContextSize int `debugmap:"visible" default:"25_000"`
 
 	// Namespace cache
 	NamespaceCacheConfig CacheConfig `debugmap:"visible"`


### PR DESCRIPTION
it was still possible to end up creating a server.Config programatically that didn't have defaults set. This causes constant friction when a new flag is added.

This introduces the usage of optgen defaults in
server.Config, and replaces any Config value creation with the helper method that invokes `defaults.MustSet`