### PR TITLE
Change how dispatches are counted in LookupResources

### DIFF
--- a/internal/dispatch/graph/lookupresources_test.go
+++ b/internal/dispatch/graph/lookupresources_test.go
@@ -61,7 +61,7 @@ func TestSimpleLookupResources(t *testing.T) {
 				resolvedRes("masterplan"),
 			},
 			2,
-			2,
+			1,
 		},
 		{
 			RR("document", "owner"),
@@ -70,7 +70,7 @@ func TestSimpleLookupResources(t *testing.T) {
 				resolvedRes("masterplan"),
 			},
 			2,
-			1,
+			0,
 		},
 		{
 			RR("document", "view"),
@@ -80,7 +80,7 @@ func TestSimpleLookupResources(t *testing.T) {
 				resolvedRes("masterplan"),
 			},
 			6,
-			4,
+			3,
 		},
 		{
 			RR("document", "view_and_edit"),
@@ -99,7 +99,7 @@ func TestSimpleLookupResources(t *testing.T) {
 				resolvedRes("company"),
 			},
 			8,
-			5,
+			4,
 		},
 	}
 

--- a/internal/graph/computed/computecheck_test.go
+++ b/internal/graph/computed/computecheck_test.go
@@ -921,7 +921,7 @@ func TestComputeBulkCheck(t *testing.T) {
 			CaveatContext: nil,
 			AtRevision:    revision,
 			MaximumDepth:  50,
-			DebugOption:   computed.BasicDebuggingEnabled,
+			DebugOption:   computed.NoDebugging,
 		},
 		[]string{"direct", "first", "second", "third"},
 	)

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -97,3 +97,12 @@ func addCallToResponseMetadata(metadata *v1.ResponseMeta) *v1.ResponseMeta {
 		DebugInfo:           metadata.DebugInfo,
 	}
 }
+
+func addAdditionalDepthRequired(metadata *v1.ResponseMeta) *v1.ResponseMeta {
+	return &v1.ResponseMeta{
+		DispatchCount:       metadata.DispatchCount,
+		DepthRequired:       metadata.DepthRequired + 1,
+		CachedDispatchCount: metadata.CachedDispatchCount,
+		DebugInfo:           metadata.DebugInfo,
+	}
+}

--- a/internal/services/v1/permissions.go
+++ b/internal/services/v1/permissions.go
@@ -348,7 +348,7 @@ func (ps *permissionServer) LookupResources(req *v1.LookupResourcesRequest, resp
 	respMetadata := &dispatch.ResponseMeta{
 		DispatchCount:       1,
 		CachedDispatchCount: 0,
-		DepthRequired:       0,
+		DepthRequired:       1,
 		DebugInfo:           nil,
 	}
 	usagemetrics.SetInContext(ctx, respMetadata)


### PR DESCRIPTION
Before the cursoring change, LR and RR issued *batch* operations, with the batch dispatch counting as only a single dispatch. Following the cursoring change, which changed all results to be streamed back individually, the dispatch was counted in *every* result, which caused the aggregation to be MUCH larger than correct in the LookupResources API handler.

This change adds tests to ensure that the dispatch count is in line with expectations when using batching, and fixes the above issue by only counting the dispatch once on the first result streamed back. If the first result (or any subsequently) are filtered, then the dispatch count is "held" until another result is ready to be published and the count can be appended to that result. This does mean that we might get *lower* counts, but never higher.