### PR TITLE
Add support for experimental secondary dispatching

### DIFF
--- a/internal/dispatch/remote/cluster_test.go
+++ b/internal/dispatch/remote/cluster_test.go
@@ -16,20 +16,23 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/authzed/spicedb/internal/dispatch/keys"
-	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 )
 
 type fakeDispatchSvc struct {
 	v1.UnimplementedDispatchServiceServer
 
-	sleepTime time.Duration
+	sleepTime     time.Duration
+	dispatchCount uint32
 }
 
 func (fds *fakeDispatchSvc) DispatchCheck(context.Context, *v1.DispatchCheckRequest) (*v1.DispatchCheckResponse, error) {
 	time.Sleep(fds.sleepTime)
 	return &v1.DispatchCheckResponse{
-		Metadata: emptyMetadata,
+		Metadata: &v1.ResponseMeta{
+			DispatchCount: fds.dispatchCount,
+		},
 	}, nil
 }
 
@@ -90,16 +93,16 @@ func TestDispatchTimeout(t *testing.T) {
 			dispatcher := NewClusterDispatcher(v1.NewDispatchServiceClient(conn), conn, ClusterDispatcherConfig{
 				KeyHandler:             &keys.DirectKeyHandler{},
 				DispatchOverallTimeout: tc.timeout,
-			})
+			}, nil, nil)
 			require.True(t, dispatcher.ReadyState().IsReady)
 
 			// Invoke a dispatched "check" and ensure it times out, as the fake dispatch will wait
 			// longer than the configured timeout.
 			resp, err := dispatcher.DispatchCheck(context.Background(), &v1.DispatchCheckRequest{
-				ResourceRelation: &core.RelationReference{Namespace: "sometype", Relation: "somerel"},
+				ResourceRelation: &corev1.RelationReference{Namespace: "sometype", Relation: "somerel"},
 				ResourceIds:      []string{"foo"},
 				Metadata:         &v1.ResolverMeta{DepthRemaining: 50},
-				Subject:          &core.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
+				Subject:          &corev1.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
 			})
 			if tc.sleepTime > tc.timeout {
 				require.Error(t, err)
@@ -113,10 +116,10 @@ func TestDispatchTimeout(t *testing.T) {
 			// Invoke a dispatched "LookupSubjects" and test as well.
 			stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupSubjectsResponse](context.Background())
 			err = dispatcher.DispatchLookupSubjects(&v1.DispatchLookupSubjectsRequest{
-				ResourceRelation: &core.RelationReference{Namespace: "sometype", Relation: "somerel"},
+				ResourceRelation: &corev1.RelationReference{Namespace: "sometype", Relation: "somerel"},
 				ResourceIds:      []string{"foo"},
 				Metadata:         &v1.ResolverMeta{DepthRemaining: 50},
-				SubjectRelation:  &core.RelationReference{Namespace: "sometype", Relation: "somerel"},
+				SubjectRelation:  &corev1.RelationReference{Namespace: "sometype", Relation: "somerel"},
 			}, stream)
 			if tc.sleepTime > tc.timeout {
 				require.Error(t, err)
@@ -128,4 +131,144 @@ func TestDispatchTimeout(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSecondaryDispatch(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		expr             string
+		request          *v1.DispatchCheckRequest
+		primarySleepTime time.Duration
+		expectedResult   uint32
+	}{
+		{
+			"no multidispatch",
+			"['invalid']",
+			&v1.DispatchCheckRequest{
+				ResourceRelation: &corev1.RelationReference{
+					Namespace: "somenamespace",
+					Relation:  "somerelation",
+				},
+				ResourceIds: []string{"foo"},
+				Metadata:    &v1.ResolverMeta{DepthRemaining: 50},
+				Subject:     &corev1.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
+			},
+			0 * time.Millisecond,
+			1,
+		},
+		{
+			"basic multidispatch",
+			"['secondary']",
+			&v1.DispatchCheckRequest{
+				ResourceRelation: &corev1.RelationReference{
+					Namespace: "somenamespace",
+					Relation:  "somerelation",
+				},
+				ResourceIds: []string{"foo"},
+				Metadata:    &v1.ResolverMeta{DepthRemaining: 50},
+				Subject:     &corev1.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
+			},
+			1 * time.Second,
+			2,
+		},
+		{
+			"basic multidispatch, expr doesn't call secondary",
+			"['notconfigured']",
+			&v1.DispatchCheckRequest{
+				ResourceRelation: &corev1.RelationReference{
+					Namespace: "somenamespace",
+					Relation:  "somerelation",
+				},
+				ResourceIds: []string{"foo"},
+				Metadata:    &v1.ResolverMeta{DepthRemaining: 50},
+				Subject:     &corev1.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
+			},
+			1 * time.Second,
+			1,
+		},
+		{
+			"expr matches request",
+			"request.resource_relation.namespace == 'somenamespace' ? ['secondary'] : []",
+			&v1.DispatchCheckRequest{
+				ResourceRelation: &corev1.RelationReference{
+					Namespace: "somenamespace",
+					Relation:  "somerelation",
+				},
+				ResourceIds: []string{"foo"},
+				Metadata:    &v1.ResolverMeta{DepthRemaining: 50},
+				Subject:     &corev1.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
+			},
+			1 * time.Second,
+			2,
+		},
+		{
+			"expr does not match request",
+			"request.resource_relation.namespace == 'somenamespace' ? ['secondary'] : []",
+			&v1.DispatchCheckRequest{
+				ResourceRelation: &corev1.RelationReference{
+					Namespace: "someothernamespace",
+					Relation:  "somerelation",
+				},
+				ResourceIds: []string{"foo"},
+				Metadata:    &v1.ResolverMeta{DepthRemaining: 50},
+				Subject:     &corev1.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
+			},
+			1 * time.Second,
+			1,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			conn := connectionForDispatching(t, &fakeDispatchSvc{dispatchCount: 1, sleepTime: tc.primarySleepTime})
+			secondaryConn := connectionForDispatching(t, &fakeDispatchSvc{dispatchCount: 2, sleepTime: 0 * time.Millisecond})
+
+			parsed, err := ParseDispatchExpression("check", tc.expr)
+			require.NoError(t, err)
+
+			dispatcher := NewClusterDispatcher(v1.NewDispatchServiceClient(conn), conn, ClusterDispatcherConfig{
+				KeyHandler:             &keys.DirectKeyHandler{},
+				DispatchOverallTimeout: 30 * time.Second,
+			}, map[string]SecondaryDispatch{
+				"secondary": {Name: "secondary", Client: v1.NewDispatchServiceClient(secondaryConn)},
+			}, map[string]*DispatchExpr{
+				"check": parsed,
+			})
+			require.True(t, dispatcher.ReadyState().IsReady)
+
+			resp, err := dispatcher.DispatchCheck(context.Background(), tc.request)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedResult, resp.Metadata.DispatchCount)
+		})
+	}
+}
+
+func connectionForDispatching(t *testing.T, svc v1.DispatchServiceServer) *grpc.ClientConn {
+	listener := bufconn.Listen(humanize.MiByte)
+	s := grpc.NewServer()
+
+	v1.RegisterDispatchServiceServer(s, svc)
+
+	go func() {
+		// Ignore any errors
+		_ = s.Serve(listener)
+	}()
+
+	conn, err := grpc.DialContext(
+		context.Background(),
+		"",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		conn.Close()
+		listener.Close()
+		s.Stop()
+	})
+
+	return conn
 }

