### PR TITLE
tracing ux: enriches traversal operations

### DIFF
--- a/internal/testserver/datastore/spanner.go
+++ b/internal/testserver/datastore/spanner.go
@@ -38,7 +38,7 @@ func RunSpannerForTesting(t testing.TB, bridgeNetworkName string, targetMigratio
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Name:         name,
 		Repository:   "gcr.io/cloud-spanner-emulator/emulator",
-		Tag:          "1.5.8",
+		Tag:          "1.5.11",
 		ExposedPorts: []string{"9010/tcp"},
 		NetworkID:    bridgeNetworkName,
 	})


### PR DESCRIPTION
⚠️ built on top of https://github.com/authzed/spicedb/pull/1598

this renders in a more obvious way how graph traversal is happening during check requests, showing
where is time being spent in the schema.