### PR TITLE
Enable the experimental apis in the http gateway

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -74,6 +74,11 @@ func NewHandler(ctx context.Context, upstreamAddr, upstreamTLSCertPath string) (
 		return nil, err
 	}
 
+	experimentalConn, err := registerHandler(ctx, gwMux, upstreamAddr, opts, v1.RegisterExperimentalServiceHandler)
+	if err != nil {
+		return nil, err
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/openapi.json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, proto.OpenAPISchema)
@@ -81,7 +86,7 @@ func NewHandler(ctx context.Context, upstreamAddr, upstreamTLSCertPath string) (
 	mux.Handle("/", gwMux)
 
 	finalHandler := promhttp.InstrumentHandlerDuration(histogram, otelhttp.NewHandler(mux, "gateway"))
-	return newCloserHandler(finalHandler, schemaConn, permissionsConn, watchConn, healthConn), nil
+	return newCloserHandler(finalHandler, schemaConn, permissionsConn, watchConn, healthConn, experimentalConn), nil
 }
 
 // CloserHandler is a http.Handler and a io.Closer. Meant to keep track of resources to closer

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -49,8 +49,8 @@ func TestCloseConnections(t *testing.T) {
 
 	gatewayHandler, err := NewHandler(context.Background(), "192.0.2.0:4321", "")
 	require.NoError(t, err)
-	// 3 conns for permission+schema+watch services, 1 for health check
-	require.Len(t, gatewayHandler.closers, 4)
+	// 4 conns for permission+schema+watch+experimental services, 1 for health check
+	require.Len(t, gatewayHandler.closers, 5)
 
 	// if connections are not closed, goleak would detect it
 	require.NoError(t, gatewayHandler.Close())


### PR DESCRIPTION
It looks like the experimental apis are not usable in http, and it seems they were never included in the gateway handlers.