### PR TITLE
schemadsl/compiler: optionally skip validation

### DIFF
--- a/internal/graph/computed/computecheck_test.go
+++ b/internal/graph/computed/computecheck_test.go
@@ -934,11 +934,10 @@ func TestComputeBulkCheck(t *testing.T) {
 }
 
 func writeCaveatedTuples(ctx context.Context, _ *testing.T, ds datastore.Datastore, schema string, updates []caveatedUpdate) (datastore.Revision, error) {
-	empty := ""
 	compiled, err := compiler.Compile(compiler.InputSchema{
 		Source:       "schema",
 		SchemaString: schema,
-	}, &empty)
+	})
 	if err != nil {
 		return datastore.NoRevision, err
 	}

--- a/internal/namespace/annotate_test.go
+++ b/internal/namespace/annotate_test.go
@@ -18,7 +18,6 @@ func TestAnnotateNamespace(t *testing.T) {
 	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 	require.NoError(err)
 
-	empty := ""
 	compiled, err := compiler.Compile(compiler.InputSchema{
 		Source: input.Source("schema"),
 		SchemaString: `definition document {
@@ -30,7 +29,7 @@ func TestAnnotateNamespace(t *testing.T) {
 	permission other = editor - viewer
 	permission also_aliased = viewer
 }`,
-	}, &empty)
+	})
 	require.NoError(err)
 
 	lastRevision, err := ds.HeadRevision(context.Background())

--- a/internal/namespace/canonicalization_test.go
+++ b/internal/namespace/canonicalization_test.go
@@ -514,12 +514,11 @@ func TestCanonicalizationComparison(t *testing.T) {
 
 			ctx := context.Background()
 
-			empty := ""
 			schemaText := fmt.Sprintf(comparisonSchemaTemplate, tc.first, tc.second)
 			compiled, err := compiler.Compile(compiler.InputSchema{
 				Source:       input.Source("schema"),
 				SchemaString: schemaText,
-			}, &empty)
+			})
 			require.NoError(err)
 
 			lastRevision, err := ds.HeadRevision(context.Background())

--- a/internal/services/shared/schema_test.go
+++ b/internal/services/shared/schema_test.go
@@ -33,7 +33,6 @@ func TestApplySchemaChanges(t *testing.T) {
 	`, nil, require)
 
 	// Update the schema and ensure it works.
-	emptyDefaultPrefix := ""
 	compiled, err := compiler.Compile(compiler.InputSchema{
 		Source: input.Source("schema"),
 		SchemaString: `
@@ -45,7 +44,7 @@ func TestApplySchemaChanges(t *testing.T) {
 			  value == 22
 			}
 		`,
-	}, &emptyDefaultPrefix)
+	})
 	require.NoError(err)
 
 	validated, err := ValidateSchemaChanges(context.Background(), compiled, false)

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -344,11 +344,10 @@ func TestCheckPermissionWithDebugInfo(t *testing.T) {
 	require.NotEmpty(debugInfo.SchemaUsed)
 
 	// Compile the schema into the namespace definitions.
-	emptyDefaultPrefix := ""
 	compiled, err := compiler.Compile(compiler.InputSchema{
 		Source:       input.Source("schema"),
 		SchemaString: debugInfo.SchemaUsed,
-	}, &emptyDefaultPrefix)
+	})
 	require.NoError(err, "Invalid schema: %s", debugInfo.SchemaUsed)
 	require.Equal(4, len(compiled.OrderedDefinitions))
 }

--- a/internal/services/v1/schema.go
+++ b/internal/services/v1/schema.go
@@ -103,11 +103,10 @@ func (ss *schemaServer) WriteSchema(ctx context.Context, in *v1.WriteSchemaReque
 	ds := datastoremw.MustFromContext(ctx)
 
 	// Compile the schema into the namespace definitions.
-	emptyDefaultPrefix := ""
 	compiled, err := compiler.Compile(compiler.InputSchema{
 		Source:       input.Source("schema"),
 		SchemaString: in.GetSchema(),
-	}, &emptyDefaultPrefix)
+	})
 	if err != nil {
 		return nil, ss.rewriteError(ctx, err)
 	}

--- a/internal/testfixtures/datastore.go
+++ b/internal/testfixtures/datastore.go
@@ -216,11 +216,10 @@ func DatastoreFromSchemaAndTestRelationships(ds datastore.Datastore, schema stri
 	ctx := context.Background()
 	validating := NewValidatingDatastore(ds)
 
-	emptyDefaultPrefix := ""
 	compiled, err := compiler.Compile(compiler.InputSchema{
 		Source:       input.Source("schema"),
 		SchemaString: schema,
-	}, &emptyDefaultPrefix)
+	})
 	require.NoError(err)
 
 	_ = writeDefinitions(validating, require, compiled.ObjectDefinitions, compiled.CaveatDefinitions)

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -258,11 +258,10 @@ definition document {
 }`
 
 	// Compile namespace to write to the datastore.
-	empty := ""
 	compiled, err := compiler.Compile(compiler.InputSchema{
 		Source:       input.Source("schema"),
 		SchemaString: schemaString,
-	}, &empty)
+	})
 	require.NoError(err)
 	require.Equal(2, len(compiled.OrderedDefinitions))
 

