### PR TITLE
Increase allowable timeout on memdb panic test

### DIFF
--- a/internal/datastore/memdb/memdb_test.go
+++ b/internal/datastore/memdb/memdb_test.go
@@ -76,7 +76,7 @@ func TestConcurrentWritePanic(t *testing.T) {
 			return g.Wait()
 		})
 		return numPanics > 0
-	}, 1*time.Second, 10*time.Millisecond)
+	}, 3*time.Second, 10*time.Millisecond)
 	require.ErrorIs(err, recoverErr)
 }
 


### PR DESCRIPTION
CI runner can be slower and cause this to timeout

Fixes #1560