### PR TITLE
datastore/*: singleflight HeadRevision

### DIFF
--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 
 	datastoreinternal "github.com/authzed/spicedb/internal/datastore"
 	"github.com/authzed/spicedb/internal/datastore/common"
@@ -427,6 +428,8 @@ type Datastore struct {
 
 	optimizedRevisionQuery string
 	validTransactionQuery  string
+
+	headGroup singleflight.Group
 
 	gcGroup  *errgroup.Group
 	gcCtx    context.Context

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 
 	datastoreinternal "github.com/authzed/spicedb/internal/datastore"
 	"github.com/authzed/spicedb/internal/datastore/common"
@@ -291,6 +292,8 @@ type pgDatastore struct {
 	readTxOptions           pgx.TxOptions
 	maxRetries              uint8
 	watchEnabled            bool
+
+	headGroup singleflight.Group
 
 	gcGroup  *errgroup.Group
 	gcCtx    context.Context

--- a/internal/datastore/spanner/revisions.go
+++ b/internal/datastore/spanner/revisions.go
@@ -25,21 +25,17 @@ func (sd *spannerDatastore) HeadRevision(ctx context.Context) (datastore.Revisio
 	return sd.headRevisionInternal(ctx)
 }
 
-func (sd *spannerDatastore) now(ctx context.Context) (time.Time, error) {
-	resultChan := sd.headGroup.DoChan("", func() (any, error) {
+func (sd *spannerDatastore) now(_ context.Context) (time.Time, error) {
+	// Ignores any cancellation from the parent context.
+	// Unlike DoChan(), Do() also avoids spawning goroutines.
+	result, err, _ := sd.headGroup.Do("", func() (any, error) {
 		var timestamp time.Time
 		err := sd.client.Single().Query(context.Background(), spanner.NewStatement("SELECT CURRENT_TIMESTAMP()")).Do(func(r *spanner.Row) error {
 			return r.Columns(&timestamp)
 		})
 		return timestamp, err
 	})
-
-	select {
-	case <-ctx.Done():
-		return time.Time{}, ctx.Err()
-	case result := <-resultChan:
-		return result.Val.(time.Time), result.Err
-	}
+	return result.(time.Time), err
 }
 
 func revisionFromTimestamp(t time.Time) revision.Decimal {

--- a/internal/datastore/spanner/revisions.go
+++ b/internal/datastore/spanner/revisions.go
@@ -12,7 +12,7 @@ import (
 	"github.com/authzed/spicedb/pkg/datastore/revision"
 )
 
-func (sd spannerDatastore) headRevisionInternal(ctx context.Context) (revision.Decimal, error) {
+func (sd *spannerDatastore) headRevisionInternal(ctx context.Context) (revision.Decimal, error) {
 	now, err := sd.now(ctx)
 	if err != nil {
 		return revision.NoRevision, fmt.Errorf(errRevision, err)
@@ -21,19 +21,25 @@ func (sd spannerDatastore) headRevisionInternal(ctx context.Context) (revision.D
 	return revisionFromTimestamp(now), nil
 }
 
-func (sd spannerDatastore) HeadRevision(ctx context.Context) (datastore.Revision, error) {
+func (sd *spannerDatastore) HeadRevision(ctx context.Context) (datastore.Revision, error) {
 	return sd.headRevisionInternal(ctx)
 }
 
-func (sd spannerDatastore) now(ctx context.Context) (time.Time, error) {
-	var timestamp time.Time
-	if err := sd.client.Single().Query(ctx, spanner.NewStatement("SELECT CURRENT_TIMESTAMP()")).Do(func(r *spanner.Row) error {
-		return r.Columns(&timestamp)
-	}); err != nil {
-		return time.Time{}, err
-	}
+func (sd *spannerDatastore) now(ctx context.Context) (time.Time, error) {
+	resultChan := sd.headGroup.DoChan("", func() (any, error) {
+		var timestamp time.Time
+		err := sd.client.Single().Query(context.Background(), spanner.NewStatement("SELECT CURRENT_TIMESTAMP()")).Do(func(r *spanner.Row) error {
+			return r.Columns(&timestamp)
+		})
+		return timestamp, err
+	})
 
-	return timestamp, nil
+	select {
+	case <-ctx.Done():
+		return time.Time{}, ctx.Err()
+	case result := <-resultChan:
+		return result.Val.(time.Time), result.Err
+	}
 }
 
 func revisionFromTimestamp(t time.Time) revision.Decimal {

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Implement TestableDatastore interface
-func (sd spannerDatastore) ExampleRetryableError() error {
+func (sd *spannerDatastore) ExampleRetryableError() error {
 	return status.New(codes.Aborted, "retryable").Err()
 }
 

--- a/internal/datastore/spanner/stats.go
+++ b/internal/datastore/spanner/stats.go
@@ -20,7 +20,7 @@ var (
 	rng = rand.NewSource(time.Now().UnixNano())
 )
 
-func (sd spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, error) {
+func (sd *spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, error) {
 	var uniqueID string
 	if err := sd.client.Single().Read(
 		context.Background(),

--- a/internal/datastore/spanner/watch.go
+++ b/internal/datastore/spanner/watch.go
@@ -34,7 +34,7 @@ func parseDatabaseName(db string) (project, instance, database string, err error
 	return matches[1], matches[2], matches[3], nil
 }
 
-func (sd spannerDatastore) Watch(ctx context.Context, afterRevisionRaw datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
+func (sd *spannerDatastore) Watch(ctx context.Context, afterRevisionRaw datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
 	updates := make(chan *datastore.RevisionChanges, 10)
 	errs := make(chan error, 1)
 


### PR DESCRIPTION
This PR performs each datastore's network call to process the HeadRevision within a one, shared singleflight context.
This should vastly reduce the overall number of these calls at the datastore, which are very expensive.

Another hugely positive side effect is that requests are more likely to share the same revision (and thus cache).