### PR TITLE
grpc middleware order assertion

### DIFF
--- a/pkg/cmd/server/defaults.go
+++ b/pkg/cmd/server/defaults.go
@@ -142,35 +142,26 @@ func DefaultUnaryMiddleware(logger zerolog.Logger, authFunc grpcauth.AuthFunc, e
 		NewUnaryMiddleware().
 			WithName(DefaultMiddlewareRequestID).
 			WithInterceptor(requestid.UnaryServerInterceptor(requestid.GenerateIfMissing(true))).
-			EnsureAlreadyExecuted(none).
-			EnsureNotExecuted(DefaultMiddlewareLog).
 			Done(),
 
 		NewUnaryMiddleware().
 			WithName(DefaultMiddlewareLog).
 			WithInterceptor(logmw.UnaryServerInterceptor(logmw.ExtractMetadataField("x-request-id", "requestID"))).
-			EnsureAlreadyExecuted(DefaultMiddlewareRequestID).
-			EnsureNotExecuted(DefaultMiddlewareGRPCLog).
 			Done(),
 
 		NewUnaryMiddleware().
 			WithName(DefaultMiddlewareGRPCLog).
 			WithInterceptor(grpclog.UnaryServerInterceptor(grpczerolog.InterceptorLogger(logger), defaultGRPCLogOptions...)).
-			EnsureAlreadyExecuted(DefaultMiddlewareLog).
-			EnsureNotExecuted(DefaultMiddlewareOTelGRPC).
 			Done(),
 
 		NewUnaryMiddleware().
 			WithName(DefaultMiddlewareOTelGRPC).
 			WithInterceptor(otelgrpc.UnaryServerInterceptor()).
-			EnsureAlreadyExecuted(DefaultMiddlewareGRPCLog).
-			EnsureNotExecuted(DefaultMiddlewareGRPCProm).
 			Done(),
 
 		NewUnaryMiddleware().
 			WithName(DefaultMiddlewareGRPCProm).
 			WithInterceptor(grpcprom.UnaryServerInterceptor).
-			EnsureAlreadyExecuted(DefaultMiddlewareOTelGRPC).
 			EnsureNotExecuted(DefaultMiddlewareGRPCAuth).
 			Done(),
 
@@ -178,45 +169,35 @@ func DefaultUnaryMiddleware(logger zerolog.Logger, authFunc grpcauth.AuthFunc, e
 			WithName(DefaultMiddlewareGRPCAuth).
 			WithInterceptor(grpcauth.UnaryServerInterceptor(authFunc)).
 			EnsureAlreadyExecuted(DefaultMiddlewareGRPCProm).
-			EnsureNotExecuted(DefaultMiddlewareServerVersion).
 			Done(),
 
 		NewUnaryMiddleware().
 			WithName(DefaultMiddlewareServerVersion).
 			WithInterceptor(serverversion.UnaryServerInterceptor(enableVersionResponse)).
-			EnsureAlreadyExecuted(DefaultMiddlewareGRPCAuth).
-			EnsureNotExecuted(DefaultInternalMiddlewareDispatch).
 			Done(),
 
 		NewUnaryMiddleware().
 			WithName(DefaultInternalMiddlewareDispatch).
 			WithInternal(true).
 			WithInterceptor(dispatchmw.UnaryServerInterceptor(dispatcher)).
-			EnsureAlreadyExecuted(DefaultMiddlewareServerVersion).
-			EnsureNotExecuted(DefaultInternalMiddlewareDatastore).
 			Done(),
 
 		NewUnaryMiddleware().
 			WithName(DefaultInternalMiddlewareDatastore).
 			WithInternal(true).
 			WithInterceptor(datastoremw.UnaryServerInterceptor(ds)).
-			EnsureAlreadyExecuted(DefaultInternalMiddlewareDispatch).
-			EnsureNotExecuted(DefaultInternalMiddlewareConsistency).
 			Done(),
 
 		NewUnaryMiddleware().
 			WithName(DefaultInternalMiddlewareConsistency).
 			WithInternal(true).
 			WithInterceptor(consistencymw.UnaryServerInterceptor()).
-			EnsureAlreadyExecuted(DefaultInternalMiddlewareDatastore).
-			EnsureNotExecuted(DefaultInternalMiddlewareServerSpecific).
 			Done(),
 
 		NewUnaryMiddleware().
 			WithName(DefaultInternalMiddlewareServerSpecific).
 			WithInternal(true).
 			WithInterceptor(servicespecific.UnaryServerInterceptor).
-			EnsureAlreadyExecuted(DefaultInternalMiddlewareConsistency).
 			Done(),
 	}...)
 	return &chain, err
