### PR TITLE
compiler: adds a helper method to require any object type prefix

### DIFF
--- a/pkg/schemadsl/compiler/compiler.go
+++ b/pkg/schemadsl/compiler/compiler.go
@@ -52,6 +52,10 @@ func ObjectTypePrefix(prefix string) ObjectPrefixOption {
 	return func(cfg *config) { cfg.objectTypePrefix = &prefix }
 }
 
+func RequirePrefixedObjectType() ObjectPrefixOption {
+	return func(cfg *config) { cfg.objectTypePrefix = nil }
+}
+
 func AllowUnprefixedObjectType() ObjectPrefixOption {
 	return func(cfg *config) { cfg.objectTypePrefix = new(string) }
 }


### PR DESCRIPTION
Follow up to breaking changes from https://github.com/authzed/spicedb/pull/1679 and subsequent fixes in https://github.com/authzed/spicedb/pull/1683

The compiler API contract allowed clients to enforce the schema having _any prefix_ not just one specific. The Safeguards introduced in https://github.com/authzed/spicedb/pull/1683 mean it was no longer possible to achieve the same semantics originally exposed.

This introduces a new `Option` `RequirePrefixedObjectType` which will cause the compiler to fail if a namespace or caveat is found without prefixes. The alternative `ObjectTypePrefix` should be used when _a specific_ object type prefix is required.