### PR TITLE
propagates gRPC errors in graph package

### DIFF
--- a/internal/dispatch/graph/graph_test.go
+++ b/internal/dispatch/graph/graph_test.go
@@ -1,10 +1,21 @@
 package graph
 
 import (
+	"context"
 	"testing"
 
+	"github.com/authzed/spicedb/internal/graph"
+
+	"github.com/authzed/grpcutil"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+func TestUnwrapStatusError(t *testing.T) {
+	err := rewriteError(context.Background(), graph.NewCheckFailureErr(status.Error(codes.Canceled, "canceled")))
+	grpcutil.RequireStatus(t, codes.Canceled, err)
+}
 
 func TestConcurrencyLimitsWithOverallDefaultLimit(t *testing.T) {
 	cl := ConcurrencyLimits{}

--- a/internal/graph/errors.go
+++ b/internal/graph/errors.go
@@ -33,6 +33,10 @@ type ErrCheckFailure struct {
 	error
 }
 
+func (e ErrCheckFailure) Unwrap() error {
+	return e.error
+}
+
 // NewCheckFailureErr constructs a new check failed error.
 func NewCheckFailureErr(baseErr error) error {
 	return ErrCheckFailure{
@@ -44,6 +48,10 @@ func NewCheckFailureErr(baseErr error) error {
 // namespaces and relations not being found.
 type ErrExpansionFailure struct {
 	error
+}
+
+func (e ErrExpansionFailure) Unwrap() error {
+	return e.error
 }
 
 // NewExpansionFailureErr constructs a new expansion failed error.
@@ -157,6 +165,10 @@ func NewErrInvalidArgument(baseErr error) error {
 	}
 }
 
+func (e ErrInvalidArgument) Unwrap() error {
+	return e.error
+}
+
 // ErrUnimplemented is returned when some functionality is not yet supported.
 type ErrUnimplemented struct {
 	error
@@ -167,6 +179,10 @@ func NewUnimplementedErr(baseErr error) error {
 	return ErrUnimplemented{
 		error: baseErr,
 	}
+}
+
+func (e ErrUnimplemented) Unwrap() error {
+	return e.error
 }
 
 // ErrInvalidCursor is returned when a cursor is no longer valid.

--- a/internal/services/dispatch/v1/acl.go
+++ b/internal/services/dispatch/v1/acl.go
@@ -82,6 +82,11 @@ func (ds *dispatchServer) Close() error {
 }
 
 func rewriteGraphError(ctx context.Context, err error) error {
+	// Check if the error can be directly used.
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
 	switch {
 	case errors.As(err, &graph.ErrRequestCanceled{}):
 		return status.Errorf(codes.Canceled, "request canceled: %s", err)

--- a/internal/testserver/datastore/spanner.go
+++ b/internal/testserver/datastore/spanner.go
@@ -38,7 +38,7 @@ func RunSpannerForTesting(t testing.TB, bridgeNetworkName string, targetMigratio
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Name:         name,
 		Repository:   "gcr.io/cloud-spanner-emulator/emulator",
-		Tag:          "1.5.8",
+		Tag:          "1.5.11",
 		ExposedPorts: []string{"9010/tcp"},
 		NetworkID:    bridgeNetworkName,
 	})


### PR DESCRIPTION
When the datastore has a gRPC API, we may get
a grpc.Status as error, which does not respond to
`error.Is(ctx, context.Canceled)`.

Like in other parts of the code, we determine if
this is a `grpc.Status` and return it as is.