### PR TITLE
fix trivy CI failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 RUN git clone https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout 680bc1a
+RUN git checkout 46b326771cb9e57af7a495973a180e388b1a516f
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 FROM cgr.dev/chainguard/static:latest

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -6,7 +6,7 @@ WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 RUN git clone https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout 680bc1a
+RUN git checkout 46b326771cb9e57af7a495973a180e388b1a516f
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 FROM $BASE


### PR DESCRIPTION
uses latest git SHA to fix a vuln in `grpc-health-probe` reported by trivy
GHSA-2c7c-3mj9-8fq