### PR TITLE
changes reverse query ordering clause to be by subject

### DIFF
--- a/internal/graph/reachableresources.go
+++ b/internal/graph/reachableresources.go
@@ -245,7 +245,7 @@ func (crr *CursoredReachableResources) chunkedRedispatch(
 					Namespace: resourceType.Namespace,
 					Relation:  resourceType.Relation,
 				}),
-				options.WithSortForReverse(options.ByResource),
+				options.WithSortForReverse(options.BySubject),
 				options.WithAfterForReverse(queryCursor),
 				options.WithLimitForReverse(&queryLimit),
 			)

--- a/pkg/datastore/test/pagination.go
+++ b/pkg/datastore/test/pagination.go
@@ -163,7 +163,7 @@ func reverseIterator(subjectType string, _ options.SortOrder) iterator {
 	return func(ctx context.Context, reader datastore.Reader, limit uint64, cursor options.Cursor) (datastore.RelationshipIterator, error) {
 		return reader.ReverseQueryRelationships(ctx, datastore.SubjectsFilter{
 			SubjectType: subjectType,
-		}, options.WithSortForReverse(options.ByResource), options.WithLimitForReverse(&limit), options.WithAfterForReverse(cursor))
+		}, options.WithSortForReverse(options.BySubject), options.WithLimitForReverse(&limit), options.WithAfterForReverse(cursor))
 	}
 }
 


### PR DESCRIPTION
this will change the order of cursors in reachable resources to be by subject instead of by resource. The resulting where clause would use the right
index, but the ordering will be in the actual inverse order of the index, making the query slow.