### PR TITLE
add singleflight check dispatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
+	resenje.org/singleflight v0.4.0
 	sigs.k8s.io/controller-runtime v0.16.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1398,6 +1398,8 @@ mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b h1:DxJ5nJdkhDlLok9K6qO+5290kphD
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20230312165513-e84e2d14e3b8 h1:VuJo4Mt0EVPychre4fNlDWDuE5AjXtPJpRUWqZDQhaI=
 mvdan.cc/unparam v0.0.0-20230312165513-e84e2d14e3b8/go.mod h1:Oh/d7dEtzsNHGOq1Cdv8aMm3KdKhVvPbRQcM8WFpBR8=
+resenje.org/singleflight v0.4.0 h1:NdOEhCxEikK2S2WxGjZV9EGSsItolQKslOOi6pE1tJc=
+resenje.org/singleflight v0.4.0/go.mod h1:lAgQK7VfjG6/pgredbQfmV0RvG/uVhKo6vSuZ0vCWfk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/dispatch/cluster/cluster.go
+++ b/internal/dispatch/cluster/cluster.go
@@ -7,6 +7,7 @@ import (
 	"github.com/authzed/spicedb/internal/dispatch/caching"
 	"github.com/authzed/spicedb/internal/dispatch/graph"
 	"github.com/authzed/spicedb/internal/dispatch/keys"
+	"github.com/authzed/spicedb/internal/dispatch/singleflight"
 	"github.com/authzed/spicedb/pkg/cache"
 )
 
@@ -67,6 +68,7 @@ func NewClusterDispatcher(dispatch dispatch.Dispatcher, options ...Option) (disp
 	}
 
 	clusterDispatch := graph.NewDispatcher(dispatch, opts.concurrencyLimits)
+	clusterDispatch = singleflight.New(clusterDispatch, &keys.CanonicalKeyHandler{})
 
 	if opts.prometheusSubsystem == "" {
 		opts.prometheusSubsystem = "dispatch"

--- a/internal/dispatch/singleflight/singleflight.go
+++ b/internal/dispatch/singleflight/singleflight.go
@@ -1,0 +1,81 @@
+package singleflight
+
+import (
+	"context"
+	"encoding/hex"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"resenje.org/singleflight"
+
+	"github.com/authzed/spicedb/internal/dispatch"
+	"github.com/authzed/spicedb/internal/dispatch/keys"
+	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+)
+
+var singleFlightCount = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "spicedb",
+	Subsystem: "dispatch",
+	Name:      "single_flight_total",
+	Help:      "total number of dispatch requests that were single flighted",
+}, []string{"method", "shared"})
+
+func New(delegate dispatch.Dispatcher, handler keys.Handler) dispatch.Dispatcher {
+	return &Dispatcher{delegate: delegate, keyHandler: handler}
+}
+
+type Dispatcher struct {
+	delegate   dispatch.Dispatcher
+	keyHandler keys.Handler
+	checkGroup singleflight.Group[string, *v1.DispatchCheckResponse]
+}
+
+func (d *Dispatcher) DispatchCheck(ctx context.Context, req *v1.DispatchCheckRequest) (*v1.DispatchCheckResponse, error) {
+	key, err := d.keyHandler.CheckDispatchKey(ctx, req)
+	if err != nil {
+		return &v1.DispatchCheckResponse{Metadata: &v1.ResponseMeta{
+			DispatchCount: 1,
+		}}, status.Error(codes.Internal, "unexpected DispatchCheck error")
+	}
+
+	keyString := hex.EncodeToString(key)
+	v, isShared, err := d.checkGroup.Do(ctx, keyString, func(innerCtx context.Context) (*v1.DispatchCheckResponse, error) {
+		return d.delegate.DispatchCheck(innerCtx, req)
+	})
+
+	singleFlightCount.WithLabelValues("DispatchCheck", strconv.FormatBool(isShared)).Inc()
+	if err != nil {
+		return &v1.DispatchCheckResponse{Metadata: &v1.ResponseMeta{
+			DispatchCount: 1,
+		}}, err
+	}
+
+	return v, err
+}
+
+func (d *Dispatcher) DispatchExpand(ctx context.Context, req *v1.DispatchExpandRequest) (*v1.DispatchExpandResponse, error) {
+	return d.delegate.DispatchExpand(ctx, req)
+}
+
+func (d *Dispatcher) DispatchReachableResources(req *v1.DispatchReachableResourcesRequest, stream dispatch.ReachableResourcesStream) error {
+	return d.delegate.DispatchReachableResources(req, stream)
+}
+
+func (d *Dispatcher) DispatchLookupResources(req *v1.DispatchLookupResourcesRequest, stream dispatch.LookupResourcesStream) error {
+	return d.delegate.DispatchLookupResources(req, stream)
+}
+
+func (d *Dispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsRequest, stream dispatch.LookupSubjectsStream) error {
+	return d.delegate.DispatchLookupSubjects(req, stream)
+}
+
+func (d *Dispatcher) Close() error {
+	return d.delegate.Close()
+}
+
+func (d *Dispatcher) ReadyState() dispatch.ReadyState {
+	return d.delegate.ReadyState()
+}

