### PR TITLE
Fixes for the watching schema cache

### DIFF
--- a/internal/datastore/proxy/schemacaching/caching.go
+++ b/internal/datastore/proxy/schemacaching/caching.go
@@ -69,5 +69,5 @@ func NewCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache, gcWin
 		}
 	}
 
-	return createWatchingCacheProxy(watchable, gcWindow)
+	return createWatchingCacheProxy(watchable, c, gcWindow)
 }

--- a/internal/datastore/proxy/schemacaching/standardcache.go
+++ b/internal/datastore/proxy/schemacaching/standardcache.go
@@ -175,7 +175,7 @@ func readAndCache[T schemaDefinition](
 			// sever the context so that another branch doesn't cancel the
 			// single-flighted read
 			loaded, updatedRev, err := reader(internaldatastore.SeparateContextWithTracing(ctx), name)
-			if err != nil && !errors.Is(err, &datastore.ErrNamespaceNotFound{}) && !errors.Is(err, &datastore.ErrCaveatNameNotFound{}) {
+			if err != nil && !errors.As(err, &datastore.ErrNamespaceNotFound{}) && !errors.As(err, &datastore.ErrCaveatNameNotFound{}) {
 				// Propagate this error to the caller
 				return nil, err
 			}
@@ -187,7 +187,6 @@ func readAndCache[T schemaDefinition](
 			// We have to call wait here or else Ristretto may not have the key
 			// available to a subsequent caller.
 			r.p.c.Wait()
-
 			return entry, nil
 		})
 		if err != nil {


### PR DESCRIPTION
1) Make sure to use the *caching* datastore proxy as the fallback, as opposed to always reading
2) Prepopulate the definition caches so that the watching cache can function on existing schema without a WriteSchema call being necessary
3) Add tests for the above and fix a discovered issue in the existing caching proxy around error type checking