### PR TITLE
introduces flags to set min/max Spanner sessions

### DIFF
--- a/internal/datastore/spanner/options.go
+++ b/internal/datastore/spanner/options.go
@@ -18,6 +18,8 @@ type spannerOptions struct {
 	readMaxOpen                 int
 	writeMaxOpen                int
 	schemaWatchHeartbeat        time.Duration
+	minSessions                 uint64
+	maxSessions                 uint64
 }
 
 const (
@@ -49,6 +51,8 @@ func generateConfig(options []Option) (spannerOptions, error) {
 		readMaxOpen:                 int(defaultNumberConnections),
 		writeMaxOpen:                int(defaultNumberConnections),
 		schemaWatchHeartbeat:        defaultSchemaWatchHeartbeat,
+		minSessions:                 100,
+		maxSessions:                 400,
 	}
 
 	for _, option := range options {
@@ -157,4 +161,20 @@ func SchemaWatchHeartbeat(heartbeat time.Duration) Option {
 			po.schemaWatchHeartbeat = heartbeat
 		}
 	}
+}
+
+// MinSessionCount minimum number of session the Spanner client can have
+// at a given time.
+//
+// Defaults to 100.
+func MinSessionCount(minSessions uint64) Option {
+	return func(po *spannerOptions) { po.minSessions = minSessions }
+}
+
+// MaxSessionCount maximum number of session the Spanner client can have
+// at a given time.
+//
+// Defaults to 400 sessions.
+func MaxSessionCount(maxSessions uint64) Option {
+	return func(po *spannerOptions) { po.maxSessions = maxSessions }
 }

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -116,7 +116,11 @@ func NewSpannerDatastore(database string, opts ...Option) (datastore.Datastore, 
 		return nil, fmt.Errorf("failed to enable spanner GFE latency stats: %w", err)
 	}
 
-	client, err := spanner.NewClient(context.Background(), database,
+	cfg := spanner.DefaultSessionPoolConfig
+	cfg.MinOpened = config.minSessions
+	cfg.MaxOpened = config.maxSessions
+	client, err := spanner.NewClientWithConfig(context.Background(), database,
+		spanner.ClientConfig{SessionPoolConfig: cfg},
 		option.WithCredentialsFile(config.credentialsFilePath),
 		option.WithGRPCConnectionPool(max(config.readMaxOpen, config.writeMaxOpen)),
 		option.WithGRPCDialOption(

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -60,6 +60,8 @@ func (c *Config) ToOption() ConfigOption {
 		to.GCMaxOperationTime = c.GCMaxOperationTime
 		to.SpannerCredentialsFile = c.SpannerCredentialsFile
 		to.SpannerEmulatorHost = c.SpannerEmulatorHost
+		to.SpannerMinSessions = c.SpannerMinSessions
+		to.SpannerMaxSessions = c.SpannerMaxSessions
 		to.TablePrefix = c.TablePrefix
 		to.WatchBufferLength = c.WatchBufferLength
 		to.MigrationPhase = c.MigrationPhase
@@ -99,6 +101,8 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["GCMaxOperationTime"] = helpers.DebugValue(c.GCMaxOperationTime, false)
 	debugMap["SpannerCredentialsFile"] = helpers.DebugValue(c.SpannerCredentialsFile, false)
 	debugMap["SpannerEmulatorHost"] = helpers.DebugValue(c.SpannerEmulatorHost, false)
+	debugMap["SpannerMinSessions"] = helpers.DebugValue(c.SpannerMinSessions, false)
+	debugMap["SpannerMaxSessions"] = helpers.DebugValue(c.SpannerMaxSessions, false)
 	debugMap["TablePrefix"] = helpers.DebugValue(c.TablePrefix, false)
 	debugMap["WatchBufferLength"] = helpers.DebugValue(c.WatchBufferLength, false)
 	debugMap["MigrationPhase"] = helpers.DebugValue(c.MigrationPhase, false)
@@ -336,6 +340,20 @@ func WithSpannerCredentialsFile(spannerCredentialsFile string) ConfigOption {
 func WithSpannerEmulatorHost(spannerEmulatorHost string) ConfigOption {
 	return func(c *Config) {
 		c.SpannerEmulatorHost = spannerEmulatorHost
+	}
+}
+
+// WithSpannerMinSessions returns an option that can set SpannerMinSessions on a Config
+func WithSpannerMinSessions(spannerMinSessions uint64) ConfigOption {
+	return func(c *Config) {
+		c.SpannerMinSessions = spannerMinSessions
+	}
+}
+
+// WithSpannerMaxSessions returns an option that can set SpannerMaxSessions on a Config
+func WithSpannerMaxSessions(spannerMaxSessions uint64) ConfigOption {
+	return func(c *Config) {
+		c.SpannerMaxSessions = spannerMaxSessions
 	}
 }
 


### PR DESCRIPTION
Aside from having a connection pool of gRPC sessions against the Spanner API, the client library also
keeps a number of sessions spread over those connections. This setting may need tweaking depending on the dispatch fan out of the schema, and may end blocking on
the session pool if not enough sessions are available.

From the Spanner docs:
>Set MinSessions=MaxSessions if the expected concurrency does
not change much during the application lifetime. This prevents the session pool from scaling up or down. Scaling the session pool up or down also consumes some resources.