### PR TITLE
log payloads, and add grpc duration as an integer

### DIFF
--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -47,6 +47,10 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	config.DispatchClusterMetricsEnabled = true
 	config.DispatchClientMetricsEnabled = true
 
+	// Flags for logging
+	cmd.Flags().BoolVar(&config.EnableRequestLogs, "grpc-log-requests-enabled", false, "logs API request payloads")
+	cmd.Flags().BoolVar(&config.EnableResponseLogs, "grpc-log-responses-enabled", false, "logs API response payloads")
+
 	// Flags for the gRPC API server
 	util.RegisterGRPCServerFlags(cmd.Flags(), &config.GRPCServer, "grpc", "gRPC", ":50051", true)
 	cmd.Flags().StringSliceVar(&config.PresharedSecureKey, PresharedKeyFlag, []string{}, "preshared key(s) to require for authenticated requests")

--- a/pkg/cmd/server/defaults.go
+++ b/pkg/cmd/server/defaults.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/go-logr/zerologr"
@@ -116,7 +117,10 @@ var defaultGRPCLogOptions = []grpclog.Option{
 		return grpclog.DefaultServerCodeToLevel(code)
 	}),
 	// changes default logging behaviour to only log finish call message
-	grpclog.WithLogOnEvents(grpclog.FinishCall),
+	grpclog.WithLogOnEvents(grpclog.PayloadReceived, grpclog.PayloadSent, grpclog.FinishCall),
+	grpclog.WithDurationField(func(duration time.Duration) grpclog.Fields {
+		return grpclog.Fields{"grpc.time_ms", duration.Milliseconds()}
+	}),
 }
 
 const (

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -127,6 +127,10 @@ type Config struct {
 	TelemetryCAOverridePath  string        `debugmap:"visible"`
 	TelemetryEndpoint        string        `debugmap:"visible"`
 	TelemetryInterval        time.Duration `debugmap:"visible"`
+
+	// Logs
+	EnableRequestLogs  bool `debugmap:"visible"`
+	EnableResponseLogs bool `debugmap:"visible"`
 }
 
 type closeableStack struct {
@@ -349,12 +353,21 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		watchServiceOption = services.WatchServiceDisabled
 	}
 
-	defaultUnaryMiddlewareChain, err := DefaultUnaryMiddleware(log.Logger, c.GRPCAuthFunc, !c.DisableVersionResponse, dispatcher, ds)
+	opts := MiddlewareOption{
+		log.Logger,
+		c.GRPCAuthFunc,
+		!c.DisableVersionResponse,
+		dispatcher,
+		ds,
+		c.EnableRequestLogs,
+		c.EnableResponseLogs,
+	}
+	defaultUnaryMiddlewareChain, err := DefaultUnaryMiddleware(opts)
 	if err != nil {
 		return nil, fmt.Errorf("error building default middlewares: %w", err)
 	}
 
-	defaultStreamingMiddlewareChain, err := DefaultStreamingMiddleware(log.Logger, c.GRPCAuthFunc, !c.DisableVersionResponse, dispatcher, ds)
+	defaultStreamingMiddlewareChain, err := DefaultStreamingMiddleware(opts)
 	if err != nil {
 		return nil, fmt.Errorf("error building default middlewares: %w", err)
 	}

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -230,7 +230,8 @@ func TestModifyUnaryMiddleware(t *testing.T) {
 		},
 	}}
 
-	defaultMw, err := DefaultUnaryMiddleware(logging.Logger, nil, false, nil, nil)
+	opt := MiddlewareOption{logging.Logger, nil, false, nil, nil, false, false}
+	defaultMw, err := DefaultUnaryMiddleware(opt)
 	require.NoError(t, err)
 
 	unary, err := c.buildUnaryMiddleware(defaultMw)
@@ -255,7 +256,8 @@ func TestModifyStreamingMiddleware(t *testing.T) {
 		},
 	}}
 
-	defaultMw, err := DefaultStreamingMiddleware(logging.Logger, nil, false, nil, nil)
+	opt := MiddlewareOption{logging.Logger, nil, false, nil, nil, false, false}
+	defaultMw, err := DefaultStreamingMiddleware(opt)
 	require.NoError(t, err)
 
 	streaming, err := c.buildStreamingMiddleware(defaultMw)

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -88,6 +88,8 @@ func (c *Config) ToOption() ConfigOption {
 		to.TelemetryCAOverridePath = c.TelemetryCAOverridePath
 		to.TelemetryEndpoint = c.TelemetryEndpoint
 		to.TelemetryInterval = c.TelemetryInterval
+		to.EnableRequestLogs = c.EnableRequestLogs
+		to.EnableResponseLogs = c.EnableResponseLogs
 	}
 }
 
@@ -140,6 +142,8 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["TelemetryCAOverridePath"] = helpers.DebugValue(c.TelemetryCAOverridePath, false)
 	debugMap["TelemetryEndpoint"] = helpers.DebugValue(c.TelemetryEndpoint, false)
 	debugMap["TelemetryInterval"] = helpers.DebugValue(c.TelemetryInterval, false)
+	debugMap["EnableRequestLogs"] = helpers.DebugValue(c.EnableRequestLogs, false)
+	debugMap["EnableResponseLogs"] = helpers.DebugValue(c.EnableResponseLogs, false)
 	return debugMap
 }
 
@@ -562,5 +566,19 @@ func WithTelemetryEndpoint(telemetryEndpoint string) ConfigOption {
 func WithTelemetryInterval(telemetryInterval time.Duration) ConfigOption {
 	return func(c *Config) {
 		c.TelemetryInterval = telemetryInterval
+	}
+}
+
+// WithEnableRequestLogs returns an option that can set EnableRequestLogs on a Config
+func WithEnableRequestLogs(enableRequestLogs bool) ConfigOption {
+	return func(c *Config) {
+		c.EnableRequestLogs = enableRequestLogs
+	}
+}
+
+// WithEnableResponseLogs returns an option that can set EnableResponseLogs on a Config
+func WithEnableResponseLogs(enableResponseLogs bool) ConfigOption {
+	return func(c *Config) {
+		c.EnableResponseLogs = enableResponseLogs
 	}
 }


### PR DESCRIPTION
in order to better troubleshoot certain situations, it would be useful to load request and response payloads.

Also in certain log aggregators it's not possible to convert duration fields that are represented as a string, and this is useful in order to filter requests by a specific duration threshold. This commit changes the duration function to log it as an integer

Adds options to control request and response payloads via CLI 