### PR TITLE
makes paginatedIterator.Close() idempotent

### DIFF
--- a/pkg/datastore/pagination/iterator.go
+++ b/pkg/datastore/pagination/iterator.go
@@ -116,5 +116,7 @@ func (pi *paginatedIterator) Err() error {
 
 func (pi *paginatedIterator) Close() {
 	pi.closed = true
-	pi.delegate.Close()
+	if pi.delegate != nil {
+		pi.delegate.Close()
+	}
 }


### PR DESCRIPTION
There are scenarios where a paginated iterator may fail to fetch a page from the database after previous successes. This would lead to a runtime panic because the delegate `datastore.RelationshipIterator` could be nil due to an error in `startNewBatch()`, and any call to `paginatedIterator.Close()` would attempt to call `Close()` on a nil delegate.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x17e6129]

goroutine 8271694 [running]:
github.com/authzed/spicedb/pkg/datastore/pagination.(*paginatedIterator).Close(0xc0057da3f0?)
	/go/pkg/mod/github.com/authzed/spicedb@v1.23.0/pkg/datastore/pagination/iterator.go:119 +0x29
github.com/authzed/spicedb/internal/services/v1.(*permissionServer).ReadRelationships(0xc00048b540, 0xc0064e44b0, {0x36fd610, 0xc0035ab7d0})
	/go/pkg/mod/github.com/authzed/spicedb@v1.23.0/internal/services/v1/relationships.go:241 +0xd4b
github.com/authzed/authzed-go/proto/authzed/api/v1._PermissionsService_ReadRelationships_Handler({0x2ec7480?, 0xc00048b540}, {0x36f9300, 0xc0025ddbc0})
	/go/pkg/mod/github.com/authzed/authzed-go@v0.9.0/proto/authzed/api/v1/permission_service_grpc.pb.go:277 +0xd0
github.com/authzed/spicedb/internal/middleware/streamtimeout.MustStreamServerInterceptor.func1({0x2ec7480, 0xc00048b540}, {0x36f9c48, 0xc0025ddb30}, 
```