### PR TITLE
default termination-log to disabled to make sure SpiceDB does not fail to start

### DIFF
--- a/pkg/cmd/termination/termination.go
+++ b/pkg/cmd/termination/termination.go
@@ -17,9 +17,8 @@ import (
 )
 
 const (
-	defaultTerminationLogPath = "/dev/termination-log"
-	terminationLogFlagName    = "termination-log-path"
-	kubeTerminationLogLimit   = 4096
+	terminationLogFlagName  = "termination-log-path"
+	kubeTerminationLogLimit = 4096
 )
 
 // PublishError returns a new wrapping cobra run function that executes the provided argument runFunc, and
@@ -34,6 +33,9 @@ func PublishError(runFunc cobrautil.CobraRunFunc) cobrautil.CobraRunFunc {
 				ctx = cmd.Context()
 			}
 			terminationLogPath := cobrautil.MustGetString(cmd, terminationLogFlagName)
+			if terminationLogPath == "" {
+				return runFuncErr
+			}
 			bytes, err := json.Marshal(termErr)
 			if err != nil {
 				log.Ctx(ctx).Error().Err(fmt.Errorf("unable to marshall termination log: %w", err)).Msg("failed to report termination log")
@@ -67,7 +69,7 @@ func PublishError(runFunc cobrautil.CobraRunFunc) cobrautil.CobraRunFunc {
 // RegisterFlags registers the termination log flag
 func RegisterFlags(flagset *flag.FlagSet) {
 	flagset.String(terminationLogFlagName,
-		defaultTerminationLogPath,
-		"define the path to the termination log file, which contains a JSON payload to surface as reason for termination",
+		"",
+		"define the path to the termination log file, which contains a JSON payload to surface as reason for termination - disabled by default",
 	)
 }

--- a/pkg/cmd/termination/termination_test.go
+++ b/pkg/cmd/termination/termination_test.go
@@ -58,6 +58,20 @@ func TestPublishError(t *testing.T) {
 	require.Len(t, readErr.Metadata, 0)
 }
 
+func TestPublishDisabled(t *testing.T) {
+	cmd := cobra.Command{}
+	RegisterFlags(cmd.Flags())
+
+	filePath := ""
+	cmd.Flag(terminationLogFlagName).Value = newStringValue(filePath, &filePath)
+	publishedError := spiceerrors.NewTerminationErrorBuilder(errors.New("hi")).Metadata("k", "v").Component("test").Error()
+	err := PublishError(func(cmd *cobra.Command, args []string) error {
+		return publishedError
+	})(&cmd, nil)
+	var termErr spiceerrors.TerminationError
+	require.ErrorAs(t, err, &termErr)
+}
+
 type testValue string
 
 func newStringValue(val string, p *string) *testValue {


### PR DESCRIPTION
While `/dev/termination-log` is the default path to
termination logs in kube environments, for non-kube
environments the process may not have permission
to write to this path and would fail to start.

This makes the termination log default to disabled
if the flag has a value of empty string.