### PR TITLE
expose revision parsing function for tests

### DIFF
--- a/pkg/datastore/revisionparsing/revisionparsing.go
+++ b/pkg/datastore/revisionparsing/revisionparsing.go
@@ -7,14 +7,30 @@ import (
 	"github.com/authzed/spicedb/internal/datastore/postgres"
 	"github.com/authzed/spicedb/internal/datastore/revisions"
 	"github.com/authzed/spicedb/internal/datastore/spanner"
+	"github.com/authzed/spicedb/pkg/datastore"
 )
+
+// ParsingFunc is a function that can parse a string into a revision.
+type ParsingFunc func(revisionStr string) (rev datastore.Revision, err error)
 
 // ParseRevisionStringByDatastoreEngineID defines a map from datastore engine ID to its associated
 // revision parsing function.
-var ParseRevisionStringByDatastoreEngineID = map[string]revisions.ParsingFunc{
-	memdb.Engine:    memdb.ParseRevisionString,
-	crdb.Engine:     crdb.ParseRevisionString,
-	postgres.Engine: postgres.ParseRevisionString,
-	mysql.Engine:    mysql.ParseRevisionString,
-	spanner.Engine:  spanner.ParseRevisionString,
+var ParseRevisionStringByDatastoreEngineID = map[string]ParsingFunc{
+	memdb.Engine:    ParsingFunc(memdb.ParseRevisionString),
+	crdb.Engine:     ParsingFunc(crdb.ParseRevisionString),
+	postgres.Engine: ParsingFunc(postgres.ParseRevisionString),
+	mysql.Engine:    ParsingFunc(mysql.ParseRevisionString),
+	spanner.Engine:  ParsingFunc(spanner.ParseRevisionString),
 }
+
+// MustParseRevisionForTest is a convenience ParsingFunc that can be used in tests and panics when parsing an error.
+func MustParseRevisionForTest(revisionStr string) (rev datastore.Revision) {
+	rev, err := testParser(revisionStr)
+	if err != nil {
+		panic(err)
+	}
+
+	return rev
+}
+
+var testParser = revisions.RevisionParser(revisions.HybridLogicalClock)


### PR DESCRIPTION
since most of the Revision parsing APIs have been
recently refactored and the surface
is now exclusively the parsing functions
for each datastore