--- a/pkg/development/schema.go
+++ b/pkg/development/schema.go
@@ -12,11 +12,10 @@ import (
 // error if the schema could not be compiled. The non-developer error is returned only if an
 // internal errors occurred.
 func CompileSchema(schema string) (*compiler.CompiledSchema, *devinterface.DeveloperError, error) {
-	empty := ""
 	compiled, err := compiler.Compile(compiler.InputSchema{
 		Source:       input.Source("schema"),
 		SchemaString: schema,
-	}, &empty)
+	})
 
 	var contextError compiler.ErrorWithContext
 	if errors.As(err, &contextError) {

--- a/pkg/schemadsl/compiler/compiler_test.go
+++ b/pkg/schemadsl/compiler/compiler_test.go
@@ -927,7 +927,7 @@ func TestCompile(t *testing.T) {
 			require := require.New(t)
 			compiled, err := Compile(InputSchema{
 				input.Source(test.name), test.input,
-			}, test.implicitTenant)
+			}, ObjectTypePrefix(test.implicitTenant))
 
 			if test.expectedError != "" {
 				require.Error(err)
@@ -1010,7 +1010,7 @@ func TestSuperLargeCaveatCompile(t *testing.T) {
 
 	compiled, err := Compile(InputSchema{
 		input.Source("superlarge"), string(b),
-	}, new(string))
+	})
 	require.NoError(t, err)
 	require.Equal(t, 29, len(compiled.ObjectDefinitions))
 	require.Equal(t, 1, len(compiled.CaveatDefinitions))

