### PR TITLE
Reenable -race on unit tests and fix tests

### DIFF
--- a/internal/datastore/memdb/memdb_test.go
+++ b/internal/datastore/memdb/memdb_test.go
@@ -94,7 +94,7 @@ func TestConcurrentWriteRelsError(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		i := i
 		g.Go(func() error {
-			_, err = ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
+			_, err := ds.ReadWriteTx(ctx, func(rwt datastore.ReadWriteTransaction) error {
 				updates := []*corev1.RelationTupleUpdate{}
 				for j := 0; j < 500; j++ {
 					updates = append(updates, &corev1.RelationTupleUpdate{

--- a/internal/graph/cursors.go
+++ b/internal/graph/cursors.go
@@ -358,9 +358,12 @@ func withInternalParallelizedStreamingIterableInCursor[T any, Q any](
 		taskIndex := taskIndex
 		item := item
 		tr.Add(func(ctx context.Context) error {
+			stream.lock.Lock()
 			if ci.limits.hasExhaustedLimit() {
+				stream.lock.Unlock()
 				return nil
 			}
+			stream.lock.Unlock()
 
 			ici, err := getItemCursor(taskIndex)
 			if err != nil {

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -25,7 +25,7 @@ func (t Test) All() error {
 // Unit Runs the unit tests
 func (Test) Unit() error {
 	fmt.Println("running unit tests")
-	return goTest("./...", "-tags", "ci,skipintegrationtests", "-timeout", "10m")
+	return goTest("./...", "-tags", "ci,skipintegrationtests", "-race", "-timeout", "10m")
 }
 
 // Image Run tests that run the built image


### PR DESCRIPTION
Was accidentally removed when we switched to mage for running tests

Fixes #1569