### PR TITLE
spanner: split read/write, add connpool config

### DIFF
--- a/internal/datastore/spanner/options.go
+++ b/internal/datastore/spanner/options.go
@@ -13,6 +13,8 @@ type spannerOptions struct {
 	credentialsFilePath         string
 	emulatorHost                string
 	disableStats                bool
+	readMaxOpen                 int
+	writeMaxOpen                int
 }
 
 const (
@@ -24,6 +26,8 @@ const (
 	defaultWatchBufferLength           = 128
 	defaultDisableStats                = false
 	maxRevisionQuantization            = 24 * time.Hour
+	defaultReadMaxOpen                 = 20
+	defaultWriteMaxOpen                = 10
 )
 
 // Option provides the facility to configure how clients within the Spanner
@@ -37,6 +41,8 @@ func generateConfig(options []Option) (spannerOptions, error) {
 		followerReadDelay:           defaultFollowerReadDelay,
 		maxRevisionStalenessPercent: defaultMaxRevisionStalenessPercent,
 		disableStats:                defaultDisableStats,
+		readMaxOpen:                 defaultReadMaxOpen,
+		writeMaxOpen:                defaultWriteMaxOpen,
 	}
 
 	for _, option := range options {
@@ -117,4 +123,18 @@ func DisableStats(disable bool) Option {
 	return func(po *spannerOptions) {
 		po.disableStats = disable
 	}
+}
+
+// ReadConnsMaxOpen is the maximum size of the connection pool used for reads.
+//
+// This value defaults to having 20 connections.
+func ReadConnsMaxOpen(conns int) Option {
+	return func(po *spannerOptions) { po.readMaxOpen = conns }
+}
+
+// WriteConnsMaxOpen is the maximum size of the connection pool used for writes.
+//
+// This value defaults to having 10 connections.
+func WriteConnsMaxOpen(conns int) Option {
+	return func(po *spannerOptions) { po.writeMaxOpen = conns }
 }

--- a/internal/datastore/spanner/revisions.go
+++ b/internal/datastore/spanner/revisions.go
@@ -30,7 +30,7 @@ func (sd spannerDatastore) now(ctx context.Context) (time.Time, error) {
 	defer span.End()
 
 	var timestamp time.Time
-	if err := sd.client.Single().Query(ctx, spanner.NewStatement("SELECT CURRENT_TIMESTAMP()")).Do(func(r *spanner.Row) error {
+	if err := sd.readClient.Single().Query(ctx, spanner.NewStatement("SELECT CURRENT_TIMESTAMP()")).Do(func(r *spanner.Row) error {
 		return r.Columns(&timestamp)
 	}); err != nil {
 		return time.Time{}, err

--- a/internal/datastore/spanner/stats.go
+++ b/internal/datastore/spanner/stats.go
@@ -21,7 +21,7 @@ var (
 
 func (sd spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, error) {
 	var uniqueID string
-	if err := sd.client.Single().Read(
+	if err := sd.readClient.Single().Read(
 		context.Background(),
 		tableMetadata,
 		spanner.AllKeys(),
@@ -32,7 +32,7 @@ func (sd spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, err
 		return datastore.Stats{}, fmt.Errorf("unable to read unique ID: %w", err)
 	}
 
-	iter := sd.client.Single().Read(
+	iter := sd.readClient.Single().Read(
 		ctx,
 		tableNamespace,
 		spanner.AllKeys(),
@@ -45,7 +45,7 @@ func (sd spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, err
 	}
 
 	var estimate spanner.NullInt64
-	if err := sd.client.Single().Query(ctx, spanner.Statement{SQL: queryRelationshipEstimate}).Do(func(r *spanner.Row) error {
+	if err := sd.readClient.Single().Query(ctx, spanner.Statement{SQL: queryRelationshipEstimate}).Do(func(r *spanner.Row) error {
 		return r.Columns(&estimate)
 	}); err != nil {
 		return datastore.Stats{}, fmt.Errorf("unable to read row counts: %w", err)

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -418,6 +418,8 @@ func newSpannerDatastore(opts Config) (datastore.Datastore, error) {
 		spanner.WatchBufferLength(opts.WatchBufferLength),
 		spanner.EmulatorHost(opts.SpannerEmulatorHost),
 		spanner.DisableStats(opts.DisableStats),
+		spanner.ReadConnsMaxOpen(opts.ReadConnPool.MaxOpenConns),
+		spanner.WriteConnsMaxOpen(opts.WriteConnPool.MaxOpenConns),
 	)
 }
 


### PR DESCRIPTION
This PR connects up the SpiceDB datastore flags for connection pooling with the underlying Spanner client's gRPC connection pooling.

This also enables gzip compression for the underlying Spanner gRPC connections.

Possible future work:
- Support the min read/write open connection flags -- this end up just being `grpcConns = max(config.min, config.max)` because we don't have access to set a minimum
- Use optgen to generate the spanner datastore config