### PR TITLE
Fix flakiness in hedging test

### DIFF
--- a/internal/datastore/proxy/hedging_test.go
+++ b/internal/datastore/proxy/hedging_test.go
@@ -164,7 +164,7 @@ func TestDatastoreRequestHedging(t *testing.T) {
 
 			delegate.
 				On(tc.methodName, tc.arguments...).
-				WaitUntil(mockTime.After(3 * slowQueryTime)).
+				WaitUntil(mockTime.After(5 * slowQueryTime)).
 				Return(tc.firstCallResults...).
 				Once()
 			delegate.
@@ -172,7 +172,7 @@ func TestDatastoreRequestHedging(t *testing.T) {
 				Return(tc.secondCallResults...).
 				Once()
 
-			done := autoAdvance(mockTime, slowQueryTime, 5*slowQueryTime)
+			done := autoAdvance(mockTime, slowQueryTime, 6*slowQueryTime)
 
 			tc.f(t, proxy, false)
 			delegate.AssertExpectations(t)
@@ -181,16 +181,16 @@ func TestDatastoreRequestHedging(t *testing.T) {
 
 			delegate.
 				On(tc.methodName, tc.arguments...).
-				WaitUntil(mockTime.After(3 * slowQueryTime)).
+				WaitUntil(mockTime.After(7 * slowQueryTime)).
 				Return(tc.firstCallResults...).
 				Once()
 			delegate.
 				On(tc.methodName, tc.arguments...).
-				WaitUntil(mockTime.After(4 * slowQueryTime)).
+				WaitUntil(mockTime.After(8 * slowQueryTime)).
 				Return(tc.secondCallResults...).
 				Once()
 
-			autoAdvance(mockTime, slowQueryTime, 8*slowQueryTime)
+			autoAdvance(mockTime, slowQueryTime, 9*slowQueryTime)
 
 			tc.f(t, proxy, true)
 			delegate.AssertExpectations(t)


### PR DESCRIPTION
Fixes #885

```
$ stress ./proxy.test
5s: 10 runs so far, 0 failures
10s: 20 runs so far, 0 failures
15s: 34 runs so far, 0 failures
20s: 51 runs so far, 0 failures
25s: 66 runs so far, 0 failures
30s: 78 runs so far, 0 failures
35s: 91 runs so far, 0 failures
40s: 111 runs so far, 0 failures
45s: 123 runs so far, 0 failures
50s: 140 runs so far, 0 failures
55s: 158 runs so far, 0 failures
1m0s: 170 runs so far, 0 failures
1m5s: 186 runs so far, 0 failures
1m10s: 201 runs so far, 0 failures
1m15s: 217 runs so far, 0 failures
1m20s: 234 runs so far, 0 failures
1m25s: 248 runs so far, 0 failures
1m30s: 262 runs so far, 0 failures
1m35s: 278 runs so far, 0 failures
1m40s: 294 runs so far, 0 failures
1m45s: 313 runs so far, 0 failures
1m50s: 328 runs so far, 0 failures
1m55s: 346 runs so far, 0 failures
2m0s: 360 runs so far, 0 failures
2m5s: 374 runs so far, 0 failures
2m10s: 394 runs so far, 0 failures
2m15s: 411 runs so far, 0 failures
2m20s: 427 runs so far, 0 failures
2m25s: 442 runs so far, 0 failures
2m30s: 454 runs so far, 0 failures
2m35s: 468 runs so far, 0 failures
2m40s: 485 runs so far, 0 failures
2m45s: 500 runs so far, 0 failures
2m50s: 514 runs so far, 0 failures
2m55s: 526 runs so far, 0 failures
3m0s: 541 runs so far, 0 failures
3m5s: 553 runs so far, 0 failures
3m10s: 569 runs so far, 0 failures
3m15s: 586 runs so far, 0 failures
3m20s: 599 runs so far, 0 failures
3m25s: 613 runs so far, 0 failures
3m30s: 623 runs so far, 0 failures
3m35s: 639 runs so far, 0 failures
3m40s: 656 runs so far, 0 failures
3m45s: 669 runs so far, 0 failures
3m50s: 684 runs so far, 0 failures
3m55s: 701 runs so far, 0 failures
4m0s: 712 runs so far, 0 failures
4m5s: 725 runs so far, 0 failures
4m10s: 738 runs so far, 0 failures
4m15s: 755 runs so far, 0 failures
4m20s: 771 runs so far, 0 failures
4m25s: 785 runs so far, 0 failures
4m30s: 797 runs so far, 0 failures
4m35s: 809 runs so far, 0 failures
4m40s: 824 runs so far, 0 failures
4m45s: 843 runs so far, 0 failures
4m50s: 856 runs so far, 0 failures
4m55s: 875 runs so far, 0 failures
5m0s: 889 runs so far, 0 failures
5m5s: 900 runs so far, 0 failures
5m10s: 913 runs so far, 0 failures
5m15s: 925 runs so far, 0 failures
5m20s: 945 runs so far, 0 failures
5m25s: 958 runs so far, 0 failures
5m30s: 971 runs so far, 0 failures
5m35s: 989 runs so far, 0 failures
5m40s: 1004 runs so far, 0 failures
5m45s: 1022 runs so far, 0 failures
5m50s: 1037 runs so far, 0 failures
5m55s: 1055 runs so far, 0 failures
6m0s: 1067 runs so far, 0 failures
6m5s: 1079 runs so far, 0 failures
6m10s: 1099 runs so far, 0 failures
6m15s: 1114 runs so far, 0 failures
6m20s: 1129 runs so far, 0 failures
6m25s: 1147 runs so far, 0 failures
6m30s: 1161 runs so far, 0 failures
6m35s: 1173 runs so far, 0 failures
6m40s: 1190 runs so far, 0 failures
6m45s: 1207 runs so far, 0 failures
6m50s: 1222 runs so far, 0 failures
6m55s: 1240 runs so far, 0 failures
7m0s: 1254 runs so far, 0 failures
7m5s: 1266 runs so far, 0 failures
7m10s: 1286 runs so far, 0 failures
7m15s: 1302 runs so far, 0 failures
7m20s: 1320 runs so far, 0 failures
7m25s: 1336 runs so far, 0 failures
7m30s: 1350 runs so far, 0 failures
7m35s: 1362 runs so far, 0 failures
7m40s: 1380 runs so far, 0 failures
7m45s: 1393 runs so far, 0 failures
7m50s: 1406 runs so far, 0 failures
7m55s: 1419 runs so far, 0 failures
8m0s: 1436 runs so far, 0 failures
8m5s: 1451 runs so far, 0 failures
8m10s: 1469 runs so far, 0 failures
8m15s: 1487 runs so far, 0 failures
8m20s: 1503 runs so far, 0 failures
8m25s: 1518 runs so far, 0 failures
8m30s: 1531 runs so far, 0 failures
8m35s: 1549 runs so far, 0 failures
8m40s: 1565 runs so far, 0 failures
8m45s: 1581 runs so far, 0 failures
8m50s: 1600 runs so far, 0 failures
8m55s: 1617 runs so far, 0 failures
9m0s: 1630 runs so far, 0 failures
9m5s: 1645 runs so far, 0 failures
9m10s: 1663 runs so far, 0 failures
9m15s: 1681 runs so far, 0 failures
9m20s: 1697 runs so far, 0 failures
9m25s: 1710 runs so far, 0 failures
9m30s: 1723 runs so far, 0 failures
9m35s: 1735 runs so far, 0 failures
9m40s: 1756 runs so far, 0 failures
9m45s: 1770 runs so far, 0 failures
9m50s: 1784 runs so far, 0 failures
9m55s: 1802 runs so far, 0 failures
10m0s: 1813 runs so far, 0 failures
10m5s: 1830 runs so far, 0 failures
10m10s: 1848 runs so far, 0 failures
10m15s: 1864 runs so far, 0 failures
10m20s: 1881 runs so far, 0 failures
10m25s: 1899 runs so far, 0 failures
10m30s: 1911 runs so far, 0 failures
10m35s: 1927 runs so far, 0 failures
10m40s: 1942 runs so far, 0 failures
10m45s: 1962 runs so far, 0 failures
10m50s: 1978 runs so far, 0 failures
10m55s: 1993 runs so far, 0 failures
11m0s: 2008 runs so far, 0 failures
11m5s: 2025 runs so far, 0 failures
11m10s: 2042 runs so far, 0 failures
11m15s: 2057 runs so far, 0 failures
11m20s: 2070 runs so far, 0 failures
```