### PR TITLE
cmd: deprecate root-level head and migrate

### DIFF
--- a/cmd/spicedb/main.go
+++ b/cmd/spicedb/main.go
@@ -43,11 +43,6 @@ func main() {
 	cmd.RegisterVersionFlags(versionCmd)
 	rootCmd.AddCommand(versionCmd)
 
-	// Add migration commands
-	migrateCmd := cmd.NewMigrateCommand(rootCmd.Use)
-	cmd.RegisterMigrateFlags(migrateCmd)
-	rootCmd.AddCommand(migrateCmd)
-
 	// Add datastore commands
 	datastoreCmd, err := cmd.NewDatastoreCommand(rootCmd.Use)
 	if err != nil {
@@ -57,10 +52,19 @@ func main() {
 	cmd.RegisterDatastoreRootFlags(datastoreCmd)
 	rootCmd.AddCommand(datastoreCmd)
 
-	// Add head command.
+	// Add deprecated head command
 	headCmd := cmd.NewHeadCommand(rootCmd.Use)
 	cmd.RegisterHeadFlags(headCmd)
+	headCmd.Hidden = true
+	headCmd.RunE = cmd.DeprecatedRunE(headCmd.RunE, "spicedb datastore head")
 	rootCmd.AddCommand(headCmd)
+
+	// Add deprecated migrate command
+	migrateCmd := cmd.NewMigrateCommand(rootCmd.Use)
+	migrateCmd.Hidden = true
+	migrateCmd.RunE = cmd.DeprecatedRunE(migrateCmd.RunE, "spicedb datastore migrate")
+	cmd.RegisterMigrateFlags(migrateCmd)
+	rootCmd.AddCommand(migrateCmd)
 
 	// Add server commands
 	serverConfig := cmdutil.NewConfigWithOptionsAndDefaults()

--- a/pkg/cmd/datastore.go
+++ b/pkg/cmd/datastore.go
@@ -43,6 +43,10 @@ func NewDatastoreCommand(programName string) (*cobra.Command, error) {
 	}
 	datastoreCmd.AddCommand(repairCmd)
 
+	headCmd := NewHeadCommand(programName)
+	RegisterHeadFlags(headCmd)
+	datastoreCmd.AddCommand(headCmd)
+
 	return datastoreCmd, nil
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/cobrautil/v2/cobraotel"
 	"github.com/jzelinskie/cobrautil/v2/cobrazerolog"
 	"github.com/spf13/cobra"
 
+	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/releases"
@@ -17,6 +19,14 @@ func RegisterRootFlags(cmd *cobra.Command) {
 	releases.RegisterFlags(cmd.PersistentFlags())
 	termination.RegisterFlags(cmd.PersistentFlags())
 	runtime.RegisterFlags(cmd.PersistentFlags())
+}
+
+// DeprecatedRunE wraps the RunFunc with a warning log statement.
+func DeprecatedRunE(fn cobrautil.CobraRunFunc, newCmd string) cobrautil.CobraRunFunc {
+	return func(cmd *cobra.Command, args []string) error {
+		log.Warn().Str("newCommand", newCmd).Msg("use of deprecated command")
+		return fn(cmd, args)
+	}
 }
 
 func NewRootCommand(programName string) *cobra.Command {


### PR DESCRIPTION
These make more sense under the datastore command.

This change introduces a convenience function for warning when a deprecated command is used.