### PR TITLE
Deduplicate resources in Check dispatch

### DIFF
--- a/internal/services/integrationtesting/testconfigs/arrowtosameresource.yaml
+++ b/internal/services/integrationtesting/testconfigs/arrowtosameresource.yaml
@@ -1,0 +1,32 @@
+---
+schema: |+
+  definition user {}
+
+  definition folder {
+    relation parent: folder
+    relation viewer: user
+    permission view = viewer + parent->view
+  }
+
+  definition document {
+    relation folder: folder
+    permission view = folder->view
+  }
+
+relationships: >-
+  document:firstdoc#folder@folder:folder1
+
+  document:firstdoc#folder@folder:folder2
+
+  document:firstdoc#folder@folder:folder3
+
+  folder:folder1#parent@folder:parentfolder
+
+  folder:folder2#parent@folder:parentfolder
+
+  folder:folder3#parent@folder:parentfolder
+
+  folder:parentfolder#viewer@user:tom
+assertions:
+  assertTrue:
+    - "document:firstdoc#view@user:tom#..."

--- a/pkg/tuple/onrbytypeset.go
+++ b/pkg/tuple/onrbytypeset.go
@@ -2,6 +2,7 @@ package tuple
 
 import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/util"
 )
 
 // ONRByTypeSet is a set of ObjectAndRelation's, grouped by namespace+relation.
@@ -34,7 +35,7 @@ func (s *ONRByTypeSet) ForEachType(handler func(rr *core.RelationReference, obje
 		handler(&core.RelationReference{
 			Namespace: ns,
 			Relation:  rel,
-		}, objectIds)
+		}, util.UniqueSlice(objectIds))
 	}
 }
 
@@ -54,7 +55,7 @@ func (s *ONRByTypeSet) Map(mapper func(rr *core.RelationReference) (*core.Relati
 		if updatedType == nil {
 			continue
 		}
-		mapped.byType[JoinRelRef(updatedType.Namespace, updatedType.Relation)] = objectIds
+		mapped.byType[JoinRelRef(updatedType.Namespace, updatedType.Relation)] = util.UniqueSlice(objectIds)
 	}
 	return mapped, nil
 }

--- a/pkg/util/unique.go
+++ b/pkg/util/unique.go
@@ -1,0 +1,16 @@
+package util
+
+// UniqueSlice returns the items slice, but with duplicate items removed.
+func UniqueSlice[T comparable](items []T) []T {
+	updated := make([]T, 0, len(items))
+	encountered := make(map[T]struct{}, len(items))
+	for _, item := range items {
+		if _, ok := encountered[item]; ok {
+			continue
+		}
+
+		updated = append(updated, item)
+		encountered[item] = struct{}{}
+	}
+	return updated
+}

--- a/pkg/util/unique_test.go
+++ b/pkg/util/unique_test.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniqueSlice(t *testing.T) {
+	tcs := []struct {
+		input  []int
+		output []int
+	}{
+		{
+			[]int{},
+			[]int{},
+		},
+		{
+			[]int{1, 2, 3},
+			[]int{1, 2, 3},
+		},
+		{
+			[]int{2, 3, 1},
+			[]int{2, 3, 1},
+		},
+		{
+			[]int{2, 3, 1, 2},
+			[]int{2, 3, 1},
+		},
+		{
+			[]int{2, 3, 1, 2, 1},
+			[]int{2, 3, 1},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("%v", tc.input), func(t *testing.T) {
+			require.Equal(t, tc.output, UniqueSlice(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
This can occur if multiple relationships refer to the same subject on an arrow