### PR TITLE
Change CRDB driver to use new method for getting transaction timestamp

### DIFF
--- a/internal/datastore/crdb/migrations/zz_migration.0005_remove_stats_table.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0005_remove_stats_table.go
@@ -1,0 +1,25 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	dropStatsTable = `DROP TABLE relationship_estimate_counters;`
+)
+
+func init() {
+	err := CRDBMigrations.Register("remove-stats-table", "add-caveats", removeStatsTable, noAtomicMigration)
+	if err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}
+
+func removeStatsTable(ctx context.Context, conn *pgx.Conn) error {
+	if _, err := conn.Exec(ctx, dropStatsTable); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/datastore/crdb/options.go
+++ b/internal/datastore/crdb/options.go
@@ -20,8 +20,8 @@ type crdbOptions struct {
 	maxRetries                  uint8
 	overlapStrategy             string
 	overlapKey                  string
-	disableStats                bool
 	enableConnectionBalancing   bool
+	analyzeBeforeStatistics     bool
 
 	enablePrometheusStats bool
 }
@@ -65,7 +65,6 @@ func generateConfig(options []Option) (crdbOptions, error) {
 		maxRetries:                  defaultMaxRetries,
 		overlapKey:                  defaultOverlapKey,
 		overlapStrategy:             defaultOverlapStrategy,
-		disableStats:                false,
 		enablePrometheusStats:       defaultEnablePrometheusStats,
 		enableConnectionBalancing:   defaultEnableConnectionBalancing,
 		connectRate:                 defaultConnectRate,
@@ -283,11 +282,6 @@ func OverlapKey(key string) Option {
 	return func(po *crdbOptions) { po.overlapKey = key }
 }
 
-// DisableStats disables recording counts to the stats table
-func DisableStats(disable bool) Option {
-	return func(po *crdbOptions) { po.disableStats = disable }
-}
-
 // WithEnablePrometheusStats marks whether Prometheus metrics provided by the Postgres
 // clients being used by the datastore are enabled.
 //
@@ -302,4 +296,13 @@ func WithEnablePrometheusStats(enablePrometheusStats bool) Option {
 // Prometheus metrics are disabled by default.
 func WithEnableConnectionBalancing(connectionBalancing bool) Option {
 	return func(po *crdbOptions) { po.enableConnectionBalancing = connectionBalancing }
+}
+
+// DebugAnalyzeBeforeStatistics signals to the Statistics method that it should
+// run Analyze on the database before returning statistics. This should only be
+// used for debug and testing.
+//
+// Disabled by default.
+func DebugAnalyzeBeforeStatistics() Option {
+	return func(po *crdbOptions) { po.analyzeBeforeStatistics = true }
 }

--- a/internal/datastore/crdb/stats.go
+++ b/internal/datastore/crdb/stats.go
@@ -3,39 +3,24 @@ package crdb
 import (
 	"context"
 	"fmt"
-	"math/rand"
-	"time"
+	"slices"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/jackc/pgx/v5"
-	"github.com/shopspring/decimal"
+	"github.com/rs/zerolog/log"
 
 	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
-	"github.com/authzed/spicedb/internal/datastore/revisions"
 	"github.com/authzed/spicedb/pkg/datastore"
 )
 
 const (
 	tableMetadata = "metadata"
 	colUniqueID   = "unique_id"
-
-	tableCounters = "relationship_estimate_counters"
-	colID         = "id"
-	colCount      = "count"
 )
 
 var (
-	queryReadUniqueID         = psql.Select(colUniqueID).From(tableMetadata)
-	queryRelationshipEstimate = fmt.Sprintf("SELECT COALESCE(SUM(%s), 0) FROM %s AS OF SYSTEM TIME follower_read_timestamp()", colCount, tableCounters)
-
-	upsertCounterQuery = psql.Insert(tableCounters).Columns(
-		colID,
-		colCount,
-	).Suffix(fmt.Sprintf("ON CONFLICT (%[1]s) DO UPDATE SET %[2]s = %[3]s.%[2]s + EXCLUDED.%[2]s RETURNING cluster_logical_timestamp()", colID, colCount, tableCounters))
-
-	rng = rand.NewSource(time.Now().UnixNano())
-
-	uniqueID string
+	queryReadUniqueID = psql.Select(colUniqueID).From(tableMetadata)
+	uniqueID          string
 )
 
 func (cds *crdbDatastore) Statistics(ctx context.Context) (datastore.Stats, error) {
@@ -52,14 +37,6 @@ func (cds *crdbDatastore) Statistics(ctx context.Context) (datastore.Stats, erro
 	}
 
 	var nsDefs []datastore.RevisionedNamespace
-	var relCount int64
-
-	if err := cds.readPool.QueryRowFunc(ctx, func(ctx context.Context, row pgx.Row) error {
-		return row.Scan(&relCount)
-	}, queryRelationshipEstimate); err != nil {
-		return datastore.Stats{}, fmt.Errorf("unable to read relationship count: %w", err)
-	}
-
 	if err := cds.readPool.BeginTxFunc(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly}, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, "SET TRANSACTION AS OF SYSTEM TIME follower_read_timestamp()")
 		if err != nil {
@@ -76,37 +53,85 @@ func (cds *crdbDatastore) Statistics(ctx context.Context) (datastore.Stats, erro
 		return datastore.Stats{}, err
 	}
 
-	// NOTE: this is a stop-gap solution to prevent panics in telemetry collection
-	if relCount < 0 {
-		relCount = 0
+	if cds.analyzeBeforeStatistics {
+		if err := cds.readPool.BeginTxFunc(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly}, func(tx pgx.Tx) error {
+			if _, err := tx.Exec(ctx, "ANALYZE "+tableTuple); err != nil {
+				return fmt.Errorf("unable to analyze tuple table: %w", err)
+			}
+
+			return nil
+		}); err != nil {
+			return datastore.Stats{}, err
+		}
+	}
+
+	var estimatedRelCount uint64
+	if err := cds.readPool.QueryFunc(ctx, func(ctx context.Context, rows pgx.Rows) error {
+		hasRows := false
+
+		for rows.Next() {
+			hasRows = true
+			values, err := rows.Values()
+			if err != nil {
+				log.Warn().Err(err).Msg("unable to read statistics")
+				return nil
+			}
+
+			// Find the row whose column_names contains the expected columns for the
+			// full relationship.
+			isFullRelationshipRow := false
+			for index, fd := range rows.FieldDescriptions() {
+				if fd.Name != "column_names" {
+					continue
+				}
+
+				columnNames, ok := values[index].([]any)
+				if !ok {
+					log.Warn().Msg("unable to read column names")
+					return nil
+				}
+
+				if slices.Contains(columnNames, "namespace") &&
+					slices.Contains(columnNames, "object_id") &&
+					slices.Contains(columnNames, "relation") &&
+					slices.Contains(columnNames, "userset_namespace") &&
+					slices.Contains(columnNames, "userset_object_id") &&
+					slices.Contains(columnNames, "userset_relation") {
+					isFullRelationshipRow = true
+					break
+				}
+			}
+
+			if !isFullRelationshipRow {
+				continue
+			}
+
+			// Read the estimated relationship count.
+			for index, fd := range rows.FieldDescriptions() {
+				if fd.Name != "row_count" {
+					continue
+				}
+
+				rowCount, ok := values[index].(int64)
+				if !ok {
+					log.Warn().Msg("unable to read row count")
+					return nil
+				}
+
+				estimatedRelCount = uint64(rowCount)
+				return nil
+			}
+		}
+
+		log.Warn().Bool("has-rows", hasRows).Msg("unable to find row count in statistics query result")
+		return nil
+	}, "SHOW STATISTICS FOR TABLE relation_tuple;"); err != nil {
+		return datastore.Stats{}, fmt.Errorf("unable to query unique estimated row count: %w", err)
 	}
 
 	return datastore.Stats{
 		UniqueID:                   uniqueID,
-		EstimatedRelationshipCount: uint64(relCount),
+		EstimatedRelationshipCount: estimatedRelCount,
 		ObjectTypeStatistics:       datastore.ComputeObjectTypeStats(nsDefs),
 	}, nil
-}
-
-func updateCounter(ctx context.Context, tx pgx.Tx, change int64) (datastore.Revision, error) {
-	counterID := make([]byte, 2)
-	// nolint:gosec
-	// G404 use of non cryptographically secure random number generator is not concern here,
-	// as this is only used to randomly distributed the counters across multiple rows and reduce write row contention
-	_, err := rand.New(rng).Read(counterID)
-	if err != nil {
-		return datastore.NoRevision, fmt.Errorf("unable to select random counter: %w", err)
-	}
-
-	sql, args, err := upsertCounterQuery.Values(counterID, change).ToSql()
-	if err != nil {
-		return datastore.NoRevision, fmt.Errorf("unable to prepare upsert counter sql: %w", err)
-	}
-
-	var timestamp decimal.Decimal
-	if err := tx.QueryRow(ctx, sql, args...).Scan(&timestamp); err != nil {
-		return datastore.NoRevision, fmt.Errorf("unable to executed upsert counter query: %w", err)
-	}
-
-	return revisions.NewForHLC(timestamp)
 }

--- a/internal/testserver/datastore/crdb.go
+++ b/internal/testserver/datastore/crdb.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	CRDBTestVersionTag = "v22.2.0"
+	CRDBTestVersionTag = "v23.1.16"
 
 	enableRangefeeds = `SET CLUSTER SETTING kv.rangefeed.enabled = true;`
 )

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -382,7 +382,6 @@ func newCRDBDatastore(ctx context.Context, opts Config) (datastore.Datastore, er
 		crdb.OverlapStrategy(opts.OverlapStrategy),
 		crdb.WatchBufferLength(opts.WatchBufferLength),
 		crdb.WatchBufferWriteTimeout(opts.WatchBufferWriteTimeout),
-		crdb.DisableStats(opts.DisableStats),
 		crdb.WithEnablePrometheusStats(opts.EnableDatastoreMetrics),
 		crdb.WithEnableConnectionBalancing(opts.EnableConnectionBalancing),
 		crdb.ConnectRate(opts.ConnectRate),

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -101,6 +101,7 @@ func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories) 
 	t.Run("TestCreateDeleteTouchTest", func(t *testing.T) { CreateDeleteTouchTest(t, tester) })
 	t.Run("TestCreateTouchDeleteTouchTest", func(t *testing.T) { CreateTouchDeleteTouchTest(t, tester) })
 	t.Run("TestTouchAlreadyExistingCaveated", func(t *testing.T) { TouchAlreadyExistingCaveatedTest(t, tester) })
+	t.Run("TestBulkDeleteRelationships", func(t *testing.T) { BulkDeleteRelationshipsTest(t, tester) })
 
 	t.Run("TestMultipleReadsInRWT", func(t *testing.T) { MultipleReadsInRWTTest(t, tester) })
 	t.Run("TestConcurrentWriteSerialization", func(t *testing.T) { ConcurrentWriteSerializationTest(t, tester) })

--- a/pkg/datastore/test/stats.go
+++ b/pkg/datastore/test/stats.go
@@ -34,7 +34,7 @@ func StatsTest(t *testing.T, tester DatastoreTester) {
 
 		if stats.EstimatedRelationshipCount == uint64(0) && retryCount > 0 {
 			// Sleep for a bit to get the stats table to update.
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 			continue
 		}
 


### PR DESCRIPTION
The existing call disables most optimizations on write transactions, but was necessary for legacy reasons. Following this change, any CRDB version 23 (or later) will use the newer, better call

Also changes the stats system to use the CRDB stats instead of a custom table