### PR TITLE
Fix handling of NULL caveats in Postgres watch

### DIFF
--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -206,7 +206,7 @@ func (pgd *pgDatastore) loadChanges(ctx context.Context, revisions []revisionWit
 		}
 
 		var createdXID, deletedXID xid8
-		var caveatName string
+		var caveatName *string
 		var caveatContext map[string]any
 		if err := changes.Scan(
 			&nextTuple.ResourceAndRelation.Namespace,
@@ -223,13 +223,13 @@ func (pgd *pgDatastore) loadChanges(ctx context.Context, revisions []revisionWit
 			return nil, fmt.Errorf("unable to parse changed tuple: %w", err)
 		}
 
-		if caveatName != "" {
+		if caveatName != nil && *caveatName != "" {
 			contextStruct, err := structpb.NewStruct(caveatContext)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read caveat context from update: %w", err)
 			}
 			nextTuple.Caveat = &core.ContextualizedCaveat{
-				CaveatName: caveatName,
+				CaveatName: *caveatName,
 				Context:    contextStruct,
 			}
 		}

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -125,6 +125,7 @@ func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories) 
 		t.Run("TestWatchCancel", func(t *testing.T) { WatchCancelTest(t, tester) })
 		t.Run("TestCaveatedRelationshipWatch", func(t *testing.T) { CaveatedRelationshipWatchTest(t, tester) })
 		t.Run("TestWatchWithTouch", func(t *testing.T) { WatchWithTouchTest(t, tester) })
+		t.Run("TestWatchWithDelete", func(t *testing.T) { WatchWithDeleteTest(t, tester) })
 	}
 }
 


### PR DESCRIPTION
Normally, the Postgres driver sets the caveat name column to empty string when no caveat is present. However, the field IS nullable and bulk import can set it to a NULL instead.

The watch API code therefore needs to support this scenario