### PR TITLE
fixes pgx min connection count always being set to max count

### DIFF
--- a/internal/datastore/postgres/common/pgx.go
+++ b/internal/datastore/postgres/common/pgx.go
@@ -249,9 +249,10 @@ func (opts PoolOptions) ConfigurePgx(pgxConfig *pgxpool.Config) {
 		pgxConfig.MaxConns = int32(*opts.MaxOpenConns)
 	}
 
+	// Default to keeping the pool maxed out at all times.
+	pgxConfig.MinConns = pgxConfig.MaxConns
 	if opts.MinOpenConns != nil {
-		// Default to keeping the pool maxed out at all times.
-		pgxConfig.MinConns = pgxConfig.MaxConns
+		pgxConfig.MinConns = int32(*opts.MinOpenConns)
 	}
 
 	if pgxConfig.MaxConns > 0 && pgxConfig.MinConns > 0 && pgxConfig.MaxConns < pgxConfig.MinConns {


### PR DESCRIPTION
the logic ignored teh provided `opts.MinOpenConns` and always defaulted to the max value provided.

It affects both Postgres and CockroachDB datastores.