### PR TITLE
Add timeout to watch buffers

### DIFF
--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -166,13 +166,14 @@ func newCRDBDatastore(ctx context.Context, url string, options ...Option) (datas
 			config.followerReadDelay,
 			config.revisionQuantization,
 		),
-		CommonDecoder:        revisions.CommonDecoder{Kind: revisions.HybridLogicalClock},
-		dburl:                url,
-		watchBufferLength:    config.watchBufferLength,
-		writeOverlapKeyer:    keyer,
-		overlapKeyInit:       keySetInit,
-		disableStats:         config.disableStats,
-		beginChangefeedQuery: changefeedQuery,
+		CommonDecoder:           revisions.CommonDecoder{Kind: revisions.HybridLogicalClock},
+		dburl:                   url,
+		watchBufferLength:       config.watchBufferLength,
+		watchBufferWriteTimeout: config.watchBufferWriteTimeout,
+		writeOverlapKeyer:       keyer,
+		overlapKeyInit:          keySetInit,
+		disableStats:            config.disableStats,
+		beginChangefeedQuery:    changefeedQuery,
 	}
 	ds.RemoteClockRevisions.SetNowFunc(ds.headRevisionInternal)
 
@@ -247,12 +248,13 @@ type crdbDatastore struct {
 	*revisions.RemoteClockRevisions
 	revisions.CommonDecoder
 
-	dburl               string
-	readPool, writePool *pool.RetryPool
-	watchBufferLength   uint16
-	writeOverlapKeyer   overlapKeyer
-	overlapKeyInit      func(ctx context.Context) keySet
-	disableStats        bool
+	dburl                   string
+	readPool, writePool     *pool.RetryPool
+	watchBufferLength       uint16
+	watchBufferWriteTimeout time.Duration
+	writeOverlapKeyer       overlapKeyer
+	overlapKeyInit          func(ctx context.Context) keySet
+	disableStats            bool
 
 	beginChangefeedQuery string
 

--- a/internal/datastore/crdb/options.go
+++ b/internal/datastore/crdb/options.go
@@ -12,6 +12,7 @@ type crdbOptions struct {
 	connectRate                 time.Duration
 
 	watchBufferLength           uint16
+	watchBufferWriteTimeout     time.Duration
 	revisionQuantization        time.Duration
 	followerReadDelay           time.Duration
 	maxRevisionStalenessPercent float64
@@ -37,6 +38,7 @@ const (
 	defaultFollowerReadDelay           = 0 * time.Second
 	defaultMaxRevisionStalenessPercent = 0.1
 	defaultWatchBufferLength           = 128
+	defaultWatchBufferWriteTimeout     = 1 * time.Second
 	defaultSplitSize                   = 1024
 
 	defaultMaxRetries      = 5
@@ -56,6 +58,7 @@ func generateConfig(options []Option) (crdbOptions, error) {
 	computed := crdbOptions{
 		gcWindow:                    24 * time.Hour,
 		watchBufferLength:           defaultWatchBufferLength,
+		watchBufferWriteTimeout:     defaultWatchBufferWriteTimeout,
 		revisionQuantization:        defaultRevisionQuantization,
 		followerReadDelay:           defaultFollowerReadDelay,
 		maxRevisionStalenessPercent: defaultMaxRevisionStalenessPercent,
@@ -214,6 +217,12 @@ func WriteConnsMaxOpen(conns int) Option {
 // This value defaults to 128.
 func WatchBufferLength(watchBufferLength uint16) Option {
 	return func(po *crdbOptions) { po.watchBufferLength = watchBufferLength }
+}
+
+// WatchBufferWriteTimeout is the maximum timeout for writing to the watch buffer,
+// after which the caller to the watch will be disconnected.
+func WatchBufferWriteTimeout(watchBufferWriteTimeout time.Duration) Option {
+	return func(po *crdbOptions) { po.watchBufferWriteTimeout = watchBufferWriteTimeout }
 }
 
 // RevisionQuantization is the time bucket size to which advertised revisions

--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -68,10 +68,11 @@ func NewMemdbDatastore(
 			},
 		},
 
-		negativeGCWindow:   gcWindow.Nanoseconds() * -1,
-		quantizationPeriod: revisionQuantization.Nanoseconds(),
-		watchBufferLength:  watchBufferLength,
-		uniqueID:           uniqueID,
+		negativeGCWindow:        gcWindow.Nanoseconds() * -1,
+		quantizationPeriod:      revisionQuantization.Nanoseconds(),
+		watchBufferLength:       watchBufferLength,
+		watchBufferWriteTimeout: 100 * time.Millisecond,
+		uniqueID:                uniqueID,
 	}, nil
 }
 
@@ -83,10 +84,11 @@ type memdbDatastore struct {
 	revisions      []snapshot
 	activeWriteTxn *memdb.Txn
 
-	negativeGCWindow   int64
-	quantizationPeriod int64
-	watchBufferLength  uint16
-	uniqueID           string
+	negativeGCWindow        int64
+	quantizationPeriod      int64
+	watchBufferLength       uint16
+	watchBufferWriteTimeout time.Duration
+	uniqueID                string
 }
 
 type snapshot struct {

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -197,24 +197,25 @@ func newMySQLDatastore(ctx context.Context, uri string, options ...Option) (*Dat
 	)
 
 	store := &Datastore{
-		db:                     db,
-		driver:                 driver,
-		url:                    uri,
-		revisionQuantization:   config.revisionQuantization,
-		gcWindow:               config.gcWindow,
-		gcInterval:             config.gcInterval,
-		gcTimeout:              config.gcMaxOperationTime,
-		gcCtx:                  gcCtx,
-		cancelGc:               cancelGc,
-		watchBufferLength:      config.watchBufferLength,
-		optimizedRevisionQuery: revisionQuery,
-		validTransactionQuery:  validTransactionQuery,
-		createTxn:              createTxn,
-		createBaseTxn:          createBaseTxn,
-		QueryBuilder:           queryBuilder,
-		readTxOptions:          &sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: true},
-		maxRetries:             config.maxRetries,
-		analyzeBeforeStats:     config.analyzeBeforeStats,
+		db:                      db,
+		driver:                  driver,
+		url:                     uri,
+		revisionQuantization:    config.revisionQuantization,
+		gcWindow:                config.gcWindow,
+		gcInterval:              config.gcInterval,
+		gcTimeout:               config.gcMaxOperationTime,
+		gcCtx:                   gcCtx,
+		cancelGc:                cancelGc,
+		watchBufferLength:       config.watchBufferLength,
+		watchBufferWriteTimeout: config.watchBufferWriteTimeout,
+		optimizedRevisionQuery:  revisionQuery,
+		validTransactionQuery:   validTransactionQuery,
+		createTxn:               createTxn,
+		createBaseTxn:           createBaseTxn,
+		QueryBuilder:            queryBuilder,
+		readTxOptions:           &sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: true},
+		maxRetries:              config.maxRetries,
+		analyzeBeforeStats:      config.analyzeBeforeStats,
 		CachedOptimizedRevisions: revisions.NewCachedOptimizedRevisions(
 			maxRevisionStaleness,
 		),
@@ -430,12 +431,13 @@ type Datastore struct {
 	url                string
 	analyzeBeforeStats bool
 
-	revisionQuantization time.Duration
-	gcWindow             time.Duration
-	gcInterval           time.Duration
-	gcTimeout            time.Duration
-	watchBufferLength    uint16
-	maxRetries           uint8
+	revisionQuantization    time.Duration
+	gcWindow                time.Duration
+	gcInterval              time.Duration
+	gcTimeout               time.Duration
+	watchBufferLength       uint16
+	watchBufferWriteTimeout time.Duration
+	maxRetries              uint8
 
 	optimizedRevisionQuery string
 	validTransactionQuery  string

--- a/internal/datastore/mysql/options.go
+++ b/internal/datastore/mysql/options.go
@@ -15,6 +15,7 @@ const (
 	defaultConnMaxIdleTime                   = 30 * time.Minute
 	defaultConnMaxLifetime                   = 30 * time.Minute
 	defaultWatchBufferLength                 = 128
+	defaultWatchBufferWriteTimeout           = 1 * time.Second
 	defaultQuantization                      = 5 * time.Second
 	defaultMaxRevisionStalenessPercent       = 0.1
 	defaultEnablePrometheusStats             = false
@@ -29,6 +30,7 @@ type mysqlOptions struct {
 	gcMaxOperationTime          time.Duration
 	maxRevisionStalenessPercent float64
 	watchBufferLength           uint16
+	watchBufferWriteTimeout     time.Duration
 	tablePrefix                 string
 	enablePrometheusStats       bool
 	maxOpenConns                int
@@ -50,6 +52,7 @@ func generateConfig(options []Option) (mysqlOptions, error) {
 		gcInterval:                  defaultGarbageCollectionInterval,
 		gcMaxOperationTime:          defaultGarbageCollectionMaxOperationTime,
 		watchBufferLength:           defaultWatchBufferLength,
+		watchBufferWriteTimeout:     defaultWatchBufferWriteTimeout,
 		maxOpenConns:                defaultMaxOpenConns,
 		connMaxIdleTime:             defaultConnMaxIdleTime,
 		connMaxLifetime:             defaultConnMaxLifetime,
@@ -84,6 +87,12 @@ func WatchBufferLength(watchBufferLength uint16) Option {
 	return func(mo *mysqlOptions) {
 		mo.watchBufferLength = watchBufferLength
 	}
+}
+
+// WatchBufferWriteTimeout is the maximum timeout for writing to the watch buffer,
+// after which the caller to the watch will be disconnected.
+func WatchBufferWriteTimeout(watchBufferWriteTimeout time.Duration) Option {
+	return func(mo *mysqlOptions) { mo.watchBufferWriteTimeout = watchBufferWriteTimeout }
 }
 
 // RevisionQuantization is the time bucket size to which advertised

--- a/internal/datastore/postgres/options.go
+++ b/internal/datastore/postgres/options.go
@@ -12,12 +12,13 @@ type postgresOptions struct {
 
 	maxRevisionStalenessPercent float64
 
-	watchBufferLength    uint16
-	revisionQuantization time.Duration
-	gcWindow             time.Duration
-	gcInterval           time.Duration
-	gcMaxOperationTime   time.Duration
-	maxRetries           uint8
+	watchBufferLength       uint16
+	watchBufferWriteTimeout time.Duration
+	revisionQuantization    time.Duration
+	gcWindow                time.Duration
+	gcInterval              time.Duration
+	gcMaxOperationTime      time.Duration
+	maxRetries              uint8
 
 	enablePrometheusStats   bool
 	analyzeBeforeStatistics bool
@@ -48,6 +49,7 @@ const (
 	errQuantizationTooLarge = "revision quantization interval (%s) must be less than GC window (%s)"
 
 	defaultWatchBufferLength                 = 128
+	defaultWatchBufferWriteTimeout           = 1 * time.Second
 	defaultGarbageCollectionWindow           = 24 * time.Hour
 	defaultGarbageCollectionInterval         = time.Minute * 3
 	defaultGarbageCollectionMaxOperationTime = time.Minute
@@ -68,6 +70,7 @@ func generateConfig(options []Option) (postgresOptions, error) {
 		gcInterval:                  defaultGarbageCollectionInterval,
 		gcMaxOperationTime:          defaultGarbageCollectionMaxOperationTime,
 		watchBufferLength:           defaultWatchBufferLength,
+		watchBufferWriteTimeout:     defaultWatchBufferWriteTimeout,
 		revisionQuantization:        defaultQuantization,
 		maxRevisionStalenessPercent: defaultMaxRevisionStalenessPercent,
 		enablePrometheusStats:       defaultEnablePrometheusStats,
@@ -226,6 +229,12 @@ func WriteConnsMaxOpen(conns int) Option {
 // This value defaults to 128.
 func WatchBufferLength(watchBufferLength uint16) Option {
 	return func(po *postgresOptions) { po.watchBufferLength = watchBufferLength }
+}
+
+// WatchBufferWriteTimeout is the maximum timeout for writing to the watch buffer,
+// after which the caller to the watch will be disconnected.
+func WatchBufferWriteTimeout(watchBufferWriteTimeout time.Duration) Option {
+	return func(po *postgresOptions) { po.watchBufferWriteTimeout = watchBufferWriteTimeout }
 }
 
 // RevisionQuantization is the time bucket size to which advertised

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -248,6 +248,7 @@ func newPostgresDatastore(
 		readPool:                pgxcommon.MustNewInterceptorPooler(readPool, config.queryInterceptor),
 		writePool:               pgxcommon.MustNewInterceptorPooler(writePool, config.queryInterceptor),
 		watchBufferLength:       config.watchBufferLength,
+		watchBufferWriteTimeout: config.watchBufferWriteTimeout,
 		optimizedRevisionQuery:  revisionQuery,
 		validTransactionQuery:   validTransactionQuery,
 		gcWindow:                config.gcWindow,
@@ -288,6 +289,7 @@ type pgDatastore struct {
 	dburl                   string
 	readPool, writePool     pgxcommon.ConnPooler
 	watchBufferLength       uint16
+	watchBufferWriteTimeout time.Duration
 	optimizedRevisionQuery  string
 	validTransactionQuery   string
 	gcWindow                time.Duration

--- a/internal/datastore/spanner/options.go
+++ b/internal/datastore/spanner/options.go
@@ -9,6 +9,7 @@ import (
 
 type spannerOptions struct {
 	watchBufferLength           uint16
+	watchBufferWriteTimeout     time.Duration
 	revisionQuantization        time.Duration
 	followerReadDelay           time.Duration
 	maxRevisionStalenessPercent float64
@@ -39,6 +40,7 @@ const (
 	defaultFollowerReadDelay           = 0 * time.Second
 	defaultMaxRevisionStalenessPercent = 0.1
 	defaultWatchBufferLength           = 128
+	defaultWatchBufferWriteTimeout     = 1 * time.Second
 	defaultDisableStats                = false
 	maxRevisionQuantization            = 24 * time.Hour
 )
@@ -53,6 +55,7 @@ func generateConfig(options []Option) (spannerOptions, error) {
 	defaultNumberConnections := max(1, math.Round(float64(runtime.GOMAXPROCS(0))))
 	computed := spannerOptions{
 		watchBufferLength:           defaultWatchBufferLength,
+		watchBufferWriteTimeout:     defaultWatchBufferWriteTimeout,
 		revisionQuantization:        defaultRevisionQuantization,
 		followerReadDelay:           defaultFollowerReadDelay,
 		maxRevisionStalenessPercent: defaultMaxRevisionStalenessPercent,
@@ -93,6 +96,12 @@ func WatchBufferLength(watchBufferLength uint16) Option {
 	return func(so *spannerOptions) {
 		so.watchBufferLength = watchBufferLength
 	}
+}
+
+// WatchBufferWriteTimeout is the maximum timeout for writing to the watch buffer,
+// after which the caller to the watch will be disconnected.
+func WatchBufferWriteTimeout(watchBufferWriteTimeout time.Duration) Option {
+	return func(so *spannerOptions) { so.watchBufferWriteTimeout = watchBufferWriteTimeout }
 }
 
 // RevisionQuantization is the time bucket size to which advertised revisions

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -72,6 +72,9 @@ type spannerDatastore struct {
 	*revisions.RemoteClockRevisions
 	revisions.CommonDecoder
 
+	watchBufferLength       uint16
+	watchBufferWriteTimeout time.Duration
+
 	client   *spanner.Client
 	config   spannerOptions
 	database string
@@ -149,9 +152,11 @@ func NewSpannerDatastore(ctx context.Context, database string, opts ...Option) (
 		CommonDecoder: revisions.CommonDecoder{
 			Kind: revisions.Timestamp,
 		},
-		client:   client,
-		config:   config,
-		database: database,
+		client:                  client,
+		config:                  config,
+		database:                database,
+		watchBufferWriteTimeout: config.watchBufferWriteTimeout,
+		watchBufferLength:       config.watchBufferLength,
 	}
 	ds.RemoteClockRevisions.SetNowFunc(ds.headRevisionInternal)
 

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -64,6 +64,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.SpannerMaxSessions = c.SpannerMaxSessions
 		to.TablePrefix = c.TablePrefix
 		to.WatchBufferLength = c.WatchBufferLength
+		to.WatchBufferWriteTimeout = c.WatchBufferWriteTimeout
 		to.MigrationPhase = c.MigrationPhase
 	}
 }
@@ -104,6 +105,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["SpannerMaxSessions"] = helpers.DebugValue(c.SpannerMaxSessions, false)
 	debugMap["TablePrefix"] = helpers.DebugValue(c.TablePrefix, false)
 	debugMap["WatchBufferLength"] = helpers.DebugValue(c.WatchBufferLength, false)
+	debugMap["WatchBufferWriteTimeout"] = helpers.DebugValue(c.WatchBufferWriteTimeout, false)
 	debugMap["MigrationPhase"] = helpers.DebugValue(c.MigrationPhase, false)
 	return debugMap
 }
@@ -366,6 +368,13 @@ func WithTablePrefix(tablePrefix string) ConfigOption {
 func WithWatchBufferLength(watchBufferLength uint16) ConfigOption {
 	return func(c *Config) {
 		c.WatchBufferLength = watchBufferLength
+	}
+}
+
+// WithWatchBufferWriteTimeout returns an option that can set WatchBufferWriteTimeout on a Config
+func WithWatchBufferWriteTimeout(watchBufferWriteTimeout time.Duration) ConfigOption {
+	return func(c *Config) {
+		c.WatchBufferWriteTimeout = watchBufferWriteTimeout
 	}
 }
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -342,6 +342,14 @@ type WatchOptions struct {
 	// If given the zero value, the datastore's default will be used. If smaller
 	// than the datastore's minimum, the minimum will be used.
 	CheckpointInterval time.Duration
+
+	// WatchBufferLength is the length of the buffer for the watch channel. If
+	// given the zero value, the datastore's default will be used.
+	WatchBufferLength uint16
+
+	// WatchBufferWriteTimeout is the timeout for writing to the watch channel.
+	// If given the zero value, the datastore's default will be used.
+	WatchBufferWriteTimeout time.Duration
 }
 
 // WatchJustRelationships returns watch options for just relationships.


### PR DESCRIPTION
This ensures that even if the buffer fills, there is a window where it can be read from before the watch is terminated