### PR TITLE
Fix a panic in Postgres revision parsing for incompatible ZedTokens

### DIFF
--- a/internal/datastore/postgres/revisions_test.go
+++ b/internal/datastore/postgres/revisions_test.go
@@ -162,6 +162,11 @@ func TestCombinedRevisionParsing(t *testing.T) {
 	}
 }
 
+func TestBrokenInvalidRevision(t *testing.T) {
+	_, err := parseRevision("1693540940373045727.0000000001")
+	require.Error(t, err)
+}
+
 func FuzzRevision(f *testing.F) {
 	// Attempt to find a decimal revision that is a valid base64 encoded proto revision
 	f.Add(uint64(0), -1)

--- a/pkg/zedtoken/zedtoken_test.go
+++ b/pkg/zedtoken/zedtoken_test.go
@@ -113,6 +113,18 @@ var decodeTests = []struct {
 		expectedRevision: decimal.New(12345, -2),
 		expectError:      false,
 	},
+	{
+		format: "V1 ZedToken",
+		token:  "GiAKHjE2OTM1NDA5NDAzNzMwNDU3MjcuMDAwMDAwMDAwMQ==",
+		expectedRevision: (func() decimal.Decimal {
+			v, err := decimal.NewFromString("1693540940373045727.0000000001")
+			if err != nil {
+				panic(err)
+			}
+			return v
+		})(),
+		expectError: false,
+	},
 }
 
 func TestDecode(t *testing.T) {


### PR DESCRIPTION
If Postgres is passed a ZedToken from CRDB, it will (incorrectly) interpret the token and try to create a slice with too much capacity. This change caps the delta on the transaction IDs and returns an error in that scenario

Fixes #1539