### PR TITLE
Use the same default port for the HTTP API across serve and serve-testing

### DIFF
--- a/pkg/cmd/testing.go
+++ b/pkg/cmd/testing.go
@@ -15,8 +15,8 @@ func RegisterTestingFlags(cmd *cobra.Command, config *testserver.Config) {
 	util.RegisterGRPCServerFlags(cmd.Flags(), &config.GRPCServer, "grpc", "gRPC", ":50051", true)
 	util.RegisterGRPCServerFlags(cmd.Flags(), &config.ReadOnlyGRPCServer, "readonly-grpc", "read-only gRPC", ":50052", true)
 
-	util.RegisterHTTPServerFlags(cmd.Flags(), &config.HTTPGateway, "http", "http", ":8081", false)
-	util.RegisterHTTPServerFlags(cmd.Flags(), &config.ReadOnlyHTTPGateway, "readonly-http", "read-only HTTP", ":8082", false)
+	util.RegisterHTTPServerFlags(cmd.Flags(), &config.HTTPGateway, "http", "http", ":8443", false)
+	util.RegisterHTTPServerFlags(cmd.Flags(), &config.ReadOnlyHTTPGateway, "readonly-http", "read-only HTTP", ":8444", false)
 
 	cmd.Flags().StringSliceVar(&config.LoadConfigs, "load-configs", []string{}, "configuration yaml files to load")
 


### PR DESCRIPTION
Issue #1748: Use the same default port for the HTTP API across serve and serve-testing 