@@ -228,81 +209,62 @@ func DefaultStreamingMiddleware(logger zerolog.Logger, authFunc grpcauth.AuthFun
 		NewStreamMiddleware().
 			WithName(DefaultMiddlewareRequestID).
 			WithInterceptor(requestid.StreamServerInterceptor(requestid.GenerateIfMissing(true))).
-			EnsureAlreadyExecuted(DefaultMiddlewareLog).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultMiddlewareLog).
 			WithInterceptor(logmw.StreamServerInterceptor(logmw.ExtractMetadataField("x-request-id", "requestID"))).
-			EnsureAlreadyExecuted(DefaultMiddlewareGRPCLog).
-			EnsureNotExecuted(DefaultMiddlewareRequestID).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultMiddlewareGRPCLog).
 			WithInterceptor(grpclog.StreamServerInterceptor(grpczerolog.InterceptorLogger(logger), defaultGRPCLogOptions...)).
-			EnsureAlreadyExecuted(DefaultMiddlewareOTelGRPC).
-			EnsureNotExecuted(DefaultMiddlewareLog).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultMiddlewareOTelGRPC).
 			WithInterceptor(grpclog.StreamServerInterceptor(grpczerolog.InterceptorLogger(logger), defaultGRPCLogOptions...)).
-			EnsureAlreadyExecuted(DefaultMiddlewareGRPCProm).
-			EnsureNotExecuted(DefaultMiddlewareGRPCLog).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultMiddlewareGRPCProm).
 			WithInterceptor(grpcprom.StreamServerInterceptor).
 			EnsureAlreadyExecuted(DefaultMiddlewareGRPCAuth).
-			EnsureNotExecuted(DefaultMiddlewareOTelGRPC).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultMiddlewareGRPCAuth).
 			WithInterceptor(grpcauth.StreamServerInterceptor(authFunc)).
-			EnsureAlreadyExecuted(DefaultMiddlewareServerVersion).
 			EnsureNotExecuted(DefaultMiddlewareGRPCProm).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultMiddlewareServerVersion).
 			WithInterceptor(serverversion.StreamServerInterceptor(enableVersionResponse)).
-			EnsureAlreadyExecuted(DefaultInternalMiddlewareDispatch).
-			EnsureNotExecuted(DefaultMiddlewareGRPCAuth).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultInternalMiddlewareDispatch).
 			WithInternal(true).
 			WithInterceptor(dispatchmw.StreamServerInterceptor(dispatcher)).
-			EnsureAlreadyExecuted(DefaultInternalMiddlewareDatastore).
-			EnsureNotExecuted(DefaultMiddlewareServerVersion).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultInternalMiddlewareDatastore).
 			WithInternal(true).
 			WithInterceptor(datastoremw.StreamServerInterceptor(ds)).
-			EnsureAlreadyExecuted(DefaultInternalMiddlewareConsistency).
-			EnsureNotExecuted(DefaultInternalMiddlewareDispatch).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultInternalMiddlewareConsistency).
 			WithInternal(true).
 			WithInterceptor(consistencymw.StreamServerInterceptor()).
-			EnsureAlreadyExecuted(DefaultInternalMiddlewareServerSpecific).
-			EnsureNotExecuted(DefaultInternalMiddlewareDatastore).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultInternalMiddlewareServerSpecific).
 			WithInternal(true).
 			WithInterceptor(servicespecific.StreamServerInterceptor).
-			EnsureAlreadyExecuted(none).
-			EnsureNotExecuted(DefaultInternalMiddlewareConsistency).
 			Done(),
 	}...)
 	return &chain, err

