### PR TITLE
.github: move to buildjet

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,7 +14,7 @@ env:
   GO_VERSION: "~1.21.3"
 jobs:
   paths-filter:
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     outputs:
       codechange: "${{ steps.code-filter.outputs.codechange }}"
       protochange: "${{ steps.proto-filter.outputs.protochange }}"
@@ -44,7 +44,7 @@ jobs:
               - "go.mod"
   build:
     name: "Build Binary"
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -71,7 +71,7 @@ jobs:
 
   unit:
     name: "Unit"
-    runs-on: "ubuntu-latest-4-cores"
+    runs-on: "buildjet-4vcpu-ubuntu-2204"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -85,7 +85,7 @@ jobs:
 
   integration:
     name: "Integration Tests"
-    runs-on: "ubuntu-latest-4-cores"
+    runs-on: "buildjet-4vcpu-ubuntu-2204"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -99,7 +99,7 @@ jobs:
 
   datastore:
     name: "Datastore Tests"
-    runs-on: "ubuntu-latest-4-cores"
+    runs-on: "buildjet-4vcpu-ubuntu-2204"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -117,7 +117,7 @@ jobs:
 
   datastoreconsistency:
     name: "Datastore Consistency Tests"
-    runs-on: "ubuntu-latest-4-cores"
+    runs-on: "buildjet-4vcpu-ubuntu-2204"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -135,7 +135,7 @@ jobs:
 
   e2e:
     name: "E2E"
-    runs-on: "ubuntu-latest-8-cores"
+    runs-on: "buildjet-8vcpu-ubuntu-2204"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -187,7 +187,7 @@ jobs:
           path: "e2e/newenemy/*.log"
   analyzers-unit-tests:
     name: "Analyzers Unit Tests"
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -202,7 +202,7 @@ jobs:
         run: "go run mage.go test:analyzers"
   development:
     name: "WASM Tests"
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -216,7 +216,7 @@ jobs:
 
   protobuf:
     name: "Generate Protobufs"
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.protochange == 'true'

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -148,7 +148,7 @@ jobs:
           cache-dependency-path: "e2e/go.sum"
       - name: "Cache Binaries"
         id: "cache-binaries"
-        uses: "actions/cache@v2"
+        uses: "buildjet/cache@v3"
         with:
           path: |
             e2e/newenemy/cockroach
@@ -162,7 +162,7 @@ jobs:
         run: |
           curl https://binaries.cockroachdb.com/cockroach-v22.1.5.linux-amd64.tgz | tar -xz && mv cockroach-v22.1.5.linux-amd64/cockroach ./cockroach
           curl -fsSL https://mirrors.chaos-mesh.org/chaosd-v1.1.1-linux-amd64.tar.gz | tar -xz && mv chaosd-v1.1.1-linux-amd64/chaosd ./chaosd
-      - uses: "actions/cache@v2"
+      - uses: "buildjet/cache@v3"
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -43,8 +43,8 @@ jobs:
               - "proto/**"
               - "go.mod"
   build:
-    name: "Build Binary"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    name: "Build Binary & Image"
+    runs-on: "buildjet-4vcpu-ubuntu-2204"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -54,18 +54,6 @@ jobs:
         with:
           go-version: "${{ env.GO_VERSION }}"
       - uses: "authzed/actions/go-build@main"
-
-  image-build:
-    name: "Build Container Image"
-    runs-on: "ubuntu-latest-4-cores"
-    needs: "paths-filter"
-    if: |
-      needs.paths-filter.outputs.codechange == 'true'
-    steps:
-      - uses: "actions/checkout@v3"
-      - uses: "authzed/actions/setup-go@main"
-        with:
-          go-version: "${{ env.GO_VERSION }}"
       - name: "Image tests"
         run: "go run mage.go test:image"
 
@@ -114,22 +102,6 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
       - name: "Integration tests"
         run: "go run mage.go testds:${{ matrix.datastore }}"
