### PR TITLE
Switch HLC timestamps to be stored as an array of two int64s

### DIFF
--- a/internal/datastore/common/changes_test.go
+++ b/internal/datastore/common/changes_test.go
@@ -411,10 +411,10 @@ func TestHLCOrdering(t *testing.T) {
 	ch := NewChanges(revisions.HLCKeyFunc, datastore.WatchRelationships|datastore.WatchSchema)
 	require.True(t, ch.IsEmpty())
 
-	rev1, err := revisions.HLCRevisionFromString("1.1")
+	rev1, err := revisions.HLCRevisionFromString("1.0000000001")
 	require.NoError(t, err)
 
-	rev0, err := revisions.HLCRevisionFromString("1.0")
+	rev0, err := revisions.HLCRevisionFromString("1")
 	require.NoError(t, err)
 
 	err = ch.AddRelationshipChange(ctx, rev1, tuple.MustParse("document:foo#viewer@user:tom"), core.RelationTupleUpdate_DELETE)
@@ -454,10 +454,10 @@ func TestHLCSameRevision(t *testing.T) {
 	ch := NewChanges(revisions.HLCKeyFunc, datastore.WatchRelationships|datastore.WatchSchema)
 	require.True(t, ch.IsEmpty())
 
-	rev0, err := revisions.HLCRevisionFromString("1.0")
+	rev0, err := revisions.HLCRevisionFromString("1")
 	require.NoError(t, err)
 
-	rev0again, err := revisions.HLCRevisionFromString("1.0")
+	rev0again, err := revisions.HLCRevisionFromString("1")
 	require.NoError(t, err)
 
 	err = ch.AddRelationshipChange(ctx, rev0, tuple.MustParse("document:foo#viewer@user:tom"), core.RelationTupleUpdate_TOUCH)

--- a/internal/datastore/proxy/schemacaching/intervaltracker_test.go
+++ b/internal/datastore/proxy/schemacaching/intervaltracker_test.go
@@ -48,7 +48,7 @@ func TestIntervalTrackerBasic(t *testing.T) {
 	validate(t, tracker)
 
 	// Ensure that revisions 1-3 find the first.
-	for _, rv := range []string{"1", "1.1", "2", "2.6", "3", "3.9", "3.999"} {
+	for _, rv := range []string{"1", "1.0000000001", "2", "2.0000000006", "3", "3.0000000009", "3.0000000010"} {
 		value, found = tracker.lookup(rev(rv), rev("5"))
 		require.True(t, found)
 		require.Equal(t, "first", value)
@@ -68,7 +68,7 @@ func TestIntervalTrackerBasic(t *testing.T) {
 	require.Equal(t, "second", value)
 
 	// Ensure the entry is not found if the tracking revision is less than that specified.
-	_, found = tracker.lookup(rev("5.1"), rev("5"))
+	_, found = tracker.lookup(rev("5.0000000001"), rev("5"))
 	require.False(t, found)
 }
 
@@ -85,7 +85,7 @@ func TestIntervalTrackerBeginningGap(t *testing.T) {
 	require.Equal(t, "first", value)
 
 	// Ensure the value is *not* found at revision 4.1 with max tracked 4.
-	_, found = tracker.lookup(rev("4.1"), rev("4"))
+	_, found = tracker.lookup(rev("4.0000000001"), rev("4"))
 	require.False(t, found)
 
 	// Ensure the value is found at revision 4.1 when maxed tracked is 5.
@@ -94,7 +94,7 @@ func TestIntervalTrackerBeginningGap(t *testing.T) {
 	require.Equal(t, "first", value)
 
 	// Make sure a request for revision 1-3 (exclusive) with the tracking revision less (since that "update" hasn't "arrived" yet)
-	for _, rv := range []string{"1", "1.1", "2", "2.6", "2.999"} {
+	for _, rv := range []string{"1", "1.0000000001", "2", "2.0000000006", "2.0000000009"} {
 		_, found = tracker.lookup(rev(rv), rev("3"))
 		require.False(t, found)
 	}
@@ -120,22 +120,22 @@ func TestIntervalTrackerOutOfOrderInsertion(t *testing.T) {
 	validate(t, tracker)
 
 	// Make sure a request for revision 1-2 (exclusive) refer to 'first'.
-	for _, rv := range []string{"1", "1.1", "1.999"} {
-		value, found := tracker.lookup(rev(rv), rev("4.1"))
+	for _, rv := range []string{"1", "1.0000000001", "1.0000000009"} {
+		value, found := tracker.lookup(rev(rv), rev("4.0000000001"))
 		require.True(t, found)
 		require.Equal(t, "first", value)
 	}
 
 	// Make sure a request for revision 2-4 (exclusive) refer to 'second'.
-	for _, rv := range []string{"2", "2.5", "3.999"} {
-		value, found := tracker.lookup(rev(rv), rev("4.1"))
+	for _, rv := range []string{"2", "2.0000000005", "3.0000000009"} {
+		value, found := tracker.lookup(rev(rv), rev("4.0000000001"))
 		require.True(t, found)
 		require.Equal(t, "second", value)
 	}
 
 	// Make sure a request for revision 4+ refers to 'four'
-	for _, rv := range []string{"4", "4.01", "4.05", "4.1"} {
-		value, found := tracker.lookup(rev(rv), rev("4.1"))
+	for _, rv := range []string{"4", "4.0000000001", "4.0000000005", "4.0000000009"} {
+		value, found := tracker.lookup(rev(rv), rev("4.0000000009"))
 		require.True(t, found)
 		require.Equal(t, "four", value)
 	}
@@ -145,15 +145,15 @@ func TestIntervalTrackerOutOfOrderInsertion(t *testing.T) {
 	validate(t, tracker)
 
 	// Make sure a request for revision 4-8 (exclusive) refers to 'four'
-	for _, rv := range []string{"4", "4.01", "4.05", "4.1", "7.999"} {
-		value, found := tracker.lookup(rev(rv), rev("8.1"))
+	for _, rv := range []string{"4", "4.0000000001", "4.0000000005", "4.0000000001", "7.0000000009"} {
+		value, found := tracker.lookup(rev(rv), rev("8.0000000001"))
 		require.True(t, found)
 		require.Equal(t, "four", value)
 	}
 
 	// Make sure a request for revision 8+ refers to 'eight'
-	for _, rv := range []string{"8", "8.01", "8.05", "8.1"} {
-		value, found := tracker.lookup(rev(rv), rev("8.1"))
+	for _, rv := range []string{"8", "8.0000000001", "8.0000000005", "8.0000000009"} {
+		value, found := tracker.lookup(rev(rv), rev("8.0000000009"))
 		require.True(t, found)
 		require.Equal(t, "eight", value)
 	}
@@ -291,7 +291,7 @@ func TestIntervalTrackerRealWorldUsage(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, "notfound5", value)
 
-	value, found = tracker.lookup(rev("5"), rev("3.5"))
+	value, found = tracker.lookup(rev("5"), rev("3.0000000005"))
 	require.True(t, found)
 	require.Equal(t, "notfound5", value)
 
@@ -299,15 +299,15 @@ func TestIntervalTrackerRealWorldUsage(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, "real2", value)
 
-	value, found = tracker.lookup(rev("2"), rev("3.5"))
+	value, found = tracker.lookup(rev("2"), rev("3.0000000005"))
 	require.True(t, found)
 	require.Equal(t, "real2", value)
 
-	value, found = tracker.lookup(rev("3.5"), rev("5"))
+	value, found = tracker.lookup(rev("3.0000000005"), rev("5"))
 	require.True(t, found)
 	require.Equal(t, "real2-again", value)
 
-	value, found = tracker.lookup(rev("3.5"), rev("3.5"))
+	value, found = tracker.lookup(rev("3.0000000005"), rev("3.0000000005"))
 	require.True(t, found)
 	require.Equal(t, "real2-again", value)
 }

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -83,12 +83,12 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 	fakeDS.disableReads()
 
 	// Read again, which should now be via the cache.
-	nsDef, _, err = wcache.SnapshotReader(rev("3.5")).ReadNamespaceByName(context.Background(), "somenamespace")
+	nsDef, _, err = wcache.SnapshotReader(rev("3.0000000005")).ReadNamespaceByName(context.Background(), "somenamespace")
 	require.NoError(t, err)
 	require.Equal(t, "somenamespace", nsDef.Name)
 
 	// Read via a lookup.
-	nsDefs, err := wcache.SnapshotReader(rev("3.5")).LookupNamespacesWithNames(context.Background(), []string{"somenamespace"})
+	nsDefs, err := wcache.SnapshotReader(rev("3.0000000005")).LookupNamespacesWithNames(context.Background(), []string{"somenamespace"})
 	require.NoError(t, err)
 	require.Equal(t, "somenamespace", nsDefs[0].Definition.Name)
 
@@ -96,7 +96,7 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 	fakeDS.updateNamespace("somenamespace", nil, rev("5"))
 
 	// Re-read at an earlier revision.
-	nsDef, _, err = wcache.SnapshotReader(rev("3.5")).ReadNamespaceByName(context.Background(), "somenamespace")
+	nsDef, _, err = wcache.SnapshotReader(rev("3.0000000005")).ReadNamespaceByName(context.Background(), "somenamespace")
 	require.NoError(t, err)
 	require.Equal(t, "somenamespace", nsDef.Name)
 

--- a/internal/datastore/revisions/commonrevision.go
+++ b/internal/datastore/revisions/commonrevision.go
@@ -77,3 +77,10 @@ type WithTimestampRevision interface {
 	TimestampNanoSec() int64
 	ConstructForTimestamp(timestampNanoSec int64) WithTimestampRevision
 }
+
+// WithIntegerRepresentation is an interface that can be implemented by a revision to
+// provide an integer representation of the revision.
+type WithIntegerRepresentation interface {
+	datastore.Revision
+	IntegerRepresentation() [2]int64
+}

--- a/internal/datastore/revisions/commonrevision.go
+++ b/internal/datastore/revisions/commonrevision.go
@@ -82,5 +82,5 @@ type WithTimestampRevision interface {
 // provide an integer representation of the revision.
 type WithIntegerRepresentation interface {
 	datastore.Revision
-	IntegerRepresentation() [2]int64
+	IntegerRepresentation() (int64, uint32)
 }

--- a/internal/datastore/revisions/commonrevision_test.go
+++ b/internal/datastore/revisions/commonrevision_test.go
@@ -31,18 +31,18 @@ func TestRevisionEqual(t *testing.T) {
 			true,
 		},
 		{
-			"1.1",
+			"1.0000000004",
 			"1",
 			false,
 		},
 		{
 			"1",
-			"1.1",
+			"1.0000000004",
 			false,
 		},
 		{
-			"1.1",
-			"1.1",
+			"1.0000000004",
+			"1.0000000004",
 			true,
 		},
 	}
@@ -97,18 +97,18 @@ func TestRevisionComparison(t *testing.T) {
 			false,
 		},
 		{
-			"1.1",
+			"1.0000000004",
 			"1",
 			true,
 		},
 		{
 			"1",
-			"1.1",
+			"1.0000000004",
 			false,
 		},
 		{
-			"1.1",
-			"1.1",
+			"1.0000000004",
+			"1.0000000004",
 			false,
 		},
 	}
@@ -151,7 +151,7 @@ func TestRevisionComparison(t *testing.T) {
 
 func TestRevisionBidirectionalParsing(t *testing.T) {
 	tcs := []string{
-		"1", "2", "42", "192747564535", "1.1", "1.2", "1.42", "-1235",
+		"1", "2", "42", "192747564535", "1.0000000004", "1.0000000002", "1.0000000042", "-1235",
 	}
 
 	for _, tc := range tcs {
@@ -178,7 +178,7 @@ func TestTimestampRevisionParsing(t *testing.T) {
 		"42":                  false,
 		"1257894000000000000": false,
 		"-1":                  false,
-		"1.23":                true,
+		"1.0000000004":        true,
 	}
 
 	for tc, expectError := range tcs {
@@ -203,7 +203,7 @@ func TestTransactionIDRevisionParsing(t *testing.T) {
 		"42":                  false,
 		"1257894000000000000": false,
 		"-1":                  true,
-		"1.23":                true,
+		"1.0000000004":        true,
 	}
 
 	for tc, expectError := range tcs {
@@ -223,13 +223,13 @@ func TestTransactionIDRevisionParsing(t *testing.T) {
 
 func TestHLCRevisionParsing(t *testing.T) {
 	tcs := map[string]bool{
-		"1":                     false,
-		"2":                     false,
-		"42":                    false,
-		"1257894000000000000":   false,
-		"-1":                    false,
-		"1.23":                  false,
-		"9223372036854775807.2": false,
+		"1":                              false,
+		"2":                              false,
+		"42":                             false,
+		"1257894000000000000":            false,
+		"-1":                             false,
+		"1.0000000004":                   false,
+		"9223372036854775807.0000000004": false,
 	}
 
 	for tc, expectError := range tcs {

--- a/internal/datastore/revisions/hlcrevision.go
+++ b/internal/datastore/revisions/hlcrevision.go
@@ -132,6 +132,10 @@ func (hlc HLCRevision) ConstructForTimestamp(timestamp int64) WithTimestampRevis
 	return HLCRevision([2]int64{timestamp, 0})
 }
 
+func (hlc HLCRevision) IntegerRepresentation() [2]int64 {
+	return hlc
+}
+
 var (
 	_ datastore.Revision    = HLCRevision{}
 	_ WithTimestampRevision = HLCRevision{}

--- a/internal/datastore/revisions/hlcrevision.go
+++ b/internal/datastore/revisions/hlcrevision.go
@@ -1,112 +1,135 @@
 package revisions
 
 import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
 	"time"
 
-	"github.com/cockroachdb/apd"
 	"github.com/shopspring/decimal"
 
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
-var zeroHLC = HLCRevision(*apd.New(0, 0))
+var zeroHLC = HLCRevision([2]int64{0, 0})
 
-// HLCRevision is a revision that is a hybrid logical clock, stored as a decimal.
-type HLCRevision apd.Decimal
+// NOTE: This *must* match the length defined in CRDB or the implementation below will break.
+const logicalClockLength = 10
+
+var logicalClockOffset = int64(math.Pow10(logicalClockLength + 1))
+
+// HLCRevision is a revision that is a hybrid logical clock, stored as two integers.
+// The first integer is the timestamp in nanoseconds, and the second integer is the
+// logical clock defined as 11 digits, with the first digit being ignored to ensure
+// precision of the given logical clock.
+type HLCRevision [2]int64
 
 // parseHLCRevisionString parses a string into a hybrid logical clock revision.
 func parseHLCRevisionString(revisionStr string) (datastore.Revision, error) {
-	parsed, _, err := apd.NewFromString(revisionStr)
+	pieces := strings.Split(revisionStr, ".")
+	if len(pieces) == 1 {
+		// If there is no decimal point, assume the revision is a timestamp.
+		timestamp, err := strconv.ParseInt(pieces[0], 10, 64)
+		if err != nil {
+			return datastore.NoRevision, fmt.Errorf("invalid revision string: %q", revisionStr)
+		}
+		return HLCRevision([2]int64{timestamp, 0}), nil
+	}
+
+	if len(pieces) != 2 {
+		return datastore.NoRevision, fmt.Errorf("invalid revision string: %q", revisionStr)
+	}
+
+	timestamp, err := strconv.ParseInt(pieces[0], 10, 64)
 	if err != nil {
-		return datastore.NoRevision, err
+		return datastore.NoRevision, fmt.Errorf("invalid revision string: %q", revisionStr)
 	}
-	if parsed == nil {
-		return datastore.NoRevision, spiceerrors.MustBugf("got nil parsed HLC")
+
+	logicalclock, err := strconv.ParseInt(pieces[1], 10, 64)
+	if err != nil {
+		return datastore.NoRevision, fmt.Errorf("invalid revision string: %q", revisionStr)
 	}
-	return HLCRevision(*parsed), nil
+
+	if len(pieces[1]) != logicalClockLength {
+		return datastore.NoRevision, spiceerrors.MustBugf("invalid revision string due to unexpected logical clock size (%d): %q", len(pieces[1]), revisionStr)
+	}
+
+	return HLCRevision([2]int64{timestamp, logicalclock + logicalClockOffset}), nil
 }
 
 // HLCRevisionFromString parses a string into a hybrid logical clock revision.
 func HLCRevisionFromString(revisionStr string) (HLCRevision, error) {
-	parsed, _, err := apd.NewFromString(revisionStr)
+	rev, err := parseHLCRevisionString(revisionStr)
 	if err != nil {
 		return zeroHLC, err
 	}
-	if parsed == nil {
-		return zeroHLC, spiceerrors.MustBugf("got nil parsed HLC")
-	}
-	return HLCRevision(*parsed), nil
+
+	return rev.(HLCRevision), nil
 }
 
 // NewForHLC creates a new revision for the given hybrid logical clock.
 func NewForHLC(decimal decimal.Decimal) HLCRevision {
-	return HLCRevision(*apd.NewWithBigInt(decimal.Coefficient(), decimal.Exponent()))
+	rev, _ := HLCRevisionFromString(decimal.String())
+	return rev
 }
 
 // NewHLCForTime creates a new revision for the given time.
 func NewHLCForTime(time time.Time) HLCRevision {
-	return HLCRevision(*apd.New(0, 0).SetInt64(time.UnixNano()))
+	return HLCRevision([2]int64{time.UnixNano(), 0})
 }
 
 func (hlc HLCRevision) Equal(rhs datastore.Revision) bool {
 	if rhs == datastore.NoRevision {
-		rhs = HLCRevision(*apd.New(0, 0))
+		rhs = zeroHLC
 	}
 
-	lhsD := apd.Decimal(hlc)
-	lhsDP := &lhsD
-	rhsD := apd.Decimal(rhs.(HLCRevision))
-	return lhsDP.Cmp(&rhsD) == 0
+	rhsHLC := rhs.(HLCRevision)
+	return hlc[0] == rhsHLC[0] && hlc[1] == rhsHLC[1]
 }
 
 func (hlc HLCRevision) GreaterThan(rhs datastore.Revision) bool {
 	if rhs == datastore.NoRevision {
-		rhs = HLCRevision(*apd.New(0, 0))
+		rhs = zeroHLC
 	}
 
-	lhsD := apd.Decimal(hlc)
-	lhsDP := &lhsD
-	rhsD := apd.Decimal(rhs.(HLCRevision))
-	return lhsDP.Cmp(&rhsD) == 1
+	rhsHLC := rhs.(HLCRevision)
+	return hlc[0] > rhsHLC[0] || (hlc[0] == rhsHLC[0] && hlc[1] > rhsHLC[1])
 }
 
 func (hlc HLCRevision) LessThan(rhs datastore.Revision) bool {
 	if rhs == datastore.NoRevision {
-		return false
+		rhs = zeroHLC
 	}
 
-	lhsD := apd.Decimal(hlc)
-	lhsDP := &lhsD
-	rhsD := apd.Decimal(rhs.(HLCRevision))
-	return lhsDP.Cmp(&rhsD) == -1
+	rhsHLC := rhs.(HLCRevision)
+	return hlc[0] < rhsHLC[0] || (hlc[0] == rhsHLC[0] && hlc[1] < rhsHLC[1])
 }
 
 func (hlc HLCRevision) String() string {
-	d := apd.Decimal(hlc)
-	dp := &d
-	return dp.String()
+	if hlc[1] == 0 {
+		return strconv.FormatInt(hlc[0], 10)
+	}
+
+	logicalClockString := strconv.FormatInt(hlc[1]-logicalClockOffset, 10)
+	return strconv.FormatInt(hlc[0], 10) + "." + strings.Repeat("0", logicalClockLength-len(logicalClockString)) + logicalClockString
 }
 
 func (hlc HLCRevision) TimestampNanoSec() int64 {
-	d := apd.Decimal(hlc)
-	dp := &d
-	c := apd.BaseContext
-	output := new(apd.Decimal)
-	_, _ = c.Floor(output, dp)
-	i, _ := output.Int64()
-	return i
+	return hlc[0]
 }
 
 func (hlc HLCRevision) InexactFloat64() float64 {
-	d := apd.Decimal(hlc)
-	dp := &d
-	f, _ := dp.Float64()
-	return f
+	if hlc[1] == 0 {
+		return float64(hlc[0])
+	}
+
+	return float64(hlc[0]) + float64(hlc[1]-logicalClockOffset)/math.Pow10(logicalClockLength)
 }
 
 func (hlc HLCRevision) ConstructForTimestamp(timestamp int64) WithTimestampRevision {
-	return HLCRevision(*(apd.New(0, 0).SetInt64(timestamp)))
+	return HLCRevision([2]int64{timestamp, 0})
 }
 
 var (
@@ -115,22 +138,11 @@ var (
 )
 
 // HLCKeyFunc is used to convert a simple HLC for use in maps.
-func HLCKeyFunc(r HLCRevision) string {
-	return r.String()
+func HLCKeyFunc(r HLCRevision) [2]int64 {
+	return r
 }
 
 // HLCKeyLessThanFunc is used to compare keys created by the HLCKeyFunc.
-func HLCKeyLessThanFunc(lhs, rhs string) bool {
-	// Return the HLCs as strings to ensure precise is maintained.
-	lp := mustParseDecimal(lhs)
-	rp := mustParseDecimal(rhs)
-	return lp.Cmp(rp) == -1
-}
-
-func mustParseDecimal(value string) *apd.Decimal {
-	parsed, _, err := apd.NewFromString(value)
-	if err != nil {
-		panic("could not parse decimal")
-	}
-	return parsed
+func HLCKeyLessThanFunc(lhs, rhs [2]int64) bool {
+	return lhs[0] < rhs[0] || (lhs[0] == rhs[0] && lhs[1] < rhs[1])
 }

--- a/internal/datastore/revisions/hlcrevision_test.go
+++ b/internal/datastore/revisions/hlcrevision_test.go
@@ -15,9 +15,7 @@ func TestNewForHLC(t *testing.T) {
 		"42",
 		"1257894000000000000",
 		"-1",
-		"1.23",
-		"9223372036854775807.2",
-		"9223372036854775807.2345987348543",
+		"1.0000000023",
 		"1703283409994227985.0000000004",
 	}
 
@@ -34,15 +32,14 @@ func TestNewForHLC(t *testing.T) {
 
 func TestTimestampNanoSec(t *testing.T) {
 	tcs := map[string]int64{
-		"1":                                 1,
-		"2":                                 2,
-		"42":                                42,
-		"1257894000000000000":               1257894000000000000,
-		"-1":                                -1,
-		"1.23":                              1,
-		"9223372036854775807.2":             9223372036854775807,
-		"9223372036854775807.2345987348543": 9223372036854775807,
-		"1703283409994227985.0000000004":    1703283409994227985,
+		"1":                              1,
+		"2":                              2,
+		"42":                             42,
+		"1257894000000000000":            1257894000000000000,
+		"-1":                             -1,
+		"1.0000000023":                   1,
+		"9223372036854775807.0000000002": 9223372036854775807,
+		"1703283409994227985.0000000004": 1703283409994227985,
 	}
 
 	for tc, nano := range tcs {
@@ -55,10 +52,86 @@ func TestTimestampNanoSec(t *testing.T) {
 	}
 }
 
+func TestInexactFloat64(t *testing.T) {
+	tcs := map[string]float64{
+		"1":                              1,
+		"2":                              2,
+		"42":                             42,
+		"1257894000000000000":            1257894000000000000,
+		"-1":                             -1,
+		"1.0000000023":                   1.0000000023,
+		"9223372036854775807.0000000002": 9223372036854775807.0000000002,
+		"1703283409994227985.0000000004": 1703283409994227985.0000000004,
+	}
+
+	for tc, floatValue := range tcs {
+		t.Run(tc, func(t *testing.T) {
+			rev, err := HLCRevisionFromString(tc)
+			require.NoError(t, err)
+
+			require.Equal(t, floatValue, rev.InexactFloat64())
+		})
+	}
+}
+
 func TestNewHLCForTime(t *testing.T) {
 	time := time.Now()
 	rev := NewForTime(time)
 	require.Equal(t, time.UnixNano(), rev.TimestampNanoSec())
+}
+
+func TestHLCKeyEquals(t *testing.T) {
+	tcs := []struct {
+		left    string
+		right   string
+		isEqual bool
+	}{
+		{
+			"1", "2", false,
+		},
+		{
+			"2", "1", false,
+		},
+		{
+			"2", "2", true,
+		},
+		{
+			"1", "1.0000000005", false,
+		},
+		{
+			"1.0000000001", "1.0000000001", true,
+		},
+		{
+			"1.0000000001", "1", false,
+		},
+		{
+			"1703283409994227985.0000000004", "1703283409994227985.0000000005", false,
+		},
+		{
+			"1703283409994227985.0000000005", "1703283409994227985.0000000004", false,
+		},
+		{
+			"1703283409994227985.0000000014", "1703283409994227985.0000000005", false,
+		},
+		{
+			"1703283409994227985.0000000005", "1703283409994227985.0000000005", true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.left+"-"+tc.right, func(t *testing.T) {
+			left, err := HLCRevisionFromString(tc.left)
+			require.NoError(t, err)
+
+			right, err := HLCRevisionFromString(tc.right)
+			require.NoError(t, err)
+
+			lk := HLCKeyFunc(left)
+			rk := HLCKeyFunc(right)
+
+			require.Equal(t, tc.isEqual, lk == rk)
+		})
+	}
 }
 
 func TestHLCKeyLessThanFunc(t *testing.T) {
@@ -77,16 +150,25 @@ func TestHLCKeyLessThanFunc(t *testing.T) {
 			"2", "2", false,
 		},
 		{
-			"1", "1.1", true,
+			"1", "1.0000000005", true,
 		},
 		{
-			"1.1", "1.1", false,
+			"1.0000000001", "1.0000000001", false,
 		},
 		{
-			"1.1", "1", false,
+			"1.0000000001", "1", false,
 		},
 		{
 			"1703283409994227985.0000000004", "1703283409994227985.0000000005", true,
+		},
+		{
+			"1703283409994227985.0000000005", "1703283409994227985.0000000004", false,
+		},
+		{
+			"1703283409994227985.0000000014", "1703283409994227985.0000000005", false,
+		},
+		{
+			"1703283409994227985.0000000005", "1703283409994227985.0000000014", true,
 		},
 	}
 
@@ -102,6 +184,117 @@ func TestHLCKeyLessThanFunc(t *testing.T) {
 			rk := HLCKeyFunc(right)
 
 			require.Equal(t, tc.isLessThan, HLCKeyLessThanFunc(lk, rk))
+		})
+	}
+}
+
+func BenchmarkHLCParsing(b *testing.B) {
+	tcs := []string{
+		"1",
+		"2",
+		"42",
+		"1257894000000000000",
+		"-1",
+		"9223372036854775807.1000000025",
+		"1703283409994227985.0000000004",
+	}
+
+	for _, tc := range tcs {
+		b.Run(tc, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := HLCRevisionFromString(tc)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkHLCLessThan(b *testing.B) {
+	tcs := []struct {
+		left  string
+		right string
+	}{
+		{
+			"1", "2",
+		},
+		{
+			"2", "1",
+		},
+		{
+			"2", "2",
+		},
+		{
+			"1703283409994227985.0000000004", "1703283409994227985.0000000005",
+		},
+		{
+			"1703283409994227985.0000000005", "1703283409994227985.0000000004",
+		},
+	}
+
+	for _, tc := range tcs {
+		b.Run(tc.left+"-"+tc.right, func(b *testing.B) {
+			left, err := HLCRevisionFromString(tc.left)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			right, err := HLCRevisionFromString(tc.right)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			left.LessThan(right)
+		})
+	}
+}
+
+func BenchmarkHLCLessThanFunc(b *testing.B) {
+	tcs := []struct {
+		left  string
+		right string
+	}{
+		{
+			"1", "2",
+		},
+		{
+			"2", "1",
+		},
+		{
+			"2", "2",
+		},
+		{
+			"1703283409994227985.0000000001", "1703283409994227985.0000000001",
+		},
+		{
+			"1703283409994227985.0000000004", "1703283409994227985.0000000005",
+		},
+		{
+			"1703283409994227985.0000000005", "1703283409994227985.0000000004",
+		},
+	}
+
+	for _, tc := range tcs {
+		b.Run(tc.left+"-"+tc.right, func(b *testing.B) {
+			left, err := HLCRevisionFromString(tc.left)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			right, err := HLCRevisionFromString(tc.right)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			lk := HLCKeyFunc(left)
+			rk := HLCKeyFunc(right)
+
+			for i := 0; i < b.N; i++ {
+				HLCKeyLessThanFunc(lk, rk)
+			}
 		})
 	}
 }

--- a/internal/datastore/revisions/timestamprevision.go
+++ b/internal/datastore/revisions/timestamprevision.go
@@ -63,6 +63,10 @@ func (ir TimestampRevision) ConstructForTimestamp(timestamp int64) WithTimestamp
 	return TimestampRevision(timestamp)
 }
 
+func (ir TimestampRevision) IntegerRepresentation() [2]int64 {
+	return [2]int64{int64(ir), 0}
+}
+
 var (
 	_ datastore.Revision    = TimestampRevision(0)
 	_ WithTimestampRevision = TimestampRevision(0)

--- a/internal/datastore/revisions/timestamprevision.go
+++ b/internal/datastore/revisions/timestamprevision.go
@@ -63,8 +63,8 @@ func (ir TimestampRevision) ConstructForTimestamp(timestamp int64) WithTimestamp
 	return TimestampRevision(timestamp)
 }
 
-func (ir TimestampRevision) IntegerRepresentation() [2]int64 {
-	return [2]int64{int64(ir), 0}
+func (ir TimestampRevision) IntegerRepresentation() (int64, uint32) {
+	return int64(ir), 0
 }
 
 var (

--- a/internal/datastore/revisions/txidrevision.go
+++ b/internal/datastore/revisions/txidrevision.go
@@ -49,6 +49,10 @@ func (ir TransactionIDRevision) WithInexactFloat64() float64 {
 	return float64(ir)
 }
 
+func (ir TransactionIDRevision) IntegerRepresentation() [2]int64 {
+	return [2]int64{int64(ir), 0}
+}
+
 var _ datastore.Revision = TransactionIDRevision(0)
 
 // TransactionIDKeyFunc is used to create keys for transaction IDs.

--- a/internal/datastore/revisions/txidrevision.go
+++ b/internal/datastore/revisions/txidrevision.go
@@ -49,8 +49,8 @@ func (ir TransactionIDRevision) WithInexactFloat64() float64 {
 	return float64(ir)
 }
 
-func (ir TransactionIDRevision) IntegerRepresentation() [2]int64 {
-	return [2]int64{int64(ir), 0}
+func (ir TransactionIDRevision) IntegerRepresentation() (int64, uint32) {
+	return int64(ir), 0
 }
 
 var _ datastore.Revision = TransactionIDRevision(0)

--- a/pkg/zedtoken/zedtoken_test.go
+++ b/pkg/zedtoken/zedtoken_test.go
@@ -23,9 +23,17 @@ var encodeRevisionTests = []datastore.Revision{
 	revisions.NewForTransactionID(1621538189028928000),
 }
 
+func mustHLC(str string) datastore.Revision {
+	rev, err := revisions.HLCRevisionFromString(str)
+	if err != nil {
+		panic(err)
+	}
+	return rev
+}
+
 var encodeHLCRevisionTests = []datastore.Revision{
-	revisions.NewForHLC(decimal.New(12345, -2)),
-	revisions.NewForHLC(decimal.New(0, -10)),
+	mustHLC("1235"),
+	mustHLC("1234.0000000001"),
 }
 
 func TestZedTokenEncode(t *testing.T) {
@@ -161,12 +169,6 @@ var hlcDecodeTests = []struct {
 		format:           "V1 ZedToken",
 		token:            "CAIaFQoTMTYyMTUzODE4OTAyODkyODAwMA==",
 		expectedRevision: revisions.NewForHLC(decimal.NewFromInt(1621538189028928000)),
-		expectError:      false,
-	},
-	{
-		format:           "V1 ZedToken",
-		token:            "CAIaCAoGMTIzLjQ1",
-		expectedRevision: revisions.NewForHLC(decimal.New(12345, -2)),
 		expectError:      false,
 	},
 	{


### PR DESCRIPTION
Benchmarks:

```
benchmark                                                                                     old ns/op     new ns/op     delta
BenchmarkHLCParsing/1-10                                                                      122           44.2          -63.64%
BenchmarkHLCParsing/2-10                                                                      121           44.6          -63.17%
BenchmarkHLCParsing/42-10                                                                     128           48.5          -62.24%
BenchmarkHLCParsing/1257894000000000000-10                                                    248           71.7          -71.10%
BenchmarkHLCParsing/-1-10                                                                     122           46.6          -61.87%
BenchmarkHLCParsing/9223372036854775807.1000000025-10                                         376           103           -72.71%
BenchmarkHLCParsing/1703283409994227985.0000000004-10                                         376           102           -72.81%
BenchmarkHLCLessThan/1-2-10                                                                   0.00          0.00          -100.00%
BenchmarkHLCLessThan/2-1-10                                                                   0.00          0.00          +0.00%
BenchmarkHLCLessThan/2-2-10                                                                   0.00          0.00          +0.00%
BenchmarkHLCLessThan/1703283409994227985.0000000004-1703283409994227985.0000000005-10         0.00          0.00          -80.00%
BenchmarkHLCLessThan/1703283409994227985.0000000005-1703283409994227985.0000000004-10         0.00          0.00          -100.00%
BenchmarkHLCLessThanFunc/1-2-10                                                               242           0.33          -99.86%
BenchmarkHLCLessThanFunc/2-1-10                                                               240           0.33          -99.86%
BenchmarkHLCLessThanFunc/2-2-10                                                               243           0.32          -99.87%
BenchmarkHLCLessThanFunc/1703283409994227985.0000000001-1703283409994227985.0000000001-10     750           0.32          -99.96%
BenchmarkHLCLessThanFunc/1703283409994227985.0000000004-1703283409994227985.0000000005-10     757           0.33          -99.96%
BenchmarkHLCLessThanFunc/1703283409994227985.0000000005-1703283409994227985.0000000004-10     751           0.33          -99.96%
```