### PR TITLE
Fix a deadlock in preloaded task runner

### DIFF
--- a/internal/dispatch/graph/lookupresources_test.go
+++ b/internal/dispatch/graph/lookupresources_test.go
@@ -363,6 +363,18 @@ func genTuples(resourceName string, relation string, subjectName string, subject
 	return genTuplesWithOffset(resourceName, relation, subjectName, subjectID, 0, number)
 }
 
+func genSubjectTuples(resourceName string, relation string, subjectName string, subjectRelation string, number int) []*core.RelationTuple {
+	tuples := make([]*core.RelationTuple, 0, number)
+	for i := 0; i < number; i++ {
+		tpl := &core.RelationTuple{
+			ResourceAndRelation: ONR(resourceName, fmt.Sprintf("%s-%d", resourceName, i), relation),
+			Subject:             ONR(subjectName, fmt.Sprintf("%s-%d", subjectName, i), subjectRelation),
+		}
+		tuples = append(tuples, tpl)
+	}
+	return tuples
+}
+
 func genTuplesWithCaveat(resourceName string, relation string, subjectName string, subjectID string, caveatName string, context map[string]any, offset int, number int) []*core.RelationTuple {
 	tuples := make([]*core.RelationTuple, 0, number)
 	for i := 0; i < number; i++ {
@@ -512,6 +524,26 @@ func TestLookupResourcesOverSchema(t *testing.T) {
 			RR("document", "view"),
 			ONR("user", "tom", "..."),
 			genResourceIds("document", 2450),
+		},
+		{
+			"larger arrow dispatch",
+			`definition user {}
+	
+			 definition folder {
+				relation viewer: user
+			 }
+
+		 	 definition document {
+				relation folder: folder
+				permission view = folder->viewer
+  			 }`,
+			joinTuples(
+				genTuples("folder", "viewer", "user", "tom", 150),
+				genSubjectTuples("document", "folder", "folder", "...", 150),
+			),
+			RR("document", "view"),
+			ONR("user", "tom", "..."),
+			genResourceIds("document", 150),
 		},
 	}
 

--- a/internal/graph/preloadedtaskrunner.go
+++ b/internal/graph/preloadedtaskrunner.go
@@ -74,6 +74,8 @@ func (tr *preloadedTaskRunner) spawnIfAvailable() {
 		go tr.runner()
 
 	case <-tr.ctx.Done():
+		// If the context was canceled, nothing more to do.
+		tr.emptyForCancel()
 		return
 
 	default:

--- a/internal/graph/preloadedtaskrunner_test.go
+++ b/internal/graph/preloadedtaskrunner_test.go
@@ -113,3 +113,42 @@ func TestPreloadedTaskRunnerCancelsEarlyDueToCancel(t *testing.T) {
 	require.GreaterOrEqual(t, count, 1)
 	require.Less(t, count, 9)
 }
+
+func TestPreloadedTaskRunnerReturnsError(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tr := newPreloadedTaskRunner(ctx, 3, 10)
+	completed := sync.Map{}
+
+	for i := 0; i < 10; i++ {
+		i := i
+		tr.add(func(ctx context.Context) error {
+			if i == 1 {
+				return fmt.Errorf("some error")
+			}
+
+			time.Sleep(time.Duration(i*50) * time.Millisecond)
+			completed.Store(i, true)
+			return nil
+		})
+	}
+
+	time.Sleep(1 * time.Second)
+
+	err := tr.startAndWait()
+	require.ErrorContains(t, err, "some error")
+
+	count := 0
+	for i := 0; i < 10; i++ {
+		if _, ok := completed.Load(i); ok {
+			count++
+		}
+	}
+
+	require.GreaterOrEqual(t, count, 1)
+	require.Less(t, count, 9)
+}

--- a/internal/graph/reachableresources.go
+++ b/internal/graph/reachableresources.go
@@ -121,10 +121,7 @@ func (crr *CursoredReachableResources) afterSameType(
 		func(ctx context.Context, ci cursorInformation, entrypoint namespace.ReachabilityEntrypoint, stream dispatch.ReachableResourcesStream) error {
 			switch entrypoint.EntrypointKind() {
 			case core.ReachabilityEntrypoint_RELATION_ENTRYPOINT:
-				err := crr.lookupRelationEntrypoint(ctx, ci, entrypoint, rg, reader, req, stream, dispatched)
-				if err != nil {
-					return err
-				}
+				return crr.lookupRelationEntrypoint(ctx, ci, entrypoint, rg, reader, req, stream, dispatched)
 
 			case core.ReachabilityEntrypoint_COMPUTED_USERSET_ENTRYPOINT:
 				containingRelation := entrypoint.ContainingRelationOrPermission()
@@ -136,7 +133,7 @@ func (crr *CursoredReachableResources) afterSameType(
 				rsm := subjectIDsToResourcesMap(rewrittenSubjectRelation, req.SubjectIds)
 				drsm := rsm.asReadOnly()
 
-				err := crr.redispatchOrReport(
+				return crr.redispatchOrReport(
 					ctx,
 					ci,
 					rewrittenSubjectRelation,
@@ -147,21 +144,13 @@ func (crr *CursoredReachableResources) afterSameType(
 					req,
 					dispatched,
 				)
-				if err != nil {
-					return err
-				}
 
 			case core.ReachabilityEntrypoint_TUPLESET_TO_USERSET_ENTRYPOINT:
-				err := crr.lookupTTUEntrypoint(ctx, ci, entrypoint, rg, reader, req, stream, dispatched)
-				if err != nil {
-					return err
-				}
+				return crr.lookupTTUEntrypoint(ctx, ci, entrypoint, rg, reader, req, stream, dispatched)
 
 			default:
 				return spiceerrors.MustBugf("Unknown kind of entrypoint: %v", entrypoint.EntrypointKind())
 			}
-
-			return nil
 		})
 }
 
@@ -234,7 +223,7 @@ func (crr *CursoredReachableResources) lookupRelationEntrypoint(
 		})
 }
 
-var queryLimit uint64 = 100
+var queryLimit uint64 = uint64(datastore.FilterMaximumIDCount)
 
 func (crr *CursoredReachableResources) chunkedRedispatch(
 	ctx context.Context,


### PR DESCRIPTION
We need to make sure to completely cancel the runner if context was canceled