### PR TITLE
rm -rf pkg/util

### DIFF
--- a/cmd/spicedb/migrate_integration_test.go
+++ b/cmd/spicedb/migrate_integration_test.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jzelinskie/stringz"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 
 	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
 	"github.com/authzed/spicedb/pkg/datastore"
@@ -38,7 +38,7 @@ func TestMigrate(t *testing.T) {
 	})
 
 	for _, engineKey := range datastore.Engines {
-		if stringz.SliceContains(toSkip, engineKey) {
+		if slices.Contains(toSkip, engineKey) {
 			continue
 		}
 

--- a/internal/caveats/diff.go
+++ b/internal/caveats/diff.go
@@ -6,8 +6,8 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/authzed/spicedb/pkg/caveats/types"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // DeltaType defines the type of caveat deltas.
@@ -95,8 +95,8 @@ func DiffCaveats(existing *core.CaveatDefinition, updated *core.CaveatDefinition
 	}
 
 	deltas := make([]Delta, 0, len(existing.ParameterTypes)+len(updated.ParameterTypes))
-	existingParameterNames := util.NewSet[string](maps.Keys(existing.ParameterTypes)...)
-	updatedParameterNames := util.NewSet[string](maps.Keys(updated.ParameterTypes)...)
+	existingParameterNames := mapz.NewSet(maps.Keys(existing.ParameterTypes)...)
+	updatedParameterNames := mapz.NewSet(maps.Keys(updated.ParameterTypes)...)
 
 	for _, removed := range existingParameterNames.Subtract(updatedParameterNames).AsSlice() {
 		deltas = append(deltas, Delta{

--- a/internal/caveats/run.go
+++ b/internal/caveats/run.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/authzed/spicedb/pkg/caveats"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // RunCaveatExpressionDebugOption are the options for running caveat expression evaluation
@@ -100,7 +100,7 @@ func runExpression(
 	debugOption RunCaveatExpressionDebugOption,
 ) (ExpressionResult, error) {
 	// Collect all referenced caveat definitions in the expression.
-	caveatNames := util.NewSet[string]()
+	caveatNames := mapz.NewSet[string]()
 	collectCaveatNames(expr, caveatNames)
 
 	if caveatNames.IsEmpty() {
@@ -317,7 +317,7 @@ func combineMaps(first map[string]any, second map[string]any) map[string]any {
 	return cloned
 }
 
-func collectCaveatNames(expr *core.CaveatExpression, caveatNames *util.Set[string]) {
+func collectCaveatNames(expr *core.CaveatExpression, caveatNames *mapz.Set[string]) {
 	if expr.GetCaveat() != nil {
 		caveatNames.Add(expr.GetCaveat().CaveatName)
 		return

--- a/internal/datastore/memdb/caveat.go
+++ b/internal/datastore/memdb/caveat.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/go-memdb"
 
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 const tableCaveats = "caveats"
@@ -96,7 +96,7 @@ func (r *memdbReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []
 		return nil, err
 	}
 
-	allowedCaveatNames := util.NewSet[string]()
+	allowedCaveatNames := mapz.NewSet[string]()
 	allowedCaveatNames.Extend(caveatNames)
 
 	toReturn := make([]datastore.RevisionedCaveat, 0, len(caveatNames))
@@ -119,7 +119,7 @@ func (rwt *memdbReadWriteTx) WriteCaveats(_ context.Context, caveats []*core.Cav
 }
 
 func (rwt *memdbReadWriteTx) writeCaveat(tx *memdb.Txn, caveats []*core.CaveatDefinition) error {
-	caveatNames := util.NewSet[string]()
+	caveatNames := mapz.NewSet[string]()
 	for _, coreCaveat := range caveats {
 		if !caveatNames.Add(coreCaveat.Name) {
 			return fmt.Errorf("duplicate caveat %s", coreCaveat.Name)

--- a/internal/datastore/memdb/readonly.go
+++ b/internal/datastore/memdb/readonly.go
@@ -9,7 +9,7 @@ import (
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 
 	"github.com/hashicorp/go-memdb"
-	"github.com/jzelinskie/stringz"
+	"golang.org/x/exp/slices"
 
 	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/pkg/datastore"
@@ -293,7 +293,7 @@ func filterFuncForFilters(
 		switch {
 		case optionalResourceType != "" && optionalResourceType != tuple.namespace:
 			return true
-		case len(optionalResourceIds) > 0 && !stringz.SliceContains(optionalResourceIds, tuple.resourceID):
+		case len(optionalResourceIds) > 0 && !slices.Contains(optionalResourceIds, tuple.resourceID):
 			return true
 		case optionalRelation != "" && optionalRelation != tuple.relation:
 			return true
@@ -305,7 +305,7 @@ func filterFuncForFilters(
 			switch {
 			case len(selector.OptionalSubjectType) > 0 && selector.OptionalSubjectType != tuple.subjectNamespace:
 				return false
-			case len(selector.OptionalSubjectIds) > 0 && !stringz.SliceContains(selector.OptionalSubjectIds, tuple.subjectObjectID):
+			case len(selector.OptionalSubjectIds) > 0 && !slices.Contains(selector.OptionalSubjectIds, tuple.subjectObjectID):
 				return false
 			}
 
@@ -322,7 +322,7 @@ func filterFuncForFilters(
 				relations = append(relations, selector.RelationFilter.NonEllipsisRelation)
 			}
 
-			return len(relations) == 0 || stringz.SliceContains(relations, tuple.subjectRelation)
+			return len(relations) == 0 || slices.Contains(relations, tuple.subjectRelation)
 		}
 
 		if len(optionalSubjectsSelectors) > 0 {

--- a/internal/datastore/proxy/caching.go
+++ b/internal/datastore/proxy/caching.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 
 	"github.com/authzed/spicedb/pkg/datastore/options"
-	"github.com/authzed/spicedb/pkg/util"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 
@@ -156,7 +156,7 @@ func listAndCache[T schemaDefinition](
 	}
 
 	// Check the cache for each entry.
-	remainingToLoad := util.NewSet[string]()
+	remainingToLoad := mapz.NewSet[string]()
 	remainingToLoad.Extend(names)
 
 	foundDefs := make([]datastore.RevisionedDefinition[T], 0, len(names))

--- a/internal/datastore/proxy/caching_test.go
+++ b/internal/datastore/proxy/caching_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
 	"github.com/authzed/spicedb/pkg/datastore/revision"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	ns "github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/testutil"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 var (
@@ -490,7 +490,7 @@ func TestMixedCaching(t *testing.T) {
 			require.NoError(err)
 			require.Equal(2, len(found))
 
-			names := util.NewSet[string]()
+			names := mapz.NewSet[string]()
 			for _, d := range found {
 				names.Add(d.GetName())
 			}
@@ -503,7 +503,7 @@ func TestMixedCaching(t *testing.T) {
 			require.NoError(err)
 			require.Equal(2, len(foundAgain))
 
-			namesAgain := util.NewSet[string]()
+			namesAgain := mapz.NewSet[string]()
 			for _, d := range foundAgain {
 				namesAgain.Add(d.GetName())
 			}

--- a/internal/developmentmembership/trackingsubjectset_test.go
+++ b/internal/developmentmembership/trackingsubjectset_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 func set(subjects ...*core.DirectSubject) *TrackingSubjectSet {
@@ -335,8 +335,8 @@ func TestTrackingSubjectSet(t *testing.T) {
 					found, ok := tc.set.Get(fs.subject)
 					require.True(ok, "missing expected subject %s", fs.subject)
 
-					expectedExcluded := util.NewSet[string](fs.excludedSubjectStrings()...)
-					foundExcluded := util.NewSet[string](found.excludedSubjectStrings()...)
+					expectedExcluded := mapz.NewSet[string](fs.excludedSubjectStrings()...)
+					foundExcluded := mapz.NewSet[string](found.excludedSubjectStrings()...)
 					require.Len(expectedExcluded.Subtract(foundExcluded).AsSlice(), 0, "mismatch on excluded subjects on %s: expected: %s, found: %s", fs.subject, expectedExcluded, foundExcluded)
 					require.Len(foundExcluded.Subtract(expectedExcluded).AsSlice(), 0, "mismatch on excluded subjects on %s: expected: %s, found: %s", fs.subject, expectedExcluded, foundExcluded)
 				} else {

--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -19,10 +19,10 @@ import (
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/internal/testfixtures"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 var ONR = tuple.ObjectAndRelation
@@ -292,7 +292,7 @@ func TestCheckMetadata(t *testing.T) {
 	}
 }
 
-func addFrame(trace *v1.CheckDebugTrace, foundFrames *util.Set[string]) {
+func addFrame(trace *v1.CheckDebugTrace, foundFrames *mapz.Set[string]) {
 	foundFrames.Add(fmt.Sprintf("%s:%s#%s", trace.Request.ResourceRelation.Namespace, strings.Join(trace.Request.ResourceIds, ","), trace.Request.ResourceRelation.Relation))
 	for _, subTrace := range trace.SubProblems {
 		addFrame(subTrace, foundFrames)
@@ -398,12 +398,12 @@ func TestCheckDebugging(t *testing.T) {
 			require.NotNil(checkResult.Metadata.DebugInfo.Check)
 			require.NotNil(checkResult.Metadata.DebugInfo.Check.Duration)
 
-			expectedFrames := util.NewSet[string]()
+			expectedFrames := mapz.NewSet[string]()
 			for _, expectedFrame := range tc.expectedFrames {
 				expectedFrames.Add(fmt.Sprintf("%s:%s#%s", expectedFrame.resourceType.Namespace, strings.Join(expectedFrame.resourceIDs, ","), expectedFrame.resourceType.Relation))
 			}
 
-			foundFrames := util.NewSet[string]()
+			foundFrames := mapz.NewSet[string]()
 			addFrame(checkResult.Metadata.DebugInfo.Check, foundFrames)
 
 			require.Empty(expectedFrames.Subtract(foundFrames).AsSlice(), "missing expected frames: %v", expectedFrames.Subtract(foundFrames).AsSlice())

--- a/internal/dispatch/graph/lookupresources_test.go
+++ b/internal/dispatch/graph/lookupresources_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/authzed/spicedb/internal/dispatch"
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/internal/testfixtures"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 const veryLargeLimit = 1000000000
@@ -196,7 +196,7 @@ func TestSimpleLookupResourcesWithCursor(t *testing.T) {
 			ctx, dispatcher, revision := newLocalDispatcher(t)
 			defer dispatcher.Close()
 
-			found := util.NewSet[string]()
+			found := mapz.NewSet[string]()
 
 			stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupResourcesResponse](ctx)
 			err := dispatcher.DispatchLookupResources(&v1.DispatchLookupResourcesRequest{
@@ -583,7 +583,7 @@ func TestLookupResourcesOverSchemaWithCursors(t *testing.T) {
 					require.NoError(datastoremw.SetInContext(ctx, ds))
 
 					var currentCursor *v1.Cursor
-					foundResourceIDs := util.NewSet[string]()
+					foundResourceIDs := mapz.NewSet[string]()
 					for {
 						stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupResourcesResponse](ctx)
 						err = dispatcher.DispatchLookupResources(&v1.DispatchLookupResourcesRequest{

--- a/internal/dispatch/graph/reachableresources_test.go
+++ b/internal/dispatch/graph/reachableresources_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/authzed/spicedb/internal/testfixtures"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 type reachableResource struct {
@@ -791,7 +791,7 @@ func TestReachableResourcesCursors(t *testing.T) {
 			require.NoError(t, err)
 			defer cancel()
 
-			foundResources := util.NewSet[string]()
+			foundResources := mapz.NewSet[string]()
 			var cursor *v1.Cursor
 
 			for index, result := range stream.Results() {
@@ -875,7 +875,7 @@ func TestReachableResourcesPaginationWithLimit(t *testing.T) {
 		t.Run(fmt.Sprintf("limit-%d", limit), func(t *testing.T) {
 			dispatcher := NewLocalOnlyDispatcher(2)
 			var cursor *v1.Cursor
-			foundResources := util.NewSet[string]()
+			foundResources := mapz.NewSet[string]()
 
 			for i := 0; i < (410/int(limit))+1; i++ {
 				ctx := log.Logger.WithContext(datastoremw.ContextWithHandle(context.Background()))
@@ -1235,7 +1235,7 @@ func TestReachableResourcesOverSchema(t *testing.T) {
 					ctx := datastoremw.ContextWithHandle(context.Background())
 					require.NoError(datastoremw.SetInContext(ctx, ds))
 
-					foundResourceIDs := util.NewSet[string]()
+					foundResourceIDs := mapz.NewSet[string]()
 
 					var currentCursor *v1.Cursor
 					for {
@@ -1423,7 +1423,7 @@ func TestReachableResourcesWithCachingInParallelTest(t *testing.T) {
 	require.NoError(t, err)
 
 	testRels := make([]*core.RelationTuple, 0)
-	expectedResources := util.NewSet[string]()
+	expectedResources := mapz.NewSet[string]()
 
 	for i := 0; i < 410; i++ {
 		if i < 250 {
@@ -1480,7 +1480,7 @@ func TestReachableResourcesWithCachingInParallelTest(t *testing.T) {
 			}, stream)
 			require.NoError(t, err)
 
-			foundResources := util.NewSet[string]()
+			foundResources := mapz.NewSet[string]()
 			for _, result := range stream.Results() {
 				foundResources.Add(result.Resource.ResourceId)
 			}

--- a/internal/dispatch/keys/computed_test.go
+++ b/internal/dispatch/keys/computed_test.go
@@ -6,12 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/authzed/spicedb/pkg/util"
-
-	"github.com/stretchr/testify/require"
-
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -560,9 +558,9 @@ func TestCacheKeyNoOverlap(t *testing.T) {
 
 	revisions := []string{"1234", "4567", "1235"}
 
-	dataCombinationSeen := util.NewSet[string]()
-	stableCacheKeysSeen := util.NewSet[string]()
-	unstableCacheKeysSeen := util.NewSet[uint64]()
+	dataCombinationSeen := mapz.NewSet[string]()
+	stableCacheKeysSeen := mapz.NewSet[string]()
+	unstableCacheKeysSeen := mapz.NewSet[uint64]()
 
 	// Ensure all key functions are generated.
 	require.Equal(t, len(generatorFuncs), len(cachePrefixes))

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -14,6 +14,7 @@ import (
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/slicez"
 	nspkg "github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
@@ -153,7 +154,7 @@ func (cc *ConcurrentChecker) checkInternal(ctx context.Context, req ValidatedChe
 	}
 
 	// Deduplicate any incoming resource IDs.
-	resourceIds := util.UniqueSlice(req.ResourceIds)
+	resourceIds := slicez.Unique(req.ResourceIds)
 
 	// Filter the incoming resource IDs for any which match the subject directly. For example, if we receive
 	// a check for resource `user:{tom, fred, sarah}#...` and a subject of `user:sarah#...`, then we know

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -22,7 +22,6 @@ import (
 	iv1 "github.com/authzed/spicedb/pkg/proto/impl/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 var dispatchChunkCountHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
@@ -378,7 +377,7 @@ func (cc *ConcurrentChecker) checkDirect(ctx context.Context, crc currentRequest
 	toDispatch := make([]directDispatch, 0, subjectsToDispatch.Len())
 	subjectsToDispatch.ForEachType(func(rr *core.RelationReference, resourceIds []string) {
 		chunkCount := 0.0
-		util.ForEachChunk(resourceIds, crc.maxDispatchCount, func(resourceIdChunk []string) {
+		slicez.ForEachChunk(resourceIds, crc.maxDispatchCount, func(resourceIdChunk []string) {
 			chunkCount++
 			toDispatch = append(toDispatch, directDispatch{
 				resourceType: rr,
@@ -581,7 +580,7 @@ func (cc *ConcurrentChecker) checkTupleToUserset(ctx context.Context, crc curren
 	toDispatch := make([]directDispatch, 0, subjectsToDispatch.Len())
 	subjectsToDispatch.ForEachType(func(rr *core.RelationReference, resourceIds []string) {
 		chunkCount := 0.0
-		util.ForEachChunk(resourceIds, crc.maxDispatchCount, func(resourceIdChunk []string) {
+		slicez.ForEachChunk(resourceIds, crc.maxDispatchCount, func(resourceIdChunk []string) {
 			chunkCount++
 			toDispatch = append(toDispatch, directDispatch{
 				resourceType: rr,

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -14,6 +14,7 @@ import (
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	"github.com/authzed/spicedb/pkg/genutil/slicez"
 	nspkg "github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -356,7 +357,7 @@ func (cc *ConcurrentChecker) checkDirect(ctx context.Context, crc currentRequest
 
 	// Find the subjects over which to dispatch.
 	subjectsToDispatch := tuple.NewONRByTypeSet()
-	relationshipsBySubjectONR := util.NewMultiMap[string, *core.RelationTuple]()
+	relationshipsBySubjectONR := mapz.NewMultiMap[string, *core.RelationTuple]()
 
 	for tpl := it.Next(); tpl != nil; tpl = it.Next() {
 		if it.Err() != nil {
@@ -411,7 +412,7 @@ func (cc *ConcurrentChecker) checkDirect(ctx context.Context, crc currentRequest
 	return combineResultWithFoundResources(result, foundResources)
 }
 
-func mapFoundResources(result CheckResult, resourceType *core.RelationReference, relationshipsBySubjectONR *util.MultiMap[string, *core.RelationTuple]) CheckResult {
+func mapFoundResources(result CheckResult, resourceType *core.RelationReference, relationshipsBySubjectONR *mapz.MultiMap[string, *core.RelationTuple]) CheckResult {
 	// Map any resources found to the parent resource IDs.
 	membershipSet := NewMembershipSet()
 	for foundResourceID, result := range result.Resp.ResultsByResourceId {
@@ -565,7 +566,7 @@ func (cc *ConcurrentChecker) checkTupleToUserset(ctx context.Context, crc curren
 	defer it.Close()
 
 	subjectsToDispatch := tuple.NewONRByTypeSet()
-	relationshipsBySubjectONR := util.NewMultiMap[string, *core.RelationTuple]()
+	relationshipsBySubjectONR := mapz.NewMultiMap[string, *core.RelationTuple]()
 	for tpl := it.Next(); tpl != nil; tpl = it.Next() {
 		if it.Err() != nil {
 			return checkResultError(NewCheckFailureErr(it.Err()), emptyMetadata)

--- a/internal/graph/checkingresourcestream.go
+++ b/internal/graph/checkingresourcestream.go
@@ -10,9 +10,9 @@ import (
 	"github.com/authzed/spicedb/internal/dispatch"
 	"github.com/authzed/spicedb/internal/graph/computed"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // possibleResource is a resource that was returned by reachable resources and, after processing,
@@ -403,7 +403,7 @@ func (crs *checkingResourceStream) process() {
 func (crs *checkingResourceStream) runProcess(alwaysProcess bool) (bool, error) {
 	// Collect any resources that need to be checked, up to the configured limit, and issue a check.
 	// If a resource does not require a check, simply place on the toPublish queue.
-	toCheck := util.NewMultiMap[string, possibleResource]()
+	toCheck := mapz.NewMultiMap[string, possibleResource]()
 	toProcess := crs.rq.selectResourcesToProcess(alwaysProcess)
 	if len(toProcess) == 0 {
 		return false, nil

--- a/internal/graph/computed/computecheck.go
+++ b/internal/graph/computed/computecheck.go
@@ -7,9 +7,9 @@ import (
 	"github.com/authzed/spicedb/internal/dispatch"
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/slicez"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // DebugOption defines the various debug level options for Checks.
@@ -95,7 +95,7 @@ func computeCheck(ctx context.Context,
 	resultMetadatas := make(map[string]*v1.ResponseMeta, len(resourceIDs))
 
 	// TODO(jschorr): Should we make this run in parallel via the preloadedTaskRunner?
-	_, err := util.ForEachChunkUntil(resourceIDs, datastore.FilterMaximumIDCount, func(resourceIDsToCheck []string) (bool, error) {
+	_, err := slicez.ForEachChunkUntil(resourceIDs, datastore.FilterMaximumIDCount, func(resourceIDsToCheck []string) (bool, error) {
 		checkResult, err := d.DispatchCheck(ctx, &v1.DispatchCheckRequest{
 			ResourceRelation: params.ResourceType,
 			ResourceIds:      resourceIDsToCheck,

--- a/internal/graph/lookupsubjects.go
+++ b/internal/graph/lookupsubjects.go
@@ -13,6 +13,7 @@ import (
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -111,7 +112,7 @@ func (cl *ConcurrentLookupSubjects) lookupDirectSubjects(
 
 	toDispatchByType := datasets.NewSubjectByTypeSet()
 	foundSubjectsByResourceID := datasets.NewSubjectSetByResourceID()
-	relationshipsBySubjectONR := util.NewMultiMap[string, *core.RelationTuple]()
+	relationshipsBySubjectONR := mapz.NewMultiMap[string, *core.RelationTuple]()
 	for tpl := it.Next(); tpl != nil; tpl = it.Next() {
 		if it.Err() != nil {
 			return it.Err()

--- a/internal/graph/lookupsubjects.go
+++ b/internal/graph/lookupsubjects.go
@@ -206,7 +206,7 @@ func (cl *ConcurrentLookupSubjects) lookupViaTupleToUserset(
 	defer it.Close()
 
 	toDispatchByTuplesetType := datasets.NewSubjectByTypeSet()
-	relationshipsBySubjectONR := util.NewMultiMap[string, *core.RelationTuple]()
+	relationshipsBySubjectONR := mapz.NewMultiMap[string, *core.RelationTuple]()
 	for tpl := it.Next(); tpl != nil; tpl = it.Next() {
 		if it.Err() != nil {
 			return it.Err()
@@ -326,7 +326,7 @@ func (cl *ConcurrentLookupSubjects) dispatchTo(
 	ctx context.Context,
 	parentRequest ValidatedLookupSubjectsRequest,
 	toDispatchByType *datasets.SubjectByTypeSet,
-	relationshipsBySubjectONR *util.MultiMap[string, *core.RelationTuple],
+	relationshipsBySubjectONR *mapz.MultiMap[string, *core.RelationTuple],
 	parentStream dispatch.LookupSubjectsStream,
 ) error {
 	if toDispatchByType.IsEmpty() {

--- a/internal/graph/lookupsubjects.go
+++ b/internal/graph/lookupsubjects.go
@@ -14,10 +14,10 @@ import (
 	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
+	"github.com/authzed/spicedb/pkg/genutil/slicez"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // ValidatedLookupSubjectsRequest represents a request after it has been validated and parsed for internal
@@ -417,7 +417,7 @@ func (cl *ConcurrentLookupSubjects) dispatchTo(
 		}
 
 		// Dispatch the found subjects as the resources of the next step.
-		util.ForEachChunk(resourceIds, maxDispatchChunkSize, func(resourceIdChunk []string) {
+		slicez.ForEachChunk(resourceIds, maxDispatchChunkSize, func(resourceIdChunk []string) {
 			g.Go(func() error {
 				return cl.d.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{
 					ResourceRelation: resourceType,

--- a/internal/graph/resourcesubjectsmap.go
+++ b/internal/graph/resourcesubjectsmap.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
@@ -26,7 +27,7 @@ func (s *syncONRSet) Add(onr *core.ObjectAndRelation) bool {
 // is conditional due to the use of a caveat on the relationship which formed the mapping.
 type resourcesSubjectMap struct {
 	resourceType         *core.RelationReference
-	resourcesAndSubjects *util.MultiMap[string, subjectInfo]
+	resourcesAndSubjects *mapz.MultiMap[string, subjectInfo]
 }
 
 // subjectInfo is the information about a subject contained in a resourcesSubjectMap.
@@ -38,14 +39,14 @@ type subjectInfo struct {
 func newResourcesSubjectMap(resourceType *core.RelationReference) resourcesSubjectMap {
 	return resourcesSubjectMap{
 		resourceType:         resourceType,
-		resourcesAndSubjects: util.NewMultiMap[string, subjectInfo](),
+		resourcesAndSubjects: mapz.NewMultiMap[string, subjectInfo](),
 	}
 }
 
 func newResourcesSubjectMapWithCapacity(resourceType *core.RelationReference, capacity uint32) resourcesSubjectMap {
 	return resourcesSubjectMap{
 		resourceType:         resourceType,
-		resourcesAndSubjects: util.NewMultiMapWithCapacity[string, subjectInfo](capacity),
+		resourcesAndSubjects: mapz.NewMultiMapWithCap[string, subjectInfo](capacity),
 	}
 }
 
@@ -90,7 +91,7 @@ func (rsm resourcesSubjectMap) len() int {
 // its use by concurrent callers.
 type dispatchableResourcesSubjectMap struct {
 	resourceType         *core.RelationReference
-	resourcesAndSubjects util.ReadOnlyMultimap[string, subjectInfo]
+	resourcesAndSubjects mapz.ReadOnlyMultimap[string, subjectInfo]
 }
 
 func (rsm dispatchableResourcesSubjectMap) isEmpty() bool {

--- a/internal/graph/resourcesubjectsmap.go
+++ b/internal/graph/resourcesubjectsmap.go
@@ -9,7 +9,6 @@ import (
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 type syncONRSet struct {
@@ -187,8 +186,8 @@ func (rsm dispatchableResourcesSubjectMap) mapFoundResource(foundResource *v1.Re
 		status = v1.ReachableResource_REQUIRES_CHECK
 	}
 
-	forSubjectIDs := util.NewSet[string]()
-	nonCaveatedSubjectIDs := util.NewSet[string]()
+	forSubjectIDs := mapz.NewSet[string]()
+	nonCaveatedSubjectIDs := mapz.NewSet[string]()
 	for _, forSubjectID := range foundResource.ForSubjectIds {
 		// Map from the incoming subject ID to the subject ID(s) that caused the dispatch.
 		infos, ok := rsm.resourcesAndSubjects.Get(forSubjectID)

--- a/internal/namespace/diff.go
+++ b/internal/namespace/diff.go
@@ -4,10 +4,10 @@ import (
 	"github.com/scylladb/go-set/strset"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	nspkg "github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	iv1 "github.com/authzed/spicedb/pkg/proto/impl/v1"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // DeltaType defines the type of namespace deltas.
@@ -214,8 +214,8 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 			updatedTypeInfo = &core.TypeInformation{}
 		}
 
-		existingAllowedRels := util.NewSet[string]()
-		updatedAllowedRels := util.NewSet[string]()
+		existingAllowedRels := mapz.NewSet[string]()
+		updatedAllowedRels := mapz.NewSet[string]()
 		allowedRelsBySource := map[string]*core.AllowedRelation{}
 
 		for _, existingAllowed := range existingTypeInfo.AllowedDirectRelations {

--- a/internal/namespace/typesystem.go
+++ b/internal/namespace/typesystem.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	"github.com/authzed/spicedb/pkg/graph"
 	nspkg "github.com/authzed/spicedb/pkg/namespace"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	iv1 "github.com/authzed/spicedb/pkg/proto/impl/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // AllowedDirectRelation indicates whether a relation is allowed on the right side of another relation.
@@ -474,7 +473,7 @@ func (nts *TypeSystem) Validate(ctx context.Context) (*ValidatedNamespaceTypeSys
 		// 2) that they exist within the referenced namespace
 		// 3) that they are not duplicated in any way
 		// 4) that if they have a caveat reference, the caveat is valid
-		encountered := util.NewSet[string]()
+		encountered := mapz.NewSet[string]()
 
 		for _, allowedRelation := range allowedDirectRelations {
 			source := SourceForAllowedRelation(allowedRelation)

--- a/internal/namespace/typesystem_test.go
+++ b/internal/namespace/typesystem_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 
 	"github.com/authzed/spicedb/internal/datastore/memdb"
@@ -17,7 +18,6 @@ import (
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 func TestTypeSystem(t *testing.T) {
@@ -397,12 +397,12 @@ func noError[T any](result T, err error) T {
 }
 
 func requireSameAllowedRelations(t *testing.T, found []*core.AllowedRelation, expected ...*core.AllowedRelation) {
-	foundSet := util.NewSet[string]()
+	foundSet := mapz.NewSet[string]()
 	for _, f := range found {
 		foundSet.Add(SourceForAllowedRelation(f))
 	}
 
-	expectSet := util.NewSet[string]()
+	expectSet := mapz.NewSet[string]()
 	for _, e := range expected {
 		expectSet.Add(SourceForAllowedRelation(e))
 	}
@@ -417,12 +417,12 @@ func requireSameAllowedRelations(t *testing.T, found []*core.AllowedRelation, ex
 }
 
 func requireSameSubjectRelations(t *testing.T, found []*core.RelationReference, expected ...*core.RelationReference) {
-	foundSet := util.NewSet[string]()
+	foundSet := mapz.NewSet[string]()
 	for _, f := range found {
 		foundSet.Add(tuple.StringRR(f))
 	}
 
-	expectSet := util.NewSet[string]()
+	expectSet := mapz.NewSet[string]()
 	for _, e := range expected {
 		expectSet.Add(tuple.StringRR(e))
 	}

--- a/internal/namespace/util.go
+++ b/internal/namespace/util.go
@@ -3,9 +3,8 @@ package namespace
 import (
 	"context"
 
-	"github.com/authzed/spicedb/pkg/util"
-
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
@@ -53,7 +52,7 @@ type TypeAndRelationToCheck struct {
 // Returns ErrRelationNotFound if the relation was not found in the namespace.
 // Returns the direct downstream error for all other unknown error.
 func CheckNamespaceAndRelations(ctx context.Context, checks []TypeAndRelationToCheck, ds datastore.Reader) error {
-	nsNames := util.NewSet[string]()
+	nsNames := mapz.NewSet[string]()
 	for _, toCheck := range checks {
 		nsNames.Add(toCheck.NamespaceName)
 	}
@@ -148,7 +147,7 @@ func ReadNamespaceAndTypes(
 // given namespace definitions. This includes the namespaces themselves, as well as
 // any found in type information on relations.
 func ListReferencedNamespaces(nsdefs []*core.NamespaceDefinition) []string {
-	referencedNamespaceNamesSet := util.NewSet[string]()
+	referencedNamespaceNamesSet := mapz.NewSet[string]()
 	for _, nsdef := range nsdefs {
 		referencedNamespaceNamesSet.Add(nsdef.Name)
 

--- a/internal/relationships/validation.go
+++ b/internal/relationships/validation.go
@@ -6,10 +6,10 @@ import (
 	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/pkg/caveats"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	ns "github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // ValidateRelationships performs validation on the given relationships, ensuring that
@@ -19,8 +19,8 @@ func ValidateRelationships(
 	reader datastore.Reader,
 	rels []*core.RelationTuple,
 ) error {
-	referencedNamespaceNames := util.NewSet[string]()
-	referencedCaveatNamesWithContext := util.NewSet[string]()
+	referencedNamespaceNames := mapz.NewSet[string]()
+	referencedCaveatNamesWithContext := mapz.NewSet[string]()
 	for _, rel := range rels {
 		referencedNamespaceNames.Add(rel.ResourceAndRelation.Namespace)
 		referencedNamespaceNames.Add(rel.Subject.Namespace)

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/authzed/spicedb/internal/services/integrationtesting/consistencytestutil"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/development"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	devinterface "github.com/authzed/spicedb/pkg/proto/developer/v1"
 	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 	"github.com/authzed/spicedb/pkg/validationfile"
 	"github.com/authzed/spicedb/pkg/validationfile/blocks"
 )
@@ -249,7 +249,7 @@ func validateRelationshipReads(t *testing.T, vctx validationContext) {
 		)
 		require.NoError(t, err)
 
-		foundRelationshipsSet := util.NewSet[string]()
+		foundRelationshipsSet := mapz.NewSet[string]()
 		for _, rel := range foundRelationships {
 			foundRelationshipsSet.Add(tuple.MustString(rel))
 		}
@@ -320,8 +320,8 @@ func validateExpansionSubjects(t *testing.T, vctx validationContext) {
 }
 
 func requireSameSets(t *testing.T, expected []string, found []string) {
-	expectedSet := util.NewSet(expected...)
-	foundSet := util.NewSet(found...)
+	expectedSet := mapz.NewSet(expected...)
+	foundSet := mapz.NewSet(found...)
 
 	orderedExpected := expectedSet.AsSlice()
 	orderedFound := foundSet.AsSlice()
@@ -337,7 +337,7 @@ func requireSubsetOf(t *testing.T, found []string, expected []string) {
 		return
 	}
 
-	foundSet := util.NewSet(found...)
+	foundSet := mapz.NewSet(found...)
 	for _, expectedObjectID := range expected {
 		require.True(t, foundSet.Has(expectedObjectID), "missing expected object ID %s", expectedObjectID)
 	}

--- a/internal/services/integrationtesting/consistencytestutil/accessibilityset.go
+++ b/internal/services/integrationtesting/consistencytestutil/accessibilityset.go
@@ -15,7 +15,6 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // ObjectAndPermission contains an object ID and whether it is a caveated result.
@@ -84,7 +83,7 @@ func BuildAccessibilitySet(t *testing.T, ccd ConsistencyClusterAndData) *Accessi
 	relsByResourceNamespace := mapz.NewMultiMap[string, *core.RelationTuple]()
 	resourcesByNamespace := mapz.NewMultiMap[string, *core.ObjectAndRelation]()
 	subjectsByNamespace := mapz.NewMultiMap[string, *core.ObjectAndRelation]()
-	allObjectIds := util.NewSet[string]()
+	allObjectIds := mapz.NewSet[string]()
 
 	for _, tpl := range ccd.Populated.Tuples {
 		relsByResourceNamespace.Add(tpl.ResourceAndRelation.Namespace, tpl)
@@ -305,7 +304,7 @@ func (as *AccessibilitySet) SubjectTypes() []*core.RelationReference {
 // AllSubjectsNoWildcards returns all *defined*, non-wildcard subjects found.
 func (as *AccessibilitySet) AllSubjectsNoWildcards() []*core.ObjectAndRelation {
 	subjects := make([]*core.ObjectAndRelation, 0)
-	seenSubjects := util.NewSet[string]()
+	seenSubjects := mapz.NewSet[string]()
 	for _, subject := range as.SubjectsByNamespace.Values() {
 		if subject.ObjectId == tuple.PublicWildcard {
 			continue

--- a/internal/services/integrationtesting/consistencytestutil/accessibilityset.go
+++ b/internal/services/integrationtesting/consistencytestutil/accessibilityset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/authzed/spicedb/internal/dispatch/graph"
 	"github.com/authzed/spicedb/internal/graph/computed"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -51,13 +52,13 @@ const (
 // and subjects found for consistency testing.
 type AccessibilitySet struct {
 	// ResourcesByNamespace is a multimap of all defined resources, by resource namespace.
-	ResourcesByNamespace *util.MultiMap[string, *core.ObjectAndRelation]
+	ResourcesByNamespace *mapz.MultiMap[string, *core.ObjectAndRelation]
 
 	// SubjectsByNamespace is a multimap of all defined subjects, by subject namespace.
-	SubjectsByNamespace *util.MultiMap[string, *core.ObjectAndRelation]
+	SubjectsByNamespace *mapz.MultiMap[string, *core.ObjectAndRelation]
 
 	// RelationshipsByResourceNamespace is a multimap of all defined relationships, by resource namespace.
-	RelationshipsByResourceNamespace *util.MultiMap[string, *core.RelationTuple]
+	RelationshipsByResourceNamespace *mapz.MultiMap[string, *core.RelationTuple]
 
 	// UncomputedPermissionshipByRelationship is a map from a relationship string of the form
 	// "resourceType:resourceObjectID#permission@subjectType:subjectObjectID" to its
@@ -80,9 +81,9 @@ type AccessibilitySet struct {
 // outside of testing.
 func BuildAccessibilitySet(t *testing.T, ccd ConsistencyClusterAndData) *AccessibilitySet {
 	// Compute all relationships and objects by namespace.
-	relsByResourceNamespace := util.NewMultiMap[string, *core.RelationTuple]()
-	resourcesByNamespace := util.NewMultiMap[string, *core.ObjectAndRelation]()
-	subjectsByNamespace := util.NewMultiMap[string, *core.ObjectAndRelation]()
+	relsByResourceNamespace := mapz.NewMultiMap[string, *core.RelationTuple]()
+	resourcesByNamespace := mapz.NewMultiMap[string, *core.ObjectAndRelation]()
+	subjectsByNamespace := mapz.NewMultiMap[string, *core.ObjectAndRelation]()
 	allObjectIds := util.NewSet[string]()
 
 	for _, tpl := range ccd.Populated.Tuples {

--- a/internal/services/integrationtesting/dispatch_test.go
+++ b/internal/services/integrationtesting/dispatch_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/jzelinskie/stringz"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 
 	"github.com/authzed/spicedb/internal/datastore/spanner"
 	"github.com/authzed/spicedb/internal/testserver"
@@ -315,7 +315,7 @@ func TestDispatchIntegration(t *testing.T) {
 	}
 
 	for _, engine := range datastore.Engines {
-		if stringz.SliceContains(blacklist, engine) {
+		if slices.Contains(blacklist, engine) {
 			continue
 		}
 		b := testdatastore.RunDatastoreEngine(t, engine)

--- a/internal/services/integrationtesting/perf_test.go
+++ b/internal/services/integrationtesting/perf_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/jzelinskie/stringz"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 
 	"github.com/authzed/spicedb/internal/datastore/spanner"
 	tf "github.com/authzed/spicedb/internal/testfixtures"
@@ -30,7 +30,7 @@ func TestBurst(t *testing.T) {
 	}
 
 	for _, engine := range datastore.Engines {
-		if stringz.SliceContains(blacklist, engine) {
+		if slices.Contains(blacklist, engine) {
 			continue
 		}
 		b := testdatastore.RunDatastoreEngine(t, engine)

--- a/internal/services/v1/debug_test.go
+++ b/internal/services/v1/debug_test.go
@@ -20,9 +20,9 @@ import (
 	tf "github.com/authzed/spicedb/internal/testfixtures"
 	"github.com/authzed/spicedb/internal/testserver"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
 
@@ -45,7 +45,7 @@ type debugCheckInfo struct {
 
 func expectDebugFrames(permissionNames ...string) rda {
 	return func(req *require.Assertions, debugInfo *v1.DebugInformation) {
-		found := util.NewSet[string]()
+		found := mapz.NewSet[string]()
 		for _, sp := range debugInfo.Check.GetSubProblems().Traces {
 			for _, permissionName := range permissionNames {
 				if sp.Permission == permissionName {

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -28,12 +28,12 @@ import (
 	tf "github.com/authzed/spicedb/internal/testfixtures"
 	"github.com/authzed/spicedb/internal/testserver"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	pgraph "github.com/authzed/spicedb/pkg/graph"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
 
@@ -1467,7 +1467,7 @@ func TestLookupResourcesWithCursors(t *testing.T) {
 							t.Cleanup(cleanup)
 
 							var currentCursor *v1.Cursor
-							foundObjectIds := util.NewSet[string]()
+							foundObjectIds := mapz.NewSet[string]()
 
 							for i := 0; i < 5; i++ {
 								var trailer metadata.MD
@@ -1553,7 +1553,7 @@ func TestLookupResourcesDeduplication(t *testing.T) {
 
 	require.NoError(t, err)
 
-	foundObjectIds := util.NewSet[string]()
+	foundObjectIds := mapz.NewSet[string]()
 	for {
 		resp, err := lookupClient.Recv()
 		if errors.Is(err, io.EOF) {

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -26,11 +26,11 @@ import (
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
 	"github.com/authzed/spicedb/pkg/datastore/pagination"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	"github.com/authzed/spicedb/pkg/middleware/consistency"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
 
@@ -265,7 +265,7 @@ func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.Writ
 	}
 
 	// Check for duplicate updates and create the set of caveat names to load.
-	updateRelationshipSet := util.NewSet[string]()
+	updateRelationshipSet := mapz.NewSet[string]()
 	for _, update := range req.Updates {
 		tupleStr := tuple.StringRelationshipWithoutCaveat(update.Relationship)
 		if !updateRelationshipSet.Add(tupleStr) {

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 type validatingDatastore struct {
@@ -198,7 +198,7 @@ func (vrwt validatingReadWriteTransaction) WriteRelationships(ctx context.Contex
 	}
 
 	// Ensure there are no duplicate mutations.
-	tupleSet := util.NewSet[string]()
+	tupleSet := mapz.NewSet[string]()
 	for _, mutation := range mutations {
 		if err := mutation.Validate(); err != nil {
 			return err

--- a/internal/testutil/subjects.go
+++ b/internal/testutil/subjects.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // WrapFoundSubject wraps the given subject into a pointer to it, unless nil, in which case this method returns
@@ -210,7 +210,7 @@ func checkEquivalentCaveatExprs(expected *core.CaveatExpression, found *core.Cav
 	// so we compare by building a boolean table for each referenced caveat name and then checking all combinations
 	// of boolean inputs to ensure the expressions produce the same output. Note that while this isn't the most
 	// efficient means of comparison, it is logically correct.
-	referencedNamesSet := util.NewSet[string]()
+	referencedNamesSet := mapz.NewSet[string]()
 	collectReferencedNames(expected, referencedNamesSet)
 	collectReferencedNames(found, referencedNamesSet)
 
@@ -321,7 +321,7 @@ func combinatorialValues(names []string) []map[string]bool {
 }
 
 // collectReferencedNames collects all referenced caveat names into the given set.
-func collectReferencedNames(expr *core.CaveatExpression, nameSet *util.Set[string]) {
+func collectReferencedNames(expr *core.CaveatExpression, nameSet *mapz.Set[string]) {
 	if expr.GetCaveat() != nil {
 		nameSet.Add(expr.GetCaveat().CaveatName)
 		return

--- a/pkg/caveats/compile.go
+++ b/pkg/caveats/compile.go
@@ -6,8 +6,8 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common"
 
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	impl "github.com/authzed/spicedb/pkg/proto/impl/v1"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 const anonymousCaveat = ""
@@ -52,9 +52,9 @@ func (cc CompiledCaveat) Serialize() ([]byte, error) {
 }
 
 // ReferencedParameters returns the names of the parameters referenced in the expression.
-func (cc CompiledCaveat) ReferencedParameters(parameters []string) *util.Set[string] {
-	referencedParams := util.NewSet[string]()
-	definedParameters := util.NewSet[string]()
+func (cc CompiledCaveat) ReferencedParameters(parameters []string) *mapz.Set[string] {
+	referencedParams := mapz.NewSet[string]()
+	definedParameters := mapz.NewSet[string]()
 	definedParameters.Extend(parameters)
 
 	referencedParameters(definedParameters, cc.ast.Expr(), referencedParams)

--- a/pkg/caveats/structure.go
+++ b/pkg/caveats/structure.go
@@ -5,12 +5,12 @@ import (
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
-	"github.com/authzed/spicedb/pkg/util"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 )
 
 // referencedParameters traverses the expression given and finds all parameters which are referenced
 // in the expression for the purpose of usage tracking.
-func referencedParameters(definedParameters *util.Set[string], expr *exprpb.Expr, referencedParams *util.Set[string]) {
+func referencedParameters(definedParameters *mapz.Set[string], expr *exprpb.Expr, referencedParams *mapz.Set[string]) {
 	if expr == nil {
 		return
 	}

--- a/pkg/cmd/server/middleware.go
+++ b/pkg/cmd/server/middleware.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
-	"github.com/authzed/spicedb/pkg/util"
 
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 	"google.golang.org/grpc"
@@ -52,7 +52,7 @@ func (mm MiddlewareModification[T]) validate() error {
 }
 
 func validate[T middlewareTypes](mws []ReferenceableMiddleware[T]) error {
-	names := util.NewSet[string]()
+	names := mapz.NewSet[string]()
 	for _, mw := range mws {
 		if mw.Name == "" {
 			return fmt.Errorf("unnamed middleware found: %v", mw)
@@ -94,8 +94,8 @@ const (
 )
 
 // Names returns the names of the middlewares in a chain
-func (mc *MiddlewareChain[T]) Names() *util.Set[string] {
-	names := util.NewSet[string]()
+func (mc *MiddlewareChain[T]) Names() *mapz.Set[string] {
+	names := mapz.NewSet[string]()
 	for _, mw := range mc.chain {
 		names.Add(mw.Name)
 	}

--- a/pkg/genutil/mapz/multimap.go
+++ b/pkg/genutil/mapz/multimap.go
@@ -1,16 +1,17 @@
-package util
+package mapz
 
 import (
 	"golang.org/x/exp/maps"
 )
 
-// ReadOnlyMultimap is a read-only version of the multimap.
+// ReadOnlyMultimap is a read-only multimap.
 type ReadOnlyMultimap[T comparable, Q any] interface {
 	// Has returns true if the key is found in the map.
 	Has(key T) bool
 
-	// Get returns the values for the given key in the map and whether the key existed. If the key
-	// does not exist, an empty slice is returned.
+	// Get returns the values for the given key in the map and whether the key
+	// existed.
+	// If the key does not exist, an empty slice is returned.
 	Get(key T) ([]Q, bool)
 
 	// IsEmpty returns true if the map is currently empty.
@@ -26,18 +27,15 @@ type ReadOnlyMultimap[T comparable, Q any] interface {
 	Values() []Q
 }
 
-// NewMultiMap creates and returns a new MultiMap from keys of type T to values of type Q.
+// NewMultiMap initializes a new MultiMap.
 func NewMultiMap[T comparable, Q any]() *MultiMap[T, Q] {
-	return &MultiMap[T, Q]{
-		items: map[T][]Q{},
-	}
+	return &MultiMap[T, Q]{items: map[T][]Q{}}
 }
 
-// NewMultiMapWithCapacity creates and returns a new MultiMap from keys of type T to values of type Q.
-func NewMultiMapWithCapacity[T comparable, Q any](capacity uint32) *MultiMap[T, Q] {
-	return &MultiMap[T, Q]{
-		items: make(map[T][]Q, capacity),
-	}
+// NewMultiMapWithCap initializes with the provided capacity for the top-level
+// map.
+func NewMultiMapWithCap[T comparable, Q any](capacity uint32) *MultiMap[T, Q] {
+	return &MultiMap[T, Q]{items: make(map[T][]Q, capacity)}
 }
 
 // MultiMap represents a map that can contain 1 or more values for each key.
@@ -50,9 +48,11 @@ func (mm *MultiMap[T, Q]) Clear() {
 	mm.items = map[T][]Q{}
 }
 
-// Add adds the value to the map for the given key. If there exists an existing value, then this
-// value is added to those already present *without comparison*. This means a value can be added
-// twice, if this method is called again for the same value.
+// Add inserts the value into the map at the given key.
+//
+// If there exists an existing value, then this value is appended
+// *without comparison*. Put another way, a value can be added twice, if this
+// method is called twice for the same value.
 func (mm *MultiMap[T, Q]) Add(key T, item Q) {
 	if _, ok := mm.items[key]; !ok {
 		mm.items[key] = []Q{}
@@ -72,8 +72,10 @@ func (mm *MultiMap[T, Q]) Has(key T) bool {
 	return ok
 }
 
-// Get returns the values for the given key in the map and whether the key existed. If the key
-// does not exist, an empty slice is returned.
+// Get returns the values stored in the map for the provided key and whether
+// the key existed.
+//
+// If the key does not exist, an empty slice is returned.
 func (mm *MultiMap[T, Q]) Get(key T) ([]Q, bool) {
 	found, ok := mm.items[key]
 	if !ok {
@@ -84,19 +86,13 @@ func (mm *MultiMap[T, Q]) Get(key T) ([]Q, bool) {
 }
 
 // IsEmpty returns true if the map is currently empty.
-func (mm *MultiMap[T, Q]) IsEmpty() bool {
-	return len(mm.items) == 0
-}
+func (mm *MultiMap[T, Q]) IsEmpty() bool { return len(mm.items) == 0 }
 
 // Len returns the length of the map, e.g. the number of *keys* present.
-func (mm *MultiMap[T, Q]) Len() int {
-	return len(mm.items)
-}
+func (mm *MultiMap[T, Q]) Len() int { return len(mm.items) }
 
 // Keys returns the keys of the map.
-func (mm *MultiMap[T, Q]) Keys() []T {
-	return maps.Keys(mm.items)
-}
+func (mm *MultiMap[T, Q]) Keys() []T { return maps.Keys(mm.items) }
 
 // Values returns all values in the map.
 func (mm MultiMap[T, Q]) Values() []Q {
@@ -136,19 +132,13 @@ func (mm readOnlyMultimap[T, Q]) Get(key T) ([]Q, bool) {
 }
 
 // IsEmpty returns true if the map is currently empty.
-func (mm readOnlyMultimap[T, Q]) IsEmpty() bool {
-	return len(mm.items) == 0
-}
+func (mm readOnlyMultimap[T, Q]) IsEmpty() bool { return len(mm.items) == 0 }
 
 // Len returns the length of the map, e.g. the number of *keys* present.
-func (mm readOnlyMultimap[T, Q]) Len() int {
-	return len(mm.items)
-}
+func (mm readOnlyMultimap[T, Q]) Len() int { return len(mm.items) }
 
 // Keys returns the keys of the map.
-func (mm readOnlyMultimap[T, Q]) Keys() []T {
-	return maps.Keys(mm.items)
-}
+func (mm readOnlyMultimap[T, Q]) Keys() []T { return maps.Keys(mm.items) }
 
 // Values returns all values in the map.
 func (mm readOnlyMultimap[T, Q]) Values() []Q {

--- a/pkg/genutil/mapz/multimap_test.go
+++ b/pkg/genutil/mapz/multimap_test.go
@@ -1,4 +1,4 @@
-package util
+package mapz
 
 import (
 	"sort"

--- a/pkg/genutil/mapz/set.go
+++ b/pkg/genutil/mapz/set.go
@@ -1,4 +1,4 @@
-package util
+package mapz
 
 import (
 	"github.com/rs/zerolog"
@@ -83,7 +83,7 @@ func (s *Set[T]) Subtract(other *Set[T]) *Set[T] {
 
 // Copy returns a copy of this set.
 func (s *Set[T]) Copy() *Set[T] {
-	return NewSet[T](s.AsSlice()...)
+	return NewSet(s.AsSlice()...)
 }
 
 // Intersect removes any values from this set that
@@ -147,17 +147,10 @@ func (s *Set[T]) ForEach(callback func(value T) error) error {
 	return nil
 }
 
-// StringSetWrapper wraps a set of strings and provides marshalling for zerolog.
-type StringSetWrapper struct {
-	StrSet *Set[string]
-}
-
-// MarshalZerologObject implements zerolog object marshalling.
-func (s StringSetWrapper) MarshalZerologObject(e *zerolog.Event) {
-	e.Strs("values", s.StrSet.AsSlice())
-}
-
-// StringSet wraps a Set of strings and provides automatic log marshalling.
-func StringSet(set *Set[string]) StringSetWrapper {
-	return StringSetWrapper{set}
+func (s *Set[T]) MarshalZerologObject(e *zerolog.Event) {
+	xs := zerolog.Arr()
+	for _, value := range s.values {
+		xs.Interface(value)
+	}
+	e.Array("values", xs)
 }

--- a/pkg/genutil/mapz/set_test.go
+++ b/pkg/genutil/mapz/set_test.go
@@ -1,4 +1,4 @@
-package util
+package mapz
 
 import (
 	"fmt"

--- a/pkg/genutil/slicez/chunking.go
+++ b/pkg/genutil/slicez/chunking.go
@@ -1,4 +1,4 @@
-package util
+package slicez
 
 import (
 	"github.com/authzed/spicedb/internal/logging"
@@ -6,7 +6,7 @@ import (
 
 // ForEachChunk executes the given handler for each chunk of items in the slice.
 func ForEachChunk[T any](data []T, chunkSize uint16, handler func(items []T)) {
-	_, _ = ForEachChunkUntil[T](data, chunkSize, func(items []T) (bool, error) {
+	_, _ = ForEachChunkUntil(data, chunkSize, func(items []T) (bool, error) {
 		handler(items)
 		return true, nil
 	})

--- a/pkg/genutil/slicez/chunking_test.go
+++ b/pkg/genutil/slicez/chunking_test.go
@@ -1,4 +1,4 @@
-package util
+package slicez
 
 import (
 	"fmt"

--- a/pkg/genutil/slicez/unique.go
+++ b/pkg/genutil/slicez/unique.go
@@ -1,7 +1,7 @@
-package util
+package slicez
 
-// UniqueSlice returns the items slice, but with duplicate items removed.
-func UniqueSlice[T comparable](items []T) []T {
+// Unique returns the items slice, but with duplicate items removed.
+func Unique[T comparable](items []T) []T {
 	updated := make([]T, 0, len(items))
 	encountered := make(map[T]struct{}, len(items))
 	for _, item := range items {

--- a/pkg/genutil/slicez/unique_test.go
+++ b/pkg/genutil/slicez/unique_test.go
@@ -1,4 +1,4 @@
-package util
+package slicez
 
 import (
 	"fmt"
@@ -36,7 +36,7 @@ func TestUniqueSlice(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("%v", tc.input), func(t *testing.T) {
-			require.Equal(t, tc.output, UniqueSlice(tc.input))
+			require.Equal(t, tc.output, Unique(tc.input))
 		})
 	}
 }

--- a/pkg/schemadsl/compiler/translator.go
+++ b/pkg/schemadsl/compiler/translator.go
@@ -5,18 +5,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/authzed/spicedb/pkg/caveats"
-
-	"github.com/authzed/spicedb/pkg/util"
-
 	"github.com/jzelinskie/stringz"
 
-	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-
+	"github.com/authzed/spicedb/pkg/caveats"
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/namespace"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/schemadsl/dslshape"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
+	"github.com/authzed/spicedb/pkg/util"
 )
 
 type translationContext struct {

--- a/pkg/schemadsl/compiler/translator.go
+++ b/pkg/schemadsl/compiler/translator.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/authzed/spicedb/pkg/caveats"
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	"github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/schemadsl/dslshape"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 type translationContext struct {
@@ -46,7 +46,7 @@ func translate(tctx translationContext, root *dslNode) (*CompiledSchema, error) 
 	var objectDefinitions []*core.NamespaceDefinition
 	var caveatDefinitions []*core.CaveatDefinition
 
-	names := util.NewSet[string]()
+	names := mapz.NewSet[string]()
 
 	for _, definitionNode := range root.GetChildren() {
 		var definition SchemaDefinition

--- a/pkg/tuple/onr.go
+++ b/pkg/tuple/onr.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/jzelinskie/stringz"
+	"golang.org/x/exp/slices"
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
@@ -37,14 +37,14 @@ func ParseSubjectONR(subjectOnr string) *core.ObjectAndRelation {
 	}
 
 	relation := Ellipsis
-	subjectRelIndex := stringz.SliceIndex(subjectRegex.SubexpNames(), "subjectRel")
+	subjectRelIndex := slices.Index(subjectRegex.SubexpNames(), "subjectRel")
 	if len(groups[subjectRelIndex]) > 0 {
 		relation = groups[subjectRelIndex]
 	}
 
 	return &core.ObjectAndRelation{
-		Namespace: groups[stringz.SliceIndex(subjectRegex.SubexpNames(), "subjectType")],
-		ObjectId:  groups[stringz.SliceIndex(subjectRegex.SubexpNames(), "subjectID")],
+		Namespace: groups[slices.Index(subjectRegex.SubexpNames(), "subjectType")],
+		ObjectId:  groups[slices.Index(subjectRegex.SubexpNames(), "subjectID")],
 		Relation:  relation,
 	}
 }
@@ -58,9 +58,9 @@ func ParseONR(onr string) *core.ObjectAndRelation {
 	}
 
 	return &core.ObjectAndRelation{
-		Namespace: groups[stringz.SliceIndex(onrRegex.SubexpNames(), "resourceType")],
-		ObjectId:  groups[stringz.SliceIndex(onrRegex.SubexpNames(), "resourceID")],
-		Relation:  groups[stringz.SliceIndex(onrRegex.SubexpNames(), "resourceRel")],
+		Namespace: groups[slices.Index(onrRegex.SubexpNames(), "resourceType")],
+		ObjectId:  groups[slices.Index(onrRegex.SubexpNames(), "resourceID")],
+		Relation:  groups[slices.Index(onrRegex.SubexpNames(), "resourceRel")],
 	}
 }
 

--- a/pkg/tuple/onrbytypeset.go
+++ b/pkg/tuple/onrbytypeset.go
@@ -1,8 +1,8 @@
 package tuple
 
 import (
+	"github.com/authzed/spicedb/pkg/genutil/slicez"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // ONRByTypeSet is a set of ObjectAndRelation's, grouped by namespace+relation.
@@ -35,7 +35,7 @@ func (s *ONRByTypeSet) ForEachType(handler func(rr *core.RelationReference, obje
 		handler(&core.RelationReference{
 			Namespace: ns,
 			Relation:  rel,
-		}, util.UniqueSlice(objectIds))
+		}, slicez.Unique(objectIds))
 	}
 }
 
@@ -55,7 +55,7 @@ func (s *ONRByTypeSet) Map(mapper func(rr *core.RelationReference) (*core.Relati
 		if updatedType == nil {
 			continue
 		}
-		mapped.byType[JoinRelRef(updatedType.Namespace, updatedType.Relation)] = util.UniqueSlice(objectIds)
+		mapped.byType[JoinRelRef(updatedType.Namespace, updatedType.Relation)] = slicez.Unique(objectIds)
 	}
 	return mapped, nil
 }

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/jzelinskie/stringz"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -179,19 +180,19 @@ func Parse(tpl string) *core.RelationTuple {
 	}
 
 	subjectRelation := Ellipsis
-	subjectRelIndex := stringz.SliceIndex(parserRegex.SubexpNames(), "subjectRel")
+	subjectRelIndex := slices.Index(parserRegex.SubexpNames(), "subjectRel")
 	if len(groups[subjectRelIndex]) > 0 {
 		subjectRelation = groups[subjectRelIndex]
 	}
 
-	caveatName := groups[stringz.SliceIndex(parserRegex.SubexpNames(), "caveatName")]
+	caveatName := groups[slices.Index(parserRegex.SubexpNames(), "caveatName")]
 	var optionalCaveat *core.ContextualizedCaveat
 	if caveatName != "" {
 		optionalCaveat = &core.ContextualizedCaveat{
 			CaveatName: caveatName,
 		}
 
-		caveatContextString := groups[stringz.SliceIndex(parserRegex.SubexpNames(), "caveatContext")]
+		caveatContextString := groups[slices.Index(parserRegex.SubexpNames(), "caveatContext")]
 		if len(caveatContextString) > 0 {
 			contextMap := make(map[string]any, 1)
 			err := json.Unmarshal([]byte(caveatContextString), &contextMap)
@@ -208,24 +209,24 @@ func Parse(tpl string) *core.RelationTuple {
 		}
 	}
 
-	resourceID := groups[stringz.SliceIndex(parserRegex.SubexpNames(), "resourceID")]
+	resourceID := groups[slices.Index(parserRegex.SubexpNames(), "resourceID")]
 	if err := ValidateResourceID(resourceID); err != nil {
 		return nil
 	}
 
-	subjectID := groups[stringz.SliceIndex(parserRegex.SubexpNames(), "subjectID")]
+	subjectID := groups[slices.Index(parserRegex.SubexpNames(), "subjectID")]
 	if err := ValidateSubjectID(subjectID); err != nil {
 		return nil
 	}
 
 	return &core.RelationTuple{
 		ResourceAndRelation: &core.ObjectAndRelation{
-			Namespace: groups[stringz.SliceIndex(parserRegex.SubexpNames(), "resourceType")],
+			Namespace: groups[slices.Index(parserRegex.SubexpNames(), "resourceType")],
 			ObjectId:  resourceID,
-			Relation:  groups[stringz.SliceIndex(parserRegex.SubexpNames(), "resourceRel")],
+			Relation:  groups[slices.Index(parserRegex.SubexpNames(), "resourceRel")],
 		},
 		Subject: &core.ObjectAndRelation{
-			Namespace: groups[stringz.SliceIndex(parserRegex.SubexpNames(), "subjectType")],
+			Namespace: groups[slices.Index(parserRegex.SubexpNames(), "subjectType")],
 			ObjectId:  subjectID,
 			Relation:  subjectRelation,
 		},

--- a/pkg/validationfile/blocks/expectedrelations.go
+++ b/pkg/validationfile/blocks/expectedrelations.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/jzelinskie/stringz"
+	"golang.org/x/exp/slices"
 
 	yamlv3 "gopkg.in/yaml.v3"
 
@@ -179,13 +179,13 @@ func (vs ValidationString) Subject() (*SubjectWithExceptions, *spiceerrors.Error
 		return nil, spiceerrors.NewErrorWithSource(fmt.Errorf("invalid subject: `%s`", subjectStr), bracketedSubjectString, 0, 0)
 	}
 
-	subjectONRString := groups[stringz.SliceIndex(vsSubjectWithExceptionsOrCaveatRegex.SubexpNames(), "subject_onr")]
+	subjectONRString := groups[slices.Index(vsSubjectWithExceptionsOrCaveatRegex.SubexpNames(), "subject_onr")]
 	subjectONR := tuple.ParseSubjectONR(subjectONRString)
 	if subjectONR == nil {
 		return nil, spiceerrors.NewErrorWithSource(fmt.Errorf("invalid subject: `%s`", subjectONRString), subjectONRString, 0, 0)
 	}
 
-	exceptionsString := strings.TrimSpace(groups[stringz.SliceIndex(vsSubjectWithExceptionsOrCaveatRegex.SubexpNames(), "exceptions")])
+	exceptionsString := strings.TrimSpace(groups[slices.Index(vsSubjectWithExceptionsOrCaveatRegex.SubexpNames(), "exceptions")])
 	var exceptions []SubjectAndCaveat
 
 	if len(exceptionsString) > 0 {
@@ -207,7 +207,7 @@ func (vs ValidationString) Subject() (*SubjectWithExceptions, *spiceerrors.Error
 		}
 	}
 
-	isCaveated := len(strings.TrimSpace(groups[stringz.SliceIndex(vsSubjectWithExceptionsOrCaveatRegex.SubexpNames(), "caveat")])) > 0
+	isCaveated := len(strings.TrimSpace(groups[slices.Index(vsSubjectWithExceptionsOrCaveatRegex.SubexpNames(), "caveat")])) > 0
 	return &SubjectWithExceptions{SubjectAndCaveat{subjectONR, isCaveated}, exceptions}, nil
 }
 

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -12,9 +12,9 @@ import (
 	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/internal/relationships"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/slicez"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/util"
 )
 
 // PopulatedValidationFile contains the fully parsed information from a validation file.
@@ -144,7 +144,7 @@ func PopulateFromFilesContents(ctx context.Context, ds datastore.Datastore, file
 		return err
 	})
 
-	util.ForEachChunk(updates, 500, func(chunked []*core.RelationTupleUpdate) {
+	slicez.ForEachChunk(updates, 500, func(chunked []*core.RelationTupleUpdate) {
 		if err != nil {
 			return
 		}

--- a/tools/analyzers/exprstatementcheck/exprstatementcheck.go
+++ b/tools/analyzers/exprstatementcheck/exprstatementcheck.go
@@ -6,8 +6,7 @@ import (
 	"go/ast"
 	"strings"
 
-	"github.com/jzelinskie/stringz"
-
+	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
@@ -99,7 +98,7 @@ func Analyzer() *analysis.Analyzer {
 						if len(config.ignoredMethodNames) > 0 {
 							for _, parent := range stack {
 								if funcDecl, ok := parent.(*ast.FuncDecl); ok {
-									if stringz.SliceContains(config.ignoredMethodNames, funcDecl.Name.Name) {
+									if slices.Contains(config.ignoredMethodNames, funcDecl.Name.Name) {
 										break switchStatement
 									}
 								}

--- a/tools/analyzers/go.mod
+++ b/tools/analyzers/go.mod
@@ -3,7 +3,6 @@ module github.com/authzed/spicedb/tools/analyzers
 go 1.19
 
 require (
-	github.com/jzelinskie/stringz v0.0.1
 	golang.org/x/exp v0.0.0-20221114191408-850992195362
 	golang.org/x/tools v0.2.0
 )

--- a/tools/analyzers/go.sum
+++ b/tools/analyzers/go.sum
@@ -1,5 +1,3 @@
-github.com/jzelinskie/stringz v0.0.1 h1:IahR+y8ct2nyj7B6i8UtFsGFj4ex1SX27iKFYsAheLk=
-github.com/jzelinskie/stringz v0.0.1/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
 golang.org/x/exp v0.0.0-20221114191408-850992195362 h1:NoHlPRbyl1VFI6FjwHtPQCN7wAMXI6cKcqrmXhOOfBQ=
 golang.org/x/exp v0.0.0-20221114191408-850992195362/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=

--- a/tools/analyzers/nilvaluecheck/nilvaluecheck.go
+++ b/tools/analyzers/nilvaluecheck/nilvaluecheck.go
@@ -6,8 +6,7 @@ import (
 	"go/token"
 	"strings"
 
-	"github.com/jzelinskie/stringz"
-
+	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
@@ -49,7 +48,7 @@ func Analyzer() *analysis.Analyzer {
 
 			typePaths := sliceMap(strings.Split(*disallowedPaths, ","), strings.TrimSpace)
 			hasTypePath := func(path string) bool {
-				return stringz.SliceContains(typePaths, path)
+				return slices.Contains(typePaths, path)
 			}
 
 			inspect.WithStack(nodeFilter, func(n ast.Node, push bool, stack []ast.Node) bool {


### PR DESCRIPTION
This reorganizes our various generic utilities into their own packages.

I also took a moment to do two things:
1) adjust our Set type to implement the zerolog marshaling interface so that we didn't need the intermediary SliceSet
2) replace uses of stringz with the generic versions provided by golang.org/x/exp/slices