### PR TITLE
Prevent the staleness of an optimized revision from exceeding the GC window

### DIFF
--- a/internal/datastore/revisions/remoteclock.go
+++ b/internal/datastore/revisions/remoteclock.go
@@ -25,6 +25,15 @@ type RemoteClockRevisions struct {
 
 // NewRemoteClockRevisions returns a RemoteClockRevisions for the given configuration
 func NewRemoteClockRevisions(gcWindow, maxRevisionStaleness, followerReadDelay, quantization time.Duration) *RemoteClockRevisions {
+	// Ensure the max revision staleness never exceeds the GC window.
+	if maxRevisionStaleness > gcWindow {
+		log.Warn().
+			Dur("maxRevisionStaleness", maxRevisionStaleness).
+			Dur("gcWindow", gcWindow).
+			Msg("the configured maximum revision staleness exceeds the configured gc window, so capping to gcWindow")
+		maxRevisionStaleness = gcWindow - 1
+	}
+
 	revisions := &RemoteClockRevisions{
 		CachedOptimizedRevisions: NewCachedOptimizedRevisions(
 			maxRevisionStaleness,


### PR DESCRIPTION
Currently, if the max staleness percentage is configured well in excess of the norm, it can result in OptimizedRevision occasionally returning revisions that are already expired