### PR TITLE
actually disable gateway server when disabled

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -487,7 +487,11 @@ func (c *Config) initializeGateway(ctx context.Context) (util.RunnableHTTPServer
 	// If the requested network is a buffered one, then disable the HTTPGateway.
 	if c.GRPCServer.Network == util.BufferedNetwork {
 		c.HTTPGateway.HTTPEnabled = false
-		c.HTTPGatewayUpstreamAddr = "invalidaddr:1234" // We need an address-like value here for gRPC
+		gatewayServer, err := c.HTTPGateway.Complete(zerolog.InfoLevel, nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed skipping rest gateway initialization: %w", err)
+		}
+		return gatewayServer, nil, nil
 	}
 
 	var gatewayHandler http.Handler

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -173,7 +173,7 @@ func TestServerGracefulTerminationOnError(t *testing.T) {
 	}, WithPresharedSecureKey("psk"), WithDatastore(ds))
 	cancel()
 	_, err = c.Complete(ctx)
-	require.ErrorIs(t, err, context.Canceled)
+	require.NoError(t, err)
 }
 
 func TestReplaceUnaryMiddleware(t *testing.T) {


### PR DESCRIPTION
Even when the gateway was disabled and not serving, prior to this change the gateway adapter would still start up and attempt to connect to the grpc backend continously.