### PR TITLE
fixes regression in Schema Watch led schema caching

### DIFF
--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -1372,16 +1372,8 @@ func GCQueriesServedByExpectedIndexes(t *testing.T, _ testdatastore.RunningEngin
 	revision, err := ds.HeadRevision(ctx)
 	require.NoError(err)
 
-	for {
-		wds, ok := ds.(datastore.UnwrappableDatastore)
-		if !ok {
-			break
-		}
-		ds = wds.Unwrap()
-	}
-
-	casted, ok := ds.(common.GarbageCollector)
-	require.True(ok)
+	casted := datastore.UnwrapAs[common.GarbageCollector](ds)
+	require.NotNil(casted)
 
 	_, err = casted.DeleteBeforeTx(context.Background(), revision)
 	require.NoError(err)

--- a/pkg/cmd/datastore.go
+++ b/pkg/cmd/datastore.go
@@ -64,16 +64,8 @@ func NewGCDatastoreCommand(programName string, cfg *datastore.Config) *cobra.Com
 				return fmt.Errorf("failed to create datastore: %w", err)
 			}
 
-			for {
-				wds, ok := ds.(dspkg.UnwrappableDatastore)
-				if !ok {
-					break
-				}
-				ds = wds.Unwrap()
-			}
-
-			gc, ok := ds.(common.GarbageCollector)
-			if !ok {
+			gc := dspkg.UnwrapAs[common.GarbageCollector](ds)
+			if gc == nil {
 				return fmt.Errorf("datastore of type %T does not support garbage collection", ds)
 			}
 
@@ -109,16 +101,8 @@ func NewRepairDatastoreCommand(programName string, cfg *datastore.Config) *cobra
 				return fmt.Errorf("failed to create datastore: %w", err)
 			}
 
-			for {
-				wds, ok := ds.(dspkg.UnwrappableDatastore)
-				if !ok {
-					break
-				}
-				ds = wds.Unwrap()
-			}
-
-			repairable, ok := ds.(dspkg.RepairableDatastore)
-			if !ok {
+			repairable := dspkg.UnwrapAs[dspkg.RepairableDatastore](ds)
+			if repairable == nil {
 				return fmt.Errorf("datastore of type %T does not support the repair operation", ds)
 			}
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -591,14 +591,11 @@ func (c *completedServerConfig) DispatchNetDialContext(ctx context.Context, s st
 
 func (c *completedServerConfig) Run(ctx context.Context) error {
 	log.Ctx(ctx).Info().Type("datastore", c.ds).Msg("running server")
-	if unwrappableDS, ok := c.ds.(datastore.UnwrappableDatastore); ok {
-		log.Ctx(ctx).Info().Msg("checking for startable datastore")
-		if startableDS, ok := unwrappableDS.Unwrap().(datastore.StartableDatastore); ok {
-			log.Ctx(ctx).Info().Msg("Start-ing datastore")
-			err := startableDS.Start(ctx)
-			if err != nil {
-				return err
-			}
+	if startable := datastore.UnwrapAs[datastore.StartableDatastore](c.ds); startable != nil {
+		log.Ctx(ctx).Info().Msg("Start-ing datastore")
+		err := startable.Start(ctx)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -1,7 +1,10 @@
 package datastore
 
 import (
+	"context"
 	"testing"
+
+	"github.com/authzed/spicedb/pkg/datastore/options"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/stretchr/testify/require"
@@ -103,4 +106,79 @@ func TestRelationshipsFilterFromPublicFilter(t *testing.T) {
 			require.Equal(t, test.expected, computed)
 		})
 	}
+}
+
+func TestUnwrapAs(t *testing.T) {
+	result := UnwrapAs[error](nil)
+	require.Nil(t, result)
+
+	ds := fakeDatastore{delegate: fakeDatastore{fakeDatastoreError{}}}
+	result = UnwrapAs[error](ds)
+	require.NotNil(t, result)
+	require.IsType(t, fakeDatastoreError{}, result)
+
+	errorable := fakeDatastoreError{}
+	result = UnwrapAs[error](errorable)
+	require.NotNil(t, result)
+	require.IsType(t, fakeDatastoreError{}, result)
+}
+
+type fakeDatastoreError struct {
+	fakeDatastore
+}
+
+func (e fakeDatastoreError) Error() string {
+	return ""
+}
+
+type fakeDatastore struct {
+	delegate Datastore
+}
+
+func (f fakeDatastore) Unwrap() Datastore {
+	return f.delegate
+}
+
+func (f fakeDatastore) SnapshotReader(_ Revision) Reader {
+	return nil
+}
+
+func (f fakeDatastore) ReadWriteTx(_ context.Context, _ TxUserFunc, _ ...options.RWTOptionsOption) (Revision, error) {
+	return nil, nil
+}
+
+func (f fakeDatastore) OptimizedRevision(_ context.Context) (Revision, error) {
+	return nil, nil
+}
+
+func (f fakeDatastore) HeadRevision(_ context.Context) (Revision, error) {
+	return nil, nil
+}
+
+func (f fakeDatastore) CheckRevision(_ context.Context, _ Revision) error {
+	return nil
+}
+
+func (f fakeDatastore) RevisionFromString(_ string) (Revision, error) {
+	return nil, nil
+}
+
+func (f fakeDatastore) Watch(_ context.Context, _ Revision) (<-chan *RevisionChanges, <-chan error) {
+	return nil, nil
+}
+
+func (f fakeDatastore) ReadyState(_ context.Context) (ReadyState, error) {
+	return ReadyState{}, nil
+}
+
+func (f fakeDatastore) Features(_ context.Context) (*Features, error) {
+	return nil, nil
+}
+
+func (f fakeDatastore) Statistics(_ context.Context) (Stats, error) {
+	return Stats{}, nil
+}
+
+func (f fakeDatastore) Close() error {
+	return nil
 }


### PR DESCRIPTION
Initialization of schema watch happens via the `UnwrappableDatastore` interface. Given the various proxies built around the `datastore.Datastore` interface, we came up with the notion of `UnwrappableDatastore` to be able to extract a particular type from the proxy chain.

The way this is correctly done is by unwrapping in a loop until the type is found. This was unfortunately not done in the Schema Watch initialization logic, which assumed the position of the actual underlying datastore at a specific level.

With the introduction of the datastore deduplication proxy in https://github.com/authzed/spicedb/pull/1610, the proxy chain changed, and the assumed order became incorrect, making the initialization logic unable to find an instance of the `SchemaWatchableDatastore`, even though it was there. As a consequence, the logic fell back to JIT caching strategy. 

This means schema watch-led caching is broken since the 1.27.0 release, but only for CRDB users: The Spanner datastore is not subject to this bug because the CRDB datastore has one extra proxy layer and the code as it was initially was able to check for the target interface in the immediate level and the next unwrapped level. 

This replaces every bespoke piece of code handling the unwrapping logic with a new function that does this correctly and more conveniently, sparing duplicate code and being more concise.