### PR TITLE
spanner: add missing calls to RowIterator.Stop

### DIFF
--- a/internal/datastore/spanner/caveat.go
+++ b/internal/datastore/spanner/caveat.go
@@ -61,6 +61,7 @@ func (sr spannerReader) listCaveats(ctx context.Context, caveatNames []string) (
 		keyset,
 		[]string{colCaveatDefinition, colCaveatTS},
 	)
+	defer iter.Stop()
 
 	var caveats []datastore.RevisionedCaveat
 	if err := iter.Do(func(row *spanner.Row) error {

--- a/internal/datastore/spanner/reader.go
+++ b/internal/datastore/spanner/reader.go
@@ -76,6 +76,7 @@ func queryExecutor(txSource txFactory) common.ExecuteQueryFunc {
 		defer span.End()
 
 		iter := txSource().Query(ctx, statementFromSQL(sql, args))
+		defer iter.Stop()
 
 		var tuples []*core.RelationTuple
 
@@ -152,6 +153,7 @@ func (sr spannerReader) ListAllNamespaces(ctx context.Context) ([]datastore.Revi
 		spanner.AllKeys(),
 		[]string{colNamespaceConfig, colNamespaceTS},
 	)
+	defer iter.Stop()
 
 	allNamespaces, err := readAllNamespaces(iter)
 	if err != nil {
@@ -177,6 +179,7 @@ func (sr spannerReader) LookupNamespacesWithNames(ctx context.Context, nsNames [
 		spanner.KeySetFromKeys(keys...),
 		[]string{colNamespaceConfig, colNamespaceTS},
 	)
+	defer iter.Stop()
 
 	foundNamespaces, err := readAllNamespaces(iter)
 	if err != nil {

--- a/internal/datastore/spanner/stats.go
+++ b/internal/datastore/spanner/stats.go
@@ -38,6 +38,7 @@ func (sd spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, err
 		spanner.AllKeys(),
 		[]string{colNamespaceConfig, colNamespaceTS},
 	)
+	defer iter.Stop()
 
 	allNamespaces, err := readAllNamespaces(iter)
 	if err != nil {


### PR DESCRIPTION
Spanner Go client says we should be calling it