### PR TITLE
switch to authzed/cel-go

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -17,6 +17,7 @@ require (
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
+	github.com/authzed/cel-go v0.17.5 // indirect
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/creasty/defaults v1.7.0 // indirect
 	github.com/dave/jennifer v1.6.1 // indirect
@@ -25,7 +26,6 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.0.2 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/cel-go v0.17.1 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.1 // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -7,6 +7,8 @@ github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/authzed/authzed-go v0.9.1-0.20230810180432-2fb0fd4c66dd h1:BXbTDI5wLsdGpEzH9uuyChgb/I3zOaDwgR3eFiCl0po=
 github.com/authzed/authzed-go v0.9.1-0.20230810180432-2fb0fd4c66dd/go.mod h1:9Pl5jDQJHrjbMDuCrsa+Q6Tqmi1f2pDdIn/qNGI++vA=
+github.com/authzed/cel-go v0.17.5 h1:lfpkNrR99B5QRHg5qdG9oLu/kguVlZC68VJuMk8tH9Y=
+github.com/authzed/cel-go v0.17.5/go.mod h1:XL/zEq5hKGVF8aOdMbG7w+BQPihLjY2W8N+UIygDA2I=
 github.com/authzed/grpcutil v0.0.0-20230703173955-bdd0ac3f16a5 h1:Fg92G8sNNODbNe2ckJoLeMEPeDqSfygmXnpEXDnVifU=
 github.com/authzed/grpcutil v0.0.0-20230703173955-bdd0ac3f16a5/go.mod h1:qx105brQubHFYLRja6wlHA+JB8DSK+yhb8uc8aFA5NQ=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -52,8 +54,6 @@ github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaW
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/google/cel-go v0.17.1 h1:s2151PDGy/eqpCI80/8dl4VL3xTkqI/YubXLXCFw0mw=
-github.com/google/cel-go v0.17.1/go.mod h1:HXZKzB0LXqer5lHHgfWAnlYwJaQBDKMjxjulNQzhwhY=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/IBM/pgxpoolprometheus v1.1.1
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/authzed/authzed-go v0.9.1-0.20230810180432-2fb0fd4c66dd
+	github.com/authzed/cel-go v0.17.5
 	github.com/authzed/consistent v0.1.0
 	github.com/authzed/grpcutil v0.0.0-20230703173955-bdd0ac3f16a5
 	github.com/aws/aws-sdk-go v1.44.314
@@ -29,7 +30,6 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.4
 	github.com/golangci/golangci-lint v1.53.3
-	github.com/google/cel-go v0.17.1
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v43 v43.0.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -455,6 +455,8 @@ github.com/ashanbrown/makezero v1.1.1 h1:iCQ87C0V0vSyO+M9E/FZYbu65auqH0lnsOkf5Fc
 github.com/ashanbrown/makezero v1.1.1/go.mod h1:i1bJLCRSCHOcOa9Y6MyF2FTfMZMFdHvxKHxgO5Z1axI=
 github.com/authzed/authzed-go v0.9.1-0.20230810180432-2fb0fd4c66dd h1:BXbTDI5wLsdGpEzH9uuyChgb/I3zOaDwgR3eFiCl0po=
 github.com/authzed/authzed-go v0.9.1-0.20230810180432-2fb0fd4c66dd/go.mod h1:9Pl5jDQJHrjbMDuCrsa+Q6Tqmi1f2pDdIn/qNGI++vA=
+github.com/authzed/cel-go v0.17.5 h1:lfpkNrR99B5QRHg5qdG9oLu/kguVlZC68VJuMk8tH9Y=
+github.com/authzed/cel-go v0.17.5/go.mod h1:XL/zEq5hKGVF8aOdMbG7w+BQPihLjY2W8N+UIygDA2I=
 github.com/authzed/consistent v0.1.0 h1:tlh1wvKoRbjRhMm2P+X5WQQyR54SRoS4MyjLOg17Mp8=
 github.com/authzed/consistent v0.1.0/go.mod h1:plwHlrN/EJUCwQ+Bca0MhM1KnisPs7HEkZI5giCXrcc=
 github.com/authzed/grpcutil v0.0.0-20230703173955-bdd0ac3f16a5 h1:Fg92G8sNNODbNe2ckJoLeMEPeDqSfygmXnpEXDnVifU=
@@ -728,8 +730,6 @@ github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 h1:zwtduBRr5SSW
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg8RkN3rCIMLGE9CyYmU9pY2Jer6DgANEnZ/L/cQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/cel-go v0.17.1 h1:s2151PDGy/eqpCI80/8dl4VL3xTkqI/YubXLXCFw0mw=
-github.com/google/cel-go v0.17.1/go.mod h1:HXZKzB0LXqer5lHHgfWAnlYwJaQBDKMjxjulNQzhwhY=
 github.com/google/gnostic v0.6.9 h1:ZK/5VhkoX835RikCHpSUJV9a+S3e1zLh59YnyWeBW+0=
 github.com/google/gnostic v0.6.9/go.mod h1:Nm8234We1lq6iB9OmlgNv3nH91XLLVZHCDayfA3xq+E=
 github.com/google/go-cmdtest v0.4.1-0.20220921163831-55ab3332a786 h1:rcv+Ippz6RAtvaGgKxc+8FQIpxHgsF+HBzPyYL2cyVU=

--- a/magefiles/deps.go
+++ b/magefiles/deps.go
@@ -13,7 +13,7 @@ type Deps mg.Namespace
 // Tidy go mod tidy all go modules
 func (Deps) Tidy() error {
 	for _, mod := range goModules {
-		if err := RunSh("go", WithDir(mod))("mod", "tidy"); err != nil {
+		if err := RunSh("go", WithDir(mod), WithV())("mod", "tidy"); err != nil {
 			return err
 		}
 	}
@@ -24,11 +24,11 @@ func (Deps) Tidy() error {
 // Update go get -u all go dependencies
 func (Deps) Update() error {
 	for _, mod := range goModules {
-		if err := RunSh("go", WithDir(mod))("get", "-u", "-t", "-tags", "ci,tools", "./..."); err != nil {
+		if err := RunSh("go", WithDir(mod), WithV())("get", "-u", "-t", "-tags", "ci,tools", "./..."); err != nil {
 			return err
 		}
 
-		if err := RunSh("go", WithDir(mod))("mod", "tidy"); err != nil {
+		if err := RunSh("go", WithDir(mod), WithV())("mod", "tidy"); err != nil {
 			return err
 		}
 	}

--- a/pkg/caveats/compile.go
+++ b/pkg/caveats/compile.go
@@ -3,8 +3,8 @@ package caveats
 import (
 	"fmt"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common"
+	"github.com/authzed/cel-go/cel"
+	"github.com/authzed/cel-go/common"
 
 	"github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"

--- a/pkg/caveats/env.go
+++ b/pkg/caveats/env.go
@@ -3,7 +3,7 @@ package caveats
 import (
 	"fmt"
 
-	"github.com/google/cel-go/cel"
+	"github.com/authzed/cel-go/cel"
 
 	"github.com/authzed/spicedb/pkg/caveats/types"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"

--- a/pkg/caveats/errors.go
+++ b/pkg/caveats/errors.go
@@ -3,7 +3,7 @@ package caveats
 import (
 	"strconv"
 
-	"github.com/google/cel-go/cel"
+	"github.com/authzed/cel-go/cel"
 	"github.com/rs/zerolog"
 )
 

--- a/pkg/caveats/eval.go
+++ b/pkg/caveats/eval.go
@@ -5,10 +5,10 @@ import (
 
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter"
+	"github.com/authzed/cel-go/cel"
+	"github.com/authzed/cel-go/common/types"
+	"github.com/authzed/cel-go/common/types/ref"
+	"github.com/authzed/cel-go/interpreter"
 )
 
 // EvaluationConfig is configuration given to an EvaluateCaveatWithConfig call.

--- a/pkg/caveats/eval_test.go
+++ b/pkg/caveats/eval_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/cel-go/cel"
+	"github.com/authzed/cel-go/cel"
 	"github.com/stretchr/testify/require"
 
 	"github.com/authzed/spicedb/pkg/caveats/types"

--- a/pkg/caveats/source.go
+++ b/pkg/caveats/source.go
@@ -3,7 +3,7 @@ package caveats
 import (
 	"strings"
 
-	"github.com/google/cel-go/common"
+	"github.com/authzed/cel-go/common"
 )
 
 // SourcePosition is an incoming source position.

--- a/pkg/caveats/types/basic.go
+++ b/pkg/caveats/types/basic.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 
-	"github.com/google/cel-go/cel"
+	"github.com/authzed/cel-go/cel"
 )
 
 func requireType[T any](value any) (any, error) {

--- a/pkg/caveats/types/ipaddress.go
+++ b/pkg/caveats/types/ipaddress.go
@@ -5,9 +5,9 @@ import (
 	"net/netip"
 	"reflect"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
+	"github.com/authzed/cel-go/cel"
+	"github.com/authzed/cel-go/common/types"
+	"github.com/authzed/cel-go/common/types/ref"
 )
 
 // ParseIPAddress parses the string form of an IP Address into an IPAddress object type.

--- a/pkg/caveats/types/map.go
+++ b/pkg/caveats/types/map.go
@@ -1,9 +1,9 @@
 package types
 
 import (
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
+	"github.com/authzed/cel-go/cel"
+	"github.com/authzed/cel-go/common/types"
+	"github.com/authzed/cel-go/common/types/ref"
 )
 
 func init() {

--- a/pkg/caveats/types/registration.go
+++ b/pkg/caveats/types/registration.go
@@ -3,8 +3,8 @@ package types
 import (
 	"fmt"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types/ref"
+	"github.com/authzed/cel-go/cel"
+	"github.com/authzed/cel-go/common/types/ref"
 )
 
 var definitions = map[string]typeDefinition{}

--- a/pkg/caveats/types/types.go
+++ b/pkg/caveats/types/types.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	"github.com/google/cel-go/cel"
+	"github.com/authzed/cel-go/cel"
 )
 
 // VariableType defines the supported types of variables in caveats.

--- a/tools/analyzers/go.work.sum
+++ b/tools/analyzers/go.work.sum
@@ -1,4 +1,5 @@
 github.com/authzed/authzed-go v0.9.1-0.20230727112349-acfb99d1263b/go.mod h1:9Pl5jDQJHrjbMDuCrsa+Q6Tqmi1f2pDdIn/qNGI++vA=
+github.com/authzed/cel-go v0.17.3/go.mod h1:XL/zEq5hKGVF8aOdMbG7w+BQPihLjY2W8N+UIygDA2I=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=


### PR DESCRIPTION
cel-go introduced breaking changes in v1.17, which SpiceDB now depends on. But cel-go is a common dependency in several go projects, most notably Kubernetes (which is still on 0.16.0)

Migrating to a fork allows SpiceDB to avoid conflicts with other dependencies that use cel-go.

This should be a temporary change unless cel-go continues to make breaking API changes.