### PR TITLE
VSCode launch config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist/
 *.wasm
+.vscode/settings.json
+.env.local

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "configurations": [
+    {
+      "name": "Serve",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/spicedb/main.go",
+      "args": [
+        "serve"
+      ],
+      "envFile": "${workspaceFolder}/.env.local",
+    }
+  ]
+}


### PR DESCRIPTION
Adds the ability to run the `serve` command for SpiceDB using the VSCode debugger. Configuration will be read from an `.env.local` file.