### PR TITLE
make datastore metrics more representative of the actual underlying datastore

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -230,9 +230,9 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		cachingMode = schemacaching.WatchIfSupported
 	}
 
+	ds = proxy.NewObservableDatastoreProxy(ds)
 	ds = proxy.NewSingleflightDatastoreProxy(ds)
 	ds = schemacaching.NewCachingDatastoreProxy(ds, nscc, c.DatastoreConfig.GCWindow, cachingMode)
-	ds = proxy.NewObservableDatastoreProxy(ds)
 	closeables.AddWithError(ds.Close)
 
 	enableGRPCHistogram()


### PR DESCRIPTION
the datastore metrics proxy was installed after various other proxies that try to help with datastore performance, namely caching, and deduplication. If the proxy is installed after those, the metrics obtained do not reflect the actual latencies and requests to the datastore:
- latencies will be lower thanks to caching and deduplication
- actual datastore calls will be higher that they are because some requests may never hit the datastore

Given how important is access to the datastore for the latency and throughput of the application, this moves the proxy so it measures actual calls to the datastore by moving it around the proxy chain.