### PR TITLE
Ensure all datastores return an error if accessed after Close

### DIFF
--- a/pkg/datastore/test/basic.go
+++ b/pkg/datastore/test/basic.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func UseAfterCloseTest(t *testing.T, tester DatastoreTester) {
+	require := require.New(t)
+
+	// Create the datastore.
+	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	require.NoError(err)
+
+	// Immediately close it.
+	err = ds.Close()
+	require.NoError(err)
+
+	// Attempt to use and ensure an error is returned.
+	_, err = ds.HeadRevision(context.Background())
+	require.Error(err)
+}

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -69,6 +69,8 @@ func WithCategories(cats ...string) Categories {
 // AllWithExceptions runs all generic datastore tests on a DatastoreTester, except
 // those specified test categories
 func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories) {
+	t.Run("TestUseAfterClose", func(t *testing.T) { UseAfterCloseTest(t, tester) })
+
 	t.Run("TestNamespaceNotFound", func(t *testing.T) { NamespaceNotFoundTest(t, tester) })
 	t.Run("TestNamespaceWrite", func(t *testing.T) { NamespaceWriteTest(t, tester) })
 	t.Run("TestNamespaceDelete", func(t *testing.T) { NamespaceDeleteTest(t, tester) })


### PR DESCRIPTION
Fixes #604 by ensuring that attempts as use-after-close properly returns an error, which is safe for fire-and-forget operations