--- a/pkg/cmd/server/defaults.go
+++ b/pkg/cmd/server/defaults.go
@@ -139,54 +139,85 @@ const (
 // DefaultUnaryMiddleware generates the default middleware chain used for the public SpiceDB Unary gRPC methods
 func DefaultUnaryMiddleware(logger zerolog.Logger, authFunc grpcauth.AuthFunc, enableVersionResponse bool, dispatcher dispatch.Dispatcher, ds datastore.Datastore) (*MiddlewareChain[grpc.UnaryServerInterceptor], error) {
 	chain, err := NewMiddlewareChain([]ReferenceableMiddleware[grpc.UnaryServerInterceptor]{
-		{
-			Name:       DefaultMiddlewareRequestID,
-			Middleware: requestid.UnaryServerInterceptor(requestid.GenerateIfMissing(true)),
-		},
-		{
-			Name:       DefaultMiddlewareLog,
-			Middleware: logmw.UnaryServerInterceptor(logmw.ExtractMetadataField("x-request-id", "requestID")),
-		},
-		{
-			Name:       DefaultMiddlewareGRPCLog,
-			Middleware: grpclog.UnaryServerInterceptor(grpczerolog.InterceptorLogger(logger), defaultGRPCLogOptions...),
-		},
-		{
-			Name:       DefaultMiddlewareOTelGRPC,
-			Middleware: otelgrpc.UnaryServerInterceptor(),
-		},
-		{
-			Name:       DefaultMiddlewareGRPCProm,
-			Middleware: grpcprom.UnaryServerInterceptor,
-		},
-		{
-			Name:       DefaultMiddlewareGRPCAuth,
-			Middleware: grpcauth.UnaryServerInterceptor(authFunc),
-		},
-		{
-			Name:       DefaultMiddlewareServerVersion,
-			Middleware: serverversion.UnaryServerInterceptor(enableVersionResponse),
-		},
-		{
-			Name:       DefaultInternalMiddlewareDispatch,
-			Internal:   true,
-			Middleware: dispatchmw.UnaryServerInterceptor(dispatcher),
-		},
-		{
-			Name:       DefaultInternalMiddlewareDatastore,
-			Internal:   true,
-			Middleware: datastoremw.UnaryServerInterceptor(ds),
-		},
-		{
-			Name:       DefaultInternalMiddlewareConsistency,
-			Internal:   true,
-			Middleware: consistencymw.UnaryServerInterceptor(),
-		},
-		{
-			Name:       DefaultInternalMiddlewareServerSpecific,
-			Internal:   true,
-			Middleware: servicespecific.UnaryServerInterceptor,
-		},
+		NewUnaryMiddleware().
+			WithName(DefaultMiddlewareRequestID).
+			WithInterceptor(requestid.UnaryServerInterceptor(requestid.GenerateIfMissing(true))).
+			EnsureAlreadyExecuted(none).
+			EnsureNotExecuted(DefaultMiddlewareLog).
+			Done(),
+
+		NewUnaryMiddleware().
+			WithName(DefaultMiddlewareLog).
+			WithInterceptor(logmw.UnaryServerInterceptor(logmw.ExtractMetadataField("x-request-id", "requestID"))).
+			EnsureAlreadyExecuted(DefaultMiddlewareRequestID).
+			EnsureNotExecuted(DefaultMiddlewareGRPCLog).
+			Done(),
+
+		NewUnaryMiddleware().
+			WithName(DefaultMiddlewareGRPCLog).
+			WithInterceptor(grpclog.UnaryServerInterceptor(grpczerolog.InterceptorLogger(logger), defaultGRPCLogOptions...)).
+			EnsureAlreadyExecuted(DefaultMiddlewareLog).
+			EnsureNotExecuted(DefaultMiddlewareOTelGRPC).
+			Done(),
+
+		NewUnaryMiddleware().
+			WithName(DefaultMiddlewareOTelGRPC).
+			WithInterceptor(otelgrpc.UnaryServerInterceptor()).
+			EnsureAlreadyExecuted(DefaultMiddlewareGRPCLog).
+			EnsureNotExecuted(DefaultMiddlewareGRPCProm).
+			Done(),
+
+		NewUnaryMiddleware().
+			WithName(DefaultMiddlewareGRPCProm).
+			WithInterceptor(grpcprom.UnaryServerInterceptor).
+			EnsureAlreadyExecuted(DefaultMiddlewareOTelGRPC).
+			EnsureNotExecuted(DefaultMiddlewareGRPCAuth).
+			Done(),
+
+		NewUnaryMiddleware().
+			WithName(DefaultMiddlewareGRPCAuth).
+			WithInterceptor(grpcauth.UnaryServerInterceptor(authFunc)).
+			EnsureAlreadyExecuted(DefaultMiddlewareGRPCProm).
+			EnsureNotExecuted(DefaultMiddlewareServerVersion).
+			Done(),
+
+		NewUnaryMiddleware().
+			WithName(DefaultMiddlewareServerVersion).
+			WithInterceptor(serverversion.UnaryServerInterceptor(enableVersionResponse)).
+			EnsureAlreadyExecuted(DefaultMiddlewareGRPCAuth).
+			EnsureNotExecuted(DefaultInternalMiddlewareDispatch).
+			Done(),
+
+		NewUnaryMiddleware().
+			WithName(DefaultInternalMiddlewareDispatch).
+			WithInternal(true).
+			WithInterceptor(dispatchmw.UnaryServerInterceptor(dispatcher)).
+			EnsureAlreadyExecuted(DefaultMiddlewareServerVersion).
+			EnsureNotExecuted(DefaultInternalMiddlewareDatastore).
+			Done(),
+
+		NewUnaryMiddleware().
+			WithName(DefaultInternalMiddlewareDatastore).
+			WithInternal(true).
+			WithInterceptor(datastoremw.UnaryServerInterceptor(ds)).
+			EnsureAlreadyExecuted(DefaultInternalMiddlewareDispatch).
+			EnsureNotExecuted(DefaultInternalMiddlewareConsistency).
+			Done(),
+
+		NewUnaryMiddleware().
+			WithName(DefaultInternalMiddlewareConsistency).
+			WithInternal(true).
+			WithInterceptor(consistencymw.UnaryServerInterceptor()).
+			EnsureAlreadyExecuted(DefaultInternalMiddlewareDatastore).
+			EnsureNotExecuted(DefaultInternalMiddlewareServerSpecific).
+			Done(),
+
+		NewUnaryMiddleware().
+			WithName(DefaultInternalMiddlewareServerSpecific).
+			WithInternal(true).
+			WithInterceptor(servicespecific.UnaryServerInterceptor).
+			EnsureAlreadyExecuted(DefaultInternalMiddlewareConsistency).
+			Done(),
 	}...)
 	return &chain, err
 }
@@ -194,54 +225,85 @@ func DefaultUnaryMiddleware(logger zerolog.Logger, authFunc grpcauth.AuthFunc, e
 // DefaultStreamingMiddleware generates the default middleware chain used for the public SpiceDB Streaming gRPC methods
 func DefaultStreamingMiddleware(logger zerolog.Logger, authFunc grpcauth.AuthFunc, enableVersionResponse bool, dispatcher dispatch.Dispatcher, ds datastore.Datastore) (*MiddlewareChain[grpc.StreamServerInterceptor], error) {
 	chain, err := NewMiddlewareChain([]ReferenceableMiddleware[grpc.StreamServerInterceptor]{
-		{
-			Name:       DefaultMiddlewareRequestID,
-			Middleware: requestid.StreamServerInterceptor(requestid.GenerateIfMissing(true)),
-		},
-		{
-			Name:       DefaultMiddlewareLog,
-			Middleware: logmw.StreamServerInterceptor(logmw.ExtractMetadataField("x-request-id", "requestID")),
-		},
-		{
-			Name:       DefaultMiddlewareGRPCLog,
-			Middleware: grpclog.StreamServerInterceptor(grpczerolog.InterceptorLogger(logger), defaultGRPCLogOptions...),
-		},
-		{
-			Name:       DefaultMiddlewareOTelGRPC,
-			Middleware: otelgrpc.StreamServerInterceptor(),
-		},
-		{
-			Name:       DefaultMiddlewareGRPCProm,
-			Middleware: grpcprom.StreamServerInterceptor,
-		},
-		{
-			Name:       DefaultMiddlewareGRPCAuth,
-			Middleware: grpcauth.StreamServerInterceptor(authFunc),
-		},
-		{
-			Name:       DefaultMiddlewareServerVersion,
-			Middleware: serverversion.StreamServerInterceptor(enableVersionResponse),
-		},
-		{
-			Name:       DefaultInternalMiddlewareDispatch,
-			Internal:   true,
-			Middleware: dispatchmw.StreamServerInterceptor(dispatcher),
-		},
-		{
-			Name:       DefaultInternalMiddlewareDatastore,
-			Internal:   true,
-			Middleware: datastoremw.StreamServerInterceptor(ds),
-		},
-		{
-			Name:       DefaultInternalMiddlewareConsistency,
-			Internal:   true,
-			Middleware: consistencymw.StreamServerInterceptor(),
-		},
-		{
-			Name:       DefaultInternalMiddlewareServerSpecific,
-			Internal:   true,
-			Middleware: servicespecific.StreamServerInterceptor,
-		},
+		NewStreamMiddleware().
+			WithName(DefaultMiddlewareRequestID).
+			WithInterceptor(requestid.StreamServerInterceptor(requestid.GenerateIfMissing(true))).
+			EnsureAlreadyExecuted(DefaultMiddlewareLog).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultMiddlewareLog).
+			WithInterceptor(logmw.StreamServerInterceptor(logmw.ExtractMetadataField("x-request-id", "requestID"))).
+			EnsureAlreadyExecuted(DefaultMiddlewareGRPCLog).
+			EnsureNotExecuted(DefaultMiddlewareRequestID).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultMiddlewareGRPCLog).
+			WithInterceptor(grpclog.StreamServerInterceptor(grpczerolog.InterceptorLogger(logger), defaultGRPCLogOptions...)).
+			EnsureAlreadyExecuted(DefaultMiddlewareOTelGRPC).
+			EnsureNotExecuted(DefaultMiddlewareLog).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultMiddlewareOTelGRPC).
+			WithInterceptor(grpclog.StreamServerInterceptor(grpczerolog.InterceptorLogger(logger), defaultGRPCLogOptions...)).
+			EnsureAlreadyExecuted(DefaultMiddlewareGRPCProm).
+			EnsureNotExecuted(DefaultMiddlewareGRPCLog).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultMiddlewareGRPCProm).
+			WithInterceptor(grpcprom.StreamServerInterceptor).
+			EnsureAlreadyExecuted(DefaultMiddlewareGRPCAuth).
+			EnsureNotExecuted(DefaultMiddlewareOTelGRPC).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultMiddlewareGRPCAuth).
+			WithInterceptor(grpcauth.StreamServerInterceptor(authFunc)).
+			EnsureAlreadyExecuted(DefaultMiddlewareServerVersion).
+			EnsureNotExecuted(DefaultMiddlewareGRPCProm).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultMiddlewareServerVersion).
+			WithInterceptor(serverversion.StreamServerInterceptor(enableVersionResponse)).
+			EnsureAlreadyExecuted(DefaultInternalMiddlewareDispatch).
+			EnsureNotExecuted(DefaultMiddlewareGRPCAuth).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultInternalMiddlewareDispatch).
+			WithInternal(true).
+			WithInterceptor(dispatchmw.StreamServerInterceptor(dispatcher)).
+			EnsureAlreadyExecuted(DefaultInternalMiddlewareDatastore).
+			EnsureNotExecuted(DefaultMiddlewareServerVersion).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultInternalMiddlewareDatastore).
+			WithInternal(true).
+			WithInterceptor(datastoremw.StreamServerInterceptor(ds)).
+			EnsureAlreadyExecuted(DefaultInternalMiddlewareConsistency).
+			EnsureNotExecuted(DefaultInternalMiddlewareDispatch).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultInternalMiddlewareConsistency).
+			WithInternal(true).
+			WithInterceptor(consistencymw.StreamServerInterceptor()).
+			EnsureAlreadyExecuted(DefaultInternalMiddlewareServerSpecific).
+			EnsureNotExecuted(DefaultInternalMiddlewareDatastore).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultInternalMiddlewareServerSpecific).
+			WithInternal(true).
+			WithInterceptor(servicespecific.StreamServerInterceptor).
+			EnsureAlreadyExecuted(none).
+			EnsureNotExecuted(DefaultInternalMiddlewareConsistency).
+			Done(),
 	}...)
 	return &chain, err
 }

