### PR TITLE
implements schema watch support for MemDB

### DIFF
--- a/internal/datastore/memdb/memdb_test.go
+++ b/internal/datastore/memdb/memdb_test.go
@@ -26,7 +26,7 @@ func (mdbt memDBTest) New(revisionQuantization, _, gcWindow time.Duration, watch
 }
 
 func TestMemdbDatastore(t *testing.T) {
-	test.AllWithExceptions(t, memDBTest{}, test.WithCategories(test.WatchSchemaCategory))
+	test.All(t, memDBTest{})
 }
 
 func TestConcurrentWritePanic(t *testing.T) {

--- a/internal/datastore/memdb/watch.go
+++ b/internal/datastore/memdb/watch.go
@@ -23,11 +23,6 @@ func (mdb *memdbDatastore) Watch(ctx context.Context, ar datastore.Revision, opt
 	updates := make(chan *datastore.RevisionChanges, watchBufferLength)
 	errs := make(chan error, 1)
 
-	if options.Content&datastore.WatchSchema == datastore.WatchSchema {
-		errs <- errors.New("schema watch unsupported in MemDB")
-		return updates, errs
-	}
-
 	watchBufferWriteTimeout := options.WatchBufferWriteTimeout
 	if watchBufferWriteTimeout == 0 {
 		watchBufferWriteTimeout = mdb.watchBufferWriteTimeout

--- a/internal/datastore/revisions/commonrevision.go
+++ b/internal/datastore/revisions/commonrevision.go
@@ -65,7 +65,7 @@ func (cd CommonDecoder) RevisionFromString(s string) (datastore.Revision, error)
 // WithInexactFloat64 is an interface that can be implemented by a revision to
 // provide an inexact float64 representation of the revision.
 type WithInexactFloat64 interface {
-	// WithInexactFloat64 returns a float64 that is an inexact representation of the
+	// InexactFloat64 returns a float64 that is an inexact representation of the
 	// revision.
 	InexactFloat64() float64
 }


### PR DESCRIPTION
SchemaWatch support in MemDB was left unimplemented when the initial refactor took place. This adds the missing functionality to MemDB.