### PR TITLE
Watch improvements in datastore

### DIFF
--- a/internal/datastore/common/changes.go
+++ b/internal/datastore/common/changes.go
@@ -4,40 +4,81 @@ import (
 	"context"
 	"sort"
 
+	"golang.org/x/exp/maps"
+
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
-// Changes represents a set of tuple mutations that are kept self-consistent
+const (
+	nsPrefix     = "n$"
+	caveatPrefix = "c$"
+)
+
+// Changes represents a set of datastore mutations that are kept self-consistent
 // across one or more transaction revisions.
 type Changes[R datastore.Revision, K comparable] struct {
 	records map[K]changeRecord[R]
 	keyFunc func(R) K
+	content datastore.WatchContent
 }
 
 type changeRecord[R datastore.Revision] struct {
-	rev          R
-	tupleTouches map[string]*core.RelationTuple
-	tupleDeletes map[string]*core.RelationTuple
+	rev                R
+	tupleTouches       map[string]*core.RelationTuple
+	tupleDeletes       map[string]*core.RelationTuple
+	definitionsChanged map[string]datastore.SchemaDefinition
+	namespacesDeleted  map[string]struct{}
+	caveatsDeleted     map[string]struct{}
 }
 
 // NewChanges creates a new Changes object for change tracking and de-duplication.
-func NewChanges[R datastore.Revision, K comparable](keyFunc func(R) K) Changes[R, K] {
-	return Changes[R, K]{
-		make(map[K]changeRecord[R], 0),
-		keyFunc,
+func NewChanges[R datastore.Revision, K comparable](keyFunc func(R) K, content datastore.WatchContent) *Changes[R, K] {
+	return &Changes[R, K]{
+		records: make(map[K]changeRecord[R], 0),
+		keyFunc: keyFunc,
+		content: content,
 	}
 }
 
-// AddChange adds a specific change to the complete list of tracked changes
-func (ch Changes[R, K]) AddChange(
+// IsEmpty returns if the change set is empty.
+func (ch *Changes[R, K]) IsEmpty() bool {
+	return len(ch.records) == 0
+}
+
+// AddRelationshipChange adds a specific change to the complete list of tracked changes
+func (ch *Changes[R, K]) AddRelationshipChange(
 	ctx context.Context,
 	rev R,
 	tpl *core.RelationTuple,
 	op core.RelationTupleUpdate_Operation,
 ) {
+	if ch.content&datastore.WatchRelationships != datastore.WatchRelationships {
+		return
+	}
+
+	record := ch.recordForRevision(rev)
+	tplKey := tuple.StringWithoutCaveat(tpl)
+
+	switch op {
+	case core.RelationTupleUpdate_TOUCH:
+		// If there was a delete for the same tuple at the same revision, drop it
+		delete(record.tupleDeletes, tplKey)
+		record.tupleTouches[tplKey] = tpl
+
+	case core.RelationTupleUpdate_DELETE:
+		_, alreadyTouched := record.tupleTouches[tplKey]
+		if !alreadyTouched {
+			record.tupleDeletes[tplKey] = tpl
+		}
+	default:
+		log.Ctx(ctx).Fatal().Stringer("operation", op).Msg("unknown change operation")
+	}
+}
+
+func (ch Changes[R, K]) recordForRevision(rev R) changeRecord[R] {
 	k := ch.keyFunc(rev)
 	revisionChanges, ok := ch.records[k]
 	if !ok {
@@ -45,42 +86,109 @@ func (ch Changes[R, K]) AddChange(
 			rev,
 			make(map[string]*core.RelationTuple),
 			make(map[string]*core.RelationTuple),
+			make(map[string]datastore.SchemaDefinition),
+			make(map[string]struct{}),
+			make(map[string]struct{}),
 		}
 		ch.records[k] = revisionChanges
 	}
 
-	tplKey := tuple.StringWithoutCaveat(tpl)
+	return revisionChanges
+}
 
-	switch op {
-	case core.RelationTupleUpdate_TOUCH:
-		// If there was a delete for the same tuple at the same revision, drop it
-		delete(revisionChanges.tupleDeletes, tplKey)
+// AddDeletedNamespace adds a change indicating that the namespace with the name was deleted.
+func (ch *Changes[R, K]) AddDeletedNamespace(
+	_ context.Context,
+	rev R,
+	namespaceName string,
+) {
+	if ch.content&datastore.WatchSchema != datastore.WatchSchema {
+		return
+	}
 
-		revisionChanges.tupleTouches[tplKey] = tpl
+	record := ch.recordForRevision(rev)
+	delete(record.definitionsChanged, nsPrefix+namespaceName)
 
-	case core.RelationTupleUpdate_DELETE:
-		_, alreadyTouched := revisionChanges.tupleTouches[tplKey]
-		if !alreadyTouched {
-			revisionChanges.tupleDeletes[tplKey] = tpl
-		}
+	record.namespacesDeleted[namespaceName] = struct{}{}
+}
+
+// AddDeletedCaveat adds a change indicating that the caveat with the name was deleted.
+func (ch *Changes[R, K]) AddDeletedCaveat(
+	_ context.Context,
+	rev R,
+	caveatName string,
+) {
+	if ch.content&datastore.WatchSchema != datastore.WatchSchema {
+		return
+	}
+
+	record := ch.recordForRevision(rev)
+	delete(record.definitionsChanged, caveatPrefix+caveatName)
+
+	record.caveatsDeleted[caveatName] = struct{}{}
+}
+
+// AddChangedDefinition adds a change indicating that the schema definition (namespace or caveat)
+// was changed to the definition given.
+func (ch Changes[R, K]) AddChangedDefinition(
+	ctx context.Context,
+	rev R,
+	def datastore.SchemaDefinition,
+) {
+	if ch.content&datastore.WatchSchema != datastore.WatchSchema {
+		return
+	}
+
+	record := ch.recordForRevision(rev)
+
+	switch t := def.(type) {
+	case *core.NamespaceDefinition:
+		delete(record.namespacesDeleted, t.Name)
+		record.definitionsChanged[nsPrefix+t.Name] = t
+
+	case *core.CaveatDefinition:
+		delete(record.caveatsDeleted, t.Name)
+		record.definitionsChanged[caveatPrefix+t.Name] = t
 	default:
-		log.Ctx(ctx).Fatal().Stringer("operation", op).Msg("unknown change operation")
+		log.Ctx(ctx).Fatal().Msg("unknown schema definition kind")
 	}
 }
 
 // AsRevisionChanges returns the list of changes processed so far as a datastore watch
 // compatible, ordered, changelist.
-func (ch Changes[R, K]) AsRevisionChanges(lessThanFunc func(lhs, rhs K) bool) []datastore.RevisionChanges {
-	revisionsWithChanges := make([]K, 0, len(ch.records))
-	for rk := range ch.records {
-		revisionsWithChanges = append(revisionsWithChanges, rk)
+func (ch *Changes[R, K]) AsRevisionChanges(lessThanFunc func(lhs, rhs K) bool) []datastore.RevisionChanges {
+	return ch.revisionChanges(lessThanFunc, *new(R), false)
+}
+
+// FilteredRevisionChanges returns a list of changes processed up to the bound revision. Returns changes
+// are removed from the tracker.
+func (ch *Changes[R, K]) FilteredRevisionChanges(lessThanFunc func(lhs, rhs K) bool, boundRev R) []datastore.RevisionChanges {
+	changes := ch.revisionChanges(lessThanFunc, boundRev, true)
+	ch.removeAllChangesBefore(boundRev)
+	return changes
+}
+
+func (ch *Changes[R, K]) revisionChanges(lessThanFunc func(lhs, rhs K) bool, boundRev R, withBound bool) []datastore.RevisionChanges {
+	if ch.IsEmpty() {
+		return nil
 	}
+
+	revisionsWithChanges := make([]K, 0, len(ch.records))
+	for rk, cr := range ch.records {
+		if !withBound || boundRev.GreaterThan(cr.rev) {
+			revisionsWithChanges = append(revisionsWithChanges, rk)
+		}
+	}
+
+	if len(revisionsWithChanges) == 0 {
+		return nil
+	}
+
 	sort.Slice(revisionsWithChanges, func(i int, j int) bool {
 		return lessThanFunc(revisionsWithChanges[i], revisionsWithChanges[j])
 	})
 
 	changes := make([]datastore.RevisionChanges, len(revisionsWithChanges))
-
 	for i, k := range revisionsWithChanges {
 		revisionChangeRecord := ch.records[k]
 		changes[i].Revision = revisionChangeRecord.rev
@@ -96,7 +204,18 @@ func (ch Changes[R, K]) AsRevisionChanges(lessThanFunc func(lhs, rhs K) bool) []
 				Tuple:     tpl,
 			})
 		}
+		changes[i].ChangedDefinitions = maps.Values(revisionChangeRecord.definitionsChanged)
+		changes[i].DeletedNamespaces = maps.Keys(revisionChangeRecord.namespacesDeleted)
+		changes[i].DeletedCaveats = maps.Keys(revisionChangeRecord.caveatsDeleted)
 	}
 
 	return changes
+}
+
+func (ch *Changes[R, K]) removeAllChangesBefore(boundRev R) {
+	for rk, cr := range ch.records {
+		if boundRev.GreaterThan(cr.rev) {
+			delete(ch.records, rk)
+		}
+	}
 }

--- a/internal/datastore/common/changes.go
+++ b/internal/datastore/common/changes.go
@@ -85,13 +85,13 @@ func (ch Changes[R, K]) AsRevisionChanges(lessThanFunc func(lhs, rhs K) bool) []
 		revisionChangeRecord := ch.records[k]
 		changes[i].Revision = revisionChangeRecord.rev
 		for _, tpl := range revisionChangeRecord.tupleTouches {
-			changes[i].Changes = append(changes[i].Changes, &core.RelationTupleUpdate{
+			changes[i].RelationshipChanges = append(changes[i].RelationshipChanges, &core.RelationTupleUpdate{
 				Operation: core.RelationTupleUpdate_TOUCH,
 				Tuple:     tpl,
 			})
 		}
 		for _, tpl := range revisionChangeRecord.tupleDeletes {
-			changes[i].Changes = append(changes[i].Changes, &core.RelationTupleUpdate{
+			changes[i].RelationshipChanges = append(changes[i].RelationshipChanges, &core.RelationTupleUpdate{
 				Operation: core.RelationTupleUpdate_DELETE,
 				Tuple:     tpl,
 			})

--- a/internal/datastore/common/changes_test.go
+++ b/internal/datastore/common/changes_test.go
@@ -53,7 +53,7 @@ func TestChanges(t *testing.T) {
 				{1, tuple1, core.RelationTupleUpdate_TOUCH},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
 			},
 		},
 		{
@@ -62,7 +62,7 @@ func TestChanges(t *testing.T) {
 				{1, tuple1, core.RelationTupleUpdate_DELETE},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{del(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{del(tuple1)}},
 			},
 		},
 		{
@@ -72,7 +72,7 @@ func TestChanges(t *testing.T) {
 				{1, tuple1, core.RelationTupleUpdate_TOUCH},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
 			},
 		},
 		{
@@ -82,7 +82,7 @@ func TestChanges(t *testing.T) {
 				{1, tuple1, core.RelationTupleUpdate_DELETE},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
 			},
 		},
 		{
@@ -92,7 +92,7 @@ func TestChanges(t *testing.T) {
 				{1, tuple2, core.RelationTupleUpdate_DELETE},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func TestChanges(t *testing.T) {
 				{1, tuple2, core.RelationTupleUpdate_TOUCH},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
 			},
 		},
 		{
@@ -115,7 +115,7 @@ func TestChanges(t *testing.T) {
 				{1, tuple1, core.RelationTupleUpdate_TOUCH},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
 			},
 		},
 		{
@@ -126,8 +126,8 @@ func TestChanges(t *testing.T) {
 				{2, tuple1, core.RelationTupleUpdate_TOUCH},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
-				{Revision: rev2, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: rev2, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
 			},
 		},
 		{
@@ -138,8 +138,8 @@ func TestChanges(t *testing.T) {
 				{1_000_000, tuple1, core.RelationTupleUpdate_TOUCH},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
-				{Revision: revOneMillion, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: revOneMillion, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
 			},
 		},
 		{
@@ -150,8 +150,8 @@ func TestChanges(t *testing.T) {
 				{1_000_000, tuple1, core.RelationTupleUpdate_DELETE},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
-				{Revision: revOneMillion, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: revOneMillion, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
 			},
 		},
 		{
@@ -167,9 +167,9 @@ func TestChanges(t *testing.T) {
 				{1_000_000, tuple2, core.RelationTupleUpdate_TOUCH},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
-				{Revision: rev2, Changes: []*core.RelationTupleUpdate{touch(tuple2), del(tuple1)}},
-				{Revision: revOneMillion, Changes: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
+				{Revision: rev2, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple2), del(tuple1)}},
+				{Revision: revOneMillion, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
 			},
 		},
 	}
@@ -207,63 +207,63 @@ func TestCanonicalize(t *testing.T) {
 		{
 			"single entries",
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1)}},
 			},
 		},
 		{
 			"tuples out of order",
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{del(tuple2), touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{del(tuple2), touch(tuple1)}},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
 			},
 		},
 		{
 			"operations out of order",
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{del(tuple1), touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{del(tuple1), touch(tuple1)}},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), del(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), del(tuple1)}},
 			},
 		},
 		{
 			"equal entries",
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple1)}},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple1)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple1)}},
 			},
 		},
 		{
 			"already canonical",
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
-				{Revision: rev2, Changes: []*core.RelationTupleUpdate{del(tuple1), touch(tuple2)}},
-				{Revision: revOneMillion, Changes: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
+				{Revision: rev2, RelationshipChanges: []*core.RelationTupleUpdate{del(tuple1), touch(tuple2)}},
+				{Revision: revOneMillion, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
-				{Revision: rev2, Changes: []*core.RelationTupleUpdate{del(tuple1), touch(tuple2)}},
-				{Revision: revOneMillion, Changes: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
+				{Revision: rev2, RelationshipChanges: []*core.RelationTupleUpdate{del(tuple1), touch(tuple2)}},
+				{Revision: revOneMillion, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
 			},
 		},
 		{
 			"revisions allowed out of order",
 			[]datastore.RevisionChanges{
-				{Revision: revOneMillion, Changes: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
-				{Revision: rev2, Changes: []*core.RelationTupleUpdate{del(tuple1), touch(tuple2)}},
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
+				{Revision: revOneMillion, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
+				{Revision: rev2, RelationshipChanges: []*core.RelationTupleUpdate{del(tuple1), touch(tuple2)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
 			},
 			[]datastore.RevisionChanges{
-				{Revision: revOneMillion, Changes: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
-				{Revision: rev2, Changes: []*core.RelationTupleUpdate{del(tuple1), touch(tuple2)}},
-				{Revision: rev1, Changes: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
+				{Revision: revOneMillion, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), touch(tuple2)}},
+				{Revision: rev2, RelationshipChanges: []*core.RelationTupleUpdate{del(tuple1), touch(tuple2)}},
+				{Revision: rev1, RelationshipChanges: []*core.RelationTupleUpdate{touch(tuple1), del(tuple2)}},
 			},
 		},
 	}
@@ -295,9 +295,9 @@ func canonicalize(in []datastore.RevisionChanges) []datastore.RevisionChanges {
 	out := make([]datastore.RevisionChanges, 0, len(in))
 
 	for _, rev := range in {
-		outChanges := make([]*core.RelationTupleUpdate, 0, len(rev.Changes))
+		outChanges := make([]*core.RelationTupleUpdate, 0, len(rev.RelationshipChanges))
 
-		outChanges = append(outChanges, rev.Changes...)
+		outChanges = append(outChanges, rev.RelationshipChanges...)
 		sort.Slice(outChanges, func(i, j int) bool {
 			// Return if i < j
 			left, right := outChanges[i], outChanges[j]
@@ -314,8 +314,8 @@ func canonicalize(in []datastore.RevisionChanges) []datastore.RevisionChanges {
 		})
 
 		out = append(out, datastore.RevisionChanges{
-			Revision: rev.Revision,
-			Changes:  outChanges,
+			Revision:            rev.Revision,
+			RelationshipChanges: outChanges,
 		})
 	}
 

--- a/internal/datastore/common/changes_test.go
+++ b/internal/datastore/common/changes_test.go
@@ -314,7 +314,8 @@ func TestChanges(t *testing.T) {
 			for _, step := range tc.script {
 				if step.relationship != "" {
 					rel := tuple.MustParse(step.relationship)
-					ch.AddRelationshipChange(ctx, revisionFromTransactionID(step.revision), rel, step.op)
+					err := ch.AddRelationshipChange(ctx, revisionFromTransactionID(step.revision), rel, step.op)
+					require.NoError(err)
 				}
 
 				for _, changed := range step.changedDefinitions {
@@ -338,7 +339,7 @@ func TestChanges(t *testing.T) {
 	}
 }
 
-func TestFilteredRevisionChanges(t *testing.T) {
+func TestFilterAndRemoveRevisionChanges(t *testing.T) {
 	ctx := context.Background()
 	ch := NewChanges(revision.DecimalKeyFunc, datastore.WatchRelationships|datastore.WatchSchema)
 
@@ -350,7 +351,7 @@ func TestFilteredRevisionChanges(t *testing.T) {
 
 	require.False(t, ch.IsEmpty())
 
-	results := ch.FilteredRevisionChanges(revision.DecimalKeyLessThanFunc, rev3)
+	results := ch.FilterAndRemoveRevisionChanges(revision.DecimalKeyLessThanFunc, rev3)
 	require.Equal(t, 2, len(results))
 	require.False(t, ch.IsEmpty())
 

--- a/internal/datastore/context.go
+++ b/internal/datastore/context.go
@@ -63,8 +63,8 @@ func (p *ctxProxy) RevisionFromString(serialized string) (datastore.Revision, er
 	return p.delegate.RevisionFromString(serialized)
 }
 
-func (p *ctxProxy) Watch(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
-	return p.delegate.Watch(ctx, afterRevision)
+func (p *ctxProxy) Watch(ctx context.Context, afterRevision datastore.Revision, options datastore.WatchOptions) (<-chan *datastore.RevisionChanges, <-chan error) {
+	return p.delegate.Watch(ctx, afterRevision, options)
 }
 
 func (p *ctxProxy) Features(ctx context.Context) (*datastore.Features, error) {

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -448,7 +448,7 @@ func (cds *crdbDatastore) features(ctx context.Context) (*datastore.Features, er
 			features.Watch.Reason = fmt.Sprintf("Range feeds must be enabled in CockroachDB and the user must have permission to create them in order to enable the Watch API: %s", err.Error())
 		}
 		return nil
-	}, fmt.Sprintf(cds.beginChangefeedQuery, tableTuple, head))
+	}, fmt.Sprintf(cds.beginChangefeedQuery, tableTuple, head, "1s"))
 
 	<-streamCtx.Done()
 

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -169,7 +169,7 @@ func TestWatchFeatureDetection(t *testing.T) {
 				headRevision, err := ds.HeadRevision(ctx)
 				require.NoError(t, err)
 
-				_, errChan := ds.Watch(ctx, headRevision)
+				_, errChan := ds.Watch(ctx, headRevision, datastore.WatchJustRelationships())
 				err = <-errChan
 				require.NotNil(t, err)
 				require.Contains(t, err.Error(), "watch is currently disabled")

--- a/internal/datastore/crdb/watch.go
+++ b/internal/datastore/crdb/watch.go
@@ -2,7 +2,6 @@ package crdb
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,12 +11,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/authzed/spicedb/internal/datastore/common"
-	"github.com/authzed/spicedb/internal/datastore/crdb/pool"
 	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
-	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
 const (
@@ -46,7 +42,7 @@ func init() {
 	prometheus.MustRegister(retryHistogram)
 }
 
-func (cds *crdbDatastore) Watch(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
+func (cds *crdbDatastore) Watch(ctx context.Context, afterRevision datastore.Revision, options datastore.WatchOptions) (<-chan *datastore.RevisionChanges, <-chan error) {
 	updates := make(chan *datastore.RevisionChanges, cds.watchBufferLength)
 	errs := make(chan error, 1)
 
@@ -201,7 +197,7 @@ func (cds *crdbDatastore) Watch(ctx context.Context, afterRevision datastore.Rev
 				}
 				pendingChanges[details.Updated] = pending
 			}
-			pending.Changes = append(pending.Changes, oneChange)
+			pending.RelationshipChanges = append(pending.RelationshipChanges, oneChange)
 		}
 
 		if err := changes.Err(); err != nil {
@@ -219,232 +215,4 @@ func (cds *crdbDatastore) Watch(ctx context.Context, afterRevision datastore.Rev
 		}
 	}()
 	return updates, errs
-}
-
-type schemaChangeDetails struct {
-	Resolved string
-	Updated  string
-	After    *struct {
-		Namespace                 string `json:"namespace"`
-		SerializedNamespaceConfig string `json:"serialized_config"`
-
-		CaveatName                 string `json:"name"`
-		SerializedCaveatDefinition string `json:"definition"`
-	}
-}
-
-const maxSchemaWatchRetryCount = 15
-
-func (cds *crdbDatastore) WatchSchema(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.SchemaState, <-chan error) {
-	updates := make(chan *datastore.SchemaState, cds.watchBufferLength)
-	errs := make(chan error, 1)
-
-	features, err := cds.Features(ctx)
-	if err != nil {
-		errs <- err
-		return updates, errs
-	}
-
-	if !features.Watch.Enabled {
-		errs <- datastore.NewWatchDisabledErr(fmt.Sprintf("%s. See https://spicedb.dev/d/enable-watch-api-crdb", features.Watch.Reason))
-		return updates, errs
-	}
-
-	lastRevision := afterRevision
-	retryCount := -1
-	go (func() {
-		running := true
-		for running {
-			retryCount++
-			retryHistogram.Observe(float64(retryCount))
-			if retryCount >= maxSchemaWatchRetryCount {
-				errs <- fmt.Errorf("schema watch terminated after %d retries", retryCount)
-				return
-			}
-
-			log.Debug().Str("revision", lastRevision.String()).Int("retry-count", retryCount).Msg("starting schema watch connection")
-
-			cds.watchSchemaWithoutRetry(ctx, lastRevision, func(update *datastore.SchemaState, err error) {
-				if err != nil {
-					if pool.IsResettableError(ctx, err) || pool.IsRetryableError(ctx, err) {
-						running = true
-
-						// Sleep a bit for retrying.
-						pgxcommon.SleepOnErr(ctx, err, uint8(retryCount))
-						return
-					}
-
-					running = false
-					errs <- err
-					return
-				}
-
-				if update.Revision.GreaterThan(lastRevision) {
-					lastRevision = update.Revision
-				}
-
-				updates <- update
-				retryCount = -1
-			})
-		}
-	})()
-
-	return updates, errs
-}
-
-func (cds *crdbDatastore) watchSchemaWithoutRetry(ctx context.Context, afterRevision datastore.Revision, processUpdate func(update *datastore.SchemaState, err error)) {
-	// get non-pooled connection for watch
-	// "applications should explicitly create dedicated connections to consume
-	// changefeed data, instead of using a connection pool as most client
-	// drivers do by default."
-	// see: https://www.cockroachlabs.com/docs/v22.2/changefeed-for#considerations
-	conn, err := pgxcommon.ConnectWithInstrumentation(ctx, cds.dburl)
-	if err != nil {
-		processUpdate(nil, err)
-		return
-	}
-	defer func() { _ = conn.Close(ctx) }()
-
-	interpolated := fmt.Sprintf(cds.beginChangefeedQuery, tableNamespace+","+tableCaveat, afterRevision)
-
-	changes, err := conn.Query(ctx, interpolated)
-	if err != nil {
-		if errors.Is(ctx.Err(), context.Canceled) {
-			processUpdate(nil, datastore.NewWatchCanceledErr())
-			return
-		}
-
-		processUpdate(nil, err)
-		return
-	}
-
-	// We call Close async here because it can be slow and blocks closing the channels. There is
-	// no return value so we're not really losing anything.
-	defer func() { go changes.Close() }()
-
-	for changes.Next() {
-		var tableNameBytes []byte
-		var changeJSON []byte
-		var primaryKeyValuesJSON []byte
-
-		if err := changes.Scan(&tableNameBytes, &primaryKeyValuesJSON, &changeJSON); err != nil {
-			if errors.Is(ctx.Err(), context.Canceled) {
-				processUpdate(nil, datastore.NewWatchCanceledErr())
-				return
-			}
-
-			processUpdate(nil, err)
-			return
-		}
-
-		var details schemaChangeDetails
-		if err := json.Unmarshal(changeJSON, &details); err != nil {
-			processUpdate(nil, err)
-			return
-		}
-
-		if details.Resolved != "" {
-			revision, err := cds.RevisionFromString(details.Resolved)
-			if err != nil {
-				processUpdate(nil, fmt.Errorf("malformed resolved timestamp: %w", err))
-				return
-			}
-
-			processUpdate(&datastore.SchemaState{
-				Revision:     revision,
-				IsCheckpoint: true,
-			}, nil)
-			continue
-		}
-
-		tableName := string(tableNameBytes)
-
-		var pkValues []string
-		if err := json.Unmarshal(primaryKeyValuesJSON, &pkValues); err != nil {
-			processUpdate(nil, err)
-			return
-		}
-
-		if len(pkValues) != 1 {
-			processUpdate(nil, spiceerrors.MustBugf("expected a single definition name for the primary key in schema change feed. found: %s", string(primaryKeyValuesJSON)))
-			return
-		}
-
-		definitionName := pkValues[0]
-
-		deletedNamespaces := make([]string, 0, 1)
-		deletedCaveats := make([]string, 0, 1)
-		changedDefinitions := make([]datastore.SchemaDefinition, 0, 1)
-
-		switch tableName {
-		case tableNamespace:
-			if details.After != nil && details.After.SerializedNamespaceConfig != "" {
-				namespaceDef := &core.NamespaceDefinition{}
-				defBytes, err := hex.DecodeString(details.After.SerializedNamespaceConfig[2:]) // drop the \x
-				if err != nil {
-					processUpdate(nil, fmt.Errorf("could not decode namespace definition: %w", err))
-					return
-				}
-
-				if err := namespaceDef.UnmarshalVT(defBytes); err != nil {
-					processUpdate(nil, fmt.Errorf("could not unmarshal namespace definition: %w", err))
-					return
-				}
-				changedDefinitions = append(changedDefinitions, namespaceDef)
-			} else {
-				deletedNamespaces = append(deletedNamespaces, definitionName)
-			}
-
-		case tableCaveat:
-			if details.After != nil && details.After.SerializedCaveatDefinition != "" {
-				caveatDef := &core.CaveatDefinition{}
-				defBytes, err := hex.DecodeString(details.After.SerializedCaveatDefinition[2:]) // drop the \x
-				if err != nil {
-					processUpdate(nil, fmt.Errorf("could not decode caveat definition: %w", err))
-					return
-				}
-
-				if err := caveatDef.UnmarshalVT(defBytes); err != nil {
-					processUpdate(nil, fmt.Errorf("could not unmarshal caveat definition: %w", err))
-					return
-				}
-				changedDefinitions = append(changedDefinitions, caveatDef)
-			} else {
-				deletedCaveats = append(deletedCaveats, definitionName)
-			}
-
-		default:
-			processUpdate(nil, spiceerrors.MustBugf("unknown table in schema change feed: %s", tableName))
-			return
-		}
-
-		revision, err := cds.RevisionFromString(details.Updated)
-		if err != nil {
-			processUpdate(nil, fmt.Errorf("malformed resolved timestamp: %w", err))
-			return
-		}
-
-		processUpdate(&datastore.SchemaState{
-			Revision:           revision,
-			ChangedDefinitions: changedDefinitions,
-			DeletedNamespaces:  deletedNamespaces,
-			DeletedCaveats:     deletedCaveats,
-			IsCheckpoint:       false,
-		}, nil)
-	}
-
-	if changes.Err() != nil {
-		if errors.Is(ctx.Err(), context.Canceled) {
-			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer closeCancel()
-			if err := conn.Close(closeCtx); err != nil {
-				processUpdate(nil, err)
-				return
-			}
-			processUpdate(nil, datastore.NewWatchCanceledErr())
-		} else {
-			processUpdate(nil, changes.Err())
-		}
-		return
-	}
 }

--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -198,8 +198,8 @@ func (mdb *memdbDatastore) ReadWriteTx(
 
 		// Record the changes that were made
 		newChanges := datastore.RevisionChanges{
-			Revision: newRevision,
-			Changes:  nil,
+			Revision:            newRevision,
+			RelationshipChanges: nil,
 		}
 		if tx != nil {
 			for _, change := range tx.Changes() {
@@ -209,7 +209,7 @@ func (mdb *memdbDatastore) ReadWriteTx(
 						if err != nil {
 							return datastore.NoRevision, err
 						}
-						newChanges.Changes = append(newChanges.Changes, &corev1.RelationTupleUpdate{
+						newChanges.RelationshipChanges = append(newChanges.RelationshipChanges, &corev1.RelationTupleUpdate{
 							Operation: corev1.RelationTupleUpdate_TOUCH,
 							Tuple:     rt,
 						})
@@ -219,7 +219,7 @@ func (mdb *memdbDatastore) ReadWriteTx(
 						if err != nil {
 							return datastore.NoRevision, err
 						}
-						newChanges.Changes = append(newChanges.Changes, &corev1.RelationTupleUpdate{
+						newChanges.RelationshipChanges = append(newChanges.RelationshipChanges, &corev1.RelationTupleUpdate{
 							Operation: corev1.RelationTupleUpdate_DELETE,
 							Tuple:     rt,
 						})

--- a/internal/datastore/memdb/memdb_test.go
+++ b/internal/datastore/memdb/memdb_test.go
@@ -26,7 +26,7 @@ func (mdbt memDBTest) New(revisionQuantization, _, gcWindow time.Duration, watch
 }
 
 func TestMemdbDatastore(t *testing.T) {
-	test.All(t, memDBTest{})
+	test.AllWithExceptions(t, memDBTest{}, test.WithCategories(test.WatchSchemaCategory))
 }
 
 func TestConcurrentWritePanic(t *testing.T) {

--- a/internal/datastore/memdb/watch.go
+++ b/internal/datastore/memdb/watch.go
@@ -13,7 +13,7 @@ import (
 
 const errWatchError = "watch error: %w"
 
-func (mdb *memdbDatastore) Watch(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
+func (mdb *memdbDatastore) Watch(ctx context.Context, afterRevision datastore.Revision, options datastore.WatchOptions) (<-chan *datastore.RevisionChanges, <-chan error) {
 	ar := afterRevision.(revision.Decimal)
 
 	updates := make(chan *datastore.RevisionChanges, mdb.watchBufferLength)
@@ -37,7 +37,7 @@ func (mdb *memdbDatastore) Watch(ctx context.Context, afterRevision datastore.Re
 
 			// Write the staged updates to the channel
 			for _, changeToWrite := range stagedUpdates {
-				if len(changeToWrite.Changes) == 0 {
+				if len(changeToWrite.RelationshipChanges) == 0 {
 					continue
 				}
 

--- a/internal/datastore/memdb/watch.go
+++ b/internal/datastore/memdb/watch.go
@@ -19,6 +19,11 @@ func (mdb *memdbDatastore) Watch(ctx context.Context, afterRevision datastore.Re
 	updates := make(chan *datastore.RevisionChanges, mdb.watchBufferLength)
 	errs := make(chan error, 1)
 
+	if options.Content&datastore.WatchSchema == datastore.WatchSchema {
+		errs <- errors.New("schema watch unsupported in MemDB")
+		return updates, errs
+	}
+
 	go func() {
 		defer close(updates)
 		defer close(errs)

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -97,7 +97,7 @@ func TestMySQLDatastoreDSNWithoutParseTime(t *testing.T) {
 func TestMySQL8Datastore(t *testing.T) {
 	b := testdatastore.RunMySQLForTestingWithOptions(t, testdatastore.MySQLTesterOptions{MigrateForNewDatastore: true}, "")
 	dst := datastoreTester{b: b, t: t}
-	test.All(t, test.DatastoreTesterFunc(dst.createDatastore))
+	test.AllWithExceptions(t, test.DatastoreTesterFunc(dst.createDatastore), test.WithCategories(test.WatchSchemaCategory))
 	additionalMySQLTests(t, b)
 }
 

--- a/internal/datastore/mysql/watch.go
+++ b/internal/datastore/mysql/watch.go
@@ -22,7 +22,7 @@ const (
 // All events following afterRevision will be sent to the caller.
 //
 // TODO (@vroldanbet) dupe from postgres datastore - need to refactor
-func (mds *Datastore) Watch(ctx context.Context, afterRevisionRaw datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
+func (mds *Datastore) Watch(ctx context.Context, afterRevisionRaw datastore.Revision, options datastore.WatchOptions) (<-chan *datastore.RevisionChanges, <-chan error) {
 	afterRevision := afterRevisionRaw.(revision.Decimal)
 
 	updates := make(chan *datastore.RevisionChanges, mds.watchBufferLength)

--- a/internal/datastore/mysql/watch.go
+++ b/internal/datastore/mysql/watch.go
@@ -153,11 +153,15 @@ func (mds *Datastore) loadChanges(
 		}
 
 		if createdTxn > afterRevision && createdTxn <= newRevision {
-			stagedChanges.AddRelationshipChange(ctx, revisionFromTransaction(createdTxn), nextTuple, core.RelationTupleUpdate_TOUCH)
+			if err = stagedChanges.AddRelationshipChange(ctx, revisionFromTransaction(createdTxn), nextTuple, core.RelationTupleUpdate_TOUCH); err != nil {
+				return
+			}
 		}
 
 		if deletedTxn > afterRevision && deletedTxn <= newRevision {
-			stagedChanges.AddRelationshipChange(ctx, revisionFromTransaction(deletedTxn), nextTuple, core.RelationTupleUpdate_DELETE)
+			if err = stagedChanges.AddRelationshipChange(ctx, revisionFromTransaction(deletedTxn), nextTuple, core.RelationTupleUpdate_DELETE); err != nil {
+				return
+			}
 		}
 	}
 	if err = rows.Err(); err != nil {

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -851,7 +851,7 @@ func ConcurrentRevisionWatchTest(t *testing.T, ds datastore.Datastore) {
 	seenWatchRevisionsLock := sync.Mutex{}
 
 	go func() {
-		changes, _ := ds.Watch(withCancel, rev)
+		changes, _ := ds.Watch(withCancel, rev, datastore.WatchJustRelationships())
 
 		waitForWatch <- struct{}{}
 
@@ -1031,7 +1031,7 @@ func OverlappingRevisionWatchTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Call watch and ensure it terminates with having only read the two expected sets of changes.
-	changes, errChan := ds.Watch(ctx, rev)
+	changes, errChan := ds.Watch(ctx, rev, datastore.WatchJustRelationships())
 	transactionCount := 0
 loop:
 	for {
@@ -1177,6 +1177,7 @@ func WatchNotEnabledTest(t *testing.T, _ testdatastore.RunningEngineForTest, pgV
 	_, errChan := ds.Watch(
 		context.Background(),
 		revision,
+		datastore.WatchJustRelationships(),
 	)
 	err := <-errChan
 	require.NotNil(err)
@@ -1431,7 +1432,7 @@ func NullCaveatWatchTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Run the watch API.
-	changes, errchan := ds.Watch(ctx, lowestRevision)
+	changes, errchan := ds.Watch(ctx, lowestRevision, datastore.WatchJustRelationships())
 	require.Zero(len(errchan))
 
 	// Manually insert a relationship with a NULL caveat. This is allowed, but can only happen due to
@@ -1519,7 +1520,7 @@ func verifyUpdates(
 			}
 
 			expectedChangeSet := setOfChanges(expected)
-			actualChangeSet := setOfChanges(change.Changes)
+			actualChangeSet := setOfChanges(change.RelationshipChanges)
 
 			missingExpected := strset.Difference(expectedChangeSet, actualChangeSet)
 			unexpected := strset.Difference(actualChangeSet, expectedChangeSet)

--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -51,6 +51,7 @@ var (
 func (pgd *pgDatastore) Watch(
 	ctx context.Context,
 	afterRevisionRaw datastore.Revision,
+	options datastore.WatchOptions,
 ) (<-chan *datastore.RevisionChanges, <-chan error) {
 	updates := make(chan *datastore.RevisionChanges, pgd.watchBufferLength)
 	errs := make(chan error, 1)

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -109,8 +109,8 @@ func (p *observableProxy) RevisionFromString(serialized string) (datastore.Revis
 	return p.delegate.RevisionFromString(serialized)
 }
 
-func (p *observableProxy) Watch(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
-	return p.delegate.Watch(ctx, afterRevision)
+func (p *observableProxy) Watch(ctx context.Context, afterRevision datastore.Revision, options datastore.WatchOptions) (<-chan *datastore.RevisionChanges, <-chan error) {
+	return p.delegate.Watch(ctx, afterRevision, options)
 }
 
 func (p *observableProxy) Features(ctx context.Context) (*datastore.Features, error) {

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -55,7 +55,7 @@ func (dm *MockDatastore) RevisionFromString(s string) (datastore.Revision, error
 	return args.Get(0).(datastore.Revision), args.Error(1)
 }
 
-func (dm *MockDatastore) Watch(_ context.Context, afterRevision datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
+func (dm *MockDatastore) Watch(_ context.Context, afterRevision datastore.Revision, _ datastore.WatchOptions) (<-chan *datastore.RevisionChanges, <-chan error) {
 	args := dm.Called(afterRevision)
 	return args.Get(0).(<-chan *datastore.RevisionChanges), args.Get(1).(<-chan error)
 }

--- a/internal/datastore/proxy/readonly_test.go
+++ b/internal/datastore/proxy/readonly_test.go
@@ -122,7 +122,7 @@ func TestWatchPassthrough(t *testing.T) {
 		make(<-chan error),
 	).Times(1)
 
-	ds.Watch(ctx, expectedRevision)
+	ds.Watch(ctx, expectedRevision, datastore.WatchJustRelationships())
 	delegate.AssertExpectations(t)
 }
 

--- a/internal/datastore/proxy/schemacaching/caching.go
+++ b/internal/datastore/proxy/schemacaching/caching.go
@@ -36,7 +36,7 @@ func DatastoreProxyTestCache(t testing.TB) cache.Cache {
 
 // NewCachingDatastoreProxy creates a new datastore proxy which caches definitions that
 // are loaded at specific datastore revisions.
-func NewCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache, gcWindow time.Duration, cachingMode CachingMode) datastore.Datastore {
+func NewCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache, gcWindow time.Duration, cachingMode CachingMode, watchHeartbeat time.Duration) datastore.Datastore {
 	if c == nil {
 		c = cache.NoopCache()
 	}
@@ -49,5 +49,5 @@ func NewCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache, gcWin
 		}
 	}
 
-	return createWatchingCacheProxy(delegate, c, gcWindow)
+	return createWatchingCacheProxy(delegate, c, gcWindow, watchHeartbeat)
 }

--- a/internal/datastore/proxy/schemacaching/caching.go
+++ b/internal/datastore/proxy/schemacaching/caching.go
@@ -49,16 +49,5 @@ func NewCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache, gcWin
 		}
 	}
 
-	// Try to instantiate a schema cache that reads updates from the datastore's schema watch stream. If not possible,
-	// fallback to the just-in-time caching proxy.
-	if watchable := datastore.UnwrapAs[datastore.SchemaWatchableDatastore](delegate); watchable != nil {
-		log.Info().Type("datastore-type", watchable).Msg("schema watch caching enabled")
-		return createWatchingCacheProxy(watchable, c, gcWindow)
-	}
-
-	log.Info().Type("datastore-type", delegate).Msg("schema watch caching was requested but datastore does not support it; falling back to just-in-time caching")
-	return &definitionCachingProxy{
-		Datastore: delegate,
-		c:         c,
-	}
+	return createWatchingCacheProxy(delegate, c, gcWindow)
 }

--- a/internal/datastore/proxy/schemacaching/standardcaching_test.go
+++ b/internal/datastore/proxy/schemacaching/standardcaching_test.go
@@ -162,7 +162,7 @@ func TestSnapshotCaching(t *testing.T) {
 			twoReader.On(tester.readSingleFunctionName, nsB).Return(nil, one, nil).Once()
 
 			require := require.New(t)
-			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t), 1*time.Hour, JustInTimeCaching)
+			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 
 			_, updatedOneA, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsA)
 			require.NoError(err)
@@ -217,7 +217,7 @@ func TestRWTCaching(t *testing.T) {
 
 			ctx := context.Background()
 
-			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching)
+			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 
 			rev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 				_, updatedA, err := tester.readSingleFunc(ctx, rwt, nsA)
@@ -254,7 +254,7 @@ func TestRWTCacheWithWrites(t *testing.T) {
 
 			ctx := context.Background()
 
-			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching)
+			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 
 			rev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 				// Cache the 404
@@ -305,7 +305,7 @@ func TestSingleFlight(t *testing.T) {
 
 			require := require.New(t)
 
-			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching)
+			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 
 			readNamespace := func() error {
 				_, updatedAt, err := tester.readSingleFunc(context.Background(), ds.SnapshotReader(one), nsA)
@@ -371,7 +371,7 @@ func TestSnapshotCachingRealDatastore(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			ds := NewCachingDatastoreProxy(rawDS, nil, 1*time.Hour, JustInTimeCaching)
+			ds := NewCachingDatastoreProxy(rawDS, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 
 			if tc.nsDef != nil {
 				_, err = ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
@@ -436,7 +436,7 @@ func TestSingleFlightCancelled(t *testing.T) {
 
 			dsMock.On("SnapshotReader", one).Return(&reader{MockReader: proxy_test.MockReader{}})
 
-			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching)
+			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 
 			g := sync.WaitGroup{}
 			var d2 datastore.SchemaDefinition
@@ -477,7 +477,7 @@ func TestMixedCaching(t *testing.T) {
 			dsMock.On("SnapshotReader", one).Return(reader)
 
 			require := require.New(t)
-			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t), 1*time.Hour, JustInTimeCaching)
+			ds := NewCachingDatastoreProxy(dsMock, DatastoreProxyTestCache(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 
 			dsReader := ds.SnapshotReader(one)
 

--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -239,7 +239,7 @@ func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 			log.Info().Str("revision", headRev.String()).Int("count", len(caveats)).Msg("populated caveat watching cache")
 
 			log.Debug().Str("revision", headRev.String()).Dur("watch-heartbeat", p.watchHeartbeat).Msg("beginning schema watch")
-			ssc, serrc := p.Datastore.Watch(context.Background(), headRev, datastore.WatchOptions{
+			ssc, serrc := p.Datastore.Watch(ctx, headRev, datastore.WatchOptions{
 				Content:            datastore.WatchSchema | datastore.WatchCheckpoints,
 				CheckpointInterval: p.watchHeartbeat,
 			})
@@ -347,8 +347,7 @@ func (p *watchingCachingProxy) Close() error {
 	p.closed <- true
 	p.closed <- true
 
-	p.fallbackCache.Close()
-	return p.Datastore.Close()
+	return errors.Join(p.fallbackCache.Close(), p.Datastore.Close())
 }
 
 // schemaWatchCache is a schema cache which updates based on changes received via the WatchSchema

--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -2,11 +2,13 @@ package schemacaching
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/cache"
 	"github.com/authzed/spicedb/pkg/datastore"
@@ -51,6 +53,8 @@ var definitionsReadTotalCounter = prometheus.NewCounterVec(prometheus.CounterOpt
 	Name:      "watching_schema_cache_definitions_read_total",
 	Help:      "total number of definitions read from the watching cache",
 }, []string{"definition_kind"})
+
+const maximumRetryCount = 10
 
 func init() {
 	prometheus.MustRegister(namespacesFallbackModeGauge, caveatsFallbackModeGauge, schemaCacheRevisionGauge, definitionsReadCachedCounter, definitionsReadTotalCounter)
@@ -177,137 +181,153 @@ func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 
 	// Start watching for schema changes.
 	go (func() {
-		log.Debug().Str("revision", headRev.String()).Msg("starting watching cache watch goroutine")
-		reader := p.Datastore.SnapshotReader(headRev)
+		retryCount := 0
 
-		// Populate the cache with all definitions at the head revision.
-		log.Info().Str("revision", headRev.String()).Msg("prepopulating namespace watching cache")
-		namespaces, err := reader.ListAllNamespaces(ctx)
-		if err != nil {
-			p.namespaceCache.setFallbackMode()
-			p.caveatCache.setFallbackMode()
-			log.Warn().Err(err).Msg("received error in schema watch")
-			wg.Done()
-			return
-		}
-
-		for _, namespaceDef := range namespaces {
-			err := p.namespaceCache.updateDefinition(namespaceDef.Definition.Name, namespaceDef.Definition, false, headRev)
-			if err != nil {
-				p.namespaceCache.setFallbackMode()
-				p.caveatCache.setFallbackMode()
-				log.Warn().Err(err).Msg("received error in schema watch")
-				wg.Done()
-				return
-			}
-		}
-		log.Info().Str("revision", headRev.String()).Int("count", len(namespaces)).Msg("populated namespace watching cache")
-
-		log.Info().Str("revision", headRev.String()).Msg("prepopulating caveat watching cache")
-		caveats, err := reader.ListAllCaveats(ctx)
-		if err != nil {
-			p.namespaceCache.setFallbackMode()
-			p.caveatCache.setFallbackMode()
-			log.Warn().Err(err).Msg("received error in schema watch")
-			wg.Done()
-			return
-		}
-
-		for _, caveatDef := range caveats {
-			err := p.caveatCache.updateDefinition(caveatDef.Definition.Name, caveatDef.Definition, false, headRev)
-			if err != nil {
-				p.namespaceCache.setFallbackMode()
-				p.caveatCache.setFallbackMode()
-				log.Warn().Err(err).Msg("received error in schema watch")
-				wg.Done()
-				return
-			}
-		}
-		log.Info().Str("revision", headRev.String()).Int("count", len(caveats)).Msg("populated caveat watching cache")
-
-		log.Debug().Str("revision", headRev.String()).Msg("beginning schema watch")
-		ssc, serrc := p.Datastore.Watch(context.Background(), headRev, datastore.WatchOptions{
-			Content:             datastore.WatchSchema | datastore.WatchCheckpoints,
-			CheckpointHeartbeat: 10 * time.Millisecond,
-		})
-		log.Debug().Msg("schema watch started")
-
-		p.namespaceCache.startAtRevision(headRev)
-		p.caveatCache.startAtRevision(headRev)
-
-		wg.Done()
-
+	restartWatch:
 		for {
-			select {
-			case <-ctx.Done():
-				log.Debug().Msg("schema watch closed due to context cancelation")
+			p.namespaceCache.reset()
+			p.caveatCache.reset()
+
+			log.Debug().Str("revision", headRev.String()).Msg("starting watching cache watch operation")
+			reader := p.Datastore.SnapshotReader(headRev)
+
+			// Populate the cache with all definitions at the head revision.
+			log.Info().Str("revision", headRev.String()).Msg("prepopulating namespace watching cache")
+			namespaces, err := reader.ListAllNamespaces(ctx)
+			if err != nil {
+				p.namespaceCache.setFallbackMode()
+				p.caveatCache.setFallbackMode()
+				log.Warn().Err(err).Msg("received error in schema watch")
+				wg.Done()
 				return
+			}
 
-			case <-p.closed:
-				log.Debug().Msg("schema watch closed")
+			for _, namespaceDef := range namespaces {
+				err := p.namespaceCache.updateDefinition(namespaceDef.Definition.Name, namespaceDef.Definition, false, headRev)
+				if err != nil {
+					p.namespaceCache.setFallbackMode()
+					p.caveatCache.setFallbackMode()
+					log.Warn().Err(err).Msg("received error in schema watch")
+					wg.Done()
+					return
+				}
+			}
+			log.Info().Str("revision", headRev.String()).Int("count", len(namespaces)).Msg("populated namespace watching cache")
+
+			log.Info().Str("revision", headRev.String()).Msg("prepopulating caveat watching cache")
+			caveats, err := reader.ListAllCaveats(ctx)
+			if err != nil {
+				p.namespaceCache.setFallbackMode()
+				p.caveatCache.setFallbackMode()
+				log.Warn().Err(err).Msg("received error in schema watch")
+				wg.Done()
 				return
+			}
 
-			case ss := <-ssc:
-				log.Trace().Object("update", ss).Msg("received update from schema watch")
+			for _, caveatDef := range caveats {
+				err := p.caveatCache.updateDefinition(caveatDef.Definition.Name, caveatDef.Definition, false, headRev)
+				if err != nil {
+					p.namespaceCache.setFallbackMode()
+					p.caveatCache.setFallbackMode()
+					log.Warn().Err(err).Msg("received error in schema watch")
+					wg.Done()
+					return
+				}
+			}
+			log.Info().Str("revision", headRev.String()).Int("count", len(caveats)).Msg("populated caveat watching cache")
 
-				if ss.IsCheckpoint {
-					if converted, ok := ss.Revision.(revision.Decimal); ok {
-						schemaCacheRevisionGauge.Set(converted.InexactFloat64())
+			log.Debug().Str("revision", headRev.String()).Msg("beginning schema watch")
+			ssc, serrc := p.Datastore.Watch(context.Background(), headRev, datastore.WatchOptions{
+				Content: datastore.WatchSchema | datastore.WatchCheckpoints,
+			})
+			log.Debug().Msg("schema watch started")
+
+			p.namespaceCache.startAtRevision(headRev)
+			p.caveatCache.startAtRevision(headRev)
+
+			wg.Done()
+
+			for {
+				select {
+				case <-ctx.Done():
+					log.Debug().Msg("schema watch closed due to context cancelation")
+					return
+
+				case <-p.closed:
+					log.Debug().Msg("schema watch closed")
+					return
+
+				case ss := <-ssc:
+					log.Trace().Object("update", ss).Msg("received update from schema watch")
+
+					if ss.IsCheckpoint {
+						if converted, ok := ss.Revision.(revision.Decimal); ok {
+							schemaCacheRevisionGauge.Set(converted.InexactFloat64())
+						}
+
+						p.namespaceCache.setCheckpointRevision(ss.Revision)
+						p.caveatCache.setCheckpointRevision(ss.Revision)
+						continue
 					}
 
-					p.namespaceCache.setCheckpointRevision(ss.Revision)
-					p.caveatCache.setCheckpointRevision(ss.Revision)
-					continue
-				}
+					// Apply the change to the interval tree entry.
+					for _, changeDef := range ss.ChangedDefinitions {
+						switch t := changeDef.(type) {
+						case *core.NamespaceDefinition:
+							err := p.namespaceCache.updateDefinition(t.Name, t, false, ss.Revision)
+							if err != nil {
+								p.namespaceCache.setFallbackMode()
+								log.Warn().Err(err).Msg("received error in schema watch")
+							}
 
-				// Apply the change to the interval tree entry.
-				for _, changeDef := range ss.ChangedDefinitions {
-					switch t := changeDef.(type) {
-					case *core.NamespaceDefinition:
-						err := p.namespaceCache.updateDefinition(t.Name, t, false, ss.Revision)
+						case *core.CaveatDefinition:
+							err := p.caveatCache.updateDefinition(t.Name, t, false, ss.Revision)
+							if err != nil {
+								p.caveatCache.setFallbackMode()
+								log.Warn().Err(err).Msg("received error in schema watch")
+							}
+
+						default:
+							p.namespaceCache.setFallbackMode()
+							p.caveatCache.setFallbackMode()
+							log.Error().Msg("unknown change definition type")
+							return
+						}
+					}
+
+					for _, deletedNamespaceName := range ss.DeletedNamespaces {
+						err := p.namespaceCache.updateDefinition(deletedNamespaceName, nil, true, ss.Revision)
 						if err != nil {
 							p.namespaceCache.setFallbackMode()
 							log.Warn().Err(err).Msg("received error in schema watch")
+							break
 						}
+					}
 
-					case *core.CaveatDefinition:
-						err := p.caveatCache.updateDefinition(t.Name, t, false, ss.Revision)
+					for _, deletedCaveatName := range ss.DeletedCaveats {
+						err := p.caveatCache.updateDefinition(deletedCaveatName, nil, true, ss.Revision)
 						if err != nil {
 							p.caveatCache.setFallbackMode()
 							log.Warn().Err(err).Msg("received error in schema watch")
+							break
 						}
-
-					default:
-						p.namespaceCache.setFallbackMode()
-						p.caveatCache.setFallbackMode()
-						log.Error().Msg("unknown change definition type")
-						return
 					}
-				}
 
-				for _, deletedNamespaceName := range ss.DeletedNamespaces {
-					err := p.namespaceCache.updateDefinition(deletedNamespaceName, nil, true, ss.Revision)
-					if err != nil {
-						p.namespaceCache.setFallbackMode()
-						log.Warn().Err(err).Msg("received error in schema watch")
-						break
+				case err := <-serrc:
+					var retryable datastore.ErrWatchRetryable
+					if errors.As(err, &retryable) && retryCount <= maximumRetryCount {
+						log.Warn().Err(err).Msg("received retryable error in schema watch; sleeping for a bit and restarting watch")
+						retryCount++
+						wg.Add(1)
+						pgxcommon.SleepOnErr(ctx, err, uint8(retryCount))
+						continue restartWatch
 					}
-				}
 
-				for _, deletedCaveatName := range ss.DeletedCaveats {
-					err := p.caveatCache.updateDefinition(deletedCaveatName, nil, true, ss.Revision)
-					if err != nil {
-						p.caveatCache.setFallbackMode()
-						log.Warn().Err(err).Msg("received error in schema watch")
-						break
-					}
+					p.namespaceCache.setFallbackMode()
+					p.caveatCache.setFallbackMode()
+					log.Warn().Err(err).Msg("received terminal error in schema watch; setting to permanent fallback mode")
+					return
 				}
-
-			case err := <-serrc:
-				p.namespaceCache.setFallbackMode()
-				p.caveatCache.setFallbackMode()
-				log.Warn().Err(err).Msg("received terminal error in schema watch; setting to permanent fallback mode")
-				return
 			}
 		}
 	})()
@@ -439,6 +459,16 @@ func (swc *schemaWatchCache[T]) setFallbackMode() {
 
 	swc.inFallbackMode = true
 	swc.fallbackGauge.Set(1)
+}
+
+func (swc *schemaWatchCache[T]) reset() {
+	swc.lock.Lock()
+	defer swc.lock.Unlock()
+
+	swc.inFallbackMode = false
+	swc.fallbackGauge.Set(0)
+	swc.entries = map[string]*intervalTracker[revisionedEntry[T]]{}
+	swc.checkpointRevision = nil
 }
 
 func (swc *schemaWatchCache[T]) setCheckpointRevision(revision datastore.Revision) {

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -487,10 +487,6 @@ func (fds *fakeDatastore) SnapshotReader(rev datastore.Revision) datastore.Reade
 	return &fakeSnapshotReader{fds, rev}
 }
 
-func (fds *fakeDatastore) WatchSchema(context.Context, datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
-	return fds.schemaChan, fds.errChan
-}
-
 func (fds *fakeDatastore) HeadRevision(context.Context) (datastore.Revision, error) {
 	fds.lock.RLock()
 	defer fds.lock.RUnlock()
@@ -530,8 +526,12 @@ func (*fakeDatastore) Statistics(context.Context) (datastore.Stats, error) {
 	return datastore.Stats{}, fmt.Errorf("not implemented")
 }
 
-func (*fakeDatastore) Watch(context.Context, datastore.Revision, datastore.WatchOptions) (<-chan *datastore.RevisionChanges, <-chan error) {
-	return nil, nil
+func (fds *fakeDatastore) Watch(_ context.Context, _ datastore.Revision, opts datastore.WatchOptions) (<-chan *datastore.RevisionChanges, <-chan error) {
+	if opts.Content&datastore.WatchSchema != datastore.WatchSchema {
+		panic("unexpected option")
+	}
+
+	return fds.schemaChan, fds.errChan
 }
 
 type fakeSnapshotReader struct {

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -35,7 +35,7 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache(), 1*time.Hour)
+	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache(), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(context.Background()))
 
 	// Ensure no namespaces are found.
@@ -138,7 +138,7 @@ func TestWatchingCacheParallelOperations(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache(), 1*time.Hour)
+	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache(), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(context.Background()))
 
 	// Run some operations in parallel.
@@ -194,7 +194,7 @@ func TestWatchingCacheParallelReaderWriter(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache(), 1*time.Hour)
+	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache(), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(context.Background()))
 
 	// Write somenamespace.
@@ -253,7 +253,7 @@ func TestWatchingCacheFallbackToStandardCache(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour)
+	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(context.Background()))
 
 	// Ensure the namespace is not found, but is cached in the fallback caching layer.
@@ -309,7 +309,7 @@ func TestWatchingCachePrepopulated(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour)
+	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(context.Background()))
 
 	// Ensure the namespace is found.

--- a/internal/datastore/proxy/singleflight.go
+++ b/internal/datastore/proxy/singleflight.go
@@ -58,8 +58,8 @@ func (p *singleflightProxy) RevisionFromString(serialized string) (datastore.Rev
 	return p.delegate.RevisionFromString(serialized)
 }
 
-func (p *singleflightProxy) Watch(ctx context.Context, afterRevision datastore.Revision) (<-chan *datastore.RevisionChanges, <-chan error) {
-	return p.delegate.Watch(ctx, afterRevision)
+func (p *singleflightProxy) Watch(ctx context.Context, afterRevision datastore.Revision, options datastore.WatchOptions) (<-chan *datastore.RevisionChanges, <-chan error) {
+	return p.delegate.Watch(ctx, afterRevision, options)
 }
 
 func (p *singleflightProxy) Statistics(ctx context.Context) (datastore.Stats, error) {

--- a/internal/datastore/spanner/migrations/zz_migration.0007_register_combined_change_stream.go
+++ b/internal/datastore/spanner/migrations/zz_migration.0007_register_combined_change_stream.go
@@ -1,0 +1,26 @@
+package migrations
+
+import (
+	"context"
+
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+)
+
+var createCombinedChangeStream = `CREATE CHANGE STREAM combined_change_stream FOR namespace_config,caveat,relation_tuple`
+
+func init() {
+	if err := SpannerMigrations.Register("register-combined-change-stream", "register-schema-change-stream", func(ctx context.Context, w Wrapper) error {
+		updateOp, err := w.adminClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+			Database: w.client.DatabaseName(),
+			Statements: []string{
+				createCombinedChangeStream,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		return updateOp.Wait(ctx)
+	}, nil); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}

--- a/internal/datastore/spanner/migrations/zz_migration.0008_delete_older_changestreams.go
+++ b/internal/datastore/spanner/migrations/zz_migration.0008_delete_older_changestreams.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"context"
+
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+)
+
+const (
+	deleteTupleChangeStream  = `DROP CHANGE STREAM relation_tuple_stream`
+	deleteSchemaChangeStream = `DROP CHANGE STREAM schema_change_stream`
+)
+
+func init() {
+	if err := SpannerMigrations.Register("delete-older-changestreams", "register-combined-change-stream", func(ctx context.Context, w Wrapper) error {
+		updateOp, err := w.adminClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+			Database: w.client.DatabaseName(),
+			Statements: []string{
+				deleteTupleChangeStream,
+				deleteSchemaChangeStream,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		return updateOp.Wait(ctx)
+	}, nil); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}

--- a/internal/datastore/spanner/options.go
+++ b/internal/datastore/spanner/options.go
@@ -17,7 +17,6 @@ type spannerOptions struct {
 	disableStats                bool
 	readMaxOpen                 int
 	writeMaxOpen                int
-	schemaWatchHeartbeat        time.Duration
 	minSessions                 uint64
 	maxSessions                 uint64
 }
@@ -31,7 +30,6 @@ const (
 	defaultWatchBufferLength           = 128
 	defaultDisableStats                = false
 	maxRevisionQuantization            = 24 * time.Hour
-	defaultSchemaWatchHeartbeat        = 100 * time.Millisecond
 )
 
 // Option provides the facility to configure how clients within the Spanner
@@ -50,7 +48,6 @@ func generateConfig(options []Option) (spannerOptions, error) {
 		disableStats:                defaultDisableStats,
 		readMaxOpen:                 int(defaultNumberConnections),
 		writeMaxOpen:                int(defaultNumberConnections),
-		schemaWatchHeartbeat:        defaultSchemaWatchHeartbeat,
 		minSessions:                 100,
 		maxSessions:                 400,
 	}
@@ -147,20 +144,6 @@ func ReadConnsMaxOpen(conns int) Option {
 // This value defaults to having 10 connections.
 func WriteConnsMaxOpen(conns int) Option {
 	return func(po *spannerOptions) { po.writeMaxOpen = conns }
-}
-
-// SchemaWatchHeartbeat is the heartbeat to use for the schema watch, if enabled.
-//
-// A lower heartbeat means that the schema watch will be able to "catch up" faster.
-//
-// This value defaults to the minimum heartbeat time of 100ms.
-func SchemaWatchHeartbeat(heartbeat time.Duration) Option {
-	return func(po *spannerOptions) {
-		// NOTE: 100ms is the minimum allowed.
-		if heartbeat >= 100*time.Millisecond {
-			po.schemaWatchHeartbeat = heartbeat
-		}
-	}
 }
 
 // MinSessionCount minimum number of session the Spanner client can have

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -85,6 +85,12 @@ func NewSpannerDatastore(database string, opts ...Option) (datastore.Datastore, 
 		return nil, common.RedactAndLogSensitiveConnString(errUnableToInstantiate, err, database)
 	}
 
+	if config.migrationPhase != "" {
+		log.Info().
+			Str("phase", config.migrationPhase).
+			Msg("spanner configured to use intermediate migration phase")
+	}
+
 	if len(config.emulatorHost) > 0 {
 		if err := os.Setenv("SPANNER_EMULATOR_HOST", config.emulatorHost); err != nil {
 			log.Error().Err(err).Msg("failed to set SPANNER_EMULATOR_HOST env variable")

--- a/internal/datastore/spanner/watch.go
+++ b/internal/datastore/spanner/watch.go
@@ -73,11 +73,7 @@ func (sd spannerDatastore) watch(
 	defer close(errs)
 
 	// NOTE: 100ms is the minimum allowed.
-	heartbeatInterval := 100 * time.Millisecond
-	if opts.Content == datastore.WatchCheckpoints|datastore.WatchSchema {
-		heartbeatInterval = sd.config.schemaWatchHeartbeat
-	}
-
+	heartbeatInterval := opts.CheckpointInterval
 	if heartbeatInterval < 100*time.Millisecond {
 		heartbeatInterval = 100 * time.Millisecond
 	}
@@ -187,7 +183,10 @@ func (sd spannerDatastore) watch(
 								return err
 							}
 
-							tracked.AddRelationshipChange(ctx, changeRevision, relationTuple, core.RelationTupleUpdate_DELETE)
+							err := tracked.AddRelationshipChange(ctx, changeRevision, relationTuple, core.RelationTupleUpdate_DELETE)
+							if err != nil {
+								return err
+							}
 
 						case tableNamespace:
 							namespaceNameValue, ok := primaryKeyColumnValues[colNamespaceName]
@@ -266,7 +265,10 @@ func (sd spannerDatastore) watch(
 								return err
 							}
 
-							tracked.AddRelationshipChange(ctx, changeRevision, relationTuple, core.RelationTupleUpdate_TOUCH)
+							err := tracked.AddRelationshipChange(ctx, changeRevision, relationTuple, core.RelationTupleUpdate_TOUCH)
+							if err != nil {
+								return err
+							}
 
 						case tableNamespace:
 							namespaceConfigValue, ok := newValues[colNamespaceConfig]

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"time"
+
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/grpcutil"
 	"google.golang.org/grpc"
@@ -52,6 +54,7 @@ func RegisterGrpcServices(
 	schemaServiceOption SchemaServiceOption,
 	watchServiceOption WatchServiceOption,
 	permSysConfig v1svc.PermissionsServerConfig,
+	watchHeartbeatDuration time.Duration,
 ) {
 	healthManager.RegisterReportedService(OverallServerHealthCheckKey)
 
@@ -60,7 +63,7 @@ func RegisterGrpcServices(
 	healthManager.RegisterReportedService(v1.PermissionsService_ServiceDesc.ServiceName)
 
 	if watchServiceOption == WatchServiceEnabled {
-		v1.RegisterWatchServiceServer(srv, v1svc.NewWatchServer())
+		v1.RegisterWatchServiceServer(srv, v1svc.NewWatchServer(watchHeartbeatDuration))
 		healthManager.RegisterReportedService(v1.WatchService_ServiceDesc.ServiceName)
 	}
 

--- a/internal/services/v1/watch.go
+++ b/internal/services/v1/watch.go
@@ -62,12 +62,12 @@ func (ws *watchServer) Watch(req *v1.WatchRequest, stream v1.WatchService_WatchS
 		DispatchCount: 1,
 	})
 
-	updates, errchan := ds.Watch(ctx, afterRevision)
+	updates, errchan := ds.Watch(ctx, afterRevision, datastore.WatchJustRelationships())
 	for {
 		select {
 		case update, ok := <-updates:
 			if ok {
-				filtered := filterUpdates(objectTypesMap, update.Changes)
+				filtered := filterUpdates(objectTypesMap, update.RelationshipChanges)
 				if len(filtered) > 0 {
 					if err := stream.Send(&v1.WatchResponse{
 						Updates:        filtered,

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -428,6 +428,7 @@ func newSpannerDatastore(opts Config) (datastore.Datastore, error) {
 		spanner.WriteConnsMaxOpen(opts.WriteConnPool.MaxOpenConns),
 		spanner.MinSessionCount(opts.SpannerMinSessions),
 		spanner.MaxSessionCount(opts.SpannerMaxSessions),
+		spanner.MigrationPhase(opts.MigrationPhase),
 	)
 }
 

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -145,9 +145,6 @@ type Config struct {
 
 	// Migrations
 	MigrationPhase string `debugmap:"visible"`
-
-	// Schema watch.
-	SchemaWatchHeartbeat time.Duration `debugmap:"visible"`
 }
 
 // RegisterDatastoreFlags adds datastore flags to a cobra command.
@@ -217,8 +214,6 @@ func RegisterDatastoreFlagsWithPrefix(flagSet *pflag.FlagSet, prefix string, opt
 	flagSet.StringVar(&opts.MigrationPhase, flagName("datastore-migration-phase"), "", "datastore-specific flag that should be used to signal to a datastore which phase of a multi-step migration it is in")
 	flagSet.Uint16Var(&opts.WatchBufferLength, flagName("datastore-watch-buffer-length"), 1024, "how many events the watch buffer should queue before forcefully disconnecting reader")
 
-	flagSet.DurationVar(&opts.SchemaWatchHeartbeat, flagName("datastore-schema-watch-heartbeat"), 0*time.Millisecond, "heartbeat time on the schema watch in the datastore (if supported). 0 means to default to the datastore's minimum.")
-
 	// disabling stats is only for tests
 	flagSet.BoolVar(&opts.DisableStats, flagName("datastore-disable-stats"), false, "disable recording relationship counts to the stats table")
 	if err := flagSet.MarkHidden(flagName("datastore-disable-stats")); err != nil {
@@ -271,7 +266,6 @@ func DefaultDatastoreConfig() *Config {
 		TablePrefix:                    "",
 		MigrationPhase:                 "",
 		FollowerReadDelay:              4_800 * time.Millisecond,
-		SchemaWatchHeartbeat:           0 * time.Millisecond,
 		SpannerMinSessions:             100,
 		SpannerMaxSessions:             400,
 	}
@@ -432,7 +426,6 @@ func newSpannerDatastore(opts Config) (datastore.Datastore, error) {
 		spanner.DisableStats(opts.DisableStats),
 		spanner.ReadConnsMaxOpen(opts.ReadConnPool.MaxOpenConns),
 		spanner.WriteConnsMaxOpen(opts.WriteConnPool.MaxOpenConns),
-		spanner.SchemaWatchHeartbeat(opts.SchemaWatchHeartbeat),
 		spanner.MinSessionCount(opts.SpannerMinSessions),
 		spanner.MaxSessionCount(opts.SpannerMaxSessions),
 	)

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -65,7 +65,6 @@ func (c *Config) ToOption() ConfigOption {
 		to.TablePrefix = c.TablePrefix
 		to.WatchBufferLength = c.WatchBufferLength
 		to.MigrationPhase = c.MigrationPhase
-		to.SchemaWatchHeartbeat = c.SchemaWatchHeartbeat
 	}
 }
 
@@ -106,7 +105,6 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["TablePrefix"] = helpers.DebugValue(c.TablePrefix, false)
 	debugMap["WatchBufferLength"] = helpers.DebugValue(c.WatchBufferLength, false)
 	debugMap["MigrationPhase"] = helpers.DebugValue(c.MigrationPhase, false)
-	debugMap["SchemaWatchHeartbeat"] = helpers.DebugValue(c.SchemaWatchHeartbeat, false)
 	return debugMap
 }
 
@@ -375,12 +373,5 @@ func WithWatchBufferLength(watchBufferLength uint16) ConfigOption {
 func WithMigrationPhase(migrationPhase string) ConfigOption {
 	return func(c *Config) {
 		c.MigrationPhase = migrationPhase
-	}
-}
-
-// WithSchemaWatchHeartbeat returns an option that can set SchemaWatchHeartbeat on a Config
-func WithSchemaWatchHeartbeat(schemaWatchHeartbeat time.Duration) ConfigOption {
-	return func(c *Config) {
-		c.SchemaWatchHeartbeat = schemaWatchHeartbeat
 	}
 }

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -75,7 +75,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	server.RegisterCacheFlags(cmd.Flags(), "ns-cache", &config.NamespaceCacheConfig, namespaceCacheDefaults)
 
 	cmd.Flags().BoolVar(&config.EnableExperimentalWatchableSchemaCache, "enable-experimental-watchable-schema-cache", false, "enables the experimental schema cache which makes use of the Watch API for automatic updates")
-	cmd.Flags().DurationVar(&config.SchemaWatchHeartbeat, "datastore-schema-watch-heartbeat", 100*time.Millisecond, "heartbeat time on the schema watch in the datastore (if supported). 0 means to default to the datastore's minimum.")
+	cmd.Flags().DurationVar(&config.SchemaWatchHeartbeat, "datastore-schema-watch-heartbeat", 1*time.Second, "heartbeat time on the schema watch in the datastore (if supported). 0 means to default to the datastore's minimum.")
 
 	// Flags for parsing and validating schemas.
 	cmd.Flags().BoolVar(&config.SchemaPrefixesRequired, "schema-prefixes-required", false, "require prefixes on all object definitions in schemas")
@@ -131,6 +131,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	cmd.Flags().IntVar(&config.MaxCaveatContextSize, "max-caveat-context-size", 4096, "maximum allowed size of request caveat context in bytes. A value of zero or less means no limit")
 	cmd.Flags().IntVar(&config.MaxRelationshipContextSize, "max-relationship-context-size", 25000, "maximum allowed size of the context to be stored in a relationship")
 	cmd.Flags().DurationVar(&config.StreamingAPITimeout, "streaming-api-response-delay-timeout", 30*time.Second, "max duration time elapsed between messages sent by the server-side to the client (responses) before the stream times out")
+	cmd.Flags().DurationVar(&config.WatchHeartbeat, "watch-api-heartbeat", 1*time.Second, "heartbeat time on the watch in the API. 0 means to default to the datastore's minimum.")
 
 	cmd.Flags().BoolVar(&config.V1SchemaAdditiveOnly, "testing-only-schema-additive-writes", false, "append new definitions to the existing schema, rather than overwriting it")
 	if err := cmd.Flags().MarkHidden("testing-only-schema-additive-writes"); err != nil {

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -75,6 +75,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	server.RegisterCacheFlags(cmd.Flags(), "ns-cache", &config.NamespaceCacheConfig, namespaceCacheDefaults)
 
 	cmd.Flags().BoolVar(&config.EnableExperimentalWatchableSchemaCache, "enable-experimental-watchable-schema-cache", false, "enables the experimental schema cache which makes use of the Watch API for automatic updates")
+	cmd.Flags().DurationVar(&config.SchemaWatchHeartbeat, "datastore-schema-watch-heartbeat", 100*time.Millisecond, "heartbeat time on the schema watch in the datastore (if supported). 0 means to default to the datastore's minimum.")
 
 	// Flags for parsing and validating schemas.
 	cmd.Flags().BoolVar(&config.SchemaPrefixesRequired, "schema-prefixes-required", false, "require prefixes on all object definitions in schemas")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -75,8 +75,9 @@ type Config struct {
 	MaxRelationshipContextSize int `debugmap:"visible" default:"25_000"`
 
 	// Namespace cache
-	EnableExperimentalWatchableSchemaCache bool        `debugmap:"visible"`
-	NamespaceCacheConfig                   CacheConfig `debugmap:"visible"`
+	EnableExperimentalWatchableSchemaCache bool          `debugmap:"visible"`
+	SchemaWatchHeartbeat                   time.Duration `debugmap:"visible"`
+	NamespaceCacheConfig                   CacheConfig   `debugmap:"visible"`
 
 	// Schema options
 	SchemaPrefixesRequired bool `debugmap:"visible"`
@@ -232,7 +233,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 
 	ds = proxy.NewObservableDatastoreProxy(ds)
 	ds = proxy.NewSingleflightDatastoreProxy(ds)
-	ds = schemacaching.NewCachingDatastoreProxy(ds, nscc, c.DatastoreConfig.GCWindow, cachingMode)
+	ds = schemacaching.NewCachingDatastoreProxy(ds, nscc, c.DatastoreConfig.GCWindow, cachingMode, c.SchemaWatchHeartbeat)
 	closeables.AddWithError(ds.Close)
 
 	enableGRPCHistogram()

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -111,6 +111,7 @@ type Config struct {
 	MaximumPreconditionCount uint16        `debugmap:"visible"`
 	MaxDatastoreReadPageSize uint64        `debugmap:"visible"`
 	StreamingAPITimeout      time.Duration `debugmap:"visible"`
+	WatchHeartbeat           time.Duration `debugmap:"visible"`
 
 	// Additional Services
 	MetricsAPI util.HTTPServerConfig `debugmap:"visible"`
@@ -411,6 +412,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 				v1SchemaServiceOption,
 				watchServiceOption,
 				permSysConfig,
+				c.WatchHeartbeat,
 			)
 		},
 	)

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -80,6 +80,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.MaximumPreconditionCount = c.MaximumPreconditionCount
 		to.MaxDatastoreReadPageSize = c.MaxDatastoreReadPageSize
 		to.StreamingAPITimeout = c.StreamingAPITimeout
+		to.WatchHeartbeat = c.WatchHeartbeat
 		to.MetricsAPI = c.MetricsAPI
 		to.UnaryMiddlewareModification = c.UnaryMiddlewareModification
 		to.StreamingMiddlewareModification = c.StreamingMiddlewareModification
@@ -139,6 +140,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["MaximumPreconditionCount"] = helpers.DebugValue(c.MaximumPreconditionCount, false)
 	debugMap["MaxDatastoreReadPageSize"] = helpers.DebugValue(c.MaxDatastoreReadPageSize, false)
 	debugMap["StreamingAPITimeout"] = helpers.DebugValue(c.StreamingAPITimeout, false)
+	debugMap["WatchHeartbeat"] = helpers.DebugValue(c.WatchHeartbeat, false)
 	debugMap["MetricsAPI"] = helpers.DebugValue(c.MetricsAPI, false)
 	debugMap["SilentlyDisableTelemetry"] = helpers.DebugValue(c.SilentlyDisableTelemetry, false)
 	debugMap["TelemetryCAOverridePath"] = helpers.DebugValue(c.TelemetryCAOverridePath, false)
@@ -484,6 +486,13 @@ func WithMaxDatastoreReadPageSize(maxDatastoreReadPageSize uint64) ConfigOption 
 func WithStreamingAPITimeout(streamingAPITimeout time.Duration) ConfigOption {
 	return func(c *Config) {
 		c.StreamingAPITimeout = streamingAPITimeout
+	}
+}
+
+// WithWatchHeartbeat returns an option that can set WatchHeartbeat on a Config
+func WithWatchHeartbeat(watchHeartbeat time.Duration) ConfigOption {
+	return func(c *Config) {
+		c.WatchHeartbeat = watchHeartbeat
 	}
 }
 

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -53,6 +53,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.MaxCaveatContextSize = c.MaxCaveatContextSize
 		to.MaxRelationshipContextSize = c.MaxRelationshipContextSize
 		to.EnableExperimentalWatchableSchemaCache = c.EnableExperimentalWatchableSchemaCache
+		to.SchemaWatchHeartbeat = c.SchemaWatchHeartbeat
 		to.NamespaceCacheConfig = c.NamespaceCacheConfig
 		to.SchemaPrefixesRequired = c.SchemaPrefixesRequired
 		to.DispatchServer = c.DispatchServer
@@ -111,6 +112,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["MaxCaveatContextSize"] = helpers.DebugValue(c.MaxCaveatContextSize, false)
 	debugMap["MaxRelationshipContextSize"] = helpers.DebugValue(c.MaxRelationshipContextSize, false)
 	debugMap["EnableExperimentalWatchableSchemaCache"] = helpers.DebugValue(c.EnableExperimentalWatchableSchemaCache, false)
+	debugMap["SchemaWatchHeartbeat"] = helpers.DebugValue(c.SchemaWatchHeartbeat, false)
 	debugMap["NamespaceCacheConfig"] = helpers.DebugValue(c.NamespaceCacheConfig, false)
 	debugMap["SchemaPrefixesRequired"] = helpers.DebugValue(c.SchemaPrefixesRequired, false)
 	debugMap["DispatchServer"] = helpers.DebugValue(c.DispatchServer, false)
@@ -279,6 +281,13 @@ func WithMaxRelationshipContextSize(maxRelationshipContextSize int) ConfigOption
 func WithEnableExperimentalWatchableSchemaCache(enableExperimentalWatchableSchemaCache bool) ConfigOption {
 	return func(c *Config) {
 		c.EnableExperimentalWatchableSchemaCache = enableExperimentalWatchableSchemaCache
+	}
+}
+
+// WithSchemaWatchHeartbeat returns an option that can set SchemaWatchHeartbeat on a Config
+func WithSchemaWatchHeartbeat(schemaWatchHeartbeat time.Duration) ConfigOption {
+	return func(c *Config) {
+		c.SchemaWatchHeartbeat = schemaWatchHeartbeat
 	}
 }
 

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -3,6 +3,7 @@ package testserver
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
@@ -70,6 +71,7 @@ func (c *Config) Complete() (RunnableTestServer, error) {
 				MaximumAPIDepth:       maxDepth,
 				MaxCaveatContextSize:  c.MaxCaveatContextSize,
 			},
+			1*time.Second,
 		)
 	}
 	gRPCSrv, err := c.GRPCServer.Complete(zerolog.InfoLevel, registerServices,

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/rs/zerolog"
 
@@ -339,18 +338,19 @@ const (
 type WatchOptions struct {
 	// Content is the content to watch.
 	Content WatchContent
-
-	// CheckpointHeartbeat is the heartbeat to use for checkpoints (if requested).
-	// Some datastores will have a minimum, which will be used if the specified
-	// heartbeat is lower.
-	CheckpointHeartbeat time.Duration
 }
 
 // WatchJustRelationships returns watch options for just relationships.
 func WatchJustRelationships() WatchOptions {
 	return WatchOptions{
-		Content:             WatchRelationships,
-		CheckpointHeartbeat: 0 * time.Microsecond, // Not used
+		Content: WatchRelationships,
+	}
+}
+
+// WatchJustSchema returns watch options for just schema.
+func WatchJustSchema() WatchOptions {
+	return WatchOptions{
+		Content: WatchSchema,
 	}
 }
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -338,6 +339,11 @@ const (
 type WatchOptions struct {
 	// Content is the content to watch.
 	Content WatchContent
+
+	// CheckpointInterval is the interval to use for checkpointing in the watch.
+	// If given the zero value, the datastore's default will be used. If smaller
+	// than the datastore's minimum, the minimum will be used.
+	CheckpointInterval time.Duration
 }
 
 // WatchJustRelationships returns watch options for just relationships.
@@ -351,6 +357,15 @@ func WatchJustRelationships() WatchOptions {
 func WatchJustSchema() WatchOptions {
 	return WatchOptions{
 		Content: WatchSchema,
+	}
+}
+
+// WithCheckpointInterval sets the checkpoint interval on a watch options, returning
+// an updated options struct.
+func (wo WatchOptions) WithCheckpointInterval(interval time.Duration) WatchOptions {
+	return WatchOptions{
+		Content:            wo.Content,
+		CheckpointInterval: interval,
 	}
 }
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -48,7 +49,38 @@ const FilterMaximumIDCount uint16 = 100
 // RevisionChanges represents the changes in a single transaction.
 type RevisionChanges struct {
 	Revision Revision
-	Changes  []*core.RelationTupleUpdate
+
+	// RelationshipChanges are any relationships that were changed at this revision.
+	RelationshipChanges []*core.RelationTupleUpdate
+
+	// ChangedDefinitions are any definitions that were added or changed at this revision.
+	ChangedDefinitions []SchemaDefinition
+
+	// DeletedNamespaces are any namespaces that were deleted.
+	DeletedNamespaces []string
+
+	// DeletedCaveats are any caveats that were deleted.
+	DeletedCaveats []string
+
+	// IsCheckpoint, if true, indicates that the datastore has reported all changes
+	// up until and including the Revision and that no additional schema updates can
+	// have occurred before this point.
+	IsCheckpoint bool
+}
+
+func (rc *RevisionChanges) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("revision", rc.Revision.String())
+	e.Bool("is-checkpoint", rc.IsCheckpoint)
+	e.Array("deleted-namespaces", strArray(rc.DeletedNamespaces))
+	e.Array("deleted-caveats", strArray(rc.DeletedCaveats))
+
+	changedNames := make([]string, 0, len(rc.ChangedDefinitions))
+	for _, cd := range rc.ChangedDefinitions {
+		changedNames = append(changedNames, fmt.Sprintf("%T:%s", cd, cd.GetName()))
+	}
+
+	e.Array("changed-definitions", strArray(changedNames))
+	e.Int("num-changed-relationships", len(rc.RelationshipChanges))
 }
 
 // RelationshipsFilter is a filter for relationships.
@@ -295,6 +327,33 @@ type BulkWriteRelationshipSource interface {
 	Next(ctx context.Context) (*core.RelationTuple, error)
 }
 
+type WatchContent int
+
+const (
+	WatchRelationships WatchContent = 1 << 0
+	WatchSchema        WatchContent = 1 << 1
+	WatchCheckpoints   WatchContent = 1 << 2
+)
+
+// WatchOptions are options for a Watch call.
+type WatchOptions struct {
+	// Content is the content to watch.
+	Content WatchContent
+
+	// CheckpointHeartbeat is the heartbeat to use for checkpoints (if requested).
+	// Some datastores will have a minimum, which will be used if the specified
+	// heartbeat is lower.
+	CheckpointHeartbeat time.Duration
+}
+
+// WatchJustRelationships returns watch options for just relationships.
+func WatchJustRelationships() WatchOptions {
+	return WatchOptions{
+		Content:             WatchRelationships,
+		CheckpointHeartbeat: 0 * time.Microsecond, // Not used
+	}
+}
+
 // Datastore represents tuple access for a single namespace.
 type Datastore interface {
 	// SnapshotReader creates a read-only handle that reads the datastore at the specified revision.
@@ -321,10 +380,10 @@ type Datastore interface {
 	// used by the specific datastore implementation.
 	RevisionFromString(serialized string) (Revision, error)
 
-	// Watch notifies the caller about all changes to tuples.
+	// Watch notifies the caller about changes to the datastore, based on the specified options.
 	//
 	// All events following afterRevision will be sent to the caller.
-	Watch(ctx context.Context, afterRevision Revision) (<-chan *RevisionChanges, <-chan error)
+	Watch(ctx context.Context, afterRevision Revision, options WatchOptions) (<-chan *RevisionChanges, <-chan error)
 
 	// ReadyState returns a state indicating whether the datastore is ready to accept data.
 	// Datastores that require database schema creation will return not-ready until the migrations
@@ -340,40 +399,6 @@ type Datastore interface {
 
 	// Close closes the data store.
 	Close() error
-}
-
-// SchemaState is the state of the schema at a point in time.
-type SchemaState struct {
-	// Revision is the timestamp at which this state was created.
-	Revision Revision
-
-	// ChangedDefinitions are any definitions that were added or changed at this revision.
-	ChangedDefinitions []SchemaDefinition
-
-	// DeletedNamespaces are any namespaces that were deleted.
-	DeletedNamespaces []string
-
-	// DeletedCaveats are any caveats that were deleted.
-	DeletedCaveats []string
-
-	// IsCheckpoint, if true, indicates that the datastore has reported all changes
-	// up until and including the Revision and that no additional schema updates can
-	// have occurred before this point.
-	IsCheckpoint bool
-}
-
-func (ss *SchemaState) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("revision", ss.Revision.String())
-	e.Bool("is-checkpoint", ss.IsCheckpoint)
-	e.Array("deleted-namespaces", strArray(ss.DeletedNamespaces))
-	e.Array("deleted-caveats", strArray(ss.DeletedCaveats))
-
-	changedNames := make([]string, 0, len(ss.ChangedDefinitions))
-	for _, cd := range ss.ChangedDefinitions {
-		changedNames = append(changedNames, fmt.Sprintf("%T:%s", cd, cd.GetName()))
-	}
-
-	e.Array("changed-definitions", strArray(changedNames))
 }
 
 type strArray []string
@@ -393,21 +418,6 @@ type StartableDatastore interface {
 	// Start starts any background operations on the datastore. The context provided, if canceled, will
 	// also cancel the background operation(s) on the datastore.
 	Start(ctx context.Context) error
-}
-
-// SchemaWatchableDatastore is an optional extension to the datastore interface that, when implemented,
-// provides the ability for callers to watch the datastore for schema (namespace and caveat) changes.
-type SchemaWatchableDatastore interface {
-	Datastore
-
-	// WatchSchema notifies the caller about all changes to schema, as well as when time has moved forward
-	// without any changes.
-	//
-	// All events following afterRevision will be sent to the caller.
-	//
-	// If the SchemaState received is a checkpoint, then *no additional changes to schema* can have occurred
-	// before that revision timestamp.
-	WatchSchema(ctx context.Context, afterRevision Revision) (<-chan *SchemaState, <-chan error)
 }
 
 // RepairOperation represents a single kind of repair operation that can be run in a repairable

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -163,7 +163,7 @@ func (f fakeDatastore) RevisionFromString(_ string) (Revision, error) {
 	return nil, nil
 }
 
-func (f fakeDatastore) Watch(_ context.Context, _ Revision) (<-chan *RevisionChanges, <-chan error) {
+func (f fakeDatastore) Watch(_ context.Context, _ Revision, _ WatchOptions) (<-chan *RevisionChanges, <-chan error) {
 	return nil, nil
 }
 

--- a/pkg/datastore/errors.go
+++ b/pkg/datastore/errors.go
@@ -112,7 +112,7 @@ func NewNamespaceNotFoundErr(nsName string) error {
 // NewWatchDisconnectedErr constructs a new watch was disconnected error.
 func NewWatchDisconnectedErr() error {
 	return ErrWatchDisconnected{
-		error: fmt.Errorf("watch fell too far behind and was disconnected"),
+		error: fmt.Errorf("watch fell too far behind and was disconnected; consider increasing watch buffer size via the flag --datastore-watch-buffer-length"),
 	}
 }
 
@@ -131,10 +131,10 @@ func NewWatchDisabledErr(reason string) error {
 }
 
 // NewWatchTemporaryErr wraps another error in watch, indicating that the error is likely
-// a temporary condition and that the caller may retry the watch all if they choose (vs a fatal error).
+// a temporary condition and clients may consider retrying by calling watch again (vs a fatal error).
 func NewWatchTemporaryErr(wrapped error) error {
 	return ErrWatchRetryable{
-		error: wrapped,
+		error: fmt.Errorf("watch has failed with a temporary condition: %w. please retry the watch", wrapped),
 	}
 }
 

--- a/pkg/datastore/errors.go
+++ b/pkg/datastore/errors.go
@@ -55,6 +55,10 @@ type ErrWatchDisabled struct{ error }
 // read-only mode.
 type ErrReadOnly struct{ error }
 
+// ErrWatchRetryable is returned when a transient/temporary error occurred in watch and indicates that
+// the caller *may* retry the watch after some backoff time.
+type ErrWatchRetryable struct{ error }
+
 // InvalidRevisionReason is the reason the revision could not be used.
 type InvalidRevisionReason int
 
@@ -123,6 +127,14 @@ func NewWatchCanceledErr() error {
 func NewWatchDisabledErr(reason string) error {
 	return ErrWatchDisabled{
 		error: fmt.Errorf("watch is currently disabled: %s", reason),
+	}
+}
+
+// NewWatchTemporaryErr wraps another error in watch, indicating that the error is likely
+// a temporary condition and that the caller may retry the watch all if they choose (vs a fatal error).
+func NewWatchTemporaryErr(wrapped error) error {
+	return ErrWatchRetryable{
+		error: wrapped,
 	}
 }
 

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -342,7 +342,7 @@ func expectTupleChange(t *testing.T, ds datastore.Datastore, revBeforeWrite data
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	chanRevisionChanges, chanErr := ds.Watch(ctx, revBeforeWrite)
+	chanRevisionChanges, chanErr := ds.Watch(ctx, revBeforeWrite, datastore.WatchJustRelationships())
 	require.Zero(t, len(chanErr))
 
 	changeWait := time.NewTimer(waitForChangesTimeout)
@@ -351,7 +351,7 @@ func expectTupleChange(t *testing.T, ds datastore.Datastore, revBeforeWrite data
 		require.True(t, ok)
 
 		// do not check length of change, may contain duplicates
-		foundDiff := cmp.Diff(expectedTuple, change.Changes[0].Tuple, protocmp.Transform())
+		foundDiff := cmp.Diff(expectedTuple, change.RelationshipChanges[0].Tuple, protocmp.Transform())
 		require.Empty(t, foundDiff)
 	case <-changeWait.C:
 		require.Fail(t, "timed out waiting for relationship update via Watch API")

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -51,11 +51,17 @@ func (c Categories) Watch() bool {
 	return ok
 }
 
+func (c Categories) WatchSchema() bool {
+	_, ok := c[WatchSchemaCategory]
+	return ok
+}
+
 var noException = Categories{}
 
 const (
-	GCCategory    = "GC"
-	WatchCategory = "Watch"
+	GCCategory          = "GC"
+	WatchCategory       = "Watch"
+	WatchSchemaCategory = "WatchSchema"
 )
 
 func WithCategories(cats ...string) Categories {
@@ -121,11 +127,16 @@ func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories) 
 	t.Run("TestCaveatSnapshotReads", func(t *testing.T) { CaveatSnapshotReadsTest(t, tester) })
 
 	if !except.Watch() {
-		t.Run("TestWatch", func(t *testing.T) { WatchTest(t, tester) })
+		t.Run("TestWatchBasic", func(t *testing.T) { WatchTest(t, tester) })
 		t.Run("TestWatchCancel", func(t *testing.T) { WatchCancelTest(t, tester) })
 		t.Run("TestCaveatedRelationshipWatch", func(t *testing.T) { CaveatedRelationshipWatchTest(t, tester) })
 		t.Run("TestWatchWithTouch", func(t *testing.T) { WatchWithTouchTest(t, tester) })
 		t.Run("TestWatchWithDelete", func(t *testing.T) { WatchWithDeleteTest(t, tester) })
+	}
+
+	if !except.Watch() && !except.WatchSchema() {
+		t.Run("TestWatchSchema", func(t *testing.T) { WatchSchemaTest(t, tester) })
+		t.Run("TestWatchAll", func(t *testing.T) { WatchAllTest(t, tester) })
 	}
 }
 


### PR DESCRIPTION
Changes the Watch implementations to support a combined relationships, schema and checkpoint set of events