### PR TITLE
Fix flaky Postgres GC tests

### DIFF
--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -102,39 +102,9 @@ func testPostgresDatastore(t *testing.T, pc []postgresConfig) {
 				return ds, nil
 			}))
 
-			t.Run("GarbageCollection", createDatastoreTest(
-				b,
-				GarbageCollectionTest,
-				RevisionQuantization(0),
-				GCWindow(1*time.Millisecond),
-				GCInterval(veryLargeGCInterval),
-				WatchBufferLength(1),
-				MigrationPhase(config.migrationPhase),
-			))
-
 			t.Run("TransactionTimestamps", createDatastoreTest(
 				b,
 				TransactionTimestampsTest,
-				RevisionQuantization(0),
-				GCWindow(1*time.Millisecond),
-				GCInterval(veryLargeGCInterval),
-				WatchBufferLength(1),
-				MigrationPhase(config.migrationPhase),
-			))
-
-			t.Run("GarbageCollectionByTime", createDatastoreTest(
-				b,
-				GarbageCollectionByTimeTest,
-				RevisionQuantization(0),
-				GCWindow(1*time.Millisecond),
-				GCInterval(veryLargeGCInterval),
-				WatchBufferLength(1),
-				MigrationPhase(config.migrationPhase),
-			))
-
-			t.Run("ChunkedGarbageCollection", createDatastoreTest(
-				b,
-				ChunkedGarbageCollectionTest,
 				RevisionQuantization(0),
 				GCWindow(1*time.Millisecond),
 				GCInterval(veryLargeGCInterval),

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -4,7 +4,11 @@
 package postgres
 
 import (
+	"fmt"
 	"testing"
+	"time"
+
+	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
 )
 
 func TestPostgresDatastore(t *testing.T) {
@@ -17,4 +21,48 @@ func TestPostgresDatastoreWithoutCommitTimestamps(t *testing.T) {
 	t.Parallel()
 
 	testPostgresDatastoreWithoutCommitTimestamps(t, postgresConfigs)
+}
+
+func TestPostgresDatastoreGC(t *testing.T) {
+	for _, config := range postgresConfigs {
+		pgbouncerStr := ""
+		if config.pgbouncer {
+			pgbouncerStr = "pgbouncer-"
+		}
+		t.Run(fmt.Sprintf("%spostgres-gc-%s-%s-%s", pgbouncerStr, config.pgVersion, config.targetMigration, config.migrationPhase), func(t *testing.T) {
+			t.Parallel()
+
+			b := testdatastore.RunPostgresForTesting(t, "", config.targetMigration, config.pgVersion, config.pgbouncer)
+
+			t.Run("GarbageCollection", createDatastoreTest(
+				b,
+				GarbageCollectionTest,
+				RevisionQuantization(0),
+				GCWindow(1*time.Millisecond),
+				GCInterval(veryLargeGCInterval),
+				WatchBufferLength(1),
+				MigrationPhase(config.migrationPhase),
+			))
+
+			t.Run("GarbageCollectionByTime", createDatastoreTest(
+				b,
+				GarbageCollectionByTimeTest,
+				RevisionQuantization(0),
+				GCWindow(1*time.Millisecond),
+				GCInterval(veryLargeGCInterval),
+				WatchBufferLength(1),
+				MigrationPhase(config.migrationPhase),
+			))
+
+			t.Run("ChunkedGarbageCollection", createDatastoreTest(
+				b,
+				ChunkedGarbageCollectionTest,
+				RevisionQuantization(0),
+				GCWindow(1*time.Millisecond),
+				GCInterval(veryLargeGCInterval),
+				WatchBufferLength(1),
+				MigrationPhase(config.migrationPhase),
+			))
+		})
+	}
 }


### PR DESCRIPTION
Ensures that all Postgres GC tests run against their own PG instance

This is necessary because the GC tests check transaction IDs and those can change out from underneath the tests due to other tests performing work