### PR TITLE
Use logger from context in RedactAndLogSensitiveConnString

### DIFF
--- a/internal/datastore/common/errors.go
+++ b/internal/datastore/common/errors.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -104,7 +105,7 @@ var (
 
 // RedactAndLogSensitiveConnString elides the given error, logging it only at trace
 // level (after being redacted).
-func RedactAndLogSensitiveConnString(baseErr string, err error, pgURL string) error {
+func RedactAndLogSensitiveConnString(ctx context.Context, baseErr string, err error, pgURL string) error {
 	if err == nil {
 		return errors.New(baseErr)
 	}
@@ -114,6 +115,6 @@ func RedactAndLogSensitiveConnString(baseErr string, err error, pgURL string) er
 	filtered = strings.ReplaceAll(filtered, pgURL, "(redacted)")
 	filtered = portMatchRegex.ReplaceAllString(filtered, "(redacted)")
 	filtered = parseMatchRegex.ReplaceAllString(filtered, "(redacted)")
-	log.Trace().Msg(baseErr + ": " + filtered)
+	log.Ctx(ctx).Trace().Msg(baseErr + ": " + filtered)
 	return fmt.Errorf("%s. To view details of this error (that may contain sensitive information), please run with --log-level=trace", baseErr)
 }

--- a/internal/datastore/crdb/pool_test.go
+++ b/internal/datastore/crdb/pool_test.go
@@ -100,9 +100,11 @@ func TestTxReset(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
+			ctx := context.Background()
 
 			ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 				ds, err := newCRDBDatastore(
+					ctx,
 					uri,
 					GCWindow(24*time.Hour),
 					RevisionQuantization(5*time.Second),
@@ -114,7 +116,6 @@ func TestTxReset(t *testing.T) {
 			})
 			defer ds.Close()
 
-			ctx := context.Background()
 			r, err := ds.ReadyState(ctx)
 			require.NoError(err)
 			require.True(r.IsReady)

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -45,8 +45,9 @@ type datastoreTester struct {
 }
 
 func (dst *datastoreTester) createDatastore(revisionQuantization, gcInterval, gcWindow time.Duration, _ uint16) (datastore.Datastore, error) {
+	ctx := context.Background()
 	ds := dst.b.NewDatastore(dst.t, func(engine, uri string) datastore.Datastore {
-		ds, err := newMySQLDatastore(uri,
+		ds, err := newMySQLDatastore(ctx, uri,
 			RevisionQuantization(revisionQuantization),
 			GCWindow(gcWindow),
 			GCInterval(gcInterval),
@@ -78,8 +79,9 @@ type datastoreTestFunc func(t *testing.T, ds datastore.Datastore)
 
 func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestFunc, options ...Option) func(*testing.T) {
 	return func(t *testing.T) {
+		ctx := context.Background()
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
-			ds, err := newMySQLDatastore(uri, options...)
+			ds, err := newMySQLDatastore(ctx, uri, options...)
 			require.NoError(t, err)
 			return ds
 		})
@@ -90,7 +92,7 @@ func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestF
 }
 
 func TestMySQLDatastoreDSNWithoutParseTime(t *testing.T) {
-	_, err := NewMySQLDatastore("root:password@(localhost:1234)/mysql")
+	_, err := NewMySQLDatastore(context.Background(), "root:password@(localhost:1234)/mysql")
 	require.ErrorContains(t, err, "https://spicedb.dev/d/parse-time-mysql")
 }
 
@@ -563,6 +565,7 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 
 			ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 				ds, err := newMySQLDatastore(
+					ctx,
 					uri,
 					RevisionQuantization(5*time.Second),
 					GCWindow(24*time.Hour),

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -112,10 +112,11 @@ type sqlFilter interface {
 //
 // This datastore is also tested to be compatible with CockroachDB.
 func NewPostgresDatastore(
+	ctx context.Context,
 	url string,
 	options ...Option,
 ) (datastore.Datastore, error) {
-	ds, err := newPostgresDatastore(url, options...)
+	ds, err := newPostgresDatastore(ctx, url, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -124,24 +125,25 @@ func NewPostgresDatastore(
 }
 
 func newPostgresDatastore(
+	ctx context.Context,
 	pgURL string,
 	options ...Option,
 ) (datastore.Datastore, error) {
 	config, err := generateConfig(options)
 	if err != nil {
-		return nil, common.RedactAndLogSensitiveConnString(errUnableToInstantiate, err, pgURL)
+		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, pgURL)
 	}
 
 	// Parse the DB URI into configuration.
 	parsedConfig, err := pgxpool.ParseConfig(pgURL)
 	if err != nil {
-		return nil, common.RedactAndLogSensitiveConnString(errUnableToInstantiate, err, pgURL)
+		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, pgURL)
 	}
 
 	// Setup the default custom plan setting, if applicable.
 	pgConfig, err := defaultCustomPlan(parsedConfig)
 	if err != nil {
-		return nil, common.RedactAndLogSensitiveConnString(errUnableToInstantiate, err, pgURL)
+		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, pgURL)
 	}
 
 	// Setup the config for each of the read and write pools.
@@ -172,12 +174,12 @@ func newPostgresDatastore(
 
 	readPool, err := pgxpool.NewWithConfig(initializationContext, readPoolConfig)
 	if err != nil {
-		return nil, common.RedactAndLogSensitiveConnString(errUnableToInstantiate, err, pgURL)
+		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, pgURL)
 	}
 
 	writePool, err := pgxpool.NewWithConfig(initializationContext, writePoolConfig)
 	if err != nil {
-		return nil, common.RedactAndLogSensitiveConnString(errUnableToInstantiate, err, pgURL)
+		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, pgURL)
 	}
 
 	// Verify that the server supports commit timestamps

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -79,10 +79,10 @@ type spannerDatastore struct {
 }
 
 // NewSpannerDatastore returns a datastore backed by cloud spanner
-func NewSpannerDatastore(database string, opts ...Option) (datastore.Datastore, error) {
+func NewSpannerDatastore(ctx context.Context, database string, opts ...Option) (datastore.Datastore, error) {
 	config, err := generateConfig(opts)
 	if err != nil {
-		return nil, common.RedactAndLogSensitiveConnString(errUnableToInstantiate, err, database)
+		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, database)
 	}
 
 	if len(config.emulatorHost) > 0 {
@@ -128,7 +128,7 @@ func NewSpannerDatastore(database string, opts ...Option) (datastore.Datastore, 
 		),
 	)
 	if err != nil {
-		return nil, common.RedactAndLogSensitiveConnString(errUnableToInstantiate, err, database)
+		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, database)
 	}
 
 	maxRevisionStaleness := time.Duration(float64(config.revisionQuantization.Nanoseconds())*

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -4,6 +4,7 @@
 package spanner
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ func (sd spannerDatastore) ExampleRetryableError() error {
 }
 
 func TestSpannerDatastore(t *testing.T) {
+	ctx := context.Background()
 	b := testdatastore.RunSpannerForTesting(t, "", "head")
 
 	// TODO(jschorr): Once https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/74 has been resolved,
@@ -29,7 +31,7 @@ func TestSpannerDatastore(t *testing.T) {
 	// GC tests are disabled because they depend also on the ability to configure change streams with custom retention.
 	test.AllWithExceptions(t, test.DatastoreTesterFunc(func(revisionQuantization, _, _ time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
-			ds, err := NewSpannerDatastore(uri,
+			ds, err := NewSpannerDatastore(ctx, uri,
 				RevisionQuantization(revisionQuantization),
 				WatchBufferLength(watchBufferLength))
 			require.NoError(t, err)

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -21,7 +21,7 @@ import (
 	"github.com/authzed/spicedb/pkg/validationfile"
 )
 
-type engineBuilderFunc func(options Config) (datastore.Datastore, error)
+type engineBuilderFunc func(ctx context.Context, options Config) (datastore.Datastore, error)
 
 const (
 	MemoryEngine    = "memory"
@@ -295,7 +295,7 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 	}
 	log.Ctx(ctx).Info().Msgf("using %s datastore engine", opts.Engine)
 
-	ds, err := dsBuilder(*opts)
+	ds, err := dsBuilder(ctx, *opts)
 	if err != nil {
 		return nil, err
 	}
@@ -361,8 +361,9 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 	return ds, nil
 }
 
-func newCRDBDatastore(opts Config) (datastore.Datastore, error) {
+func newCRDBDatastore(ctx context.Context, opts Config) (datastore.Datastore, error) {
 	return crdb.NewCRDBDatastore(
+		ctx,
 		opts.URI,
 		crdb.GCWindow(opts.GCWindow),
 		crdb.RevisionQuantization(opts.RevisionQuantization),
@@ -391,7 +392,7 @@ func newCRDBDatastore(opts Config) (datastore.Datastore, error) {
 	)
 }
 
-func newPostgresDatastore(opts Config) (datastore.Datastore, error) {
+func newPostgresDatastore(ctx context.Context, opts Config) (datastore.Datastore, error) {
 	pgOpts := []postgres.Option{
 		postgres.GCWindow(opts.GCWindow),
 		postgres.GCEnabled(!opts.ReadOnly),
@@ -417,11 +418,12 @@ func newPostgresDatastore(opts Config) (datastore.Datastore, error) {
 		postgres.MaxRetries(uint8(opts.MaxRetries)),
 		postgres.MigrationPhase(opts.MigrationPhase),
 	}
-	return postgres.NewPostgresDatastore(opts.URI, pgOpts...)
+	return postgres.NewPostgresDatastore(ctx, opts.URI, pgOpts...)
 }
 
-func newSpannerDatastore(opts Config) (datastore.Datastore, error) {
+func newSpannerDatastore(ctx context.Context, opts Config) (datastore.Datastore, error) {
 	return spanner.NewSpannerDatastore(
+		ctx,
 		opts.URI,
 		spanner.FollowerReadDelay(opts.FollowerReadDelay),
 		spanner.RevisionQuantization(opts.RevisionQuantization),
@@ -438,7 +440,7 @@ func newSpannerDatastore(opts Config) (datastore.Datastore, error) {
 	)
 }
 
-func newMySQLDatastore(opts Config) (datastore.Datastore, error) {
+func newMySQLDatastore(ctx context.Context, opts Config) (datastore.Datastore, error) {
 	mysqlOpts := []mysql.Option{
 		mysql.GCInterval(opts.GCInterval),
 		mysql.GCWindow(opts.GCWindow),
@@ -456,10 +458,10 @@ func newMySQLDatastore(opts Config) (datastore.Datastore, error) {
 		mysql.MaxRetries(uint8(opts.MaxRetries)),
 		mysql.OverrideLockWaitTimeout(1),
 	}
-	return mysql.NewMySQLDatastore(opts.URI, mysqlOpts...)
+	return mysql.NewMySQLDatastore(ctx, opts.URI, mysqlOpts...)
 }
 
-func newMemoryDatstore(opts Config) (datastore.Datastore, error) {
+func newMemoryDatstore(_ context.Context, opts Config) (datastore.Datastore, error) {
 	log.Warn().Msg("in-memory datastore is not persistent and not feasible to run in a high availability fashion")
 	return memdb.NewMemdbDatastore(opts.WatchBufferLength, opts.RevisionQuantization, opts.GCWindow)
 }

--- a/pkg/datastore/errors_test.go
+++ b/pkg/datastore/errors_test.go
@@ -1,6 +1,7 @@
 package datastore_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -14,21 +15,23 @@ import (
 )
 
 func createEngine(engineID string, uri string) error {
+	ctx := context.Background()
+
 	switch engineID {
 	case "postgres":
-		_, err := postgres.NewPostgresDatastore(uri)
+		_, err := postgres.NewPostgresDatastore(ctx, uri)
 		return err
 
 	case "mysql":
-		_, err := mysql.NewMySQLDatastore(uri)
+		_, err := mysql.NewMySQLDatastore(ctx, uri)
 		return err
 
 	case "spanner":
-		_, err := spanner.NewSpannerDatastore(uri)
+		_, err := spanner.NewSpannerDatastore(ctx, uri)
 		return err
 
 	case "cockroachdb":
-		_, err := crdb.NewCRDBDatastore(uri)
+		_, err := crdb.NewCRDBDatastore(ctx, uri)
 		return err
 
 	default:


### PR DESCRIPTION
Changes the constructors for the various datastores to take contexts, and uses the logger from the context when reporting initialization errors.