### PR TITLE
Implement a schema cache which updates using a SchemaWatch API

### DIFF
--- a/internal/datastore/context.go
+++ b/internal/datastore/context.go
@@ -1,4 +1,4 @@
-package proxy
+package datastore
 
 import (
 	"context"

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -18,12 +18,12 @@ import (
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
 
+	datastoreinternal "github.com/authzed/spicedb/internal/datastore"
 	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/internal/datastore/common/revisions"
 	"github.com/authzed/spicedb/internal/datastore/crdb/migrations"
 	"github.com/authzed/spicedb/internal/datastore/crdb/pool"
 	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
-	"github.com/authzed/spicedb/internal/datastore/proxy"
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
@@ -241,7 +241,7 @@ func NewCRDBDatastore(url string, options ...Option) (datastore.Datastore, error
 	if err != nil {
 		return nil, err
 	}
-	return proxy.NewSeparatingContextDatastoreProxy(ds), nil
+	return datastoreinternal.NewSeparatingContextDatastoreProxy(ds), nil
 }
 
 type crdbDatastore struct {

--- a/internal/datastore/crdb/watch.go
+++ b/internal/datastore/crdb/watch.go
@@ -2,6 +2,7 @@ package crdb
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,10 +10,14 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog/log"
 
 	"github.com/authzed/spicedb/internal/datastore/common"
+	"github.com/authzed/spicedb/internal/datastore/crdb/pool"
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
 const (
@@ -27,6 +32,18 @@ type changeDetails struct {
 		CaveatContext map[string]any `json:"caveat_context"`
 		CaveatName    string         `json:"caveat_name"`
 	}
+}
+
+var retryHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Namespace: "spicedb",
+	Subsystem: "datastore",
+	Name:      "crdb_schema_watch_retries",
+	Help:      "schema watch retry distribution",
+	Buckets:   []float64{0, 1, 2, 5, 10, 20, 50},
+})
+
+func init() {
+	prometheus.MustRegister(retryHistogram)
 }
 
 func (cds *crdbDatastore) Watch(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
@@ -60,6 +77,7 @@ func (cds *crdbDatastore) Watch(ctx context.Context, afterRevision datastore.Rev
 	go func() {
 		defer close(updates)
 		defer close(errs)
+		defer func() { _ = conn.Close(ctx) }()
 
 		pendingChanges := make(map[string]*datastore.RevisionChanges)
 
@@ -195,10 +213,238 @@ func (cds *crdbDatastore) Watch(ctx context.Context, afterRevision datastore.Rev
 				}
 				errs <- datastore.NewWatchCanceledErr()
 			} else {
-				errs <- changes.Err()
+				errs <- err
 			}
 			return
 		}
 	}()
 	return updates, errs
+}
+
+type schemaChangeDetails struct {
+	Resolved string
+	Updated  string
+	After    *struct {
+		Namespace                 string `json:"namespace"`
+		SerializedNamespaceConfig string `json:"serialized_config"`
+
+		CaveatName                 string `json:"name"`
+		SerializedCaveatDefinition string `json:"definition"`
+	}
+}
+
+const maxSchemaWatchRetryCount = 15
+
+func (cds *crdbDatastore) WatchSchema(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.SchemaState, <-chan error) {
+	updates := make(chan *datastore.SchemaState, cds.watchBufferLength)
+	errs := make(chan error, 1)
+
+	features, err := cds.Features(ctx)
+	if err != nil {
+		errs <- err
+		return updates, errs
+	}
+
+	if !features.Watch.Enabled {
+		errs <- datastore.NewWatchDisabledErr(fmt.Sprintf("%s. See https://spicedb.dev/d/enable-watch-api-crdb", features.Watch.Reason))
+		return updates, errs
+	}
+
+	lastRevision := afterRevision
+	retryCount := -1
+	go (func() {
+		running := true
+		for running {
+			retryCount++
+			retryHistogram.Observe(float64(retryCount))
+			if retryCount >= maxSchemaWatchRetryCount {
+				errs <- fmt.Errorf("schema watch terminated after %d retries", retryCount)
+				return
+			}
+
+			log.Debug().Str("revision", lastRevision.String()).Int("retry-count", retryCount).Msg("starting schema watch connection")
+
+			cds.watchSchemaWithoutRetry(ctx, lastRevision, func(update *datastore.SchemaState, err error) {
+				if err != nil {
+					if pool.IsResettableError(ctx, err) || pool.IsRetryableError(ctx, err) {
+						running = true
+
+						// Sleep a bit for retrying.
+						pool.SleepOnErr(ctx, err, uint8(retryCount))
+						return
+					}
+
+					running = false
+					errs <- err
+					return
+				}
+
+				if update.Revision.GreaterThan(lastRevision) {
+					lastRevision = update.Revision
+				}
+
+				updates <- update
+				retryCount = -1
+			})
+		}
+	})()
+
+	return updates, errs
+}
+
+func (cds *crdbDatastore) watchSchemaWithoutRetry(ctx context.Context, afterRevision datastore.Revision, processUpdate func(update *datastore.SchemaState, err error)) {
+	// get non-pooled connection for watch
+	// "applications should explicitly create dedicated connections to consume
+	// changefeed data, instead of using a connection pool as most client
+	// drivers do by default."
+	// see: https://www.cockroachlabs.com/docs/v22.2/changefeed-for#considerations
+	conn, err := pgx.Connect(ctx, cds.dburl)
+	if err != nil {
+		processUpdate(nil, err)
+		return
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	interpolated := fmt.Sprintf(cds.beginChangefeedQuery, tableNamespace+","+tableCaveat, afterRevision)
+
+	changes, err := conn.Query(ctx, interpolated)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			processUpdate(nil, datastore.NewWatchCanceledErr())
+			return
+		}
+
+		processUpdate(nil, err)
+		return
+	}
+
+	// We call Close async here because it can be slow and blocks closing the channels. There is
+	// no return value so we're not really losing anything.
+	defer func() { go changes.Close() }()
+
+	for changes.Next() {
+		var tableNameBytes []byte
+		var changeJSON []byte
+		var primaryKeyValuesJSON []byte
+
+		if err := changes.Scan(&tableNameBytes, &primaryKeyValuesJSON, &changeJSON); err != nil {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				processUpdate(nil, datastore.NewWatchCanceledErr())
+				return
+			}
+
+			processUpdate(nil, err)
+			return
+		}
+
+		var details schemaChangeDetails
+		if err := json.Unmarshal(changeJSON, &details); err != nil {
+			processUpdate(nil, err)
+			return
+		}
+
+		if details.Resolved != "" {
+			revision, err := cds.RevisionFromString(details.Resolved)
+			if err != nil {
+				processUpdate(nil, fmt.Errorf("malformed resolved timestamp: %w", err))
+				return
+			}
+
+			processUpdate(&datastore.SchemaState{
+				Revision:     revision,
+				IsCheckpoint: true,
+			}, nil)
+			continue
+		}
+
+		tableName := string(tableNameBytes)
+
+		var pkValues []string
+		if err := json.Unmarshal(primaryKeyValuesJSON, &pkValues); err != nil {
+			processUpdate(nil, err)
+			return
+		}
+
+		if len(pkValues) != 1 {
+			processUpdate(nil, spiceerrors.MustBugf("expected a single definition name for the primary key in schema change feed. found: %s", string(primaryKeyValuesJSON)))
+			return
+		}
+
+		definitionName := pkValues[0]
+
+		deletedNamespaces := make([]string, 0, 1)
+		deletedCaveats := make([]string, 0, 1)
+		changedDefinitions := make([]datastore.SchemaDefinition, 0, 1)
+
+		switch tableName {
+		case tableNamespace:
+			if details.After != nil && details.After.SerializedNamespaceConfig != "" {
+				namespaceDef := &core.NamespaceDefinition{}
+				defBytes, err := hex.DecodeString(details.After.SerializedNamespaceConfig[2:]) // drop the \x
+				if err != nil {
+					processUpdate(nil, fmt.Errorf("could not decode namespace definition: %w", err))
+					return
+				}
+
+				if err := namespaceDef.UnmarshalVT(defBytes); err != nil {
+					processUpdate(nil, fmt.Errorf("could not unmarshal namespace definition: %w", err))
+					return
+				}
+				changedDefinitions = append(changedDefinitions, namespaceDef)
+			} else {
+				deletedNamespaces = append(deletedNamespaces, definitionName)
+			}
+
+		case tableCaveat:
+			if details.After != nil && details.After.SerializedCaveatDefinition != "" {
+				caveatDef := &core.CaveatDefinition{}
+				defBytes, err := hex.DecodeString(details.After.SerializedCaveatDefinition[2:]) // drop the \x
+				if err != nil {
+					processUpdate(nil, fmt.Errorf("could not decode caveat definition: %w", err))
+					return
+				}
+
+				if err := caveatDef.UnmarshalVT(defBytes); err != nil {
+					processUpdate(nil, fmt.Errorf("could not unmarshal caveat definition: %w", err))
+					return
+				}
+				changedDefinitions = append(changedDefinitions, caveatDef)
+			} else {
+				deletedCaveats = append(deletedCaveats, definitionName)
+			}
+
+		default:
+			processUpdate(nil, spiceerrors.MustBugf("unknown table in schema change feed: %s", tableName))
+			return
+		}
+
+		revision, err := cds.RevisionFromString(details.Updated)
+		if err != nil {
+			processUpdate(nil, fmt.Errorf("malformed resolved timestamp: %w", err))
+			return
+		}
+
+		processUpdate(&datastore.SchemaState{
+			Revision:           revision,
+			ChangedDefinitions: changedDefinitions,
+			DeletedNamespaces:  deletedNamespaces,
+			DeletedCaveats:     deletedCaveats,
+			IsCheckpoint:       false,
+		}, nil)
+	}
+
+	if changes.Err() != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer closeCancel()
+			if err := conn.Close(closeCtx); err != nil {
+				processUpdate(nil, err)
+				return
+			}
+			processUpdate(nil, datastore.NewWatchCanceledErr())
+		} else {
+			processUpdate(nil, changes.Err())
+		}
+		return
+	}
 }

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -19,10 +19,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
+	datastoreinternal "github.com/authzed/spicedb/internal/datastore"
 	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/internal/datastore/common/revisions"
 	"github.com/authzed/spicedb/internal/datastore/mysql/migrations"
