### PR TITLE
Debug migrate command in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,18 @@
         "serve"
       ],
       "envFile": "${workspaceFolder}/.env.local",
+    },
+    {
+      "name": "Migrate",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/spicedb/main.go",
+      "args": [
+        "migrate",
+        "head"
+      ],
+      "envFile": "${workspaceFolder}/.env.local",
     }
   ]
 }


### PR DESCRIPTION
Adds a VSCode launch config for debugging the `migrate` command.