### PR TITLE
Extract the type system and reachability graph into pkg

### DIFF
--- a/internal/namespace/aliasing.go
+++ b/internal/namespace/aliasing.go
@@ -2,17 +2,19 @@ package namespace
 
 import (
 	"sort"
+
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 // computePermissionAliases computes a map of aliases between the various permissions in a
 // namespace. A permission is considered an alias if it *directly* refers to another permission
 // or relation without any other form of expression.
-func computePermissionAliases(typeSystem *ValidatedNamespaceTypeSystem) (map[string]string, error) {
+func computePermissionAliases(typeSystem *typesystem.ValidatedNamespaceTypeSystem) (map[string]string, error) {
 	aliases := map[string]string{}
 	done := map[string]struct{}{}
 	unresolvedAliases := map[string]string{}
 
-	for _, rel := range typeSystem.nsDef.Relation {
+	for _, rel := range typeSystem.Namespace().Relation {
 		// Ensure the relation has a rewrite...
 		if rel.GetUsersetRewrite() == nil {
 			done[rel.Name] = struct{}{}
@@ -72,7 +74,7 @@ func computePermissionAliases(typeSystem *ValidatedNamespaceTypeSystem) (map[str
 				keys = append(keys, key)
 			}
 			sort.Strings(keys)
-			return nil, NewPermissionsCycleErr(typeSystem.nsDef.Name, keys)
+			return nil, NewPermissionsCycleErr(typeSystem.Namespace().Name, keys)
 		}
 	}
 

--- a/internal/namespace/aliasing_test.go
+++ b/internal/namespace/aliasing_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/typesystem"
 
 	"github.com/authzed/spicedb/internal/datastore/memdb"
 	ns "github.com/authzed/spicedb/pkg/namespace"
@@ -200,7 +201,7 @@ func TestAliasing(t *testing.T) {
 			lastRevision, err := ds.HeadRevision(context.Background())
 			require.NoError(err)
 
-			ts, err := NewNamespaceTypeSystem(tc.toCheck, ResolverForDatastoreReader(ds.SnapshotReader(lastRevision)))
+			ts, err := typesystem.NewNamespaceTypeSystem(tc.toCheck, typesystem.ResolverForDatastoreReader(ds.SnapshotReader(lastRevision)))
 			require.NoError(err)
 
 			ctx := context.Background()

--- a/internal/namespace/annotate.go
+++ b/internal/namespace/annotate.go
@@ -1,8 +1,10 @@
 package namespace
 
+import "github.com/authzed/spicedb/pkg/typesystem"
+
 // AnnotateNamespace annotates the namespace in the type system with computed aliasing and cache key
 // metadata for more efficient dispatching.
-func AnnotateNamespace(ts *ValidatedNamespaceTypeSystem) error {
+func AnnotateNamespace(ts *typesystem.ValidatedNamespaceTypeSystem) error {
 	aliases, aerr := computePermissionAliases(ts)
 	if aerr != nil {
 		return aerr
@@ -13,7 +15,7 @@ func AnnotateNamespace(ts *ValidatedNamespaceTypeSystem) error {
 		return cerr
 	}
 
-	for _, rel := range ts.nsDef.Relation {
+	for _, rel := range ts.Namespace().Relation {
 		if alias, ok := aliases[rel.Name]; ok {
 			rel.AliasingRelation = alias
 		}

--- a/internal/namespace/annotate_test.go
+++ b/internal/namespace/annotate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/authzed/spicedb/internal/datastore/memdb"
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 func TestAnnotateNamespace(t *testing.T) {
@@ -35,7 +36,7 @@ func TestAnnotateNamespace(t *testing.T) {
 	lastRevision, err := ds.HeadRevision(context.Background())
 	require.NoError(err)
 
-	ts, err := NewNamespaceTypeSystem(compiled.ObjectDefinitions[0], ResolverForDatastoreReader(ds.SnapshotReader(lastRevision)))
+	ts, err := typesystem.NewNamespaceTypeSystem(compiled.ObjectDefinitions[0], typesystem.ResolverForDatastoreReader(ds.SnapshotReader(lastRevision)))
 	require.NoError(err)
 
 	ctx := context.Background()
@@ -45,13 +46,13 @@ func TestAnnotateNamespace(t *testing.T) {
 	aerr := AnnotateNamespace(vts)
 	require.NoError(aerr)
 
-	require.NotEmpty(ts.relationMap["aliased"].AliasingRelation)
-	require.NotEmpty(ts.relationMap["also_aliased"].AliasingRelation)
-	require.Empty(ts.relationMap["computed"].AliasingRelation)
-	require.Empty(ts.relationMap["other"].AliasingRelation)
+	require.NotEmpty(ts.MustGetRelation("aliased").AliasingRelation)
+	require.NotEmpty(ts.MustGetRelation("also_aliased").AliasingRelation)
+	require.Empty(ts.MustGetRelation("computed").AliasingRelation)
+	require.Empty(ts.MustGetRelation("other").AliasingRelation)
 
-	require.NotEmpty(ts.relationMap["also_aliased"].CanonicalCacheKey)
-	require.NotEmpty(ts.relationMap["aliased"].CanonicalCacheKey)
-	require.NotEmpty(ts.relationMap["computed"].CanonicalCacheKey)
-	require.NotEmpty(ts.relationMap["other"].CanonicalCacheKey)
+	require.NotEmpty(ts.MustGetRelation("also_aliased").CanonicalCacheKey)
+	require.NotEmpty(ts.MustGetRelation("aliased").CanonicalCacheKey)
+	require.NotEmpty(ts.MustGetRelation("computed").CanonicalCacheKey)
+	require.NotEmpty(ts.MustGetRelation("other").CanonicalCacheKey)
 }

--- a/internal/namespace/canonicalization.go
+++ b/internal/namespace/canonicalization.go
@@ -5,6 +5,7 @@ import (
 	"hash/fnv"
 
 	"github.com/authzed/spicedb/pkg/spiceerrors"
+	"github.com/authzed/spicedb/pkg/typesystem"
 
 	"github.com/dalzilio/rudd"
 
@@ -54,8 +55,8 @@ const computedKeyPrefix = "%"
 // canonical representation of the binary expression. These hashes can then be used for caching,
 // representing the same *logical* expressions for a permission, even if the relations have
 // different names.
-func computeCanonicalCacheKeys(typeSystem *ValidatedNamespaceTypeSystem, aliasMap map[string]string) (map[string]string, error) {
-	varMap, err := buildBddVarMap(typeSystem.nsDef.Relation, aliasMap)
+func computeCanonicalCacheKeys(typeSystem *typesystem.ValidatedNamespaceTypeSystem, aliasMap map[string]string) (map[string]string, error) {
+	varMap, err := buildBddVarMap(typeSystem.Namespace().Relation, aliasMap)
 	if err != nil {
 		return nil, err
 	}
@@ -70,8 +71,8 @@ func computeCanonicalCacheKeys(typeSystem *ValidatedNamespaceTypeSystem, aliasMa
 	}
 
 	// For each permission, build a canonicalized cache key based on its expression.
-	cacheKeys := make(map[string]string, len(typeSystem.nsDef.Relation))
-	for _, rel := range typeSystem.nsDef.Relation {
+	cacheKeys := make(map[string]string, len(typeSystem.Namespace().Relation))
+	for _, rel := range typeSystem.Namespace().Relation {
 		rewrite := rel.GetUsersetRewrite()
 		if rewrite == nil {
 			// If the relation has no rewrite (making it a pure relation), then its canonical

--- a/internal/namespace/canonicalization_test.go
+++ b/internal/namespace/canonicalization_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/typesystem"
 
 	"github.com/authzed/spicedb/internal/datastore/memdb"
 	ns "github.com/authzed/spicedb/pkg/namespace"
@@ -389,7 +390,7 @@ func TestCanonicalization(t *testing.T) {
 			lastRevision, err := ds.HeadRevision(context.Background())
 			require.NoError(err)
 
-			ts, err := NewNamespaceTypeSystem(tc.toCheck, ResolverForDatastoreReader(ds.SnapshotReader(lastRevision)))
+			ts, err := typesystem.NewNamespaceTypeSystem(tc.toCheck, typesystem.ResolverForDatastoreReader(ds.SnapshotReader(lastRevision)))
 			require.NoError(err)
 
 			vts, terr := ts.Validate(ctx)
@@ -524,7 +525,7 @@ func TestCanonicalizationComparison(t *testing.T) {
 			lastRevision, err := ds.HeadRevision(context.Background())
 			require.NoError(err)
 
-			ts, err := NewNamespaceTypeSystem(compiled.ObjectDefinitions[0], ResolverForDatastoreReader(ds.SnapshotReader(lastRevision)))
+			ts, err := typesystem.NewNamespaceTypeSystem(compiled.ObjectDefinitions[0], typesystem.ResolverForDatastoreReader(ds.SnapshotReader(lastRevision)))
 			require.NoError(err)
 
 			vts, terr := ts.Validate(ctx)

--- a/internal/namespace/caveats.go
+++ b/internal/namespace/caveats.go
@@ -8,6 +8,7 @@ import (
 	"github.com/authzed/spicedb/pkg/caveats"
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 // ValidateCaveatDefinition validates the parameters and types within the given caveat
@@ -16,7 +17,7 @@ func ValidateCaveatDefinition(caveat *core.CaveatDefinition) error {
 	// Ensure all parameters are used by the caveat expression itself.
 	parameterTypes, err := caveattypes.DecodeParameterTypes(caveat.ParameterTypes)
 	if err != nil {
-		return newTypeErrorWithSource(
+		return typesystem.NewTypeErrorWithSource(
 			fmt.Errorf("could not decode caveat parameters `%s`: %w", caveat.Name, err),
 			caveat,
 			caveat.Name,
@@ -25,7 +26,7 @@ func ValidateCaveatDefinition(caveat *core.CaveatDefinition) error {
 
 	deserialized, err := caveats.DeserializeCaveat(caveat.SerializedExpression, parameterTypes)
 	if err != nil {
-		return newTypeErrorWithSource(
+		return typesystem.NewTypeErrorWithSource(
 			fmt.Errorf("could not decode caveat `%s`: %w", caveat.Name, err),
 			caveat,
 			caveat.Name,
@@ -33,7 +34,7 @@ func ValidateCaveatDefinition(caveat *core.CaveatDefinition) error {
 	}
 
 	if len(caveat.ParameterTypes) == 0 {
-		return newTypeErrorWithSource(
+		return typesystem.NewTypeErrorWithSource(
 			fmt.Errorf("caveat `%s` must have at least one parameter defined", caveat.Name),
 			caveat,
 			caveat.Name,
@@ -44,7 +45,7 @@ func ValidateCaveatDefinition(caveat *core.CaveatDefinition) error {
 	for paramName, paramType := range caveat.ParameterTypes {
 		_, err := caveattypes.DecodeParameterType(paramType)
 		if err != nil {
-			return newTypeErrorWithSource(
+			return typesystem.NewTypeErrorWithSource(
 				fmt.Errorf("type error for parameter `%s` for caveat `%s`: %w", paramName, caveat.Name, err),
 				caveat,
 				paramName,
@@ -52,7 +53,7 @@ func ValidateCaveatDefinition(caveat *core.CaveatDefinition) error {
 		}
 
 		if !referencedNames.Has(paramName) {
-			return newTypeErrorWithSource(
+			return typesystem.NewTypeErrorWithSource(
 				NewUnusedCaveatParameterErr(caveat.Name, paramName),
 				caveat,
 				paramName,

--- a/internal/namespace/diff.go
+++ b/internal/namespace/diff.go
@@ -8,6 +8,7 @@ import (
 	nspkg "github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	iv1 "github.com/authzed/spicedb/pkg/proto/impl/v1"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 // DeltaType defines the type of namespace deltas.
@@ -219,13 +220,13 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 		allowedRelsBySource := map[string]*core.AllowedRelation{}
 
 		for _, existingAllowed := range existingTypeInfo.AllowedDirectRelations {
-			source := SourceForAllowedRelation(existingAllowed)
+			source := typesystem.SourceForAllowedRelation(existingAllowed)
 			allowedRelsBySource[source] = existingAllowed
 			existingAllowedRels.Add(source)
 		}
 
 		for _, updatedAllowed := range updatedTypeInfo.AllowedDirectRelations {
-			source := SourceForAllowedRelation(updatedAllowed)
+			source := typesystem.SourceForAllowedRelation(updatedAllowed)
 			allowedRelsBySource[source] = updatedAllowed
 			updatedAllowedRels.Add(source)
 		}

--- a/internal/namespace/errors.go
+++ b/internal/namespace/errors.go
@@ -1,7 +1,6 @@
 package namespace
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -62,28 +61,6 @@ func (err ErrRelationNotFound) DetailsMetadata() map[string]string {
 	}
 }
 
-// ErrCaveatNotFound occurs when a caveat was not found.
-type ErrCaveatNotFound struct {
-	error
-	caveatName string
-}
-
-// CaveatName returns the name of the caveat not found.
-func (err ErrCaveatNotFound) CaveatName() string {
-	return err.caveatName
-}
-
-func (err ErrCaveatNotFound) MarshalZerologObject(e *zerolog.Event) {
-	e.Err(err.error).Str("caveat", err.caveatName)
-}
-
-// DetailsMetadata returns the metadata for details for this error.
-func (err ErrCaveatNotFound) DetailsMetadata() map[string]string {
-	return map[string]string{
-		"caveat_name": err.caveatName,
-	}
-}
-
 // ErrDuplicateRelation occurs when a duplicate relation was found inside a namespace.
 type ErrDuplicateRelation struct {
 	error
@@ -104,92 +81,6 @@ func (err ErrDuplicateRelation) DetailsMetadata() map[string]string {
 	}
 }
 
-// ErrPermissionUsedOnLeftOfArrow occurs when a permission is used on the left side of an arrow
-// expression.
-type ErrPermissionUsedOnLeftOfArrow struct {
-	error
-	namespaceName        string
-	parentPermissionName string
-	foundPermissionName  string
-}
-
-// MarshalZerologObject implements zerolog object marshalling.
-func (err ErrPermissionUsedOnLeftOfArrow) MarshalZerologObject(e *zerolog.Event) {
-	e.Err(err.error).Str("namespace", err.namespaceName).Str("permission", err.parentPermissionName).Str("usedPermission", err.foundPermissionName)
-}
-
-// DetailsMetadata returns the metadata for details for this error.
-func (err ErrPermissionUsedOnLeftOfArrow) DetailsMetadata() map[string]string {
-	return map[string]string{
-		"definition_name":      err.namespaceName,
-		"permission_name":      err.parentPermissionName,
-		"used_permission_name": err.foundPermissionName,
-	}
-}
-
-// ErrWildcardUsedInArrow occurs when an arrow operates over a relation that contains a wildcard.
-type ErrWildcardUsedInArrow struct {
-	error
-	namespaceName        string
-	parentPermissionName string
-	accessedRelationName string
-}
-
-// MarshalZerologObject implements zerolog object marshalling.
-func (err ErrWildcardUsedInArrow) MarshalZerologObject(e *zerolog.Event) {
-	e.Err(err.error).Str("namespace", err.namespaceName).Str("parentPermissionName", err.parentPermissionName).Str("accessedRelationName", err.accessedRelationName)
-}
-
-// DetailsMetadata returns the metadata for details for this error.
-func (err ErrWildcardUsedInArrow) DetailsMetadata() map[string]string {
-	return map[string]string{
-		"definition_name":        err.namespaceName,
-		"permission_name":        err.parentPermissionName,
-		"accessed_relation_name": err.accessedRelationName,
-	}
-}
-
-// ErrMissingAllowedRelations occurs when a relation is defined without any type information.
-type ErrMissingAllowedRelations struct {
-	error
-	namespaceName string
-	relationName  string
-}
-
-// MarshalZerologObject implements zerolog object marshalling.
-func (err ErrMissingAllowedRelations) MarshalZerologObject(e *zerolog.Event) {
-	e.Err(err.error).Str("namespace", err.namespaceName).Str("relation", err.relationName)
-}
-
-// DetailsMetadata returns the metadata for details for this error.
-func (err ErrMissingAllowedRelations) DetailsMetadata() map[string]string {
-	return map[string]string{
-		"definition_name": err.namespaceName,
-		"relation_name":   err.relationName,
-	}
-}
-
-// ErrTransitiveWildcard occurs when a wildcard relation in turn references another wildcard
-// relation.
-type ErrTransitiveWildcard struct {
-	error
-	namespaceName string
-	relationName  string
-}
-
-// MarshalZerologObject implements zerolog object marshalling.
-func (err ErrTransitiveWildcard) MarshalZerologObject(e *zerolog.Event) {
-	e.Err(err.error).Str("namespace", err.namespaceName).Str("relation", err.relationName)
-}
-
-// DetailsMetadata returns the metadata for details for this error.
-func (err ErrTransitiveWildcard) DetailsMetadata() map[string]string {
-	return map[string]string{
-		"definition_name": err.namespaceName,
-		"relation_name":   err.relationName,
-	}
-}
-
 // ErrPermissionsCycle occurs when a cycle exists within permissions.
 type ErrPermissionsCycle struct {
 	error
@@ -207,28 +98,6 @@ func (err ErrPermissionsCycle) DetailsMetadata() map[string]string {
 	return map[string]string{
 		"definition_name":  err.namespaceName,
 		"permission_names": strings.Join(err.permissionNames, ","),
-	}
-}
-
-// ErrDuplicateAllowedRelation indicates that an allowed relation was redefined on a relation.
-type ErrDuplicateAllowedRelation struct {
-	error
-	namespaceName         string
-	relationName          string
-	allowedRelationSource string
-}
-
-// MarshalZerologObject implements zerolog object marshalling.
-func (err ErrDuplicateAllowedRelation) MarshalZerologObject(e *zerolog.Event) {
-	e.Err(err.error).Str("namespace", err.namespaceName).Str("relation", err.relationName).Str("allowed-relation", err.allowedRelationSource)
-}
-
-// DetailsMetadata returns the metadata for details for this error.
-func (err ErrDuplicateAllowedRelation) DetailsMetadata() map[string]string {
-	return map[string]string{
-		"definition_name":  err.namespaceName,
-		"relation_name":    err.relationName,
-		"allowed_relation": err.allowedRelationSource,
 	}
 }
 
@@ -269,66 +138,10 @@ func NewRelationNotFoundErr(nsName string, relationName string) error {
 	}
 }
 
-// NewCaveatNotFoundErr constructs a new caveat not found error.
-func NewCaveatNotFoundErr(caveatName string) error {
-	return ErrCaveatNotFound{
-		error:      fmt.Errorf("caveat `%s` not found", caveatName),
-		caveatName: caveatName,
-	}
-}
-
 // NewDuplicateRelationError constructs an error indicating that a relation was defined more than once in a namespace.
 func NewDuplicateRelationError(nsName string, relationName string) error {
 	return ErrDuplicateRelation{
 		error:         fmt.Errorf("found duplicate relation/permission name `%s` under definition `%s`", relationName, nsName),
-		namespaceName: nsName,
-		relationName:  relationName,
-	}
-}
-
-// NewDuplicateAllowedRelationErr constructs an error indicating that an allowed relation was defined more than once for a relation.
-func NewDuplicateAllowedRelationErr(nsName string, relationName string, allowedRelationSource string) error {
-	return ErrDuplicateAllowedRelation{
-		error:                 fmt.Errorf("found duplicate allowed subject type `%s` on relation `%s` under definition `%s`", allowedRelationSource, relationName, nsName),
-		namespaceName:         nsName,
-		relationName:          relationName,
-		allowedRelationSource: allowedRelationSource,
-	}
-}
-
-// NewPermissionUsedOnLeftOfArrowErr constructs an error indicating that a permission was used on the left side of an arrow.
-func NewPermissionUsedOnLeftOfArrowErr(nsName string, parentPermissionName string, foundPermissionName string) error {
-	return ErrPermissionUsedOnLeftOfArrow{
-		error:                fmt.Errorf("under permission `%s` under definition `%s`: permissions cannot be used on the left hand side of an arrow (found `%s`)", parentPermissionName, nsName, foundPermissionName),
-		namespaceName:        nsName,
-		parentPermissionName: parentPermissionName,
-		foundPermissionName:  foundPermissionName,
-	}
-}
-
-// NewWildcardUsedInArrowErr constructs an error indicating that an arrow operated over a relation with a wildcard type.
-func NewWildcardUsedInArrowErr(nsName string, parentPermissionName string, foundRelationName string, wildcardTypeName string, wildcardRelationName string) error {
-	return ErrWildcardUsedInArrow{
-		error:                fmt.Errorf("for arrow under permission `%s`: relation `%s#%s` includes wildcard type `%s` via relation `%s`: wildcard relations cannot be used on the left side of arrows", parentPermissionName, nsName, foundRelationName, wildcardTypeName, wildcardRelationName),
-		namespaceName:        nsName,
-		parentPermissionName: parentPermissionName,
-		accessedRelationName: foundRelationName,
-	}
-}
-
-// NewMissingAllowedRelationsErr constructs an error indicating that type information is missing for a relation.
-func NewMissingAllowedRelationsErr(nsName string, relationName string) error {
-	return ErrMissingAllowedRelations{
-		error:         fmt.Errorf("at least one allowed relation/permission is required to be defined for relation `%s`", relationName),
-		namespaceName: nsName,
-		relationName:  relationName,
-	}
-}
-
-// NewTransitiveWildcardErr constructs an error indicating that a transitive wildcard exists.
-func NewTransitiveWildcardErr(nsName string, relationName string, foundRelationNamespace string, foundRelationName string, wildcardTypeName string, wildcardRelationReference string) error {
-	return ErrTransitiveWildcard{
-		error:         fmt.Errorf("for relation `%s`: relation/permission `%s#%s` includes wildcard type `%s` via relation `%s`: wildcard relations cannot be transitively included", relationName, foundRelationNamespace, foundRelationName, wildcardTypeName, wildcardRelationReference),
 		namespaceName: nsName,
 		relationName:  relationName,
 	}
@@ -350,29 +163,6 @@ func NewUnusedCaveatParameterErr(caveatName string, paramName string) error {
 		caveatName: caveatName,
 		paramName:  paramName,
 	}
-}
-
-// asTypeError wraps another error in a type error.
-func asTypeError(wrapped error) error {
-	if wrapped == nil {
-		return nil
-	}
-
-	var te TypeError
-	if errors.As(wrapped, &te) {
-		return wrapped
-	}
-
-	return TypeError{wrapped}
-}
-
-// TypeError wraps another error as a type error.
-type TypeError struct {
-	error
-}
-
-func (err TypeError) Unwrap() error {
-	return err.error
 }
 
 var (

--- a/internal/namespace/util.go
+++ b/internal/namespace/util.go
@@ -6,6 +6,7 @@ import (
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 // ReadNamespaceAndRelation checks that the specified namespace and relation exist in the
@@ -133,13 +134,13 @@ func ReadNamespaceAndTypes(
 	ctx context.Context,
 	nsName string,
 	ds datastore.Reader,
-) (*core.NamespaceDefinition, *TypeSystem, error) {
+) (*core.NamespaceDefinition, *typesystem.TypeSystem, error) {
 	nsDef, _, err := ds.ReadNamespaceByName(ctx, nsName)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	ts, terr := NewNamespaceTypeSystem(nsDef, ResolverForDatastoreReader(ds))
+	ts, terr := typesystem.NewNamespaceTypeSystem(nsDef, typesystem.ResolverForDatastoreReader(ds))
 	return nsDef, ts, terr
 }
 

--- a/internal/relationships/errors.go
+++ b/internal/relationships/errors.go
@@ -3,8 +3,6 @@ package relationships
 import (
 	"fmt"
 
-	"github.com/authzed/spicedb/internal/namespace"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -13,6 +11,7 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 // ErrInvalidSubjectType indicates that a write was attempted with a subject type which is not
@@ -28,7 +27,7 @@ func NewInvalidSubjectTypeError(update *core.RelationTuple, relationType *core.A
 	return ErrInvalidSubjectType{
 		error: fmt.Errorf(
 			"subjects of type `%s` are not allowed on relation `%s#%s`",
-			namespace.SourceForAllowedRelation(relationType),
+			typesystem.SourceForAllowedRelation(relationType),
 			update.ResourceAndRelation.Namespace,
 			update.ResourceAndRelation.Relation,
 		),
@@ -47,7 +46,7 @@ func (err ErrInvalidSubjectType) GRPCStatus() *status.Status {
 			map[string]string{
 				"definition_name": err.tuple.ResourceAndRelation.Namespace,
 				"relation_name":   err.tuple.ResourceAndRelation.Relation,
-				"subject_type":    namespace.SourceForAllowedRelation(err.relationType),
+				"subject_type":    typesystem.SourceForAllowedRelation(err.relationType),
 			},
 		),
 	)

--- a/internal/services/shared/errors.go
+++ b/internal/services/shared/errors.go
@@ -16,13 +16,13 @@ import (
 	"github.com/authzed/spicedb/internal/dispatch"
 	"github.com/authzed/spicedb/internal/graph"
 	log "github.com/authzed/spicedb/internal/logging"
-	"github.com/authzed/spicedb/internal/namespace"
 	"github.com/authzed/spicedb/internal/sharederrors"
 	"github.com/authzed/spicedb/pkg/cursor"
 	"github.com/authzed/spicedb/pkg/datastore"
 	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 // ErrServiceReadOnly is an extended GRPC error returned when a service is in read-only mode.
@@ -130,7 +130,7 @@ func RewriteError(ctx context.Context, err error, config *ConfigForErrors) error
 
 	var compilerError compiler.BaseCompilerError
 	var sourceError spiceerrors.ErrorWithSource
-	var typeError namespace.TypeError
+	var typeError typesystem.TypeError
 	var maxDepthError dispatch.MaxDepthExceededError
 
 	switch {

--- a/internal/services/shared/schema.go
+++ b/internal/services/shared/schema.go
@@ -12,6 +12,7 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 // ValidatedSchemaChanges is a set of validated schema changes that can be applied to the datastore.
@@ -38,8 +39,8 @@ func ValidateSchemaChanges(ctx context.Context, compiled *compiler.CompiledSchem
 	// 2) Validate the namespaces defined.
 	newObjectDefNames := mapz.NewSet[string]()
 	for _, nsdef := range compiled.ObjectDefinitions {
-		ts, err := namespace.NewNamespaceTypeSystem(nsdef,
-			namespace.ResolverForPredefinedDefinitions(namespace.PredefinedElements{
+		ts, err := typesystem.NewNamespaceTypeSystem(nsdef,
+			typesystem.ResolverForPredefinedDefinitions(typesystem.PredefinedElements{
 				Namespaces: compiled.ObjectDefinitions,
 				Caveats:    compiled.CaveatDefinitions,
 			}))
@@ -375,7 +376,7 @@ func sanityCheckNamespaceChanges(
 				qyr,
 				qyrErr,
 				"cannot remove allowed type `%s` from relation `%s` in object definition `%s`, as a relationship exists with it",
-				namespace.SourceForAllowedRelation(delta.AllowedType), delta.RelationName, nsdef.Name)
+				typesystem.SourceForAllowedRelation(delta.AllowedType), delta.RelationName, nsdef.Name)
 			qyr.Close()
 			if err != nil {
 				return diff, err

--- a/internal/services/v1/experimental.go
+++ b/internal/services/v1/experimental.go
@@ -40,6 +40,7 @@ import (
 	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	implv1 "github.com/authzed/spicedb/pkg/proto/impl/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 const (
@@ -116,7 +117,7 @@ type experimentalServer struct {
 
 type bulkLoadAdapter struct {
 	stream                 v1.ExperimentalService_BulkImportRelationshipsServer
-	referencedNamespaceMap map[string]*namespace.TypeSystem
+	referencedNamespaceMap map[string]*typesystem.TypeSystem
 	referencedCaveatMap    map[string]*core.CaveatDefinition
 	current                core.RelationTuple
 	caveat                 core.ContextualizedCaveat
@@ -178,7 +179,7 @@ func (a *bulkLoadAdapter) Next(_ context.Context) (*core.RelationTuple, error) {
 
 func extractBatchNewReferencedNamespacesAndCaveats(
 	batch []*v1.Relationship,
-	existingNamespaces map[string]*namespace.TypeSystem,
+	existingNamespaces map[string]*typesystem.TypeSystem,
 	existingCaveats map[string]*core.CaveatDefinition,
 ) ([]string, []string) {
 	newNamespaces := make(map[string]struct{})
@@ -209,7 +210,7 @@ func (es *experimentalServer) BulkImportRelationships(stream v1.ExperimentalServ
 
 	var numWritten uint64
 	if _, err := ds.ReadWriteTx(stream.Context(), func(rwt datastore.ReadWriteTransaction) error {
-		loadedNamespaces := make(map[string]*namespace.TypeSystem)
+		loadedNamespaces := make(map[string]*typesystem.TypeSystem)
 		loadedCaveats := make(map[string]*core.CaveatDefinition)
 
 		adapter := &bulkLoadAdapter{
@@ -236,7 +237,7 @@ func (es *experimentalServer) BulkImportRelationships(stream v1.ExperimentalServ
 				}
 
 				for _, nsDef := range nsDefs {
-					nts, err := namespace.NewNamespaceTypeSystem(nsDef.Definition, namespace.ResolverForDatastoreReader(rwt))
+					nts, err := typesystem.NewNamespaceTypeSystem(nsDef.Definition, typesystem.ResolverForDatastoreReader(rwt))
 					if err != nil {
 						return err
 					}

--- a/internal/testfixtures/datastore.go
+++ b/internal/testfixtures/datastore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
 	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 var UserNS = ns.Namespace("user")
@@ -248,8 +249,8 @@ func writeDefinitions(ds datastore.Datastore, require *require.Assertions, objec
 		}
 
 		for _, nsDef := range objectDefs {
-			ts, err := namespace.NewNamespaceTypeSystem(nsDef,
-				namespace.ResolverForDatastoreReader(rwt).WithPredefinedElements(namespace.PredefinedElements{
+			ts, err := typesystem.NewNamespaceTypeSystem(nsDef,
+				typesystem.ResolverForDatastoreReader(rwt).WithPredefinedElements(typesystem.PredefinedElements{
 					Namespaces: objectDefs,
 					Caveats:    caveatDefs,
 				}))

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -31,6 +31,7 @@ import (
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 const defaultConnBufferSize = humanize.MiByte
@@ -226,7 +227,7 @@ func loadCompiled(
 	rwt datastore.ReadWriteTransaction,
 ) ([]*devinterface.DeveloperError, error) {
 	errors := make([]*devinterface.DeveloperError, 0, len(compiled.OrderedDefinitions))
-	resolver := namespace.ResolverForPredefinedDefinitions(namespace.PredefinedElements{
+	resolver := typesystem.ResolverForPredefinedDefinitions(typesystem.PredefinedElements{
 		Namespaces: compiled.ObjectDefinitions,
 		Caveats:    compiled.CaveatDefinitions,
 	})
@@ -261,7 +262,7 @@ func loadCompiled(
 	}
 
 	for _, nsDef := range compiled.ObjectDefinitions {
-		ts, terr := namespace.NewNamespaceTypeSystem(nsDef, resolver)
+		ts, terr := typesystem.NewNamespaceTypeSystem(nsDef, resolver)
 		if terr != nil {
 			errWithSource, ok := spiceerrors.AsErrorWithSource(terr)
 			if ok {

--- a/pkg/typesystem/errors.go
+++ b/pkg/typesystem/errors.go
@@ -1,0 +1,381 @@
+package typesystem
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog"
+
+	"github.com/authzed/spicedb/internal/sharederrors"
+)
+
+// ErrNamespaceNotFound occurs when a namespace was not found.
+type ErrNamespaceNotFound struct {
+	error
+	namespaceName string
+}
+
+// NotFoundNamespaceName is the name of the namespace not found.
+func (err ErrNamespaceNotFound) NotFoundNamespaceName() string {
+	return err.namespaceName
+}
+
+// MarshalZerologObject implements zerolog object marshalling.
+func (err ErrNamespaceNotFound) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("namespace", err.namespaceName)
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrNamespaceNotFound) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"definition_name": err.namespaceName,
+	}
+}
+
+// ErrRelationNotFound occurs when a relation was not found under a namespace.
+type ErrRelationNotFound struct {
+	error
+	namespaceName string
+	relationName  string
+}
+
+// NamespaceName returns the name of the namespace in which the relation was not found.
+func (err ErrRelationNotFound) NamespaceName() string {
+	return err.namespaceName
+}
+
+// NotFoundRelationName returns the name of the relation not found.
+func (err ErrRelationNotFound) NotFoundRelationName() string {
+	return err.relationName
+}
+
+func (err ErrRelationNotFound) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("namespace", err.namespaceName).Str("relation", err.relationName)
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrRelationNotFound) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"definition_name":             err.namespaceName,
+		"relation_or_permission_name": err.relationName,
+	}
+}
+
+// ErrCaveatNotFound occurs when a caveat was not found.
+type ErrCaveatNotFound struct {
+	error
+	caveatName string
+}
+
+// CaveatName returns the name of the caveat not found.
+func (err ErrCaveatNotFound) CaveatName() string {
+	return err.caveatName
+}
+
+func (err ErrCaveatNotFound) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("caveat", err.caveatName)
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrCaveatNotFound) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"caveat_name": err.caveatName,
+	}
+}
+
+// ErrDuplicateRelation occurs when a duplicate relation was found inside a namespace.
+type ErrDuplicateRelation struct {
+	error
+	namespaceName string
+	relationName  string
+}
+
+// MarshalZerologObject implements zerolog object marshalling.
+func (err ErrDuplicateRelation) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("namespace", err.namespaceName).Str("relation", err.relationName)
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrDuplicateRelation) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"definition_name":             err.namespaceName,
+		"relation_or_permission_name": err.relationName,
+	}
+}
+
+// ErrPermissionUsedOnLeftOfArrow occurs when a permission is used on the left side of an arrow
+// expression.
+type ErrPermissionUsedOnLeftOfArrow struct {
+	error
+	namespaceName        string
+	parentPermissionName string
+	foundPermissionName  string
+}
+
+// MarshalZerologObject implements zerolog object marshalling.
+func (err ErrPermissionUsedOnLeftOfArrow) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("namespace", err.namespaceName).Str("permission", err.parentPermissionName).Str("usedPermission", err.foundPermissionName)
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrPermissionUsedOnLeftOfArrow) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"definition_name":      err.namespaceName,
+		"permission_name":      err.parentPermissionName,
+		"used_permission_name": err.foundPermissionName,
+	}
+}
+
+// ErrWildcardUsedInArrow occurs when an arrow operates over a relation that contains a wildcard.
+type ErrWildcardUsedInArrow struct {
+	error
+	namespaceName        string
+	parentPermissionName string
+	accessedRelationName string
+}
+
+// MarshalZerologObject implements zerolog object marshalling.
+func (err ErrWildcardUsedInArrow) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("namespace", err.namespaceName).Str("parentPermissionName", err.parentPermissionName).Str("accessedRelationName", err.accessedRelationName)
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrWildcardUsedInArrow) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"definition_name":        err.namespaceName,
+		"permission_name":        err.parentPermissionName,
+		"accessed_relation_name": err.accessedRelationName,
+	}
+}
+
+// ErrMissingAllowedRelations occurs when a relation is defined without any type information.
+type ErrMissingAllowedRelations struct {
+	error
+	namespaceName string
+	relationName  string
+}
+
+// MarshalZerologObject implements zerolog object marshalling.
+func (err ErrMissingAllowedRelations) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("namespace", err.namespaceName).Str("relation", err.relationName)
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrMissingAllowedRelations) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"definition_name": err.namespaceName,
+		"relation_name":   err.relationName,
+	}
+}
+
+// ErrTransitiveWildcard occurs when a wildcard relation in turn references another wildcard
+// relation.
+type ErrTransitiveWildcard struct {
+	error
+	namespaceName string
+	relationName  string
+}
+
+// MarshalZerologObject implements zerolog object marshalling.
+func (err ErrTransitiveWildcard) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("namespace", err.namespaceName).Str("relation", err.relationName)
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrTransitiveWildcard) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"definition_name": err.namespaceName,
+		"relation_name":   err.relationName,
+	}
+}
+
+// ErrPermissionsCycle occurs when a cycle exists within permissions.
+type ErrPermissionsCycle struct {
+	error
+	namespaceName   string
+	permissionNames []string
+}
+
+// MarshalZerologObject implements zerolog object marshalling.
+func (err ErrPermissionsCycle) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("namespace", err.namespaceName).Str("permissions", strings.Join(err.permissionNames, ", "))
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrPermissionsCycle) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"definition_name":  err.namespaceName,
+		"permission_names": strings.Join(err.permissionNames, ","),
+	}
+}
+
+// ErrDuplicateAllowedRelation indicates that an allowed relation was redefined on a relation.
+type ErrDuplicateAllowedRelation struct {
+	error
+	namespaceName         string
+	relationName          string
+	allowedRelationSource string
+}
+
+// MarshalZerologObject implements zerolog object marshalling.
+func (err ErrDuplicateAllowedRelation) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("namespace", err.namespaceName).Str("relation", err.relationName).Str("allowed-relation", err.allowedRelationSource)
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrDuplicateAllowedRelation) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"definition_name":  err.namespaceName,
+		"relation_name":    err.relationName,
+		"allowed_relation": err.allowedRelationSource,
+	}
+}
+
+// ErrUnusedCaveatParameter indicates that a caveat parameter is unused in the caveat expression.
+type ErrUnusedCaveatParameter struct {
+	error
+	caveatName string
+	paramName  string
+}
+
+// MarshalZerologObject implements zerolog object marshalling.
+func (err ErrUnusedCaveatParameter) MarshalZerologObject(e *zerolog.Event) {
+	e.Err(err.error).Str("caveat", err.caveatName).Str("param", err.paramName)
+}
+
+// DetailsMetadata returns the metadata for details for this error.
+func (err ErrUnusedCaveatParameter) DetailsMetadata() map[string]string {
+	return map[string]string{
+		"caveat_name":    err.caveatName,
+		"parameter_name": err.paramName,
+	}
+}
+
+// NewNamespaceNotFoundErr constructs a new namespace not found error.
+func NewNamespaceNotFoundErr(nsName string) error {
+	return ErrNamespaceNotFound{
+		error:         fmt.Errorf("object definition `%s` not found", nsName),
+		namespaceName: nsName,
+	}
+}
+
+// NewRelationNotFoundErr constructs a new relation not found error.
+func NewRelationNotFoundErr(nsName string, relationName string) error {
+	return ErrRelationNotFound{
+		error:         fmt.Errorf("relation/permission `%s` not found under definition `%s`", relationName, nsName),
+		namespaceName: nsName,
+		relationName:  relationName,
+	}
+}
+
+// NewCaveatNotFoundErr constructs a new caveat not found error.
+func NewCaveatNotFoundErr(caveatName string) error {
+	return ErrCaveatNotFound{
+		error:      fmt.Errorf("caveat `%s` not found", caveatName),
+		caveatName: caveatName,
+	}
+}
+
+// NewDuplicateRelationError constructs an error indicating that a relation was defined more than once in a namespace.
+func NewDuplicateRelationError(nsName string, relationName string) error {
+	return ErrDuplicateRelation{
+		error:         fmt.Errorf("found duplicate relation/permission name `%s` under definition `%s`", relationName, nsName),
+		namespaceName: nsName,
+		relationName:  relationName,
+	}
+}
+
+// NewDuplicateAllowedRelationErr constructs an error indicating that an allowed relation was defined more than once for a relation.
+func NewDuplicateAllowedRelationErr(nsName string, relationName string, allowedRelationSource string) error {
+	return ErrDuplicateAllowedRelation{
+		error:                 fmt.Errorf("found duplicate allowed subject type `%s` on relation `%s` under definition `%s`", allowedRelationSource, relationName, nsName),
+		namespaceName:         nsName,
+		relationName:          relationName,
+		allowedRelationSource: allowedRelationSource,
+	}
+}
+
+// NewPermissionUsedOnLeftOfArrowErr constructs an error indicating that a permission was used on the left side of an arrow.
+func NewPermissionUsedOnLeftOfArrowErr(nsName string, parentPermissionName string, foundPermissionName string) error {
+	return ErrPermissionUsedOnLeftOfArrow{
+		error:                fmt.Errorf("under permission `%s` under definition `%s`: permissions cannot be used on the left hand side of an arrow (found `%s`)", parentPermissionName, nsName, foundPermissionName),
+		namespaceName:        nsName,
+		parentPermissionName: parentPermissionName,
+		foundPermissionName:  foundPermissionName,
+	}
+}
+
+// NewWildcardUsedInArrowErr constructs an error indicating that an arrow operated over a relation with a wildcard type.
+func NewWildcardUsedInArrowErr(nsName string, parentPermissionName string, foundRelationName string, wildcardTypeName string, wildcardRelationName string) error {
+	return ErrWildcardUsedInArrow{
+		error:                fmt.Errorf("for arrow under permission `%s`: relation `%s#%s` includes wildcard type `%s` via relation `%s`: wildcard relations cannot be used on the left side of arrows", parentPermissionName, nsName, foundRelationName, wildcardTypeName, wildcardRelationName),
+		namespaceName:        nsName,
+		parentPermissionName: parentPermissionName,
+		accessedRelationName: foundRelationName,
+	}
+}
+
+// NewMissingAllowedRelationsErr constructs an error indicating that type information is missing for a relation.
+func NewMissingAllowedRelationsErr(nsName string, relationName string) error {
+	return ErrMissingAllowedRelations{
+		error:         fmt.Errorf("at least one allowed relation/permission is required to be defined for relation `%s`", relationName),
+		namespaceName: nsName,
+		relationName:  relationName,
+	}
+}
+
+// NewTransitiveWildcardErr constructs an error indicating that a transitive wildcard exists.
+func NewTransitiveWildcardErr(nsName string, relationName string, foundRelationNamespace string, foundRelationName string, wildcardTypeName string, wildcardRelationReference string) error {
+	return ErrTransitiveWildcard{
+		error:         fmt.Errorf("for relation `%s`: relation/permission `%s#%s` includes wildcard type `%s` via relation `%s`: wildcard relations cannot be transitively included", relationName, foundRelationNamespace, foundRelationName, wildcardTypeName, wildcardRelationReference),
+		namespaceName: nsName,
+		relationName:  relationName,
+	}
+}
+
+// NewPermissionsCycleErr constructs an error indicating that a cycle exists amongst permissions.
+func NewPermissionsCycleErr(nsName string, permissionNames []string) error {
+	return ErrPermissionsCycle{
+		error:           fmt.Errorf("under definition `%s`, there exists a cycle in permissions: %s", nsName, strings.Join(permissionNames, ", ")),
+		namespaceName:   nsName,
+		permissionNames: permissionNames,
+	}
+}
+
+// NewUnusedCaveatParameterErr constructs indicating that a parameter was unused in a caveat expression.
+func NewUnusedCaveatParameterErr(caveatName string, paramName string) error {
+	return ErrUnusedCaveatParameter{
+		error:      fmt.Errorf("parameter `%s` for caveat `%s` is unused", paramName, caveatName),
+		caveatName: caveatName,
+		paramName:  paramName,
+	}
+}
+
+// asTypeError wraps another error in a type error.
+func asTypeError(wrapped error) error {
+	if wrapped == nil {
+		return nil
+	}
+
+	var te TypeError
+	if errors.As(wrapped, &te) {
+		return wrapped
+	}
+
+	return TypeError{wrapped}
+}
+
+// TypeError wraps another error as a type error.
+type TypeError struct {
+	error
+}
+
+func (err TypeError) Unwrap() error {
+	return err.error
+}
+
+var (
+	_ sharederrors.UnknownNamespaceError = ErrNamespaceNotFound{}
+	_ sharederrors.UnknownRelationError  = ErrRelationNotFound{}
+)

--- a/pkg/typesystem/reachabilitygraph_test.go
+++ b/pkg/typesystem/reachabilitygraph_test.go
@@ -1,4 +1,4 @@
-package namespace
+package typesystem
 
 import (
 	"context"

--- a/pkg/typesystem/reachabilitygraphbuilder.go
+++ b/pkg/typesystem/reachabilitygraphbuilder.go
@@ -1,4 +1,4 @@
-package namespace
+package typesystem
 
 import (
 	"context"

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -1,4 +1,4 @@
-package namespace
+package typesystem
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 )
 
 // Resolver is an interface defined for resolving referenced namespaces and caveats when constructing
@@ -48,6 +49,16 @@ func ResolverForPredefinedDefinitions(predefined PredefinedElements) Resolver {
 	return &resolver{
 		predefined: predefined,
 	}
+}
+
+// ResolverForSchema returns a resolver for a schema.
+func ResolverForSchema(schema compiler.CompiledSchema) Resolver {
+	return ResolverForPredefinedDefinitions(
+		PredefinedElements{
+			Namespaces: schema.ObjectDefinitions,
+			Caveats:    schema.CaveatDefinitions,
+		},
+	)
 }
 
 type resolver struct {

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -1,4 +1,4 @@
-package namespace
+package typesystem
 
 import (
 	"context"

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -15,6 +15,7 @@ import (
 	"github.com/authzed/spicedb/pkg/genutil/slicez"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/typesystem"
 )
 
 // PopulatedValidationFile contains the fully parsed information from a validation file.
@@ -117,8 +118,8 @@ func PopulateFromFilesContents(ctx context.Context, ds datastore.Datastore, file
 
 		// Validate and write the object definitions.
 		for _, objectDef := range objectDefs {
-			ts, err := namespace.NewNamespaceTypeSystem(objectDef,
-				namespace.ResolverForDatastoreReader(rwt).WithPredefinedElements(namespace.PredefinedElements{
+			ts, err := typesystem.NewNamespaceTypeSystem(objectDef,
+				typesystem.ResolverForDatastoreReader(rwt).WithPredefinedElements(typesystem.PredefinedElements{
 					Namespaces: objectDefs,
 				}))
 			if err != nil {


### PR DESCRIPTION
This will allow external tooling such as zed to use these systems, for example for creating well-typed client libraries