### PR TITLE
fixes WriteRelationships/BulkImport GRPC error codes on conflicts and retryable errors

### DIFF
--- a/internal/datastore/crdb/readwrite.go
+++ b/internal/datastore/crdb/readwrite.go
@@ -168,12 +168,6 @@ func (rwt *crdbReadWriteTXN) WriteRelationships(ctx context.Context, mutations [
 		}
 
 		if _, err := rwt.tx.Exec(ctx, sql, args...); err != nil {
-			// If a unique constraint violation is returned, then its likely that the cause
-			// was an existing relationship given as a CREATE.
-			if cerr := pgxcommon.ConvertToWriteConstraintError(livingTupleConstraint, err); cerr != nil {
-				return cerr
-			}
-
 			return fmt.Errorf(errUnableToWriteRelationships, err)
 		}
 	}

--- a/internal/datastore/memdb/readwrite.go
+++ b/internal/datastore/memdb/readwrite.go
@@ -213,7 +213,7 @@ func (rwt *memdbReadWriteTx) DeleteNamespaces(_ context.Context, nsNames ...stri
 
 func (rwt *memdbReadWriteTx) BulkLoad(ctx context.Context, iter datastore.BulkWriteRelationshipSource) (uint64, error) {
 	updates := []*core.RelationTupleUpdate{{
-		Operation: core.RelationTupleUpdate_TOUCH,
+		Operation: core.RelationTupleUpdate_CREATE,
 	}}
 
 	var numCopied uint64

--- a/internal/datastore/mysql/readwrite.go
+++ b/internal/datastore/mysql/readwrite.go
@@ -210,10 +210,6 @@ func (rwt *mysqlReadWriteTXN) WriteRelationships(ctx context.Context, mutations 
 
 		_, err = rwt.tx.ExecContext(ctx, query, args...)
 		if err != nil {
-			if cerr := convertToWriteConstraintError(err); cerr != nil {
-				return cerr
-			}
-
 			return fmt.Errorf(errUnableToWriteRelationships, err)
 		}
 	}

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -473,6 +473,12 @@ func (pgd *pgDatastore) RepairOperations() []datastore.RepairOperation {
 }
 
 func wrapError(err error) error {
+	// If a unique constraint violation is returned, then its likely that the cause
+	// was an existing relationship given as a CREATE.
+	if cerr := pgxcommon.ConvertToWriteConstraintError(livingTupleConstraint, err); cerr != nil {
+		return cerr
+	}
+
 	if pgxcommon.IsSerializationError(err) {
 		return common.NewSerializationError(err)
 	}

--- a/internal/datastore/postgres/readwrite.go
+++ b/internal/datastore/postgres/readwrite.go
@@ -117,12 +117,6 @@ func (rwt *pgReadWriteTXN) WriteRelationships(ctx context.Context, mutations []*
 
 		_, err = rwt.tx.Exec(ctx, sql, args...)
 		if err != nil {
-			// If a unique constraint violation is returned, then its likely that the cause
-			// was an existing relationship given as a CREATE.
-			if cerr := pgxcommon.ConvertToWriteConstraintError(livingTupleConstraint, err); cerr != nil {
-				return cerr
-			}
-
 			return fmt.Errorf(errUnableToWriteRelationships, err)
 		}
 	}

--- a/pkg/datastore/test/tuples.go
+++ b/pkg/datastore/test/tuples.go
@@ -566,6 +566,14 @@ func CreateAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 	require.ErrorAs(err, &common.CreateRelationshipExistsError{})
 	require.Contains(err.Error(), "could not CREATE relationship ")
 	grpcutil.RequireStatus(t, codes.AlreadyExists, err)
+
+	f := func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
+		_, err := rwt.BulkLoad(ctx, testfixtures.NewBulkTupleGenerator(testResourceNamespace, testReaderRelation, testUserNamespace, 1, t))
+		return err
+	}
+	_, _ = ds.ReadWriteTx(ctx, f)
+	_, err = ds.ReadWriteTx(ctx, f)
+	grpcutil.RequireStatus(t, codes.AlreadyExists, err)
 }
 
 // TouchAlreadyExistingTest tests touching a relationship twice.


### PR DESCRIPTION
Built to support https://github.com/authzed/zed/pull/316

Adjusts BulkImport so it returns gRPC codes to let clients know if it's ok to retry.
- duplicate relationship now reports gRPC code `AlreadyExists`
- retriable errors now return grpc code `Unavailable`