--- a/pkg/cmd/server/middleware.go
+++ b/pkg/cmd/server/middleware.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"flag"
 	"fmt"
 
 	"github.com/authzed/spicedb/pkg/spiceerrors"
@@ -215,10 +214,6 @@ func (mc *MiddlewareChain[T]) modify(modifications ...MiddlewareModification[T])
 	return nil
 }
 
-func inTest() bool {
-	return flag.Lookup("test.v") != nil
-}
-
 type streamOrderAssertion struct {
 	grpc.ServerStream
 	name            string
@@ -282,7 +277,7 @@ func (soeb *StreamOrderEnforcerBuilder) EnsureNotExecuted(name string) *StreamOr
 }
 
 func (soeb *StreamOrderEnforcerBuilder) Done() ReferenceableMiddleware[grpc.StreamServerInterceptor] {
-	if !inTest() {
+	if !spiceerrors.IsInTests() {
 		return ReferenceableMiddleware[grpc.StreamServerInterceptor]{
 			Name:       soeb.name,
 			Internal:   soeb.internal,
@@ -348,7 +343,7 @@ func (soeb *UnaryOrderEnforcerBuilder) EnsureNotExecuted(name string) *UnaryOrde
 }
 
 func (soeb *UnaryOrderEnforcerBuilder) Done() ReferenceableMiddleware[grpc.UnaryServerInterceptor] {
-	if !inTest() {
+	if !spiceerrors.IsInTests() {
 		return ReferenceableMiddleware[grpc.UnaryServerInterceptor]{
 			Name:       soeb.name,
 			Internal:   soeb.internal,

--- a/pkg/cmd/server/middleware.go
+++ b/pkg/cmd/server/middleware.go
@@ -1,10 +1,14 @@
 package server
 
 import (
+	"context"
+	"flag"
 	"fmt"
 
 	"github.com/authzed/spicedb/pkg/util"
 
+	"github.com/google/uuid"
+	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 	"google.golang.org/grpc"
 )
 
@@ -172,9 +176,9 @@ func (mc *MiddlewareChain[T]) validate(mod MiddlewareModification[T]) error {
 	}
 
 	// prevent appending/prepending a duplicate middleware
-	for _, middleware := range mod.Middlewares {
-		if existingNames.Has(middleware.Name) && mod.DependencyMiddlewareName == middleware.Name && mod.Operation != OperationReplace {
-			return fmt.Errorf("modification will cause a duplicate in chain: %s", middleware.Name)
+	for _, mw := range mod.Middlewares {
+		if existingNames.Has(mw.Name) && mod.DependencyMiddlewareName == mw.Name && mod.Operation != OperationReplace {
+			return fmt.Errorf("modification will cause a duplicate in chain: %s", mw.Name)
 		}
 	}
 
@@ -210,3 +214,225 @@ func (mc *MiddlewareChain[T]) modify(modifications ...MiddlewareModification[T])
 	}
 	return nil
 }
+
+var none = uuid.NewString()
+
+func inTest() bool {
+	return flag.Lookup("test.v") != nil
+}
+
+type streamOrderAssertion struct {
+	grpc.ServerStream
+	name            string
+	alreadyExecuted string
+	notExecuted     string
+}
+
+func (o streamOrderAssertion) RecvMsg(m any) error {
+	if err := mustHaveExecuted(o.Context(), o.alreadyExecuted); err != nil {
+		return err
+	}
+
+	if err := mustHaveNotExecuted(o.Context(), o.notExecuted); err != nil {
+		return err
+	}
+
+	mustMarkAsExecuted(o.Context(), o.name)
+	err := o.ServerStream.RecvMsg(m)
+	return err
+}
+
+func (o streamOrderAssertion) SendMsg(m any) error {
+	return o.ServerStream.SendMsg(m)
+}
+
+func NewStreamMiddleware() *StreamOrderEnforcerBuilder {
+	return &StreamOrderEnforcerBuilder{}
+}
+
+type StreamOrderEnforcerBuilder struct {
+	name              string
+	streamInterceptor grpc.StreamServerInterceptor
+	internal          bool
+	executed          string
+	notExecuted       string
+}
+
+func (soeb *StreamOrderEnforcerBuilder) WithName(name string) *StreamOrderEnforcerBuilder {
+	soeb.name = name
+	return soeb
+}
+
+func (soeb *StreamOrderEnforcerBuilder) WithInterceptor(interceptor grpc.StreamServerInterceptor) *StreamOrderEnforcerBuilder {
+	soeb.streamInterceptor = interceptor
+	return soeb
+}
+
+func (soeb *StreamOrderEnforcerBuilder) WithInternal(internal bool) *StreamOrderEnforcerBuilder {
+	soeb.internal = internal
+	return soeb
+}
+
+func (soeb *StreamOrderEnforcerBuilder) EnsureAlreadyExecuted(name string) *StreamOrderEnforcerBuilder {
+	soeb.executed = name
+	return soeb
+}
+
+func (soeb *StreamOrderEnforcerBuilder) EnsureNotExecuted(name string) *StreamOrderEnforcerBuilder {
+	soeb.notExecuted = name
+	return soeb
+}
+
+func (soeb *StreamOrderEnforcerBuilder) Done() ReferenceableMiddleware[grpc.StreamServerInterceptor] {
+	if !inTest() {
+		return ReferenceableMiddleware[grpc.StreamServerInterceptor]{
+			Name:       soeb.name,
+			Internal:   soeb.internal,
+			Middleware: soeb.streamInterceptor,
+		}
+	}
+
+	return ReferenceableMiddleware[grpc.StreamServerInterceptor]{
+		Name:     soeb.name,
+		Internal: soeb.internal,
+		Middleware: func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+			wss := middleware.WrapServerStream(ss)
+			if wss.WrappedContext.Value(interceptorsExecuted) == nil {
+				handle := executedHandle{executed: make(map[string]struct{}, 0)}
+				wss.WrappedContext = context.WithValue(wss.WrappedContext, interceptorsExecuted, &handle)
+			}
+			wrappedStream := streamOrderAssertion{
+				ServerStream:    wss,
+				name:            soeb.name,
+				alreadyExecuted: soeb.executed,
+				notExecuted:     soeb.notExecuted,
+			}
+			return soeb.streamInterceptor(srv, wrappedStream, info, handler)
+		},
+	}
+}
+
+func NewUnaryMiddleware() *UnaryOrderEnforcerBuilder {
+	return &UnaryOrderEnforcerBuilder{}
+}
+
+type UnaryOrderEnforcerBuilder struct {
+	name            string
+	interceptor     grpc.UnaryServerInterceptor
+	internal        bool
+	alreadyExecuted string
+	notExecuted     string
+}
+
+func (soeb *UnaryOrderEnforcerBuilder) WithName(name string) *UnaryOrderEnforcerBuilder {
+	soeb.name = name
+	return soeb
+}
+
+func (soeb *UnaryOrderEnforcerBuilder) WithInterceptor(interceptor grpc.UnaryServerInterceptor) *UnaryOrderEnforcerBuilder {
+	soeb.interceptor = interceptor
+	return soeb
+}
+
+func (soeb *UnaryOrderEnforcerBuilder) WithInternal(internal bool) *UnaryOrderEnforcerBuilder {
+	soeb.internal = internal
+	return soeb
+}
+
+func (soeb *UnaryOrderEnforcerBuilder) EnsureAlreadyExecuted(name string) *UnaryOrderEnforcerBuilder {
+	soeb.alreadyExecuted = name
+	return soeb
+}
+
+func (soeb *UnaryOrderEnforcerBuilder) EnsureNotExecuted(name string) *UnaryOrderEnforcerBuilder {
+	soeb.notExecuted = name
+	return soeb
+}
+
+func (soeb *UnaryOrderEnforcerBuilder) Done() ReferenceableMiddleware[grpc.UnaryServerInterceptor] {
+	if !inTest() {
+		return ReferenceableMiddleware[grpc.UnaryServerInterceptor]{
+			Name:       soeb.name,
+			Internal:   soeb.internal,
+			Middleware: soeb.interceptor,
+		}
+	}
+
+	return ReferenceableMiddleware[grpc.UnaryServerInterceptor]{
+		Name:     soeb.name,
+		Internal: soeb.internal,
+		Middleware: func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+			if ctx.Value(interceptorsExecuted) == nil {
+				handle := executedHandle{executed: make(map[string]struct{}, 0)}
+				ctx = context.WithValue(ctx, interceptorsExecuted, &handle)
+			}
+
+			if err := mustHaveExecuted(ctx, soeb.alreadyExecuted); err != nil {
+				return nil, err
+			}
+
+			if err := mustHaveNotExecuted(ctx, soeb.notExecuted); err != nil {
+				return nil, err
+			}
+
+			mustMarkAsExecuted(ctx, soeb.name)
+			return soeb.interceptor(ctx, req, info, handler)
+		},
+	}
+}
+
+func mustHaveNotExecuted(ctx context.Context, notExecuted string) error {
+	if notExecuted == "" {
+		return nil
+	}
+
+	val := ctx.Value(interceptorsExecuted)
+	if val == nil {
+		return fmt.Errorf("interception order validation bookkeeping not present in context")
+	}
+
+	handle := val.(*executedHandle)
+	if _, ok := handle.executed[notExecuted]; ok {
+		return fmt.Errorf("expected interceptor %s to be not already executed", notExecuted)
+	}
+
+	return nil
+}
+
+func mustHaveExecuted(ctx context.Context, expectedExecuted string) error {
+	if expectedExecuted == "" {
+		return nil
+	}
+
+	val := ctx.Value(interceptorsExecuted)
+	if val == nil {
+		panic("interception order validation bookkeeping not present in context")
+	}
+
+	handle := val.(*executedHandle)
+	if expectedExecuted == none && len(handle.executed) == 0 {
+		return nil
+	}
+
+	if _, ok := handle.executed[expectedExecuted]; ok {
+		return nil
+	}
+
+	return fmt.Errorf("expected interceptor %s to be already executed", expectedExecuted)
+}
+
+func mustMarkAsExecuted(ctx context.Context, name string) {
+	val := ctx.Value(interceptorsExecuted)
+	if val == nil {
+		panic("handle should exist")
+	} else {
+		handle := val.(*executedHandle)
+		handle.executed[name] = struct{}{}
+	}
+}
+
+type executedHandle struct {
+	executed map[string]struct{}
+}
+
+var interceptorsExecuted = struct{}{}

--- a/pkg/cmd/server/middleware.go
+++ b/pkg/cmd/server/middleware.go
@@ -5,9 +5,9 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/util"
 
-	"github.com/google/uuid"
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 	"google.golang.org/grpc"
 )
@@ -215,8 +215,6 @@ func (mc *MiddlewareChain[T]) modify(modifications ...MiddlewareModification[T])
 	return nil
 }
 
-var none = uuid.NewString()
-
 func inTest() bool {
 	return flag.Lookup("test.v") != nil
 }
@@ -406,14 +404,10 @@ func mustHaveExecuted(ctx context.Context, expectedExecuted string) error {
 
 	val := ctx.Value(interceptorsExecuted)
 	if val == nil {
-		panic("interception order validation bookkeeping not present in context")
+		return spiceerrors.MustBugf("interception order validation bookkeeping not present in context")
 	}
 
 	handle := val.(*executedHandle)
-	if expectedExecuted == none && len(handle.executed) == 0 {
-		return nil
-	}
-
 	if _, ok := handle.executed[expectedExecuted]; ok {
 		return nil
 	}

--- a/pkg/cmd/server/testdata/test_schema.yaml
+++ b/pkg/cmd/server/testdata/test_schema.yaml
@@ -1,0 +1,13 @@
+---
+schema: |-
+
+  definition user {}
+  definition resource {
+    relation reader: user
+
+    permission read = reader
+  }
+
+relationships: |
+
+  resource:doc1#reader@user:user1

--- a/pkg/spiceerrors/bug.go
+++ b/pkg/spiceerrors/bug.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 )
 
+// IsInTests returns true if go test is running
 // Based on: https://stackoverflow.com/a/58945030
-func isInTests() bool {
+func IsInTests() bool {
 	for _, arg := range os.Args {
 		if strings.HasPrefix(arg, "-test.") {
 			return true
@@ -23,7 +24,7 @@ func MustPanic(format string, args ...any) {
 
 // MustBugf returns an error representing a bug in the system. Will panic if run under testing.
 func MustBugf(format string, args ...any) error {
-	if isInTests() {
+	if IsInTests() {
 		panic(fmt.Sprintf(format, args...))
 	}
 

--- a/pkg/spiceerrors/bug_test.go
+++ b/pkg/spiceerrors/bug_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMustBug(t *testing.T) {
-	require.True(t, isInTests())
+	require.True(t, IsInTests())
 	assert.Panics(t, func() {
 		err := MustBugf("some error")
 		require.NotNil(t, err)


### PR DESCRIPTION
⚠️ built on top of https://github.com/authzed/spicedb/pull/1391

The behaviour of gRPC streaming API middlewares can be surprising w.r.t to order of execution. This is an attempt to force the developer introducing gRPC middleware in SpiceDB to be explicit about the order.

When run in tests, the fluent API builder will wrap each middlewares into another interceptor that will run assertions on the order of execution, and panic if that expected order is not met.  