### PR TITLE
changes logging level for logger used during startup

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -26,7 +26,7 @@ func main() {
 	// Enable consistent hashring gRPC load balancer
 	balancer.Register(cmdutil.ConsistentHashringBuilder)
 
-	log.SetGlobalLogger(zerolog.New(os.Stderr))
+	log.SetGlobalLogger(zerolog.New(os.Stderr).Level(zerolog.InfoLevel))
 
 	// Create a root command
 	rootCmd := cmd.NewRootCommand("spicedb")


### PR DESCRIPTION
recent changes to `cobrautil` caused the startup to be very verbose because anything that happens before `cobrautil` was logged with level `trace`