### PR TITLE
Update groupItems to use less memory

### DIFF
--- a/internal/services/v1/experimental.go
+++ b/internal/services/v1/experimental.go
@@ -469,7 +469,7 @@ func (es *experimentalServer) BulkCheckPermission(ctx context.Context, req *v1.B
 		return nil
 	}
 
-	appendResultsForError := func(params computed.CheckParameters, resourceIDs []string, err error) error {
+	appendResultsForError := func(params *computed.CheckParameters, resourceIDs []string, err error) error {
 		rewritten := es.rewriteError(ctx, err)
 		statusResp, ok := status.FromError(rewritten)
 		if !ok {
@@ -499,7 +499,7 @@ func (es *experimentalServer) BulkCheckPermission(ctx context.Context, req *v1.B
 		return nil
 	}
 
-	appendResultsForCheck := func(params computed.CheckParameters, resourceIDs []string, metadata *dispatchv1.ResponseMeta, results map[string]*dispatchv1.ResourceCheckResult) error {
+	appendResultsForCheck := func(params *computed.CheckParameters, resourceIDs []string, metadata *dispatchv1.ResponseMeta, results map[string]*dispatchv1.ResourceCheckResult) error {
 		bulkResponseMutex.Lock()
 		defer bulkResponseMutex.Unlock()
 
@@ -548,7 +548,7 @@ func (es *experimentalServer) BulkCheckPermission(ctx context.Context, req *v1.B
 				}
 
 				// Call bulk check to compute the check result(s) for the resource ID(s).
-				rcr, metadata, err := computed.ComputeBulkCheck(ctx, es.dispatch, group.params, resourceIDs)
+				rcr, metadata, err := computed.ComputeBulkCheck(ctx, es.dispatch, *group.params, resourceIDs)
 				if err != nil {
 					return appendResultsForError(group.params, resourceIDs, err)
 				}
@@ -576,7 +576,7 @@ func pairItemFromCheckResult(checkResult *dispatchv1.ResourceCheckResult) *v1.Bu
 	}
 }
 
-func requestItemFromResourceAndParameters(params computed.CheckParameters, resourceID string) (*v1.BulkCheckPermissionRequestItem, error) {
+func requestItemFromResourceAndParameters(params *computed.CheckParameters, resourceID string) (*v1.BulkCheckPermissionRequestItem, error) {
 	item := &v1.BulkCheckPermissionRequestItem{
 		Resource: &v1.ObjectReference{
 			ObjectType: params.ResourceType.Namespace,

--- a/internal/services/v1/grouping_test.go
+++ b/internal/services/v1/grouping_test.go
@@ -9,6 +9,7 @@ import (
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 
 	"github.com/authzed/spicedb/internal/graph/computed"
 	"github.com/authzed/spicedb/pkg/datastore"
@@ -198,10 +199,11 @@ func TestGroupItems(t *testing.T) {
 				maximumAPIDepth:      1,
 			}
 
-			ccp, err := groupItems(context.Background(), cp, items)
+			ccpByHash, err := groupItems(context.Background(), cp, items)
 			if tt.err != "" {
 				require.ErrorContains(t, err, tt.err)
 			} else {
+				ccp := maps.Values(ccpByHash)
 				require.NoError(t, err)
 				require.Equal(t, len(tt.groupings), len(ccp))
 


### PR DESCRIPTION
The current implementation of [groupItems](https://github.com/authzed/spicedb/blob/ab6946b836229c2ce61bc0876844ed5849d1eca4/internal/services/v1/grouping.go#L29) calls `make` twice to allocate memory for building its results. This modifies the function to build its results in one pass and removes the need for the second `make` call. This should use less memory overall.