### PR TITLE
Add a map of revision parsing functions by engine kind

### DIFF
--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	Engine                   = "memory"
 	defaultWatchBufferLength = 128
 	numAttempts              = 10
 )

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -123,10 +123,11 @@ func (pgd *pgDatastore) CheckRevision(ctx context.Context, revisionRaw datastore
 
 // RevisionFromString reverses the encoding process performed by MarshalBinary and String.
 func (pgd *pgDatastore) RevisionFromString(revisionStr string) (datastore.Revision, error) {
-	return parseRevision(revisionStr)
+	return ParseRevisionString(revisionStr)
 }
 
-func parseRevision(revisionStr string) (rev datastore.Revision, err error) {
+// ParseRevisionString parses a revision string into a Postgres revision.
+func ParseRevisionString(revisionStr string) (rev datastore.Revision, err error) {
 	rev, err = parseRevisionProto(revisionStr)
 	if err != nil {
 		decimalRev, decimalErr := parseRevisionDecimal(revisionStr)

--- a/internal/datastore/postgres/revisions_test.go
+++ b/internal/datastore/postgres/revisions_test.go
@@ -151,7 +151,7 @@ func TestCombinedRevisionParsing(t *testing.T) {
 		t.Run(tc.snapshot.String(), func(t *testing.T) {
 			require := require.New(t)
 
-			parsed, err := parseRevision(tc.inputStr)
+			parsed, err := ParseRevisionString(tc.inputStr)
 			if tc.expectErr {
 				require.Error(err)
 			} else {
@@ -163,7 +163,7 @@ func TestCombinedRevisionParsing(t *testing.T) {
 }
 
 func TestBrokenInvalidRevision(t *testing.T) {
-	_, err := parseRevision("1693540940373045727.0000000001")
+	_, err := ParseRevisionString("1693540940373045727.0000000001")
 	require.Error(t, err)
 }
 

--- a/pkg/datastore/revision/decimal.go
+++ b/pkg/datastore/revision/decimal.go
@@ -67,3 +67,9 @@ func DecimalKeyFunc(r Decimal) int64 {
 func DecimalKeyLessThanFunc(lhs, rhs int64) bool {
 	return lhs < rhs
 }
+
+// ParseRevisionString parses a decimal revision string into a revision.
+func ParseRevisionString(revisionStr string) (rev datastore.Revision, err error) {
+	dd := DecimalDecoder{}
+	return dd.RevisionFromString(revisionStr)
+}

--- a/pkg/datastore/revisionparsing/revisionparsing.go
+++ b/pkg/datastore/revisionparsing/revisionparsing.go
@@ -1,0 +1,24 @@
+package revisionparsing
+
+import (
+	"github.com/authzed/spicedb/internal/datastore/crdb"
+	"github.com/authzed/spicedb/internal/datastore/memdb"
+	"github.com/authzed/spicedb/internal/datastore/mysql"
+	"github.com/authzed/spicedb/internal/datastore/postgres"
+	"github.com/authzed/spicedb/internal/datastore/spanner"
+	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/datastore/revision"
+)
+
+// ParsingFunc defines a type representing parsing a revision string into a revision.
+type ParsingFunc func(revisionStr string) (rev datastore.Revision, err error)
+
+// ParseRevisionStringByDatastoreEngineID defines a map from datastore engine ID to its associated
+// revision parsing function.
+var ParseRevisionStringByDatastoreEngineID = map[string]ParsingFunc{
+	memdb.Engine:    revision.ParseRevisionString,
+	crdb.Engine:     revision.ParseRevisionString,
+	postgres.Engine: postgres.ParseRevisionString,
+	mysql.Engine:    revision.ParseRevisionString,
+	spanner.Engine:  revision.ParseRevisionString,
+}


### PR DESCRIPTION
This will allow calling dispatchers to parse and compare revisions used in dispatch messages