### PR TITLE
fix grpc-health-probe flagged by trivy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 RUN git clone https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout v0.4.21
+RUN git checkout 25cbb49
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 FROM cgr.dev/chainguard/static:latest

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -6,7 +6,7 @@ WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 RUN git clone https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout v0.4.21
+RUN git checkout 25cbb49
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 FROM $BASE


### PR DESCRIPTION
Due to CVE https://github.com/advisories/GHSA-m425-mq94-257g There hasn't been any grpc-health-probe release
with the fix, so this builds at the specific commit that includes a version bump for the affected dependency

https://github.com/grpc-ecosystem/grpc-health-probe/commit/25cbb494d84276f72724b5331e6466a7800a8a41