--- a/internal/dispatch/remote/expr.go
+++ b/internal/dispatch/remote/expr.go
@@ -1,0 +1,103 @@
+package remote
+
+import (
+	"fmt"
+
+	"github.com/authzed/cel-go/cel"
+	"github.com/authzed/cel-go/common"
+	"github.com/authzed/cel-go/common/types"
+	"github.com/authzed/cel-go/common/types/ref"
+	"google.golang.org/protobuf/proto"
+
+	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
+	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+)
+
+// DispatchExpr is a CEL expression that can be run to determine the secondary dispatchers, if any,
+// to invoke for the incoming request.
+type DispatchExpr struct {
+	env        *cel.Env
+	registry   *types.Registry
+	methodName string
+	exprAst    *cel.Ast
+}
+
+var dispatchRequestTypes = []proto.Message{
+	&dispatchv1.DispatchCheckRequest{},
+	&corev1.RelationReference{},
+	&corev1.ObjectAndRelation{},
+}
+
+// ParseDispatchExpression parses a dispatch expression via CEL.
+func ParseDispatchExpression(methodName string, exprString string) (*DispatchExpr, error) {
+	registry, err := types.NewRegistry(dispatchRequestTypes...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize dispatch expression type registry")
+	}
+
+	opts := make([]cel.EnvOption, 0)
+	opts = append(opts, cel.OptionalTypes(cel.OptionalTypesVersion(0)))
+	opts = append(opts, cel.Variable("request", cel.DynType))
+
+	celEnv, err := cel.NewEnv(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	ast, issues := celEnv.CompileSource(common.NewStringSource(exprString, methodName))
+	if issues != nil && issues.Err() != nil {
+		return nil, issues.Err()
+	}
+
+	if !ast.OutputType().IsEquivalentType(cel.ListType(cel.StringType)) {
+		return nil, fmt.Errorf("dispatch expression must result in a list[string] value: found `%s`", ast.OutputType().String())
+	}
+
+	return &DispatchExpr{
+		env:        celEnv,
+		registry:   registry,
+		methodName: methodName,
+		exprAst:    ast,
+	}, nil
+}
+
+// RunDispatchExpr runs a dispatch CEL expression over the given request and returns the secondary dispatchers
+// to invoke, if any.
+func RunDispatchExpr[R any](de *DispatchExpr, request R) ([]string, error) {
+	celopts := make([]cel.ProgramOption, 0, 3)
+
+	celopts = append(celopts, cel.EvalOptions(cel.OptTrackState))
+	celopts = append(celopts, cel.EvalOptions(cel.OptPartialEval))
+	celopts = append(celopts, cel.CostLimit(50))
+
+	prg, err := de.env.Program(de.exprAst, celopts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mark any unspecified variables as unknown, to ensure that partial application
+	// will result in producing a type of Unknown.
+	activation, err := de.env.PartialVars(map[string]any{
+		"request": de.registry.NativeToValue(request),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	val, _, err := prg.Eval(activation)
+	if err != nil {
+		return nil, fmt.Errorf("unable to evaluate dispatch expression: %w", err)
+	}
+
+	// If the value produced has Unknown type, then it means required context was missing.
+	if types.IsUnknown(val) {
+		return nil, fmt.Errorf("unable to eval dispatch expression; did you make sure you use `request.`?")
+	}
+
+	values := val.Value().([]ref.Val)
+	convertedValues := make([]string, 0, len(values))
+	for _, value := range values {
+		convertedValues = append(convertedValues, value.Value().(string))
+	}
+	return convertedValues, nil
+}

--- a/internal/dispatch/remote/expr_test.go
+++ b/internal/dispatch/remote/expr_test.go
@@ -1,0 +1,125 @@
+package remote
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
+	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+)
+
+func TestParseDispatchExpression(t *testing.T) {
+	tcs := []struct {
+		name          string
+		expr          string
+		expectedError string
+	}{
+		{
+			"empty",
+			"",
+			"mismatched input '<EOF>'",
+		},
+		{
+			"returns string",
+			"'somestring'",
+			"a list[string] value",
+		},
+		{
+			"invalid expression",
+			"a.b.c!d",
+			"mismatched input '!'",
+		},
+		{
+			"valid expression",
+			"['prewarm']",
+			"",
+		},
+		{
+			"valid big expression",
+			"request.resource_relation.namespace == 'foo' ? ['prewarm'] : []",
+			"",
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseDispatchExpression("somemethod", tc.expr)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRunCheckDispatchExpr(t *testing.T) {
+	tcs := []struct {
+		name           string
+		expr           string
+		request        *dispatchv1.DispatchCheckRequest
+		expectedResult []string
+		expectedError  string
+	}{
+		{
+			"static",
+			"['prewarm']",
+			nil,
+			[]string{"prewarm"},
+			"",
+		},
+		{
+			"basic",
+			"request.resource_relation.namespace == 'somenamespace' ? ['prewarm'] : ['other']",
+			&dispatchv1.DispatchCheckRequest{
+				ResourceRelation: &corev1.RelationReference{
+					Namespace: "somenamespace",
+					Relation:  "somerelation",
+				},
+			},
+			[]string{"prewarm"},
+			"",
+		},
+		{
+			"basic other branch",
+			"request.resource_relation.namespace == 'somethingelse' ? ['prewarm'] : ['other']",
+			&dispatchv1.DispatchCheckRequest{
+				ResourceRelation: &corev1.RelationReference{
+					Namespace: "somenamespace",
+					Relation:  "somerelation",
+				},
+			},
+			[]string{"other"},
+			"",
+		},
+		{
+			"invalid field",
+			"request.resource_relation.invalidfield == 'somethingelse' ? ['prewarm'] : ['other']",
+			&dispatchv1.DispatchCheckRequest{
+				ResourceRelation: &corev1.RelationReference{
+					Namespace: "somenamespace",
+					Relation:  "somerelation",
+				},
+			},
+			nil,
+			"no such field 'invalidfield'",
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := ParseDispatchExpression("check", tc.expr)
+			require.NoError(t, err)
+
+			resp, err := RunDispatchExpr(parsed, tc.request)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+			} else {
+				require.Equal(t, tc.expectedResult, resp)
+			}
+		})
+	}
+}

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -115,6 +115,9 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	cmd.Flags().Uint16Var(&config.DispatchHashringReplicationFactor, "dispatch-hashring-replication-factor", 100, "set the replication factor of the consistent hasher used for the dispatcher")
 	cmd.Flags().Uint8Var(&config.DispatchHashringSpread, "dispatch-hashring-spread", 1, "set the spread of the consistent hasher used for the dispatcher")
 
+	cmd.Flags().StringToStringVar(&config.DispatchSecondaryUpstreamAddrs, "experimental-dispatch-secondary-upstream-addrs", nil, "secondary upstream addresses for dispatches, each with a name")
+	cmd.Flags().StringToStringVar(&config.DispatchSecondaryUpstreamExprs, "experimental-dispatch-secondary-upstream-exprs", nil, "map from request type (currently supported: `check`) to its associated CEL expression, which returns the secondary upstream(s) to be used for the request")
+
 	// Flags for configuring API behavior
 	cmd.Flags().BoolVar(&config.DisableV1SchemaAPI, "disable-v1-schema-api", false, "disables the V1 schema API")
 	cmd.Flags().BoolVar(&config.DisableVersionResponse, "disable-version-response", false, "disables version response support in the API")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -97,6 +97,9 @@ type Config struct {
 	DispatchHashringReplicationFactor uint16                  `debugmap:"visible"`
 	DispatchHashringSpread            uint8                   `debugmap:"visible"`
 
+	DispatchSecondaryUpstreamAddrs map[string]string `debugmap:"visible"`
+	DispatchSecondaryUpstreamExprs map[string]string `debugmap:"visible"`
+
 	DispatchCacheConfig        CacheConfig `debugmap:"visible"`
 	ClusterDispatchCacheConfig CacheConfig `debugmap:"visible"`
 
@@ -261,6 +264,8 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		dispatcher, err = combineddispatch.NewDispatcher(
 			combineddispatch.UpstreamAddr(c.DispatchUpstreamAddr),
 			combineddispatch.UpstreamCAPath(c.DispatchUpstreamCAPath),
+			combineddispatch.SecondaryUpstreamAddrs(c.DispatchSecondaryUpstreamAddrs),
+			combineddispatch.SecondaryUpstreamExprs(c.DispatchSecondaryUpstreamExprs),
 			combineddispatch.GrpcPresharedKey(dispatchPresharedKey),
 			combineddispatch.GrpcDialOpts(
 				grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -69,6 +69,8 @@ func (c *Config) ToOption() ConfigOption {
 		to.Dispatcher = c.Dispatcher
 		to.DispatchHashringReplicationFactor = c.DispatchHashringReplicationFactor
 		to.DispatchHashringSpread = c.DispatchHashringSpread
+		to.DispatchSecondaryUpstreamAddrs = c.DispatchSecondaryUpstreamAddrs
+		to.DispatchSecondaryUpstreamExprs = c.DispatchSecondaryUpstreamExprs
 		to.DispatchCacheConfig = c.DispatchCacheConfig
 		to.ClusterDispatchCacheConfig = c.ClusterDispatchCacheConfig
 		to.DisableV1SchemaAPI = c.DisableV1SchemaAPI
@@ -123,6 +125,8 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["Dispatcher"] = helpers.DebugValue(c.Dispatcher, false)
 	debugMap["DispatchHashringReplicationFactor"] = helpers.DebugValue(c.DispatchHashringReplicationFactor, false)
 	debugMap["DispatchHashringSpread"] = helpers.DebugValue(c.DispatchHashringSpread, false)
+	debugMap["DispatchSecondaryUpstreamAddrs"] = helpers.DebugValue(c.DispatchSecondaryUpstreamAddrs, false)
+	debugMap["DispatchSecondaryUpstreamExprs"] = helpers.DebugValue(c.DispatchSecondaryUpstreamExprs, false)
 	debugMap["DispatchCacheConfig"] = helpers.DebugValue(c.DispatchCacheConfig, false)
 	debugMap["ClusterDispatchCacheConfig"] = helpers.DebugValue(c.ClusterDispatchCacheConfig, false)
 	debugMap["DisableV1SchemaAPI"] = helpers.DebugValue(c.DisableV1SchemaAPI, false)
@@ -383,6 +387,34 @@ func WithDispatchHashringReplicationFactor(dispatchHashringReplicationFactor uin
 func WithDispatchHashringSpread(dispatchHashringSpread uint8) ConfigOption {
 	return func(c *Config) {
 		c.DispatchHashringSpread = dispatchHashringSpread
+	}
+}
+
+// WithDispatchSecondaryUpstreamAddrs returns an option that can append DispatchSecondaryUpstreamAddrss to Config.DispatchSecondaryUpstreamAddrs
+func WithDispatchSecondaryUpstreamAddrs(key string, value string) ConfigOption {
+	return func(c *Config) {
+		c.DispatchSecondaryUpstreamAddrs[key] = value
+	}
+}
+
+// SetDispatchSecondaryUpstreamAddrs returns an option that can set DispatchSecondaryUpstreamAddrs on a Config
+func SetDispatchSecondaryUpstreamAddrs(dispatchSecondaryUpstreamAddrs map[string]string) ConfigOption {
+	return func(c *Config) {
+		c.DispatchSecondaryUpstreamAddrs = dispatchSecondaryUpstreamAddrs
+	}
+}
+
+// WithDispatchSecondaryUpstreamExprs returns an option that can append DispatchSecondaryUpstreamExprss to Config.DispatchSecondaryUpstreamExprs
+func WithDispatchSecondaryUpstreamExprs(key string, value string) ConfigOption {
+	return func(c *Config) {
+		c.DispatchSecondaryUpstreamExprs[key] = value
+	}
+}
+
+// SetDispatchSecondaryUpstreamExprs returns an option that can set DispatchSecondaryUpstreamExprs on a Config
+func SetDispatchSecondaryUpstreamExprs(dispatchSecondaryUpstreamExprs map[string]string) ConfigOption {
+	return func(c *Config) {
+		c.DispatchSecondaryUpstreamExprs = dispatchSecondaryUpstreamExprs
 	}
 }
 


### PR DESCRIPTION
When enabled and configured, (for now, check) dispatches will also be made to the secondary dispatchers returned by the CEL expression. This will enable items such as cache prewarming by dispatching to a backup cluster while the primary cluster is still running