--- a/pkg/schemadsl/compiler/translator.go
+++ b/pkg/schemadsl/compiler/translator.go
@@ -20,6 +20,7 @@ type translationContext struct {
 	objectTypePrefix *string
 	mapper           input.PositionMapper
 	schemaString     string
+	skipValidate     bool
 }
 
 func (tctx translationContext) prefixedPath(definitionName string) (string, error) {
@@ -220,9 +221,10 @@ func translateObjectDefinition(tctx translationContext, defNode *dslNode) (*core
 		ns := namespace.Namespace(nspath)
 		ns.Metadata = addComments(ns.Metadata, defNode)
 
-		err = ns.Validate()
-		if err != nil {
-			return nil, defNode.Errorf("error in object definition %s: %w", nspath, err)
+		if !tctx.skipValidate {
+			if err = ns.Validate(); err != nil {
+				return nil, defNode.Errorf("error in object definition %s: %w", nspath, err)
+			}
 		}
 
 		return ns, nil
@@ -232,9 +234,10 @@ func translateObjectDefinition(tctx translationContext, defNode *dslNode) (*core
 	ns.Metadata = addComments(ns.Metadata, defNode)
 	ns.SourcePosition = getSourcePosition(defNode, tctx.mapper)
 
-	err = ns.Validate()
-	if err != nil {
-		return nil, defNode.Errorf("error in object definition %s: %w", nspath, err)
+	if !tctx.skipValidate {
+		if err := ns.Validate(); err != nil {
+			return nil, defNode.Errorf("error in object definition %s: %w", nspath, err)
+		}
 	}
 
 	return ns, nil
@@ -329,9 +332,10 @@ func translateRelation(tctx translationContext, relationNode *dslNode) (*core.Re
 		return nil, err
 	}
 
-	err = relation.Validate()
-	if err != nil {
-		return nil, relationNode.Errorf("error in relation %s: %w", relationName, err)
+	if !tctx.skipValidate {
+		if err := relation.Validate(); err != nil {
+			return nil, relationNode.Errorf("error in relation %s: %w", relationName, err)
+		}
 	}
 
 	return relation, nil
@@ -358,9 +362,10 @@ func translatePermission(tctx translationContext, permissionNode *dslNode) (*cor
 		return nil, err
 	}
 
-	err = permission.Validate()
-	if err != nil {
-		return nil, permissionNode.Errorf("error in permission %s: %w", permissionName, err)
+	if !tctx.skipValidate {
+		if err := permission.Validate(); err != nil {
+			return nil, permissionNode.Errorf("error in permission %s: %w", permissionName, err)
+		}
 	}
 
 	return permission, nil
@@ -582,9 +587,10 @@ func translateSpecificTypeReference(tctx translationContext, typeRefNode *dslNod
 			return nil, typeRefNode.Errorf("invalid caveat: %w", err)
 		}
 
-		err = ref.Validate()
-		if err != nil {
-			return nil, typeRefNode.Errorf("invalid type relation: %w", err)
+		if !tctx.skipValidate {
+			if err := ref.Validate(); err != nil {
+				return nil, typeRefNode.Errorf("invalid type relation: %w", err)
+			}
 		}
 
 		ref.SourcePosition = getSourcePosition(typeRefNode, tctx.mapper)
@@ -611,9 +617,10 @@ func translateSpecificTypeReference(tctx translationContext, typeRefNode *dslNod
 		return nil, typeRefNode.Errorf("invalid caveat: %w", err)
 	}
 
-	err = ref.Validate()
-	if err != nil {
-		return nil, typeRefNode.Errorf("invalid type relation: %w", err)
+	if !tctx.skipValidate {
+		if err := ref.Validate(); err != nil {
+			return nil, typeRefNode.Errorf("invalid type relation: %w", err)
+		}
 	}
 
 	ref.SourcePosition = getSourcePosition(typeRefNode, tctx.mapper)

--- a/pkg/schemadsl/generator/generator_test.go
+++ b/pkg/schemadsl/generator/generator_test.go
@@ -362,7 +362,7 @@ definition foos/document {
 			compiled, err := compiler.Compile(compiler.InputSchema{
 				Source:       input.Source(test.name),
 				SchemaString: test.input,
-			}, nil)
+			}, compiler.ObjectTypePrefix(nil))
 			require.NoError(err)
 
 			source, _, err := GenerateSchema(compiled.OrderedDefinitions)

--- a/pkg/typesystem/reachabilitygraph_test.go
+++ b/pkg/typesystem/reachabilitygraph_test.go
@@ -484,11 +484,10 @@ func TestReachabilityGraph(t *testing.T) {
 
 			ctx := datastoremw.ContextWithDatastore(context.Background(), ds)
 
-			empty := ""
 			compiled, err := compiler.Compile(compiler.InputSchema{
 				Source:       input.Source("schema"),
 				SchemaString: tc.schema,
-			}, &empty)
+			})
 			require.NoError(err)
 
 			lastRevision, err := ds.HeadRevision(context.Background())

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -732,11 +732,10 @@ func TestTypeSystemAccessors(t *testing.T) {
 
 			ctx := datastoremw.ContextWithDatastore(context.Background(), ds)
 
-			empty := ""
 			compiled, err := compiler.Compile(compiler.InputSchema{
 				Source:       input.Source("schema"),
 				SchemaString: tc.schema,
-			}, &empty)
+			})
 			require.NoError(err)
 
 			lastRevision, err := ds.HeadRevision(context.Background())

--- a/pkg/validationfile/blocks/schema.go
+++ b/pkg/validationfile/blocks/schema.go
@@ -30,11 +30,10 @@ func (ps *ParsedSchema) UnmarshalYAML(node *yamlv3.Node) error {
 		return convertYamlError(err)
 	}
 
-	empty := ""
 	compiled, err := compiler.Compile(compiler.InputSchema{
 		Source:       input.Source("schema"),
 		SchemaString: ps.Schema,
-	}, &empty)
+	})
 	if err != nil {
 		var errWithContext compiler.ErrorWithContext
 		if errors.As(err, &errWithContext) {


### PR DESCRIPTION
This allows the schema compiler to skip the validation step, which is useful for plumbing in zed for backup & restore where the server is already going to be doing validation.