### PR TITLE
crdb: fix watch error: %!s(<nil>)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 RUN git clone https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout 680bc1a
+RUN git checkout 46b326771cb9e57af7a495973a180e388b1a516f
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 FROM cgr.dev/chainguard/static:latest

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -6,7 +6,7 @@ WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 RUN git clone https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout 680bc1a
+RUN git checkout 46b326771cb9e57af7a495973a180e388b1a516f
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 FROM $BASE

--- a/internal/datastore/crdb/watch.go
+++ b/internal/datastore/crdb/watch.go
@@ -205,7 +205,7 @@ func (cds *crdbDatastore) Watch(ctx context.Context, afterRevision datastore.Rev
 			pending.Changes = append(pending.Changes, oneChange)
 		}
 
-		if changes.Err() != nil {
+		if err := changes.Err(); err != nil {
 			if errors.Is(ctx.Err(), context.Canceled) {
 				closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer closeCancel()


### PR DESCRIPTION
I identified some error reports in CRDB-based clusters that showed the following:

```json
{
   "level":"error",
   "protocol":"grpc",
   "grpc.component":"server",
   "grpc.service":"authzed.api.v1.WatchService",
   "grpc.method":"Watch",
   "grpc.method_type":"server_stream",
   "grpc.start_time":"2023-11-27T12:38:35Z",
   "grpc.code":"Internal",
   "grpc.error":"rpc error: code = Internal desc = watch error: %!s(<nil>)",
   "grpc.time_ms":1030,
   "time":"2023-11-27T12:38:36Z",
}
```

I could only identify one spot where a nil
error could be sent over the errors channel,
which would in turn cause SpiceDB response
to have the gRPC error code "Internal".

If the `sql.Rows` returns an error that isnt
cancellation, then it's possible that nil values
will be sent over the error channel.