### PR TITLE
correct SetGlobalLogger in main.go

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -26,7 +26,7 @@ func main() {
 	// Enable consistent hashring gRPC load balancer
 	balancer.Register(cmdutil.ConsistentHashringBuilder)
 
-	log.SetGlobalLogger(zerolog.New(os.Stdout))
+	log.SetGlobalLogger(zerolog.New(os.Stderr))
 
 	// Create a root command
 	rootCmd := cmd.NewRootCommand("spicedb")


### PR DESCRIPTION
SpiceDB is configured to emit logs through
stderr via cobrautil package. The
statement changed in this commit
was originally added to make sure
that anything that logs before
cobrautil runs uses the same
logger instance. However when
that was added, it was overlooked
that cobrautil emits logs to stderr
instead of stdout. This aligns
the behaviour so that anything that
logs before cobrautil initializes
emits output to stderr