### PR TITLE
Watch revision checkpoints using memdb datastore

### DIFF
--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -100,7 +100,7 @@ func TestMySQLDatastoreDSNWithoutParseTime(t *testing.T) {
 func TestMySQL8Datastore(t *testing.T) {
 	b := testdatastore.RunMySQLForTestingWithOptions(t, testdatastore.MySQLTesterOptions{MigrateForNewDatastore: true}, "")
 	dst := datastoreTester{b: b, t: t}
-	test.AllWithExceptions(t, test.DatastoreTesterFunc(dst.createDatastore), test.WithCategories(test.WatchSchemaCategory))
+	test.AllWithExceptions(t, test.DatastoreTesterFunc(dst.createDatastore), test.WithCategories(test.WatchSchemaCategory, test.WatchCheckpointsCategory))
 	additionalMySQLTests(t, b)
 }
 

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -56,12 +56,18 @@ func (c Categories) WatchSchema() bool {
 	return ok
 }
 
+func (c Categories) WatchCheckpoints() bool {
+	_, ok := c[WatchCheckpointsCategory]
+	return ok
+}
+
 var noException = Categories{}
 
 const (
-	GCCategory          = "GC"
-	WatchCategory       = "Watch"
-	WatchSchemaCategory = "WatchSchema"
+	GCCategory               = "GC"
+	WatchCategory            = "Watch"
+	WatchSchemaCategory      = "WatchSchema"
+	WatchCheckpointsCategory = "WatchCheckpoints"
 )
 
 func WithCategories(cats ...string) Categories {
@@ -137,6 +143,10 @@ func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories) 
 	if !except.Watch() && !except.WatchSchema() {
 		t.Run("TestWatchSchema", func(t *testing.T) { WatchSchemaTest(t, tester) })
 		t.Run("TestWatchAll", func(t *testing.T) { WatchAllTest(t, tester) })
+	}
+
+	if !except.Watch() && !except.WatchCheckpoints() {
+		t.Run("TestWatchCheckpoints", func(t *testing.T) { WatchCheckpointsTest(t, tester) })
 	}
 }
 


### PR DESCRIPTION
Adds the ability to watch revision checkpoint events when using the memdb datastore implementation.