### PR TITLE
introduces an index to speed up Watch API calls

### DIFF
--- a/internal/datastore/mysql/migrations/zz_migration.0007_watch_api_rel_tuple_index.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0007_watch_api_rel_tuple_index.go
@@ -1,0 +1,17 @@
+package migrations
+
+import "fmt"
+
+func addWatchAPIIndex(t *tables) string {
+	return fmt.Sprintf(`CREATE INDEX ix_relation_tuple_watch
+    ON %s (created_transaction, deleted_transaction DESC);`, t.RelationTuple(),
+	)
+}
+
+func init() {
+	mustRegisterMigration("watch_api_relation_tuple_index", "longblob_definitions", noNonatomicMigration,
+		newStatementBatch(
+			addWatchAPIIndex,
+		).execute,
+	)
+}


### PR DESCRIPTION
Closes https://github.com/authzed/spicedb/issues/1543

See more details at https://github.com/authzed/spicedb/issues/1543#issuecomment-1744739489

This PR adds a new index to avoid sequential scans caused by the access patterns used in Watch API implementation