### PR TITLE
updates to pgx 5.4.2

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -11,7 +11,7 @@ on:  # yamllint disable-line rule:truthy
     types:
       - "checks_requested"
 env:
-  GO_VERSION: "~1.20.5"
+  GO_VERSION: "~1.20.6"
 jobs:
   paths-filter:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ on:  # yamllint disable-line rule:truthy
     types:
       - "checks_requested"
 env:
-  GO_VERSION: "~1.20.5"
+  GO_VERSION: "~1.20.6"
 jobs:
   go-lint:
     name: "Lint Go"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: "write"
   packages: "write"
 env:
-  GO_VERSION: "~1.20.5"
+  GO_VERSION: "~1.20.6"
 jobs:
   goreleaser:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: "write"
   packages: "write"
 env:
-  GO_VERSION: "~1.20.5"
+  GO_VERSION: "~1.20.6"
 jobs:
   goreleaser:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -6,7 +6,7 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: "write"
 env:
-  GO_VERSION: "~1.20.5"
+  GO_VERSION: "~1.20.6"
 jobs:
   build:
     name: "Build WASM"

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/authzed/spicedb v1.21.0
 	github.com/brianvoe/gofakeit/v6 v6.15.0
 	github.com/ecordell/optgen v0.0.10-0.20230609182709-018141bf9698
-	github.com/jackc/pgx/v5 v5.4.2-0.20230708162439-2bf5a614018d
+	github.com/jackc/pgx/v5 v5.4.2
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/tools v0.10.0
 	google.golang.org/grpc v1.56.1

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -66,8 +66,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.4.2-0.20230708162439-2bf5a614018d h1:bhm07MzjekHNgULP4JpS4k1zCtK/ojke5iK60N2Xte0=
-github.com/jackc/pgx/v5 v5.4.2-0.20230708162439-2bf5a614018d/go.mod h1:q6iHT8uDNXWiFNOlRqJzBTaSH3+2xCXkokxHZC5qWFY=
+github.com/jackc/pgx/v5 v5.4.2 h1:u1gmGDwbdRUZiwisBm/Ky2M14uQyUP65bG8+20nnyrg=
+github.com/jackc/pgx/v5 v5.4.2/go.mod h1:q6iHT8uDNXWiFNOlRqJzBTaSH3+2xCXkokxHZC5qWFY=
 github.com/jzelinskie/stringz v0.0.1 h1:IahR+y8ct2nyj7B6i8UtFsGFj4ex1SX27iKFYsAheLk=
 github.com/jzelinskie/stringz v0.0.1/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/influxdata/tdigest v0.0.1
 	github.com/jackc/pgio v1.0.0
 	github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb
-	github.com/jackc/pgx/v5 v5.4.2-0.20230708162439-2bf5a614018d
+	github.com/jackc/pgx/v5 v5.4.2
 	github.com/johannesboyne/gofakes3 v0.0.0-20220314170512-33c13122505e
 	github.com/jzelinskie/cobrautil/v2 v2.0.0-20230403163312-3593f31d8fe1
 	github.com/jzelinskie/stringz v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -921,8 +921,8 @@ github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb h1:pSv+zRVeAYjbXRFjyytFIMRBSKWVowCi7KbXSMR/+ug=
 github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb/go.mod h1:CRUuPsmIajLt3dZIlJ5+O8IDSib6y8yrst8DkCthTa4=
-github.com/jackc/pgx/v5 v5.4.2-0.20230708162439-2bf5a614018d h1:bhm07MzjekHNgULP4JpS4k1zCtK/ojke5iK60N2Xte0=
-github.com/jackc/pgx/v5 v5.4.2-0.20230708162439-2bf5a614018d/go.mod h1:q6iHT8uDNXWiFNOlRqJzBTaSH3+2xCXkokxHZC5qWFY=
+github.com/jackc/pgx/v5 v5.4.2 h1:u1gmGDwbdRUZiwisBm/Ky2M14uQyUP65bG8+20nnyrg=
+github.com/jackc/pgx/v5 v5.4.2/go.mod h1:q6iHT8uDNXWiFNOlRqJzBTaSH3+2xCXkokxHZC5qWFY=
 github.com/jackc/puddle/v2 v2.2.0 h1:RdcDk92EJBuBS55nQMMYFXTxwstHug4jkhT5pq8VxPk=
 github.com/jackc/puddle/v2 v2.2.0/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jdxcode/netrc v0.0.0-20221124155335-4616370d1a84 h1:2uT3aivO7NVpUPGcQX7RbHijHMyWix/yCnIrCWc+5co=


### PR DESCRIPTION
Follow up to https://github.com/authzed/spicedb/pull/1430

the official release with a memory-leak fix