### PR TITLE
Remove support for MySQL v5

### DIFF
--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -94,24 +94,11 @@ func TestMySQLDatastoreDSNWithoutParseTime(t *testing.T) {
 	require.ErrorContains(t, err, "https://spicedb.dev/d/parse-time-mysql")
 }
 
-func TestMySQL5Datastore(t *testing.T) {
-	b := testdatastore.RunMySQLForTesting(t, "")
-	dst := datastoreTester{b: b, t: t}
-	test.All(t, test.DatastoreTesterFunc(dst.createDatastore))
-	additionalMySQLTests(t, b)
-}
-
 func TestMySQL8Datastore(t *testing.T) {
-	b := testdatastore.RunMySQLForTestingWithOptions(t, testdatastore.MySQLTesterOptions{MigrateForNewDatastore: true, UseV8: true}, "")
+	b := testdatastore.RunMySQLForTestingWithOptions(t, testdatastore.MySQLTesterOptions{MigrateForNewDatastore: true}, "")
 	dst := datastoreTester{b: b, t: t}
 	test.All(t, test.DatastoreTesterFunc(dst.createDatastore))
 	additionalMySQLTests(t, b)
-}
-
-func TestMySQL5DatastoreWithTablePrefix(t *testing.T) {
-	b := testdatastore.RunMySQLForTestingWithOptions(t, testdatastore.MySQLTesterOptions{MigrateForNewDatastore: true, Prefix: "spicedb_"}, "")
-	dst := datastoreTester{b: b, t: t, prefix: "spicedb_"}
-	test.All(t, test.DatastoreTesterFunc(dst.createDatastore))
 }
 
 func additionalMySQLTests(t *testing.T, b testdatastore.RunningEngineForTest) {

--- a/internal/testserver/datastore/mysql.go
+++ b/internal/testserver/datastore/mysql.go
@@ -52,17 +52,13 @@ func RunMySQLForTestingWithOptions(t testing.TB, options MySQLTesterOptions, bri
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 
-	containerImageTag := "5"
-	if options.UseV8 {
-		containerImageTag = "8"
-	}
+	containerImageTag := "8"
 
 	name := fmt.Sprintf("mysql-%s", uuid.New().String())
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Name:       name,
 		Repository: "mysql",
 		Tag:        containerImageTag,
-		Platform:   "linux/amd64", // required because the mysql:5 image does not have arm support
 		Env:        []string{"MYSQL_ROOT_PASSWORD=secret"},
 		// increase max connections (default 151) to accommodate tests using the same docker container
 		Cmd:       []string{"--max-connections=500"},


### PR DESCRIPTION
Fixes #1338

To be merged no earlier than Oct 31, when MySQL v5 reaches EOL