### PR TITLE
Order onr comparisons by cardinality for short-circuiting

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -203,7 +203,7 @@ func onrEqual(lhs, rhs *core.ObjectAndRelation) bool {
 }
 
 func onrEqualOrWildcard(tpl, target *core.ObjectAndRelation) bool {
-	return onrEqual(tpl, target) || (tpl.Namespace == target.Namespace && tpl.ObjectId == tuple.PublicWildcard)
+	return onrEqual(tpl, target) || (tpl.ObjectId == tuple.PublicWildcard && tpl.Namespace == target.Namespace)
 }
 
 type directDispatch struct {


### PR DESCRIPTION
This is a small optimization that carries forward the idea set in [onrEqual](https://github.com/authzed/spicedb/blob/846f79e3b9fb86c04a59037ab25a0280e0f7090a/internal/graph/check.go#L202). The comparisons are swapped so that the higher cardinality check happens first to allow for faster short-circuiting.