### PR TITLE
Change MySQL definition columns to LONGBLOB in prep for supporting larger definitions

### DIFF
--- a/internal/datastore/mysql/migrations/zz_migration.0006_convert_definitions_to_longblob.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0006_convert_definitions_to_longblob.go
@@ -1,0 +1,26 @@
+package migrations
+
+import "fmt"
+
+func convertNamespaceDefinitionToLongBlob(t *tables) string {
+	return fmt.Sprintf(`ALTER TABLE %s
+		MODIFY serialized_config LONGBLOB NOT NULL;`,
+		t.Namespace(),
+	)
+}
+
+func convertCaveatDefinitionToLongBlob(t *tables) string {
+	return fmt.Sprintf(`ALTER TABLE %s
+		MODIFY definition LONGBLOB NOT NULL;`,
+		t.Caveat(),
+	)
+}
+
+func init() {
+	mustRegisterMigration("longblob_definitions", "extend_object_id", noNonatomicMigration,
+		newStatementBatch(
+			convertNamespaceDefinitionToLongBlob,
+			convertCaveatDefinitionToLongBlob,
+		).execute,
+	)
+}


### PR DESCRIPTION
Part #1 of #1468

While each definition will not likely be super large, there is a definite need for larger individual definitions