-
-  datastoreconsistency:
-    name: "Datastore Consistency Tests"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
-    needs: "paths-filter"
-    if: |
-      needs.paths-filter.outputs.codechange == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        datastore: ["crdb", "mysql", "postgres", "spanner"]
-    steps:
-      - uses: "actions/checkout@v3"
-      - uses: "authzed/actions/setup-go@main"
-        with:
-          go-version: "${{ env.GO_VERSION }}"
       - name: "Integration tests"
         run: "go run mage.go testcons:${{ matrix.datastore }}"
 

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   cla:
     name: "Check Signature"
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     steps:
       - uses: "authzed/actions/cla-check@main"
         with:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       - "checks_requested"
 jobs:
   triage:
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     steps:
       - uses: "actions/labeler@v3"
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   go-lint:
     name: "Lint Go"
-    runs-on: "ubuntu-latest-4-cores"
+    runs-on: "buildjet-4vcpu-ubuntu-2204"
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"
@@ -30,7 +30,7 @@ jobs:
 
   extra-lint:
     name: "Lint YAML & Markdown"
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     steps:
       - uses: "actions/checkout@v3"
       - name: "Lint Everything Else"
@@ -42,7 +42,7 @@ jobs:
 
   codeql:
     name: "Analyze with CodeQL"
-    runs-on: "ubuntu-latest-8-cores"
+    runs-on: "buildjet-8vcpu-ubuntu-2204"
     permissions:
       actions: "read"
       contents: "read"
@@ -57,7 +57,7 @@ jobs:
 
   trivy-fs:
     name: "Analyze FS with Trivy"
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     steps:
       - uses: "actions/checkout@v3"
       - uses: "aquasecurity/trivy-action@master"
@@ -70,7 +70,7 @@ jobs:
 
   trivy-image:
     name: "Analyze Release Image with Trivy"
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -55,11 +55,14 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/codeql@main"
 
-  trivy-fs:
-    name: "Analyze FS with Trivy"
+  trivy:
+    name: "Trivvy: Analyze FS and Image"
     runs-on: "buildjet-2vcpu-ubuntu-2204"
     steps:
       - uses: "actions/checkout@v3"
+      - uses: "authzed/actions/setup-go@main"
+        with:
+          go-version: "${{ env.GO_VERSION }}"
       - uses: "aquasecurity/trivy-action@master"
         with:
           scan-type: "fs"
@@ -67,15 +70,6 @@ jobs:
           format: "table"
           exit-code: "1"
           severity: "CRITICAL,HIGH,MEDIUM"
-
-  trivy-image:
-    name: "Analyze Release Image with Trivy"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
-    steps:
-      - uses: "actions/checkout@v3"
-      - uses: "authzed/actions/setup-go@main"
-        with:
-          go-version: "${{ env.GO_VERSION }}"
       # Workaround until goreleaser release supports --single-target
       # makes the build faster by not building everything
       - name: "modify goreleaser config to skip building all targets"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ env:
   GO_VERSION: "~1.21.3"
 jobs:
   goreleaser:
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-4vcpu-ubuntu-2204"
     steps:
       - uses: "actions/checkout@v3"
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ env:
   GO_VERSION: "~1.21.3"
 jobs:
   goreleaser:
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-4vcpu-ubuntu-2204"
     steps:
       - uses: "actions/checkout@v3"
         with:

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
   build:
     name: "Build WASM"
-    runs-on: "ubuntu-latest"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     steps:
       - uses: "actions/checkout@v3"
         with:


### PR DESCRIPTION
This change migrates our GitHub Actions to all run on [BuildJet](buildjet.com), which is cheaper and faster than GitHub's provided service.

Previously we were relying on some DockerHub preventing rate limiting on GitHub's network, but they've ceased that behavior. We've migrated as many public images off DockerHub, so now we can take advantage of BuildJet.