### PR TITLE
Add new index to postgres datastore

### DIFF
--- a/internal/datastore/postgres/migrations/zz_migration.0016_add_tuned_gc_index.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0016_add_tuned_gc_index.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const createTunedGCIndex = `CREATE INDEX CONCURRENTLY 
+	IF NOT EXISTS ix_gc_index
+	ON relation_tuple (deleted_xid DESC)
+    WHERE deleted_xid < '9223372036854775807'::xid8;`
+
+const deleteSuboptimalGCIndex = `DROP INDEX CONCURRENTLY IF EXISTS ix_relation_tuple_by_deleted_xid`
+
+func init() {
+	if err := DatabaseMigrations.Register("add-tuned-gc-index", "add-gc-covering-index",
+		func(ctx context.Context, conn *pgx.Conn) error {
+			if _, err := conn.Exec(ctx, createTunedGCIndex); err != nil {
+				return fmt.Errorf("failed to create new tuned GC Index: %w", err)
+			}
+			if _, err := conn.Exec(ctx, deleteSuboptimalGCIndex); err != nil {
+				return fmt.Errorf("failed to remove old GC Index: %w", err)
+			}
+			if _, err := conn.Exec(ctx, "ANALYZE relation_tuple"); err != nil {
+				return fmt.Errorf("failed to update relation_tuple table statistics after new index: %w", err)
+			}
+			return nil
+		},
+		noTxMigration); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}


### PR DESCRIPTION
This adds 1 new indexes to optimize:
- GC operations

⚠️ important! This index will not be selected by the query planner in PG 13 and 14 due to the usage of the `xid8` type 

## [add tuned GC index](https://github.com/authzed/spicedb/commit/6fb514fe065a64e7085fe2d3c5da6bb776f02595) 

the original GC index was rarely selected
when GC'ing relations with millions of relationships.
This caused a sequential scan that could load potentially
Gigabytes worth of data, and overload the database.

⚠️ Postgres 13 and 14 do not correctly select this new index
because the query planner struggles with the xid8 datatype.
Postgres 15 will be needed for this index to
actually work. For scenarios where relations aren't very wide,
older PG versions may have an acceptable query latency for GC,
but we strongly recommend moving to PG15.

This migration also deletes the old suboptimal index after
the new one is created.