--- a/internal/dispatch/singleflight/singlegflight_test.go
+++ b/internal/dispatch/singleflight/singlegflight_test.go
@@ -1,0 +1,146 @@
+package singleflight
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/dispatch"
+	"github.com/authzed/spicedb/internal/dispatch/keys"
+	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
+)
+
+func TestSingleFlightDispatcher(t *testing.T) {
+	var called atomic.Uint64
+	f := func() {
+		time.Sleep(100 * time.Millisecond)
+		called.Add(1)
+	}
+	disp := New(mockDispatcher{f: f}, &keys.DirectKeyHandler{})
+
+	req := &v1.DispatchCheckRequest{
+		ResourceRelation: tuple.RelationReference("document", "view"),
+		ResourceIds:      []string{"foo", "bar"},
+		Subject:          tuple.ObjectAndRelation("user", "tom", "..."),
+		Metadata: &v1.ResolverMeta{
+			AtRevision: "1234",
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(4)
+	go func() {
+		_, _ = disp.DispatchCheck(context.Background(), req)
+		wg.Done()
+	}()
+	go func() {
+		_, _ = disp.DispatchCheck(context.Background(), req)
+		wg.Done()
+	}()
+	go func() {
+		_, _ = disp.DispatchCheck(context.Background(), req)
+
+		wg.Done()
+	}()
+	go func() {
+		_, _ = disp.DispatchCheck(context.Background(), &v1.DispatchCheckRequest{
+			ResourceRelation: tuple.RelationReference("document", "view"),
+			ResourceIds:      []string{"foo", "baz"},
+			Subject:          tuple.ObjectAndRelation("user", "tom", "..."),
+			Metadata: &v1.ResolverMeta{
+				AtRevision: "1234",
+			},
+		})
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	require.Equal(t, uint64(2), called.Load())
+}
+
+func TestSingleFlightDispatcherCancelation(t *testing.T) {
+	var called atomic.Uint64
+	run := make(chan struct{}, 1)
+	f := func() {
+		time.Sleep(100 * time.Millisecond)
+		called.Add(1)
+		run <- struct{}{}
+	}
+	disp := New(mockDispatcher{f: f}, &keys.DirectKeyHandler{})
+
+	req := &v1.DispatchCheckRequest{
+		ResourceRelation: tuple.RelationReference("document", "view"),
+		ResourceIds:      []string{"foo", "bar"},
+		Subject:          tuple.ObjectAndRelation("user", "tom", "..."),
+		Metadata: &v1.ResolverMeta{
+			AtRevision: "1234",
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+		defer cancel()
+		_, err := disp.DispatchCheck(ctx, req)
+		wg.Done()
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	}()
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+		defer cancel()
+		_, err := disp.DispatchCheck(ctx, req)
+		wg.Done()
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	}()
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+		defer cancel()
+		_, err := disp.DispatchCheck(ctx, req)
+		wg.Done()
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	}()
+
+	wg.Wait()
+	<-run
+	require.Equal(t, uint64(1), called.Load())
+}
+
+type mockDispatcher struct {
+	f func()
+}
+
+func (m mockDispatcher) DispatchCheck(_ context.Context, _ *v1.DispatchCheckRequest) (*v1.DispatchCheckResponse, error) {
+	m.f()
+	return &v1.DispatchCheckResponse{}, nil
+}
+
+func (m mockDispatcher) DispatchExpand(_ context.Context, _ *v1.DispatchExpandRequest) (*v1.DispatchExpandResponse, error) {
+	return &v1.DispatchExpandResponse{}, nil
+}
+
+func (m mockDispatcher) DispatchReachableResources(_ *v1.DispatchReachableResourcesRequest, _ dispatch.ReachableResourcesStream) error {
+	return nil
+}
+
+func (m mockDispatcher) DispatchLookupResources(_ *v1.DispatchLookupResourcesRequest, _ dispatch.LookupResourcesStream) error {
+	return nil
+}
+
+func (m mockDispatcher) DispatchLookupSubjects(_ *v1.DispatchLookupSubjectsRequest, _ dispatch.LookupSubjectsStream) error {
+	return nil
+}
+
+func (m mockDispatcher) Close() error {
+	return nil
+}
+
+func (m mockDispatcher) ReadyState() dispatch.ReadyState {
+	return dispatch.ReadyState{}
+}

--- a/internal/services/dispatch/v1/acl.go
+++ b/internal/services/dispatch/v1/acl.go
@@ -83,8 +83,8 @@ func (ds *dispatchServer) Close() error {
 
 func rewriteGraphError(ctx context.Context, err error) error {
 	// Check if the error can be directly used.
-	if _, ok := status.FromError(err); ok {
-		return err
+	if st, ok := status.FromError(err); ok {
+		return st.Err()
 	}
 
 	switch {


### PR DESCRIPTION
(supersedes https://github.com/authzed/spicedb/pull/1602)

## What

This PR adds a new singleflight `dispatch.Dispatcher` capable of deduping `DispatchCheckRequest` (for now, more to come later).

is uses `janos/singleflight` instead of `x/sync/singleflight`, because the latter does not propagate cancelation, and
we want to abort any expensive operation (especially database operations) as soon as possible. janos/single will let the handler run until the last single-flighted caller is canceled. In exchange, it has to spin an extra goroutine compared to x/sync/singleflight.

## Previous iteration

- I previously tried to implement it as a gRPC Dispatcher API middleware, but that made things worse because we bypassed the caching dispatcher, which happens at a different level. Adding it at the dispatcher level proved to work as expected

## Other

- I also added a follow-up fix to https://github.com/authzed/spicedb/pull/1598, where the wrong error is being returned in the `rewriteGraphError` method