### PR TITLE
more robust nil caveat context handling for Spanner

### DIFF
--- a/internal/datastore/spanner/caveat.go
+++ b/internal/datastore/spanner/caveat.go
@@ -126,9 +126,9 @@ func (rwt spannerReadWriteTXN) DeleteCaveats(_ context.Context, names []string) 
 }
 
 func ContextualizedCaveatFrom(name spanner.NullString, context spanner.NullJSON) (*core.ContextualizedCaveat, error) {
-	if name.Valid {
+	if name.Valid && name.StringVal != "" {
 		var cctx map[string]any
-		if context.Valid {
+		if context.Valid && context.Value != nil {
 			cctx = context.Value.(map[string]any)
 		}
 		return common.ContextualizedCaveatFrom(name.StringVal, cctx)

--- a/internal/datastore/spanner/caveat_test.go
+++ b/internal/datastore/spanner/caveat_test.go
@@ -1,0 +1,39 @@
+package spanner
+
+import (
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextualizedCaveatFrom(t *testing.T) {
+	res, err := ContextualizedCaveatFrom(spanner.NullString{StringVal: "", Valid: false}, spanner.NullJSON{Value: nil, Valid: true})
+	require.NoError(t, err)
+	require.Nil(t, res)
+
+	res, err = ContextualizedCaveatFrom(spanner.NullString{StringVal: "", Valid: true}, spanner.NullJSON{Value: nil, Valid: false})
+	require.NoError(t, err)
+	require.Nil(t, res)
+
+	res, err = ContextualizedCaveatFrom(spanner.NullString{StringVal: "", Valid: true}, spanner.NullJSON{Value: nil, Valid: true})
+	require.NoError(t, err)
+	require.Nil(t, res)
+
+	res, err = ContextualizedCaveatFrom(spanner.NullString{StringVal: "test", Valid: true}, spanner.NullJSON{Value: nil, Valid: true})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, "test", res.CaveatName)
+	require.NotNil(t, res.Context)
+	require.Empty(t, res.Context.Fields)
+
+	res, err = ContextualizedCaveatFrom(
+		spanner.NullString{StringVal: "test", Valid: true},
+		spanner.NullJSON{Value: map[string]any{"key": "val"}, Valid: true})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, "test", res.CaveatName)
+	require.NotNil(t, res.Context)
+	require.Len(t, res.Context.Fields, 1)
+	require.Equal(t, "val", res.Context.Fields["key"].GetStringValue())
+}


### PR DESCRIPTION
As I experimented with Cloud Spanner exports and imports, I discovered the Dataflow Job that runs generates AVRO, once imported, leaves the tuple rows with a different serialization that the original one. So when
ContextualizedCaveatFrom is run:
- for the caveat name: NullString.Valid is true, even though NullString.Value is empty string
- for the caveat context: NullJSON.Valid is true, even though NullJSON.Value is nil

That leads the ContextualizedCaveatFrom method to panic when asserting the type.

I'm not able to reproduce this, but based on the panic stacktrace and the dataset (no tuple had caveats), it is only be explained by the values described above (null types coming with Valid=true, but Value being actually nil).