### PR TITLE
do not create custom canceled graph error

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -681,7 +681,7 @@ func union[T any](
 
 		case <-ctx.Done():
 			log.Ctx(ctx).Trace().Msg("anyCanceled")
-			return checkResultError(NewRequestCanceledErr(), responseMetadata)
+			return checkResultError(context.Canceled, responseMetadata)
 		}
 	}
 
@@ -736,7 +736,7 @@ func all[T any](
 				return noMembersWithMetadata(responseMetadata)
 			}
 		case <-ctx.Done():
-			return checkResultError(NewRequestCanceledErr(), responseMetadata)
+			return checkResultError(context.Canceled, responseMetadata)
 		}
 	}
 
@@ -794,7 +794,7 @@ func difference[T any](
 		}
 
 	case <-ctx.Done():
-		return checkResultError(NewRequestCanceledErr(), responseMetadata)
+		return checkResultError(context.Canceled, responseMetadata)
 	}
 
 	// Subtract the remaining sets.
@@ -813,7 +813,7 @@ func difference[T any](
 			}
 
 		case <-ctx.Done():
-			return checkResultError(NewRequestCanceledErr(), responseMetadata)
+			return checkResultError(context.Canceled, responseMetadata)
 		}
 	}
 

--- a/internal/graph/errors.go
+++ b/internal/graph/errors.go
@@ -15,18 +15,6 @@ import (
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
-// ErrRequestCanceled occurs when a request has been canceled.
-type ErrRequestCanceled struct {
-	error
-}
-
-// NewRequestCanceledErr constructs a new request was canceled error.
-func NewRequestCanceledErr() error {
-	return ErrRequestCanceled{
-		error: errors.New("request canceled"),
-	}
-}
-
 // ErrCheckFailure occurs when check failed in some manner. Note this should not apply to
 // namespaces and relations not being found.
 type ErrCheckFailure struct {

--- a/internal/graph/expand.go
+++ b/internal/graph/expand.go
@@ -335,7 +335,7 @@ func expandSetOperation(
 			}
 			children = append(children, result.Resp.TreeNode)
 		case <-ctx.Done():
-			return expandResultError(NewRequestCanceledErr(), responseMetadata)
+			return expandResultError(context.Canceled, responseMetadata)
 		}
 	}
 
@@ -388,7 +388,7 @@ func expandOne(ctx context.Context, request ReduceableExpandFunc) ExpandResult {
 		}
 		return result
 	case <-ctx.Done():
-		return expandResultError(NewRequestCanceledErr(), emptyMetadata)
+		return expandResultError(context.Canceled, emptyMetadata)
 	}
 }
 

--- a/internal/services/dispatch/v1/acl.go
+++ b/internal/services/dispatch/v1/acl.go
@@ -88,8 +88,6 @@ func rewriteGraphError(ctx context.Context, err error) error {
 	}
 
 	switch {
-	case errors.As(err, &graph.ErrRequestCanceled{}):
-		return status.Errorf(codes.Canceled, "request canceled: %s", err)
 	case errors.Is(err, context.DeadlineExceeded):
 		return status.Errorf(codes.DeadlineExceeded, "%s", err)
 	case errors.Is(err, context.Canceled):

--- a/internal/services/shared/errors.go
+++ b/internal/services/shared/errors.go
@@ -170,8 +170,6 @@ func RewriteError(ctx context.Context, err error, config *ConfigForErrors) error
 
 	case errors.As(err, &graph.ErrInvalidArgument{}):
 		return status.Errorf(codes.InvalidArgument, "%s", err)
-	case errors.As(err, &graph.ErrRequestCanceled{}):
-		return status.Errorf(codes.Canceled, "request canceled: %s", err)
 	case errors.As(err, &graph.ErrRelationMissingTypeInfo{}):
 		return status.Errorf(codes.FailedPrecondition, "failed precondition: %s", err)
 	case errors.As(err, &graph.ErrAlwaysFail{}):

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -386,9 +386,6 @@ func rewriteACLError(ctx context.Context, err error) error {
 	case errors.As(err, &relNotFoundError):
 		fallthrough
 
-	case errors.As(err, &maingraph.ErrRequestCanceled{}):
-		return status.Errorf(codes.Canceled, "request canceled: %s", err)
-
 	case errors.As(err, &maingraph.ErrInvalidArgument{}):
 		return status.Errorf(codes.InvalidArgument, "%s", err)
 
@@ -401,6 +398,12 @@ func rewriteACLError(ctx context.Context, err error) error {
 	case errors.As(err, &maingraph.ErrAlwaysFail{}):
 		log.Ctx(ctx).Err(err).Msg("internal graph error in devcontext")
 		return status.Errorf(codes.Internal, "internal error: %s", err)
+
+	case errors.Is(err, context.DeadlineExceeded):
+		return status.Errorf(codes.DeadlineExceeded, "%s", err)
+
+	case errors.Is(err, context.Canceled):
+		return status.Errorf(codes.Canceled, "%s", err)
 
 	default:
 		log.Ctx(ctx).Err(err).Msg("unexpected graph error in devcontext")


### PR DESCRIPTION
instead, use `context.Canceled`. This addresses the error being logged as an unexpected error in `graph.rewriteError()`, because it missed handling the custom cancelation error type