### PR TITLE
Invert the flag for the new schema watching cache

### DIFF
--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -70,7 +70,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	}
 	server.RegisterCacheFlags(cmd.Flags(), "ns-cache", &config.NamespaceCacheConfig, namespaceCacheDefaults)
 
-	cmd.Flags().BoolVar(&config.DisableWatchableSchemaCache, "disable-watchable-schema-cache", false, "disables the schema cache which makes use of the Watch API for automatic updates")
+	cmd.Flags().BoolVar(&config.EnableExperimentalWatchableSchemaCache, "enable-experimental-watchable-schema-cache", false, "enables the experimental schema cache which makes use of the Watch API for automatic updates")
 
 	// Flags for parsing and validating schemas.
 	cmd.Flags().BoolVar(&config.SchemaPrefixesRequired, "schema-prefixes-required", false, "require prefixes on all object definitions in schemas")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -75,8 +75,8 @@ type Config struct {
 	MaxRelationshipContextSize int `debugmap:"visible" default:"25_000"`
 
 	// Namespace cache
-	DisableWatchableSchemaCache bool        `debugmap:"visible"`
-	NamespaceCacheConfig        CacheConfig `debugmap:"visible"`
+	EnableExperimentalWatchableSchemaCache bool        `debugmap:"visible"`
+	NamespaceCacheConfig                   CacheConfig `debugmap:"visible"`
 
 	// Schema options
 	SchemaPrefixesRequired bool `debugmap:"visible"`
@@ -218,9 +218,9 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 	}
 	log.Ctx(ctx).Info().EmbedObject(nscc).Msg("configured namespace cache")
 
-	cachingMode := schemacaching.WatchIfSupported
-	if c.DisableWatchableSchemaCache {
-		cachingMode = schemacaching.JustInTimeCaching
+	cachingMode := schemacaching.JustInTimeCaching
+	if c.EnableExperimentalWatchableSchemaCache {
+		cachingMode = schemacaching.WatchIfSupported
 	}
 
 	ds = schemacaching.NewCachingDatastoreProxy(ds, nscc, c.DatastoreConfig.GCWindow, cachingMode)

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -52,7 +52,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.Datastore = c.Datastore
 		to.MaxCaveatContextSize = c.MaxCaveatContextSize
 		to.MaxRelationshipContextSize = c.MaxRelationshipContextSize
-		to.DisableWatchableSchemaCache = c.DisableWatchableSchemaCache
+		to.EnableExperimentalWatchableSchemaCache = c.EnableExperimentalWatchableSchemaCache
 		to.NamespaceCacheConfig = c.NamespaceCacheConfig
 		to.SchemaPrefixesRequired = c.SchemaPrefixesRequired
 		to.DispatchServer = c.DispatchServer
@@ -106,7 +106,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["Datastore"] = helpers.DebugValue(c.Datastore, false)
 	debugMap["MaxCaveatContextSize"] = helpers.DebugValue(c.MaxCaveatContextSize, false)
 	debugMap["MaxRelationshipContextSize"] = helpers.DebugValue(c.MaxRelationshipContextSize, false)
-	debugMap["DisableWatchableSchemaCache"] = helpers.DebugValue(c.DisableWatchableSchemaCache, false)
+	debugMap["EnableExperimentalWatchableSchemaCache"] = helpers.DebugValue(c.EnableExperimentalWatchableSchemaCache, false)
 	debugMap["NamespaceCacheConfig"] = helpers.DebugValue(c.NamespaceCacheConfig, false)
 	debugMap["SchemaPrefixesRequired"] = helpers.DebugValue(c.SchemaPrefixesRequired, false)
 	debugMap["DispatchServer"] = helpers.DebugValue(c.DispatchServer, false)
@@ -267,10 +267,10 @@ func WithMaxRelationshipContextSize(maxRelationshipContextSize int) ConfigOption
 	}
 }
 
-// WithDisableWatchableSchemaCache returns an option that can set DisableWatchableSchemaCache on a Config
-func WithDisableWatchableSchemaCache(disableWatchableSchemaCache bool) ConfigOption {
+// WithEnableExperimentalWatchableSchemaCache returns an option that can set EnableExperimentalWatchableSchemaCache on a Config
+func WithEnableExperimentalWatchableSchemaCache(enableExperimentalWatchableSchemaCache bool) ConfigOption {
 	return func(c *Config) {
-		c.DisableWatchableSchemaCache = disableWatchableSchemaCache
+		c.EnableExperimentalWatchableSchemaCache = enableExperimentalWatchableSchemaCache
 	}
 }
 


### PR DESCRIPTION
This will keep it disabled by default until the recent found issue is resolved