### PR TITLE
Fix benchmark test errors

### DIFF
--- a/internal/services/integrationtesting/benchmark_test.go
+++ b/internal/services/integrationtesting/benchmark_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
 	"github.com/authzed/spicedb/internal/services/integrationtesting/consistencytestutil"
 	"github.com/authzed/spicedb/internal/testserver"
@@ -19,7 +20,6 @@ import (
 	dsconfig "github.com/authzed/spicedb/pkg/cmd/datastore"
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/authzed/spicedb/pkg/validationfile"
 )
@@ -110,7 +110,7 @@ func BenchmarkServices(b *testing.B) {
 					ObjectId:  "tom",
 					Relation:  tuple.Ellipsis,
 				}, revision, nil)
-				require.Equal(b, dispatchv1.ResourceCheckResult_MEMBER, result)
+				require.Equal(b, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, result)
 				return err
 			},
 		},
@@ -127,7 +127,7 @@ func BenchmarkServices(b *testing.B) {
 					ObjectId:  "cto",
 					Relation:  tuple.Ellipsis,
 				}, revision, nil)
-				require.Equal(b, dispatchv1.ResourceCheckResult_MEMBER, result)
+				require.Equal(b, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, result)
 				return err
 			},
 		},
@@ -144,7 +144,7 @@ func BenchmarkServices(b *testing.B) {
 					ObjectId:  "tom",
 					Relation:  tuple.Ellipsis,
 				}, revision, nil)
-				require.Equal(b, dispatchv1.ResourceCheckResult_MEMBER, result)
+				require.Equal(b, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, result)
 				return err
 			},
 		},
@@ -161,7 +161,7 @@ func BenchmarkServices(b *testing.B) {
 					ObjectId:  "tom",
 					Relation:  tuple.Ellipsis,
 				}, revision, nil)
-				require.Equal(b, dispatchv1.ResourceCheckResult_MEMBER, result)
+				require.Equal(b, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, result)
 				return err
 			},
 		},


### PR DESCRIPTION
This fixes one type of error I encountered when running the benchmark tests with:
```
go test ./internal/services/integrationtesting/... -tags ci,docker -bench . -benchmem
```

Error:
```
--- FAIL: BenchmarkServices/wide_direct_relation_check/cockroachdb/v1
    benchmark_test.go:167:
        	Error Trace:	/Users/braden.groom/src/spicedb/internal/services/integrationtesting/benchmark_test.go:167
        	            				/Users/braden.groom/src/spicedb/internal/services/integrationtesting/benchmark_test.go:208
        	            				/opt/homebrew/Cellar/go/1.21.1/libexec/src/testing/benchmark.go:193
        	            				/opt/homebrew/Cellar/go/1.21.1/libexec/src/testing/benchmark.go:233
        	            				/opt/homebrew/Cellar/go/1.21.1/libexec/src/runtime/asm_arm64.s:1197
        	Error:      	Not equal:
        	            	expected: dispatchv1.ResourceCheckResult_Membership(2)
        	            	actual  : v1.CheckPermissionResponse_Permissionship(2)
        	Test:       	BenchmarkServices/wide_direct_relation_check/cockroachdb/v1
```

After this PR, there are still 2 remaining errors that I was unable to track down.

The first error occurs for the postgres and spanner datastores:
```
--- FAIL: BenchmarkServices/recursive_check_for_a_user/spanner
    spanner.go:94: using spanner emulator, host: localhost:33105
    benchmark_test.go:191:
        	Error Trace:	/Users/braden.groom/src/spicedb/internal/services/integrationtesting/benchmark_test.go:191
        	            				/opt/homebrew/Cellar/go/1.21.1/libexec/src/testing/benchmark.go:193
        	            				/opt/homebrew/Cellar/go/1.21.1/libexec/src/testing/benchmark.go:233
        	            				/opt/homebrew/Cellar/go/1.21.1/libexec/src/runtime/asm_arm64.s:1197
        	Error:      	Received unexpected error:
        	            	could not lookup caveat `is_not_geo_banned` for relation `readers`: caveat with name `is_not_geo_banned` not found
        	Test:       	BenchmarkServices/recursive_check_for_a_user/spanner
```

It's really strange to me that the datastores don't behave consistently on this test. It feels like this could potentially be a bug, but I'm not sure. I did find this old issue which might be relevant. https://github.com/authzed/spicedb/issues/1450


The second error occurs on the same test for mysql and cockroachdb:
```
--- FAIL: BenchmarkServices/recursive_check_for_a_user/mysql/v1
    benchmark_test.go:130:
        	Error Trace:	/Users/braden.groom/src/spicedb/internal/services/integrationtesting/benchmark_test.go:130
        	            				/Users/braden.groom/src/spicedb/internal/services/integrationtesting/benchmark_test.go:205
        	            				/opt/homebrew/Cellar/go/1.21.1/libexec/src/testing/benchmark.go:193
        	            				/opt/homebrew/Cellar/go/1.21.1/libexec/src/testing/benchmark.go:233
        	            				/opt/homebrew/Cellar/go/1.21.1/libexec/src/runtime/asm_arm64.s:1197
        	Error:      	Not equal:
        	            	expected: 2
        	            	actual  : 0
        	Test:       	BenchmarkServices/recursive_check_for_a_user/mysql/v1
```

I tried looking into the quay schema, but it's not clear to me why this wouldn't pass. It looks like we are trying to determine if the CTO is allowed to `view` the `buynlarge/orgrepo`. Looking at the relationships, it looks like the CTO is an `admin` of `organization:megacorp`. `organization:megacorp` is the `parent` of `namespace:buynlarge`. `namespace:buynlarge` is the `parent` of `buynlarge/orgrepo`. So I would expect the CTO's admin access to apply. I'm likely missing something here though.