-	"github.com/authzed/spicedb/internal/datastore/proxy"
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
@@ -100,7 +100,7 @@ func NewMySQLDatastore(uri string, options ...Option) (datastore.Datastore, erro
 		return nil, err
 	}
 
-	return proxy.NewSeparatingContextDatastoreProxy(ds), nil
+	return datastoreinternal.NewSeparatingContextDatastoreProxy(ds), nil
 }
 
 func newMySQLDatastore(uri string, options ...Option) (*Datastore, error) {

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -18,11 +18,11 @@ import (
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
 
+	datastoreinternal "github.com/authzed/spicedb/internal/datastore"
 	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/internal/datastore/common/revisions"
 	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
 	"github.com/authzed/spicedb/internal/datastore/postgres/migrations"
-	"github.com/authzed/spicedb/internal/datastore/proxy"
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
@@ -119,7 +119,7 @@ func NewPostgresDatastore(
 		return nil, err
 	}
 
-	return proxy.NewSeparatingContextDatastoreProxy(ds), nil
+	return datastoreinternal.NewSeparatingContextDatastoreProxy(ds), nil
 }
 
 func newPostgresDatastore(

--- a/internal/datastore/proxy/hedging.go
+++ b/internal/datastore/proxy/hedging.go
@@ -171,6 +171,10 @@ func newHedgingProxyWithTimeSource(
 	}, nil
 }
 
+func (hp hedgingProxy) Unwrap() datastore.Datastore {
+	return hp.Datastore
+}
+
 func (hp hedgingProxy) OptimizedRevision(ctx context.Context) (rev datastore.Revision, err error) {
 	var once sync.Once
 	subreq := func(ctx context.Context, responseReady chan<- struct{}) {

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -127,6 +127,10 @@ func (p *observableProxy) Statistics(ctx context.Context) (datastore.Stats, erro
 	return p.delegate.Statistics(ctx)
 }
 
+func (p *observableProxy) Unwrap() datastore.Datastore {
+	return p.delegate
+}
+
 func (p *observableProxy) ReadyState(ctx context.Context) (datastore.ReadyState, error) {
 	ctx, closer := observe(ctx, "ReadyState")
 	defer closer()

--- a/internal/datastore/proxy/schemacaching/caching.go
+++ b/internal/datastore/proxy/schemacaching/caching.go
@@ -1,0 +1,73 @@
+package schemacaching
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/require"
+
+	log "github.com/authzed/spicedb/internal/logging"
+	"github.com/authzed/spicedb/pkg/cache"
+	"github.com/authzed/spicedb/pkg/datastore"
+)
+
+// CachingMode is the caching mode to use for schema.
+type CachingMode int
+
+const (
+	// WatchIfSupported will use a schema watch-based cache, if caching is supported. Otherwise,
+	// it will fallback to just-in-time caching.
+	WatchIfSupported CachingMode = iota
+
+	// JustInTimeCaching will always use a just-in-time cache for schema.
+	JustInTimeCaching
+)
+
+// DatastoreProxyTestCache returns a cache used for testing.
+func DatastoreProxyTestCache(t testing.TB) cache.Cache {
+	cache, err := cache.NewCache(&cache.Config{
+		NumCounters: 1000,
+		MaxCost:     1 * humanize.MiByte,
+	})
+	require.Nil(t, err)
+	return cache
+}
+
+// NewCachingDatastoreProxy creates a new datastore proxy which caches definitions that
+// are loaded at specific datastore revisions.
+func NewCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache, gcWindow time.Duration, cachingMode CachingMode) datastore.Datastore {
+	if c == nil {
+		c = cache.NoopCache()
+	}
+
+	if cachingMode == JustInTimeCaching {
+		log.Info().Type("datastore-type", delegate).Msg("datastore driver explicitly asked to skip schema watch")
+		return &definitionCachingProxy{
+			Datastore: delegate,
+			c:         c,
+		}
+	}
+
+	// Try to instantiate a schema cache that reads updates from the datastore's schema watch stream. If not possible,
+	// fallback to the just-in-time caching proxy.
+	unwrapped, ok := delegate.(datastore.UnwrappableDatastore)
+	if !ok {
+		log.Warn().Type("datastore-type", delegate).Msg("datastore driver does not support unwrapping; falling back to just-in-time caching")
+		return &definitionCachingProxy{
+			Datastore: delegate,
+			c:         c,
+		}
+	}
+
+	watchable, ok := unwrapped.Unwrap().(datastore.SchemaWatchableDatastore)
+	if !ok {
+		log.Info().Type("datastore-type", delegate).Msg("datastore driver does not schema watch; falling back to just-in-time caching")
+		return &definitionCachingProxy{
+			Datastore: delegate,
+			c:         c,
+		}
+	}
+
+	return createWatchingCacheProxy(watchable, gcWindow)
+}

--- a/internal/datastore/proxy/schemacaching/estimatedsize_test.go
+++ b/internal/datastore/proxy/schemacaching/estimatedsize_test.go
@@ -1,4 +1,4 @@
-package proxy
+package schemacaching
 
 import (
 	"context"
@@ -24,7 +24,7 @@ func TestEstimatedDefinitionSizes(t *testing.T) {
 	// Load all consistency and benchmark YAMLs to get a set of sample namespace
 	// definitions for testing.
 	_, filename, _, _ := runtime.Caller(0)
-	integrationTestDirectoryPath := path.Join(path.Dir(filename), "../../services/integrationtesting")
+	integrationTestDirectoryPath := path.Join(path.Dir(filename), "../../../services/integrationtesting")
 
 	consistencyTestFiles := []string{}
 	err := filepath.Walk(integrationTestDirectoryPath, func(path string, info os.FileInfo, err error) error {

--- a/internal/datastore/proxy/schemacaching/intervaltracker.go
+++ b/internal/datastore/proxy/schemacaching/intervaltracker.go
@@ -1,0 +1,167 @@
+package schemacaching
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/exp/slices"
+
+	"github.com/authzed/spicedb/pkg/datastore"
+)
+
+// intervalTracker is a specialized type for tracking a value over a set of
+// revision-based time intervals.
+type intervalTracker[T any] struct {
+	// sortedEntries are the entries in the interval tracker, sorted with the *latest* being *first*.
+	sortedEntries []intervalTrackerEntry[T]
+
+	// lock is the sync lock for the tracker.
+	lock sync.RWMutex
+}
+
+// intervalTrackerEntry is a single entry in the interval tracker, over a
+// period of revisions.
+type intervalTrackerEntry[T any] struct {
+	// created is the point at which the entry was created.
+	created time.Time
+
+	// value is the value for the tracked interval.
+	value T
+
+	// startingRevision at which the interval begins.
+	startingRevision datastore.Revision
+
+	// endingRevision is the *exclusive* revision at which the interval ends. If not specified,
+	// then the interval is open until the last checkpoint revision.
+	endingRevisionOrNil datastore.Revision
+}
+
+// newIntervalTracker creates a new interval tracker.
+func newIntervalTracker[T any]() *intervalTracker[T] {
+	return &intervalTracker[T]{
+		sortedEntries: make([]intervalTrackerEntry[T], 0, 1),
+	}
+}
+
+// removeStaleIntervals removes all fully-defined intervals that were created at least window-time ago.
+// Returns true if *all* intervals were removed, and the tracker is now empty.
+func (it *intervalTracker[T]) removeStaleIntervals(window time.Duration) bool {
+	threshold := time.Now().Add(-window)
+
+	it.lock.Lock()
+	defer it.lock.Unlock()
+
+	it.sortedEntries = slices.DeleteFunc(it.sortedEntries, func(entry intervalTrackerEntry[T]) bool {
+		// The open-ended entry always remains.
+		if entry.endingRevisionOrNil == nil {
+			return false
+		}
+
+		return entry.created.Before(threshold)
+	})
+
+	return len(it.sortedEntries) == 0
+}
+
+// lookup performs lookup of the value in the tracker at the specified revision. lastCheckpointRevision is the
+// bound to use for the ending revision for the unbounded entry in the tracker (if any).
+func (it *intervalTracker[T]) lookup(revision datastore.Revision, lastCheckpointRevision datastore.Revision) (T, bool) {
+	it.lock.RLock()
+	defer it.lock.RUnlock()
+
+	// NOTE: The sortedEntries slice is sorted from latest to least recent, which is opposite that expected
+	// by BinarySearchFunc, so all the returned values below are "inverted".
+	index, ok := slices.BinarySearchFunc(
+		it.sortedEntries,
+		revision,
+		func(entry intervalTrackerEntry[T], rev datastore.Revision) int {
+			// If the entry's starting revision exactly matches the revision, then we know we've found
+			// the correct entry.
+			if entry.startingRevision.Equal(rev) {
+				return 0
+			}
+
+			// If the entry starts after the revision, then it precedes the revision in the slice.
+			if entry.startingRevision.GreaterThan(rev) {
+				return -1
+			}
+
+			// Check if the revision is found within the entry.
+			if entry.endingRevisionOrNil != nil {
+				// If the revision is less than the ending revision (exclusively), then we've found
+				// the correct entry.
+				if rev.LessThan(entry.endingRevisionOrNil) {
+					return 0
+				}
+
+				// Otherwise, the revision is later that ending the entry, which means the revision
+				// precedes the entry in the slice.
+				return 1
+			}
+
+			// If the last checkpoint revision is nil, then the entry's ending revision is closed to
+			// anything beyond the entry's starting revision.
+			endingRevisionInclusive := lastCheckpointRevision
+			if lastCheckpointRevision == nil {
+				endingRevisionInclusive = entry.startingRevision
+			}
+
+			// If the entry has no ending revision, then the supplied last checkpoint revision is the *inclusive*
+			// revision for the ending.
+			if rev.LessThan(endingRevisionInclusive) || rev.Equal(endingRevisionInclusive) {
+				return 0
+			}
+
+			if rev.GreaterThan(endingRevisionInclusive) {
+				return -1
+			}
+
+			return 1
+		})
+	if !ok {
+		return *new(T), false
+	}
+
+	return it.sortedEntries[index].value, true
+}
+
+// add adds an entry into the tracker, indicating it becomes alive at the given revision.
+// Returns whether the entry was successfully added. An entry can only be added if it is
+// the latest entry: any attempt to add an entry at a revision before the latest found will
+// return false and no-op.
+func (it *intervalTracker[T]) add(entry T, revision datastore.Revision) bool {
+	now := time.Now()
+
+	it.lock.Lock()
+	defer it.lock.Unlock()
+
+	if len(it.sortedEntries) == 0 {
+		it.sortedEntries = append(it.sortedEntries, intervalTrackerEntry[T]{
+			created:             now,
+			value:               entry,
+			startingRevision:    revision,
+			endingRevisionOrNil: nil,
+		})
+		return true
+	}
+
+	if revision.LessThan(it.sortedEntries[0].startingRevision) {
+		return false
+	}
+
+	// If given the same revision as the top entry (which can happen from some datastores), ignore.
+	if revision.Equal(it.sortedEntries[0].startingRevision) {
+		return true
+	}
+
+	it.sortedEntries[0].endingRevisionOrNil = revision
+	it.sortedEntries = append([]intervalTrackerEntry[T]{
+		{
+			created:             now,
+			value:               entry,
+			startingRevision:    revision,
+			endingRevisionOrNil: nil,
+		},
+	}, it.sortedEntries...)
+	return true
+}

--- a/internal/datastore/proxy/schemacaching/intervaltracker_test.go
+++ b/internal/datastore/proxy/schemacaching/intervaltracker_test.go
@@ -1,0 +1,321 @@
+package schemacaching
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/datastore/revision"
+)
+
+func rev(value string) datastore.Revision {
+	dd := revision.DecimalDecoder{}
+	rev, _ := dd.RevisionFromString(value)
+	return rev
+}
+
+func TestIntervalTrackerBasic(t *testing.T) {
+	tracker := newIntervalTracker[string]()
+
+	// Perform lookup on an empty tracker.
+	_, found := tracker.lookup(rev("1"), rev("0"))
+	require.False(t, found)
+
+	// Add an entry at revision.
+	tracker.add("first", rev("1"))
+	validate(t, tracker)
+
+	// Ensure the entry is found at its own revision.
+	value, found := tracker.lookup(rev("1"), rev("2"))
+	require.True(t, found)
+	require.Equal(t, "first", value)
+
+	// Ensure the entry is found after that revision based on the tracking revision.
+	value, found = tracker.lookup(rev("2"), rev("2"))
+	require.True(t, found)
+	require.Equal(t, "first", value)
+
+	// Ensure the entry is not found if the tracking revision is less than that specified.
+	_, found = tracker.lookup(rev("3"), rev("2"))
+	require.False(t, found)
+
+	// Add another entry at revision 4.
+	tracker.add("second", rev("4"))
+	validate(t, tracker)
+
+	// Ensure that revisions 1-3 find the first.
+	for _, rv := range []string{"1", "1.1", "2", "2.6", "3", "3.9", "3.999"} {
+		value, found = tracker.lookup(rev(rv), rev("5"))
+		require.True(t, found)
+		require.Equal(t, "first", value)
+
+		value, found = tracker.lookup(rev(rv), rev("12"))
+		require.True(t, found)
+		require.Equal(t, "first", value)
+	}
+
+	// Ensure that revision 4+ finds the second.
+	value, found = tracker.lookup(rev("4"), rev("5"))
+	require.True(t, found)
+	require.Equal(t, "second", value)
+
+	value, found = tracker.lookup(rev("5"), rev("5"))
+	require.True(t, found)
+	require.Equal(t, "second", value)
+
+	// Ensure the entry is not found if the tracking revision is less than that specified.
+	_, found = tracker.lookup(rev("5.1"), rev("5"))
+	require.False(t, found)
+}
+
+func TestIntervalTrackerBeginningGap(t *testing.T) {
+	tracker := newIntervalTracker[string]()
+
+	// Add an entry at revision 4.
+	tracker.add("first", rev("4"))
+	validate(t, tracker)
+
+	// Ensure the value is found at revision 4.
+	value, found := tracker.lookup(rev("4"), rev("4"))
+	require.True(t, found)
+	require.Equal(t, "first", value)
+
+	// Ensure the value is *not* found at revision 4.1 with max tracked 4.
+	_, found = tracker.lookup(rev("4.1"), rev("4"))
+	require.False(t, found)
+
+	// Ensure the value is found at revision 4.1 when maxed tracked is 5.
+	value, found = tracker.lookup(rev("4"), rev("5"))
+	require.True(t, found)
+	require.Equal(t, "first", value)
+
+	// Make sure a request for revision 1-3 (exclusive) with the tracking revision less (since that "update" hasn't "arrived" yet)
+	for _, rv := range []string{"1", "1.1", "2", "2.6", "2.999"} {
+		_, found = tracker.lookup(rev(rv), rev("3"))
+		require.False(t, found)
+	}
+}
+
+func TestIntervalTrackerOutOfOrderInsertion(t *testing.T) {
+	tracker := newIntervalTracker[string]()
+
+	// Add an entry at revision 1.
+	require.True(t, tracker.add("first", rev("1")))
+	validate(t, tracker)
+
+	// Add an entry at revision 2.
+	tracker.add("second", rev("2"))
+	validate(t, tracker)
+
+	// Add an entry at revision 4.
+	tracker.add("four", rev("4"))
+	validate(t, tracker)
+
+	// Add an entry at revision 3.
+	require.False(t, tracker.add("third", rev("3")))
+	validate(t, tracker)
+
+	// Make sure a request for revision 1-2 (exclusive) refer to 'first'.
+	for _, rv := range []string{"1", "1.1", "1.999"} {
+		value, found := tracker.lookup(rev(rv), rev("4.1"))
+		require.True(t, found)
+		require.Equal(t, "first", value)
+	}
+
+	// Make sure a request for revision 2-4 (exclusive) refer to 'second'.
+	for _, rv := range []string{"2", "2.5", "3.999"} {
+		value, found := tracker.lookup(rev(rv), rev("4.1"))
+		require.True(t, found)
+		require.Equal(t, "second", value)
+	}
+
+	// Make sure a request for revision 4+ refers to 'four'
+	for _, rv := range []string{"4", "4.01", "4.05", "4.1"} {
+		value, found := tracker.lookup(rev(rv), rev("4.1"))
+		require.True(t, found)
+		require.Equal(t, "four", value)
+	}
+
+	// Add an entry at revision 8.
+	tracker.add("eight", rev("8"))
+	validate(t, tracker)
+
+	// Make sure a request for revision 4-8 (exclusive) refers to 'four'
+	for _, rv := range []string{"4", "4.01", "4.05", "4.1", "7.999"} {
+		value, found := tracker.lookup(rev(rv), rev("8.1"))
+		require.True(t, found)
+		require.Equal(t, "four", value)
+	}
+
+	// Make sure a request for revision 8+ refers to 'eight'
+	for _, rv := range []string{"8", "8.01", "8.05", "8.1"} {
+		value, found := tracker.lookup(rev(rv), rev("8.1"))
+		require.True(t, found)
+		require.Equal(t, "eight", value)
+	}
+}
+
+func TestIntervalTrackerGC(t *testing.T) {
+	tracker := newIntervalTracker[string]()
+
+	// Add an entry at revision 2.
+	tracker.add("second", rev("2"))
+	validate(t, tracker)
+
+	// Add an entry at revision 4.
+	tracker.add("four", rev("4"))
+	validate(t, tracker)
+
+	// Add an entry at revision 1.
+	require.False(t, tracker.add("first", rev("1")))
+	validate(t, tracker)
+
+	// Wait 10ms
+	time.Sleep(10 * time.Millisecond)
+
+	// GC anything older than 5s, which shouldn't change anything.
+	result := tracker.removeStaleIntervals(5 * time.Second)
+	require.False(t, false, result)
+	require.Equal(t, 2, len(tracker.sortedEntries))
+
+	// GC anything older than 5ms. There should still be a single entry because it is unbounded.
+	result = tracker.removeStaleIntervals(5 * time.Millisecond)
+	require.False(t, false, result)
+	require.Equal(t, 1, len(tracker.sortedEntries))
+}
+
+func TestIntervalTrackerAnotherBasicTest(t *testing.T) {
+	tracker := newIntervalTracker[string]()
+
+	// Add an entry at revision.
+	tracker.add("first", rev("1"))
+	validate(t, tracker)
+
+	// Ensure the entry is found at its own revision.
+	value, found := tracker.lookup(rev("1"), rev("1"))
+	require.True(t, found)
+	require.Equal(t, "first", value)
+
+	// Add another entry at revision 2.
+	tracker.add("second", rev("2"))
+	validate(t, tracker)
+
+	// Ensure the entry is found at its own revision.
+	value, found = tracker.lookup(rev("2"), rev("2"))
+	require.True(t, found)
+	require.Equal(t, "second", value)
+
+	// Ensure entry 1 is found at its own revision.
+	value, found = tracker.lookup(rev("1"), rev("2"))
+	require.True(t, found)
+	require.Equal(t, "first", value)
+
+	// Ensure entry 1 is found at a parent revision.
+	value, found = tracker.lookup(rev("1"), rev("3"))
+	require.True(t, found)
+	require.Equal(t, "first", value)
+
+	// Ensure entry 2 is found at a parent revision.
+	value, found = tracker.lookup(rev("2"), rev("3"))
+	require.True(t, found)
+	require.Equal(t, "second", value)
+
+	value, found = tracker.lookup(rev("3"), rev("3"))
+	require.True(t, found)
+	require.Equal(t, "second", value)
+
+	// Check to ensure not found for revision 3.
+	_, found = tracker.lookup(rev("3"), rev("2"))
+	require.False(t, found)
+
+	// Ensure entry 2 is found even if last revision is lower.
+	value, found = tracker.lookup(rev("2"), rev("1"))
+	require.True(t, found)
+	require.Equal(t, "second", value)
+}
+
+func TestIntervalTrackerWithNoLastRevision(t *testing.T) {
+	tracker := newIntervalTracker[string]()
+
+	// Add an entry at revision.
+	tracker.add("first", rev("1"))
+	validate(t, tracker)
+
+	// Ensure the entry is found at its own revision.
+	value, found := tracker.lookup(rev("1"), rev("1"))
+	require.True(t, found)
+	require.Equal(t, "first", value)
+
+	// Ensure the entry is found at its own revision.
+	value, found = tracker.lookup(rev("1"), nil)
+	require.True(t, found)
+	require.Equal(t, "first", value)
+
+	// Add another entry at revision 2.
+	tracker.add("second", rev("2"))
+	validate(t, tracker)
+
+	// Ensure the entry is found at its own revision.
+	value, found = tracker.lookup(rev("2"), nil)
+	require.True(t, found)
+	require.Equal(t, "second", value)
+
+	// Ensure another revision is not found.
+	_, found = tracker.lookup(rev("3"), nil)
+	require.False(t, found)
+
+	// Ensure another revision is not found.
+	_, found = tracker.lookup(rev("0"), nil)
+	require.False(t, found)
+}
+
+func TestIntervalTrackerRealWorldUsage(t *testing.T) {
+	tracker := newIntervalTracker[string]()
+	tracker.add("notfound1", rev("1"))
+	validate(t, tracker)
+
+	tracker.add("real2", rev("2"))
+	validate(t, tracker)
+
+	tracker.add("real2-again", rev("3"))
+	validate(t, tracker)
+
+	tracker.add("notfound5", rev("5"))
+	validate(t, tracker)
+
+	value, found := tracker.lookup(rev("5"), rev("5"))
+	require.True(t, found)
+	require.Equal(t, "notfound5", value)
+
+	value, found = tracker.lookup(rev("5"), rev("3.5"))
+	require.True(t, found)
+	require.Equal(t, "notfound5", value)
+
+	value, found = tracker.lookup(rev("2"), rev("5"))
+	require.True(t, found)
+	require.Equal(t, "real2", value)
+
+	value, found = tracker.lookup(rev("2"), rev("3.5"))
+	require.True(t, found)
+	require.Equal(t, "real2", value)
+
+	value, found = tracker.lookup(rev("3.5"), rev("5"))
+	require.True(t, found)
+	require.Equal(t, "real2-again", value)
+
+	value, found = tracker.lookup(rev("3.5"), rev("3.5"))
+	require.True(t, found)
+	require.Equal(t, "real2-again", value)
+}
+
+func validate(t *testing.T, tracker *intervalTracker[string]) {
+	for index, entry := range tracker.sortedEntries {
+		if index > 0 {
+			require.NotNil(t, entry.endingRevisionOrNil, "found nil ending revision for entry %d", index)
+			require.True(t, entry.endingRevisionOrNil.LessThan(tracker.sortedEntries[index-1].startingRevision) || entry.endingRevisionOrNil.Equal(tracker.sortedEntries[index-1].startingRevision), "found entry %v->%v after entry %v->%v", entry.startingRevision, entry.endingRevisionOrNil, tracker.sortedEntries[index-1].startingRevision, tracker.sortedEntries[index-1].endingRevisionOrNil)
+			require.True(t, entry.startingRevision.LessThan(entry.endingRevisionOrNil) || entry.startingRevision.Equal(entry.endingRevisionOrNil))
+		}
+	}
+}

--- a/internal/datastore/proxy/schemacaching/standardcaching_test.go
+++ b/internal/datastore/proxy/schemacaching/standardcaching_test.go
@@ -1,4 +1,4 @@
-package proxy
+package schemacaching
 
 import (
 	"context"
@@ -162,7 +162,7 @@ func TestSnapshotCaching(t *testing.T) {
 			twoReader.On(tester.readSingleFunctionName, nsB).Return(nil, one, nil).Once()
 
 			require := require.New(t)
-			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
+			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t), 1*time.Hour, JustInTimeCaching)
 
 			_, updatedOneA, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsA)
 			require.NoError(err)
@@ -217,7 +217,7 @@ func TestRWTCaching(t *testing.T) {
 
 			ctx := context.Background()
 
-			ds := NewCachingDatastoreProxy(dsMock, nil)
+			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching)
 
 			rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 				_, updatedA, err := tester.readSingleFunc(ctx, rwt, nsA)
@@ -254,7 +254,7 @@ func TestRWTCacheWithWrites(t *testing.T) {
 
 			ctx := context.Background()
 
-			ds := NewCachingDatastoreProxy(dsMock, nil)
+			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching)
 
 			rev, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 				// Cache the 404
@@ -305,7 +305,7 @@ func TestSingleFlight(t *testing.T) {
 
 			require := require.New(t)
 
-			ds := NewCachingDatastoreProxy(dsMock, nil)
+			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching)
 
 			readNamespace := func() error {
 				_, updatedAt, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsA)
@@ -371,7 +371,7 @@ func TestSnapshotCachingRealDatastore(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			ds := NewCachingDatastoreProxy(rawDS, nil)
+			ds := NewCachingDatastoreProxy(rawDS, nil, 1*time.Hour, JustInTimeCaching)
 
 			if tc.nsDef != nil {
 				_, err = ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
@@ -436,7 +436,7 @@ func TestSingleFlightCancelled(t *testing.T) {
 
 			dsMock.On("SnapshotReader", one).Return(&reader{MockReader: proxy_test.MockReader{}})
 
-			ds := NewCachingDatastoreProxy(dsMock, nil)
+			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching)
 
 			g := sync.WaitGroup{}
 			var d2 datastore.SchemaDefinition
@@ -477,7 +477,7 @@ func TestMixedCaching(t *testing.T) {
 			dsMock.On("SnapshotReader", one).Return(reader)
 
 			require := require.New(t)
-			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t))
+			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t), 1*time.Hour, JustInTimeCaching)
 
 			dsReader := ds.SnapshotReader(one)
 

--- a/internal/datastore/proxy/schemacaching/types.go
+++ b/internal/datastore/proxy/schemacaching/types.go
@@ -1,0 +1,21 @@
+package schemacaching
+
+import "github.com/authzed/spicedb/pkg/schemadsl/compiler"
+
+// *DefinitionSizeVTMultiplier are the mulitipliers to be used for
+// estimating the in-memory cost of a SchemaDefinition based on its
+// on-wire size, as returned by SizeVT. This was determined by testing
+// all existing definitions found in consistency tests and is
+// enforced via the estimatedsize_test.
+const (
+	namespaceDefinitionSizeVTMultiplier = 10
+	namespaceDefinitionMinimumSize      = 150
+
+	caveatDefinitionSizeVTMultiplier = 10
+	caveatDefinitionMinimumSize      = 150
+)
+
+type schemaDefinition interface {
+	compiler.SchemaDefinition
+	SizeVT() int
+}

--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -1,0 +1,527 @@
+package schemacaching
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog/log"
+
+	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/datastore/options"
+	"github.com/authzed/spicedb/pkg/datastore/revision"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
+)
+
+var namespacesFallbackModeGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: "spicedb",
+	Subsystem: "datastore",
+	Name:      "watching_schema_cache_namespaces_fallback_mode",
+	Help:      "value of 1 if the cache is in fallback mode and 0 otherwise",
+})
+
+var caveatsFallbackModeGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: "spicedb",
+	Subsystem: "datastore",
+	Name:      "watching_schema_cache_caveats_fallback_mode",
+	Help:      "value of 1 if the cache is in fallback mode and 0 otherwise",
+})
+
+var schemaCacheRevisionGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: "spicedb",
+	Subsystem: "datastore",
+	Name:      "watching_schema_cache_tracked_revision",
+	Help:      "the currently tracked max revision for the schema cache",
+})
+
+var definitionsReadCachedCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "spicedb",
+	Subsystem: "datastore",
+	Name:      "watching_schema_cache_definitions_read_cached_total",
+	Help:      "cached number of definitions read from the watching cache",
+}, []string{"definition_kind"})
+
+var definitionsReadTotalCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "spicedb",
+	Subsystem: "datastore",
+	Name:      "watching_schema_cache_definitions_read_total",
+	Help:      "total number of definitions read from the watching cache",
+}, []string{"definition_kind"})
+
+func init() {
+	prometheus.MustRegister(namespacesFallbackModeGauge, caveatsFallbackModeGauge, schemaCacheRevisionGauge, definitionsReadCachedCounter, definitionsReadTotalCounter)
+}
+
+// watchingCachingProxy is a datastore proxy that caches schema (namespaces and caveat definitions)
+// and updates its cache via a WatchSchema call. If the supplied datastore to be wrapped does not support
+// this API, or the data is not available in this case or an error occurs, the updating cache fallsback
+// to the standard schema cache.
+type watchingCachingProxy struct {
+	datastore.SchemaWatchableDatastore
+
+	gcWindow time.Duration
+	closed   chan bool
+
+	namespaceCache *schemaWatchCache[*core.NamespaceDefinition]
+	caveatCache    *schemaWatchCache[*core.CaveatDefinition]
+}
+
+// createWatchingCacheProxy creates and returns a watching cache proxy.
+func createWatchingCacheProxy(wrapped datastore.SchemaWatchableDatastore, gcWindow time.Duration) *watchingCachingProxy {
+	proxy := &watchingCachingProxy{
+		SchemaWatchableDatastore: wrapped,
+
+		gcWindow: gcWindow,
+		closed:   make(chan bool, 2),
+
+		namespaceCache: newSchemaWatchCache[*core.NamespaceDefinition](
+			"namespace",
+			datastore.NewNamespaceNotFoundErr,
+			func(ctx context.Context, name string, revision datastore.Revision) (*core.NamespaceDefinition, datastore.Revision, error) {
+				return wrapped.SnapshotReader(revision).ReadNamespaceByName(ctx, name)
+			},
+			func(ctx context.Context, names []string, revision datastore.Revision) ([]datastore.RevisionedDefinition[*core.NamespaceDefinition], error) {
+				return wrapped.SnapshotReader(revision).LookupNamespacesWithNames(ctx, names)
+			},
+			definitionsReadCachedCounter,
+			definitionsReadTotalCounter,
+			namespacesFallbackModeGauge,
+		),
+		caveatCache: newSchemaWatchCache[*core.CaveatDefinition](
+			"caveat",
+			datastore.NewCaveatNameNotFoundErr,
+			func(ctx context.Context, name string, revision datastore.Revision) (*core.CaveatDefinition, datastore.Revision, error) {
+				return wrapped.SnapshotReader(revision).ReadCaveatByName(ctx, name)
+			},
+			func(ctx context.Context, names []string, revision datastore.Revision) ([]datastore.RevisionedDefinition[*core.CaveatDefinition], error) {
+				return wrapped.SnapshotReader(revision).LookupCaveatsWithNames(ctx, names)
+			},
+			definitionsReadCachedCounter,
+			definitionsReadTotalCounter,
+			caveatsFallbackModeGauge,
+		),
+	}
+	return proxy
+}
+
+func (p *watchingCachingProxy) SnapshotReader(rev datastore.Revision) datastore.Reader {
+	delegateReader := p.SchemaWatchableDatastore.SnapshotReader(rev)
+	return &watchingCachingReader{delegateReader, rev, p}
+}
+
+func (p *watchingCachingProxy) ReadWriteTx(
+	ctx context.Context,
+	f datastore.TxUserFunc,
+	opts ...options.RWTOptionsOption,
+) (datastore.Revision, error) {
+	return p.SchemaWatchableDatastore.ReadWriteTx(ctx, func(delegateRWT datastore.ReadWriteTransaction) error {
+		// NOTE: we always use the standard approach cache here, as it stores changes within the transaction
+		// itself, and should not impact the overall updating cache.
+		rwt := &definitionCachingRWT{delegateRWT, &sync.Map{}}
+		return f(rwt)
+	}, opts...)
+}
+
+func (p *watchingCachingProxy) Start(ctx context.Context) error {
+	log.Info().Msg("starting watching cache")
+
+	headRev, err := p.SchemaWatchableDatastore.HeadRevision(context.Background())
+	if err != nil {
+		p.namespaceCache.setFallbackMode()
+		p.caveatCache.setFallbackMode()
+		log.Warn().Err(err).Msg("received error in schema watch")
+		return err
+	}
+
+	// Start watching for expired entries to be GCed.
+	go (func() {
+		log.Debug().Str("revision", headRev.String()).Msg("starting watching cache GC goroutine")
+
+		for {
+			select {
+			case <-ctx.Done():
+				log.Debug().Msg("GC routine for watch closed due to context cancelation")
+				return
+
+			case <-p.closed:
+				log.Debug().Msg("GC routine for watch closed")
+				return
+
+			case <-time.After(time.Hour):
+				log.Debug().Msg("beginning GC operation for schema watch")
+				p.namespaceCache.gcStaleEntries(p.gcWindow)
+				p.caveatCache.gcStaleEntries(p.gcWindow)
+				log.Debug().Msg("schema watch gc operation completed")
+			}
+		}
+	})()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Start watching for schema changes.
+	go (func() {
+		log.Debug().Str("revision", headRev.String()).Msg("starting watching cache watch goroutine")
+
+		p.namespaceCache.startAtRevision(headRev)
+		p.caveatCache.startAtRevision(headRev)
+
+		log.Debug().Str("revision", headRev.String()).Msg("beginning schema watch")
+		ssc, serrc := p.SchemaWatchableDatastore.WatchSchema(context.Background(), headRev)
+		log.Debug().Msg("schema watch started")
+
+		wg.Done()
+
+		for {
+			select {
+			case <-ctx.Done():
+				log.Debug().Msg("schema watch closed due to context cancelation")
+				return
+
+			case <-p.closed:
+				log.Debug().Msg("schema watch closed")
+				return
+
+			case ss := <-ssc:
+				log.Trace().Object("update", ss).Msg("received update from schema watch")
+
+				if ss.IsCheckpoint {
+					if converted, ok := ss.Revision.(revision.Decimal); ok {
+						schemaCacheRevisionGauge.Set(converted.InexactFloat64())
+					}
+
+					p.namespaceCache.setCheckpointRevision(ss.Revision)
+					p.caveatCache.setCheckpointRevision(ss.Revision)
+					continue
+				}
+
+				// Apply the change to the interval tree entry.
+				for _, changeDef := range ss.ChangedDefinitions {
+					switch t := changeDef.(type) {
+					case *core.NamespaceDefinition:
+						err := p.namespaceCache.updateDefinition(t.Name, t, false, ss.Revision)
+						if err != nil {
+							p.namespaceCache.setFallbackMode()
+							log.Warn().Err(err).Msg("received error in schema watch")
+						}
+
+					case *core.CaveatDefinition:
+						err := p.caveatCache.updateDefinition(t.Name, t, false, ss.Revision)
+						if err != nil {
+							p.caveatCache.setFallbackMode()
+							log.Warn().Err(err).Msg("received error in schema watch")
+						}
+
+					default:
+						p.namespaceCache.setFallbackMode()
+						p.caveatCache.setFallbackMode()
+						log.Error().Msg("unknown change definition type")
+						return
+					}
+				}
+
+				for _, deletedNamespaceName := range ss.DeletedNamespaces {
+					err := p.namespaceCache.updateDefinition(deletedNamespaceName, nil, true, ss.Revision)
+					if err != nil {
+						p.namespaceCache.setFallbackMode()
+						log.Warn().Err(err).Msg("received error in schema watch")
+						break
+					}
+				}
+
+				for _, deletedCaveatName := range ss.DeletedCaveats {
+					err := p.caveatCache.updateDefinition(deletedCaveatName, nil, true, ss.Revision)
+					if err != nil {
+						p.caveatCache.setFallbackMode()
+						log.Warn().Err(err).Msg("received error in schema watch")
+						break
+					}
+				}
+
+			case err := <-serrc:
+				p.namespaceCache.setFallbackMode()
+				p.caveatCache.setFallbackMode()
+				log.Warn().Err(err).Msg("received terminal error in schema watch; setting to permanent fallback mode")
+				return
+			}
+		}
+	})()
+
+	wg.Wait()
+	return nil
+}
+
+func (p *watchingCachingProxy) Close() error {
+	p.caveatCache.setFallbackMode()
+	p.namespaceCache.setFallbackMode()
+
+	// Close both goroutines
+	p.closed <- true
+	p.closed <- true
+
+	return p.SchemaWatchableDatastore.Close()
+}
+
+// schemaWatchCache is a schema cache which updates based on changes received via the WatchSchema
+// call.
+type schemaWatchCache[T datastore.SchemaDefinition] struct {
+	// kind is a descriptive label of the kind of definitions in the cache.
+	kind string
+
+	notFoundError     notFoundErrorFn
+	readDefinition    readDefinitionFn[T]
+	lookupDefinitions lookupDefinitionsFn[T]
+
+	// inFallbackMode, if true, indicates that an error occurred with the WatchSchema call and that
+	// all further calls to this cache should passthrough, rather than using the cache itself (which
+	// is likely out of date).
+	// *Must* be accessed under the lock.
+	inFallbackMode bool
+
+	// checkpointRevision is the current revision at which the cache has been given *all* possible
+	// changes.
+	// *Must* be accessed under the lock.
+	checkpointRevision datastore.Revision
+
+	// entries are the entries in the cache, by name of the namespace or caveat.
+	// *Must* be accessed under the lock.
+	entries map[string]*intervalTracker[revisionedEntry[T]]
+
+	// definitionsReadCachedCounter is a counter of the number of cached definitions
+	// returned by the cache directly (without fallback)
+	definitionsReadCachedCounter *prometheus.CounterVec
+
+	// definitionsReadTotalCounter is a counter of the total number of definitions
+	// returned.
+	definitionsReadTotalCounter *prometheus.CounterVec
+
+	// fallbackGauge is a gauge holding a value of whether the cache is in fallback mode.
+	fallbackGauge prometheus.Gauge
+
+	lock sync.RWMutex
+}
+
+type revisionedEntry[T datastore.SchemaDefinition] struct {
+	revisionedDefinition datastore.RevisionedDefinition[T]
+	wasNotFound          bool
+}
+
+type (
+	notFoundErrorFn                                   func(name string) error
+	readDefinitionFn[T datastore.SchemaDefinition]    func(ctx context.Context, name string, revision datastore.Revision) (T, datastore.Revision, error)
+	lookupDefinitionsFn[T datastore.SchemaDefinition] func(ctx context.Context, names []string, revision datastore.Revision) ([]datastore.RevisionedDefinition[T], error)
+)
+
+// newSchemaWatchCache creates a new schema watch cache, starting in fallback mode.
+// To bring out of fallback mode, call startAtRevision to indicate that a watch loop
+// has begun at that revision.
+func newSchemaWatchCache[T datastore.SchemaDefinition](
+	kind string,
+	notFoundError notFoundErrorFn,
+	readDefinition readDefinitionFn[T],
+	lookupDefinitions lookupDefinitionsFn[T],
+	definitionsReadCachedCounter *prometheus.CounterVec,
+	definitionsReadTotalCounter *prometheus.CounterVec,
+	fallbackGauge prometheus.Gauge,
+) *schemaWatchCache[T] {
+	fallbackGauge.Set(1)
+
+	return &schemaWatchCache[T]{
+		kind: kind,
+
+		notFoundError:     notFoundError,
+		readDefinition:    readDefinition,
+		lookupDefinitions: lookupDefinitions,
+
+		inFallbackMode:     true,
+		entries:            map[string]*intervalTracker[revisionedEntry[T]]{},
+		checkpointRevision: nil,
+
+		lock: sync.RWMutex{},
+
+		definitionsReadCachedCounter: definitionsReadCachedCounter,
+		definitionsReadTotalCounter:  definitionsReadTotalCounter,
+		fallbackGauge:                fallbackGauge,
+	}
+}
+
+func (swc *schemaWatchCache[T]) startAtRevision(revision datastore.Revision) {
+	swc.lock.Lock()
+	defer swc.lock.Unlock()
+
+	swc.entries = map[string]*intervalTracker[revisionedEntry[T]]{}
+	swc.checkpointRevision = revision
+	swc.inFallbackMode = false
+
+	swc.fallbackGauge.Set(0)
+}
+
+func (swc *schemaWatchCache[T]) gcStaleEntries(gcWindow time.Duration) {
+	swc.lock.Lock()
+	defer swc.lock.Unlock()
+
+	for entryName, entry := range swc.entries {
+		fullyRemoved := entry.removeStaleIntervals(gcWindow)
+		if fullyRemoved {
+			delete(swc.entries, entryName)
+		}
+	}
+}
+
+func (swc *schemaWatchCache[T]) setFallbackMode() {
+	swc.lock.Lock()
+	defer swc.lock.Unlock()
+
+	swc.inFallbackMode = true
+	swc.fallbackGauge.Set(1)
+}
+
+func (swc *schemaWatchCache[T]) setCheckpointRevision(revision datastore.Revision) {
+	swc.lock.Lock()
+	defer swc.lock.Unlock()
+
+	swc.checkpointRevision = revision
+}
+
+func (swc *schemaWatchCache[T]) getTrackerForName(name string) *intervalTracker[revisionedEntry[T]] {
+	swc.lock.RLock()
+	tracker, ok := swc.entries[name]
+	swc.lock.RUnlock()
+
+	if ok {
+		return tracker
+	}
+
+	tracker = newIntervalTracker[revisionedEntry[T]]()
+	swc.lock.Lock()
+	swc.entries[name] = tracker
+	swc.lock.Unlock()
+	return tracker
+}
+
+func (swc *schemaWatchCache[T]) updateDefinition(name string, definition T, isDeletion bool, revision datastore.Revision) error {
+	tracker := swc.getTrackerForName(name)
+	result := tracker.add(revisionedEntry[T]{
+		revisionedDefinition: datastore.RevisionedDefinition[T]{
+			Definition:          definition,
+			LastWrittenRevision: revision,
+		},
+		wasNotFound: isDeletion,
+	}, revision)
+	if !result {
+		return spiceerrors.MustBugf("received out of order insertion for definition %s", name)
+	}
+	return nil
+}
+
+func (swc *schemaWatchCache[T]) readDefinitionByName(ctx context.Context, name string, revision datastore.Revision) (T, datastore.Revision, error) {
+	swc.definitionsReadTotalCounter.WithLabelValues(swc.kind).Inc()
+
+	swc.lock.RLock()
+	inFallbackMode := swc.inFallbackMode
+	lastCheckpointRevision := swc.checkpointRevision
+	swc.lock.RUnlock()
+
+	// If in fallback mode, just read the definition directly from the fallback cache.
+	if inFallbackMode {
+		return swc.readDefinition(ctx, name, revision)
+	}
+
+	// Lookup the tracker for the definition name and then find the associated definition for the specified revision,
+	// if any.
+	tracker := swc.getTrackerForName(name)
+	found, ok := tracker.lookup(revision, lastCheckpointRevision)
+	if ok {
+		swc.definitionsReadCachedCounter.WithLabelValues(swc.kind).Inc()
+
+		// If an entry was found, return the stored information.
+		if found.wasNotFound {
+			return *new(T), nil, swc.notFoundError(name)
+		}
+
+		return found.revisionedDefinition.Definition, found.revisionedDefinition.LastWrittenRevision, nil
+	}
+
+	// Otherwise, read the definition from the fallback cache.
+	return swc.readDefinition(ctx, name, revision)
+}
+
+func (swc *schemaWatchCache[T]) readDefinitionsWithNames(ctx context.Context, names []string, revision datastore.Revision) ([]datastore.RevisionedDefinition[T], error) {
+	swc.definitionsReadTotalCounter.WithLabelValues(swc.kind).Add(float64(len(names)))
+
+	swc.lock.RLock()
+	inFallbackMode := swc.inFallbackMode
+	lastCheckpointRevision := swc.checkpointRevision
+	swc.lock.RUnlock()
+
+	// If in fallback mode, just read the definition directly from the fallback cache.
+	if inFallbackMode {
+		return swc.lookupDefinitions(ctx, names, revision)
+	}
+
+	// Find whichever trackers are cached.
+	remainingNames := mapz.NewSet(names...)
+	foundDefs := make([]datastore.RevisionedDefinition[T], 0, len(names))
+	for _, name := range names {
+		tracker := swc.getTrackerForName(name)
+		found, ok := tracker.lookup(revision, lastCheckpointRevision)
+		if !ok {
+			continue
+		}
+
+		swc.definitionsReadCachedCounter.WithLabelValues(swc.kind).Inc()
+		remainingNames.Remove(name)
+		if !found.wasNotFound {
+			foundDefs = append(foundDefs, found.revisionedDefinition)
+		}
+	}
+
+	// If there are still remaining definition names to be looked up, look them up and then cache them.
+	if !remainingNames.IsEmpty() {
+		additionalDefs, err := swc.lookupDefinitions(ctx, remainingNames.AsSlice(), revision)
+		if err != nil {
+			return nil, err
+		}
+
+		foundDefs = append(foundDefs, additionalDefs...)
+	}
+
+	return foundDefs, nil
+}
+
+type watchingCachingReader struct {
+	datastore.Reader
+	rev datastore.Revision
+	p   *watchingCachingProxy
+}
+
+func (r *watchingCachingReader) ReadNamespaceByName(
+	ctx context.Context,
+	name string,
+) (*core.NamespaceDefinition, datastore.Revision, error) {
+	return r.p.namespaceCache.readDefinitionByName(ctx, name, r.rev)
+}
+
+func (r *watchingCachingReader) LookupNamespacesWithNames(
+	ctx context.Context,
+	nsNames []string,
+) ([]datastore.RevisionedNamespace, error) {
+	return r.p.namespaceCache.readDefinitionsWithNames(ctx, nsNames, r.rev)
+}
+
+func (r *watchingCachingReader) ReadCaveatByName(
+	ctx context.Context,
+	name string,
+) (*core.CaveatDefinition, datastore.Revision, error) {
+	return r.p.caveatCache.readDefinitionByName(ctx, name, r.rev)
+}
+
+func (r *watchingCachingReader) LookupCaveatsWithNames(
+	ctx context.Context,
+	caveatNames []string,
+) ([]datastore.RevisionedCaveat, error) {
+	return r.p.caveatCache.readDefinitionsWithNames(ctx, caveatNames, r.rev)
+}

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -1,0 +1,499 @@
+package schemacaching
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"golang.org/x/exp/slices"
+
+	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/datastore/options"
+	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
+)
+
+var goleakIgnores = []goleak.Option{
+	goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"),
+	goleak.IgnoreTopFunction("github.com/outcaste-io/ristretto.(*lfuPolicy).processItems"),
+	goleak.IgnoreTopFunction("github.com/outcaste-io/ristretto.(*Cache).processItems"),
+	goleak.IgnoreCurrent(),
+}
+
+func TestWatchingCacheBasicOperation(t *testing.T) {
+	defer goleak.VerifyNone(t, goleakIgnores...)
+
+	fakeDS := &fakeDatastore{
+		headRevision: rev("0"),
+		namespaces:   map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
+		caveats:      map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]{},
+		schemaChan:   make(chan *datastore.SchemaState, 1),
+		errChan:      make(chan error, 1),
+	}
+
+	cache := createWatchingCacheProxy(fakeDS, 1*time.Hour)
+	require.NoError(t, cache.Start(context.Background()))
+
+	// Ensure no namespaces are found.
+	_, _, err := cache.SnapshotReader(rev("1")).ReadNamespaceByName(context.Background(), "somenamespace")
+	require.ErrorAs(t, err, &datastore.ErrNamespaceNotFound{})
+	require.False(t, cache.namespaceCache.inFallbackMode)
+
+	// Ensure a re-read also returns not found, even before a checkpoint is received.
+	_, _, err = cache.SnapshotReader(rev("1")).ReadNamespaceByName(context.Background(), "somenamespace")
+	require.ErrorAs(t, err, &datastore.ErrNamespaceNotFound{})
+
+	// Send a checkpoint for revision 1.
+	fakeDS.sendCheckpoint(rev("1"))
+
+	// Write a namespace update at revision 2.
+	fakeDS.updateNamespace("somenamespace", &corev1.NamespaceDefinition{Name: "somenamespace"}, rev("2"))
+
+	// Ensure that reading at rev 2 returns found.
+	nsDef, _, err := cache.SnapshotReader(rev("2")).ReadNamespaceByName(context.Background(), "somenamespace")
+	require.NoError(t, err)
+	require.Equal(t, "somenamespace", nsDef.Name)
+
+	// Disable reads.
+	fakeDS.disableReads()
+
+	// Ensure that reading at rev 3 returns an error, as with reads disabled the cache should not be hit.
+	_, _, err = cache.SnapshotReader(rev("3")).ReadNamespaceByName(context.Background(), "somenamespace")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "reads are disabled")
+
+	// Re-enable reads.
+	fakeDS.enableReads()
+
+	// Ensure that reading at rev 3 returns found, even though the cache should not yet be there. This will
+	// require a datastore fallback read because the cache is not yet checkedpointed to that revision.
+	nsDef, _, err = cache.SnapshotReader(rev("3")).ReadNamespaceByName(context.Background(), "somenamespace")
+	require.NoError(t, err)
+	require.Equal(t, "somenamespace", nsDef.Name)
+
+	// Checkpoint to rev 4.
+	fakeDS.sendCheckpoint(rev("4"))
+	require.False(t, cache.namespaceCache.inFallbackMode)
+
+	// Disable reads.
+	fakeDS.disableReads()
+
+	// Read again, which should now be via the cache.
+	nsDef, _, err = cache.SnapshotReader(rev("3.5")).ReadNamespaceByName(context.Background(), "somenamespace")
+	require.NoError(t, err)
+	require.Equal(t, "somenamespace", nsDef.Name)
+
+	// Read via a lookup.
+	nsDefs, err := cache.SnapshotReader(rev("3.5")).LookupNamespacesWithNames(context.Background(), []string{"somenamespace"})
+	require.NoError(t, err)
+	require.Equal(t, "somenamespace", nsDefs[0].Definition.Name)
+
+	// Delete the namespace at revision 5.
+	fakeDS.updateNamespace("somenamespace", nil, rev("5"))
+
+	// Re-read at an earlier revision.
+	nsDef, _, err = cache.SnapshotReader(rev("3.5")).ReadNamespaceByName(context.Background(), "somenamespace")
+	require.NoError(t, err)
+	require.Equal(t, "somenamespace", nsDef.Name)
+
+	// Read at revision 5.
+	_, _, err = cache.SnapshotReader(rev("5")).ReadNamespaceByName(context.Background(), "somenamespace")
+	require.Error(t, err)
+	require.ErrorAs(t, err, &datastore.ErrNamespaceNotFound{}, "missing not found in: %v", err)
+
+	// Lookup at revision 5.
+	nsDefs, err = cache.SnapshotReader(rev("5")).LookupNamespacesWithNames(context.Background(), []string{"somenamespace"})
+	require.NoError(t, err)
+	require.Empty(t, nsDefs)
+
+	// Update a caveat.
+	fakeDS.updateCaveat("somecaveat", &corev1.CaveatDefinition{Name: "somecaveat"}, rev("6"))
+
+	// Read at revision 6.
+	caveatDef, _, err := cache.SnapshotReader(rev("6")).ReadCaveatByName(context.Background(), "somecaveat")
+	require.NoError(t, err)
+	require.Equal(t, "somecaveat", caveatDef.Name)
+
+	// Attempt to read at revision 1, which should require a read.
+	_, _, err = cache.SnapshotReader(rev("1")).ReadCaveatByName(context.Background(), "somecaveat")
+	require.ErrorContains(t, err, "reads are disabled")
+
+	// Close the proxy and ensure the background goroutines are terminated.
+	cache.Close()
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestWatchingCacheParallelOperations(t *testing.T) {
+	defer goleak.VerifyNone(t, goleakIgnores...)
+
+	fakeDS := &fakeDatastore{
+		headRevision: rev("0"),
+		namespaces:   map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
+		caveats:      map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]{},
+		schemaChan:   make(chan *datastore.SchemaState, 1),
+		errChan:      make(chan error, 1),
+	}
+
+	cache := createWatchingCacheProxy(fakeDS, 1*time.Hour)
+	require.NoError(t, cache.Start(context.Background()))
+
+	// Run some operations in parallel.
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go (func() {
+		// Read somenamespace (which should not be found)
+		_, _, err := cache.SnapshotReader(rev("1")).ReadNamespaceByName(context.Background(), "somenamespace")
+		require.ErrorAs(t, err, &datastore.ErrNamespaceNotFound{})
+		require.False(t, cache.namespaceCache.inFallbackMode)
+
+		// Write somenamespace.
+		fakeDS.updateNamespace("somenamespace", &corev1.NamespaceDefinition{Name: "somenamespace"}, rev("2"))
+
+		// Read again (which should be found now)
+		nsDef, _, err := cache.SnapshotReader(rev("2")).ReadNamespaceByName(context.Background(), "somenamespace")
+		require.NoError(t, err)
+		require.Equal(t, "somenamespace", nsDef.Name)
+
+		wg.Done()
+	})()
+
+	go (func() {
+		// Read anothernamespace (which should not be found)
+		_, _, err := cache.SnapshotReader(rev("1")).ReadNamespaceByName(context.Background(), "anothernamespace")
+		require.ErrorAs(t, err, &datastore.ErrNamespaceNotFound{})
+		require.False(t, cache.namespaceCache.inFallbackMode)
+
+		// Read again (which should still not be found)
+		_, _, err = cache.SnapshotReader(rev("3")).ReadNamespaceByName(context.Background(), "anothernamespace")
+		require.ErrorAs(t, err, &datastore.ErrNamespaceNotFound{})
+		require.False(t, cache.namespaceCache.inFallbackMode)
+
+		wg.Done()
+	})()
+
+	wg.Wait()
+
+	// Close the proxy and ensure the background goroutines are terminated.
+	cache.Close()
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestWatchingCacheParallelReaderWriter(t *testing.T) {
+	defer goleak.VerifyNone(t, goleakIgnores...)
+
+	fakeDS := &fakeDatastore{
+		headRevision: rev("0"),
+		namespaces:   map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
+		caveats:      map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]{},
+		schemaChan:   make(chan *datastore.SchemaState, 1),
+		errChan:      make(chan error, 1),
+	}
+
+	cache := createWatchingCacheProxy(fakeDS, 1*time.Hour)
+	require.NoError(t, cache.Start(context.Background()))
+
+	// Write somenamespace.
+	fakeDS.updateNamespace("somenamespace", &corev1.NamespaceDefinition{Name: "somenamespace"}, rev("0"))
+
+	// Run some operations in parallel.
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go (func() {
+		// Start a loop to write a namespace a bunch of times.
+		for i := 0; i < 1000; i++ {
+			// Write somenamespace.
+			fakeDS.updateNamespace("somenamespace", &corev1.NamespaceDefinition{Name: "somenamespace"}, rev(fmt.Sprintf("%d", i+1)))
+		}
+
+		wg.Done()
+	})()
+
+	go (func() {
+		// Start a loop to read a namespace a bunch of times.
+		for i := 0; i < 1000; i++ {
+			headRevision, err := fakeDS.HeadRevision(context.Background())
+			require.NoError(t, err)
+
+			nsDef, _, err := cache.SnapshotReader(headRevision).ReadNamespaceByName(context.Background(), "somenamespace")
+			require.NoError(t, err)
+			require.Equal(t, "somenamespace", nsDef.Name)
+		}
+
+		wg.Done()
+	})()
+
+	wg.Wait()
+
+	// Close the proxy and ensure the background goroutines are terminated.
+	cache.Close()
+	time.Sleep(10 * time.Millisecond)
+}
+
+type fakeDatastore struct {
+	headRevision datastore.Revision
+
+	namespaces map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]
+	caveats    map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]
+
+	schemaChan chan *datastore.SchemaState
+	errChan    chan error
+
+	readsDisabled bool
+
+	lock sync.RWMutex
+}
+
+func (fds *fakeDatastore) updateNamespace(name string, def *corev1.NamespaceDefinition, revision datastore.Revision) {
+	fds.lock.Lock()
+	defer fds.lock.Unlock()
+
+	updateDef(fds.namespaces, name, def, def == nil, revision, fds.schemaChan)
+	fds.headRevision = revision
+}
+
+func (fds *fakeDatastore) updateCaveat(name string, def *corev1.CaveatDefinition, revision datastore.Revision) {
+	fds.lock.Lock()
+	defer fds.lock.Unlock()
+
+	updateDef(fds.caveats, name, def, def == nil, revision, fds.schemaChan)
+	fds.headRevision = revision
+}
+
+func (fds *fakeDatastore) sendCheckpoint(revision datastore.Revision) {
+	fds.schemaChan <- &datastore.SchemaState{
+		Revision:     revision,
+		IsCheckpoint: true,
+	}
+	time.Sleep(1 * time.Millisecond)
+}
+
+type fakeEntry[T datastore.RevisionedDefinition[Q], Q datastore.SchemaDefinition] struct {
+	value      T
+	wasDeleted bool
+}
+
+type revisionGetter[T datastore.SchemaDefinition] interface {
+	datastore.RevisionedDefinition[T]
+	GetLastWrittenRevision() datastore.Revision
+}
+
+func updateDef[T datastore.SchemaDefinition](
+	defs map[string][]fakeEntry[datastore.RevisionedDefinition[T], T],
+	name string,
+	def T,
+	isDelete bool,
+	revision datastore.Revision,
+	schemaChan chan *datastore.SchemaState,
+) {
+	slice, ok := defs[name]
+	if !ok {
+		slice = []fakeEntry[datastore.RevisionedDefinition[T], T]{}
+	}
+
+	slice = append(slice, fakeEntry[datastore.RevisionedDefinition[T], T]{
+		value: datastore.RevisionedDefinition[T]{
+			Definition:          def,
+			LastWrittenRevision: revision,
+		},
+		wasDeleted: isDelete,
+	})
+	defs[name] = slice
+
+	if isDelete {
+		schemaChan <- &datastore.SchemaState{
+			Revision:          revision,
+			DeletedNamespaces: []string{name},
+		}
+	} else {
+		schemaChan <- &datastore.SchemaState{
+			Revision:           revision,
+			ChangedDefinitions: []datastore.SchemaDefinition{def},
+		}
+	}
+	time.Sleep(1 * time.Millisecond)
+}
+
+func readDefs[T datastore.SchemaDefinition, Q revisionGetter[T]](defs map[string][]fakeEntry[Q, T], names []string, revision datastore.Revision) []Q {
+	results := make([]Q, 0, len(names))
+	for _, name := range names {
+		revisionedDefs, ok := defs[name]
+		if !ok {
+			continue
+		}
+
+		revisioned := []fakeEntry[Q, T]{}
+		for _, revisionedEntry := range revisionedDefs {
+			if revisionedEntry.value.GetLastWrittenRevision().LessThan(revision) || revisionedEntry.value.GetLastWrittenRevision().Equal(revision) {
+				revisioned = append(revisioned, revisionedEntry)
+			}
+		}
+
+		if len(revisioned) == 0 {
+			continue
+		}
+
+		slices.SortFunc(revisioned, func(a fakeEntry[Q, T], b fakeEntry[Q, T]) int {
+			if a.value.GetLastWrittenRevision().Equal(b.value.GetLastWrittenRevision()) {
+				return 0
+			}
+
+			if a.value.GetLastWrittenRevision().LessThan(b.value.GetLastWrittenRevision()) {
+				return -1
+			}
+
+			return 1
+		})
+
+		entry := revisioned[len(revisioned)-1]
+		if !entry.wasDeleted {
+			results = append(results, entry.value)
+		}
+	}
+
+	return results
+}
+
+func (fds *fakeDatastore) readNamespaces(names []string, revision datastore.Revision) ([]datastore.RevisionedNamespace, error) {
+	fds.lock.RLock()
+	defer fds.lock.RUnlock()
+
+	if fds.readsDisabled {
+		return nil, fmt.Errorf("reads are disabled")
+	}
+
+	return readDefs(fds.namespaces, names, revision), nil
+}
+
+func (fds *fakeDatastore) readCaveats(names []string, revision datastore.Revision) ([]datastore.RevisionedCaveat, error) {
+	fds.lock.RLock()
+	defer fds.lock.RUnlock()
+
+	if fds.readsDisabled {
+		return nil, fmt.Errorf("reads are disabled")
+	}
+
+	return readDefs(fds.caveats, names, revision), nil
+}
+
+func (fds *fakeDatastore) disableReads() {
+	fds.lock.Lock()
+	defer fds.lock.Unlock()
+
+	fds.readsDisabled = true
+}
+
+func (fds *fakeDatastore) enableReads() {
+	fds.lock.Lock()
+	defer fds.lock.Unlock()
+
+	fds.readsDisabled = false
+}
+
+func (fds *fakeDatastore) SnapshotReader(rev datastore.Revision) datastore.Reader {
+	return &fakeSnapshotReader{fds, rev}
+}
+
+func (fds *fakeDatastore) WatchSchema(context.Context, datastore.Revision) (<-chan *datastore.SchemaState, <-chan error) {
+	return fds.schemaChan, fds.errChan
+}
+
+func (fds *fakeDatastore) HeadRevision(context.Context) (datastore.Revision, error) {
+	fds.lock.RLock()
+	defer fds.lock.RUnlock()
+
+	return fds.headRevision, nil
+}
+
+func (*fakeDatastore) ReadWriteTx(context.Context, datastore.TxUserFunc, ...options.RWTOptionsOption) (datastore.Revision, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (*fakeDatastore) CheckRevision(context.Context, datastore.Revision) error {
+	return nil
+}
+
+func (*fakeDatastore) Close() error {
+	return nil
+}
+
+func (*fakeDatastore) Features(context.Context) (*datastore.Features, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (*fakeDatastore) OptimizedRevision(context.Context) (datastore.Revision, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (*fakeDatastore) ReadyState(context.Context) (datastore.ReadyState, error) {
+	return datastore.ReadyState{}, fmt.Errorf("not implemented")
+}
+
+func (*fakeDatastore) RevisionFromString(string) (datastore.Revision, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (*fakeDatastore) Statistics(context.Context) (datastore.Stats, error) {
+	return datastore.Stats{}, fmt.Errorf("not implemented")
+}
+
+func (*fakeDatastore) Watch(context.Context, datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
+	return nil, nil
+}
+
+type fakeSnapshotReader struct {
+	fds *fakeDatastore
+	rev datastore.Revision
+}
+
+func (fsr *fakeSnapshotReader) LookupNamespacesWithNames(_ context.Context, nsNames []string) ([]datastore.RevisionedDefinition[*corev1.NamespaceDefinition], error) {
+	return fsr.fds.readNamespaces(nsNames, fsr.rev)
+}
+
+func (fsr *fakeSnapshotReader) ReadNamespaceByName(_ context.Context, nsName string) (ns *corev1.NamespaceDefinition, lastWritten datastore.Revision, err error) {
+	namespaces, err := fsr.fds.readNamespaces([]string{nsName}, fsr.rev)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(namespaces) == 0 {
+		return nil, nil, datastore.NewNamespaceNotFoundErr(nsName)
+	}
+	return namespaces[0].Definition, namespaces[0].LastWrittenRevision, nil
+}
+
+func (fsr *fakeSnapshotReader) LookupCaveatsWithNames(_ context.Context, names []string) ([]datastore.RevisionedDefinition[*corev1.CaveatDefinition], error) {
+	return fsr.fds.readCaveats(names, fsr.rev)
+}
+
+func (fsr *fakeSnapshotReader) ReadCaveatByName(_ context.Context, name string) (caveat *corev1.CaveatDefinition, lastWritten datastore.Revision, err error) {
+	caveats, err := fsr.fds.readCaveats([]string{name}, fsr.rev)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(caveats) == 0 {
+		return nil, nil, datastore.NewCaveatNameNotFoundErr(name)
+	}
+	return caveats[0].Definition, caveats[0].LastWrittenRevision, nil
+}
+
+func (*fakeSnapshotReader) ListAllCaveats(context.Context) ([]datastore.RevisionedDefinition[*corev1.CaveatDefinition], error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (*fakeSnapshotReader) ListAllNamespaces(context.Context) ([]datastore.RevisionedDefinition[*corev1.NamespaceDefinition], error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (*fakeSnapshotReader) QueryRelationships(context.Context, datastore.RelationshipsFilter, ...options.QueryOptionsOption) (datastore.RelationshipIterator, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (*fakeSnapshotReader) ReverseQueryRelationships(context.Context, datastore.SubjectsFilter, ...options.ReverseQueryOptionsOption) (datastore.RelationshipIterator, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/pkg/cache/cache_ristretto.go
+++ b/pkg/cache/cache_ristretto.go
@@ -41,13 +41,13 @@ func NewCacheWithMetrics(name string, config *Config) (Cache, error) {
 
 	cache := wrapped{name, config, config.DefaultTTL, rcache}
 	mustRegisterCache(name, cache)
-	return cache, nil
+	return &cache, nil
 }
 
 // NewCache creates a new ristretto cache from the given config.
 func NewCache(config *Config) (Cache, error) {
 	rcache, err := ristretto.NewCache(ristrettoConfig(config))
-	return wrapped{"", config, config.DefaultTTL, rcache}, err
+	return &wrapped{"", config, config.DefaultTTL, rcache}, err
 }
 
 type wrapped struct {

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -70,6 +70,8 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	}
 	server.RegisterCacheFlags(cmd.Flags(), "ns-cache", &config.NamespaceCacheConfig, namespaceCacheDefaults)
 
+	cmd.Flags().BoolVar(&config.DisableWatchableSchemaCache, "disable-watchable-schema-cache", false, "disables the schema cache which makes use of the Watch API for automatic updates")
+
 	// Flags for parsing and validating schemas.
 	cmd.Flags().BoolVar(&config.SchemaPrefixesRequired, "schema-prefixes-required", false, "require prefixes on all object definitions in schemas")
 

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -52,6 +52,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.Datastore = c.Datastore
 		to.MaxCaveatContextSize = c.MaxCaveatContextSize
 		to.MaxRelationshipContextSize = c.MaxRelationshipContextSize
+		to.DisableWatchableSchemaCache = c.DisableWatchableSchemaCache
 		to.NamespaceCacheConfig = c.NamespaceCacheConfig
 		to.SchemaPrefixesRequired = c.SchemaPrefixesRequired
 		to.DispatchServer = c.DispatchServer
@@ -105,6 +106,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["Datastore"] = helpers.DebugValue(c.Datastore, false)
 	debugMap["MaxCaveatContextSize"] = helpers.DebugValue(c.MaxCaveatContextSize, false)
 	debugMap["MaxRelationshipContextSize"] = helpers.DebugValue(c.MaxRelationshipContextSize, false)
+	debugMap["DisableWatchableSchemaCache"] = helpers.DebugValue(c.DisableWatchableSchemaCache, false)
 	debugMap["NamespaceCacheConfig"] = helpers.DebugValue(c.NamespaceCacheConfig, false)
 	debugMap["SchemaPrefixesRequired"] = helpers.DebugValue(c.SchemaPrefixesRequired, false)
 	debugMap["DispatchServer"] = helpers.DebugValue(c.DispatchServer, false)
@@ -262,6 +264,13 @@ func WithMaxCaveatContextSize(maxCaveatContextSize int) ConfigOption {
 func WithMaxRelationshipContextSize(maxRelationshipContextSize int) ConfigOption {
 	return func(c *Config) {
 		c.MaxRelationshipContextSize = maxRelationshipContextSize
+	}
+}
+
+// WithDisableWatchableSchemaCache returns an option that can set DisableWatchableSchemaCache on a Config
+func WithDisableWatchableSchemaCache(disableWatchableSchemaCache bool) ConfigOption {
+	return func(c *Config) {
+		c.DisableWatchableSchemaCache = disableWatchableSchemaCache
 	}
 }
 


### PR DESCRIPTION
When supported by a datastore implementing the SchemaWatch method, the watching schema cache will proactively update its view of the schema in the background as updates come in, rather than reaching out to the datastore on the majority of requests.

The proxy will *still* fallback to reaching out to the datastore for namespace and caveats if:
 - An error has occurred in the watch
 - The requested revision is newer than the fully resolved view within the cache

This change only adds support for CRDB currently; Spanner support will be done as a followup

Addresses a portion of https://github.com/authzed/spicedb/issues/128