### PR TITLE
disambiguate middleware dependency assertion in streaming APIs

### DIFF
--- a/pkg/cmd/server/defaults.go
+++ b/pkg/cmd/server/defaults.go
@@ -162,13 +162,12 @@ func DefaultUnaryMiddleware(logger zerolog.Logger, authFunc grpcauth.AuthFunc, e
 		NewUnaryMiddleware().
 			WithName(DefaultMiddlewareGRPCProm).
 			WithInterceptor(grpcprom.UnaryServerInterceptor).
-			EnsureNotExecuted(DefaultMiddlewareGRPCAuth).
 			Done(),
 
 		NewUnaryMiddleware().
 			WithName(DefaultMiddlewareGRPCAuth).
 			WithInterceptor(grpcauth.UnaryServerInterceptor(authFunc)).
-			EnsureAlreadyExecuted(DefaultMiddlewareGRPCProm).
+			EnsureAlreadyExecuted(DefaultMiddlewareGRPCProm). // so that prom middleware reports auth failures
 			Done(),
 
 		NewUnaryMiddleware().
@@ -229,13 +228,12 @@ func DefaultStreamingMiddleware(logger zerolog.Logger, authFunc grpcauth.AuthFun
 		NewStreamMiddleware().
 			WithName(DefaultMiddlewareGRPCProm).
 			WithInterceptor(grpcprom.StreamServerInterceptor).
-			EnsureAlreadyExecuted(DefaultMiddlewareGRPCAuth).
 			Done(),
 
 		NewStreamMiddleware().
 			WithName(DefaultMiddlewareGRPCAuth).
 			WithInterceptor(grpcauth.StreamServerInterceptor(authFunc)).
-			EnsureNotExecuted(DefaultMiddlewareGRPCProm).
+			EnsureInterceptorAlreadyExecuted(DefaultMiddlewareGRPCProm). // so that prom middleware reports auth failures
 			Done(),
 
 		NewStreamMiddleware().

--- a/pkg/cmd/server/middleware_test.go
+++ b/pkg/cmd/server/middleware_test.go
@@ -462,7 +462,7 @@ func TestIncorrectOrderAssertionFails(t *testing.T) {
 					NewStreamMiddleware().
 						WithName("test").
 						WithInterceptor(noopStreaming).
-						EnsureAlreadyExecuted("does-not-exist").
+						EnsureWrapperAlreadyExecuted("does-not-exist").
 						Done(),
 				},
 			},


### PR DESCRIPTION
the newly added API to assert middleware execution order and dependencies in tests had an ambiguous situation with streaming APIs. gRPC streaming interceptors
can execute its logic in the interceptor
handler itself (run when the stream is created) or as part of the streaming process (while sending and receiving messages).

Unfortunately the API didn't distinguish between those two, and assumed interceptors always run its logic in the stream wrapper, and this is not always the case.

These changes allow asserting dependencies based on execution of the interceptor, or execution of interceptor wrapper.

This Commit also removes an assertion in the gRPC prom middleware, since the dependencies is from the grpcauth MW to the prom MW, and not the other way around.