### PR TITLE
Have caveat diffs properly check if an expression has changed

### DIFF
--- a/pkg/caveats/compile.go
+++ b/pkg/caveats/compile.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/authzed/cel-go/cel"
 	"github.com/authzed/cel-go/common"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
@@ -52,7 +53,9 @@ func (cc CompiledCaveat) Serialize() ([]byte, error) {
 		Name: cc.name,
 	}
 
-	return caveat.MarshalVT()
+	// TODO(jschorr): change back to MarshalVT once stable is supported.
+	// See: https://github.com/planetscale/vtprotobuf/pull/133
+	return proto.MarshalOptions{Deterministic: true}.Marshal(caveat)
 }
 
 // ReferencedParameters returns the names of the parameters referenced in the expression.

--- a/pkg/diff/caveats/diff.go
+++ b/pkg/diff/caveats/diff.go
@@ -34,10 +34,8 @@ const (
 	// ParameterTypeChanged indicates that the type of the parameter was changed.
 	ParameterTypeChanged DeltaType = "parameter-type-changed"
 
-	// CaveatExpressionMayHaveChanged indicates that the expression of the caveat *may* have changed.
-	// This uses a direct byte comparison which can return that a change occurred, even when it has
-	// not.
-	CaveatExpressionMayHaveChanged DeltaType = "expression-may-have-changed"
+	// CaveatExpressionChanged indicates that the expression of the caveat has changed.
+	CaveatExpressionChanged DeltaType = "expression-has-changed"
 )
 
 // Diff holds the diff between two caveats.
@@ -154,7 +152,7 @@ func DiffCaveats(existing *core.CaveatDefinition, updated *core.CaveatDefinition
 
 	if !bytes.Equal(existing.SerializedExpression, updated.SerializedExpression) {
 		deltas = append(deltas, Delta{
-			Type: CaveatExpressionMayHaveChanged,
+			Type: CaveatExpressionChanged,
 		})
 	}
 

--- a/pkg/diff/caveats/diff_test.go
+++ b/pkg/diff/caveats/diff_test.go
@@ -187,7 +187,7 @@ func TestCaveatDiff(t *testing.T) {
 				"false",
 			),
 			[]Delta{
-				{Type: CaveatExpressionMayHaveChanged},
+				{Type: CaveatExpressionChanged},
 			},
 		},
 		{
@@ -207,8 +207,64 @@ func TestCaveatDiff(t *testing.T) {
 				"someparam <= 1",
 			),
 			[]Delta{
-				{Type: CaveatExpressionMayHaveChanged},
+				{Type: CaveatExpressionChanged},
 			},
+		},
+		{
+			"third changed expression",
+			ns.MustCaveatDefinition(
+				caveats.MustEnvForVariables(map[string]types.VariableType{
+					"someparam": types.IntType,
+				}),
+				"somecaveat",
+				"someparam == 1",
+			),
+			ns.MustCaveatDefinition(
+				caveats.MustEnvForVariables(map[string]types.VariableType{
+					"someparam": types.IntType,
+				}),
+				"somecaveat",
+				"someparam == 2",
+			),
+			[]Delta{
+				{Type: CaveatExpressionChanged},
+			},
+		},
+		{
+			"unchanged expression",
+			ns.MustCaveatDefinition(
+				caveats.MustEnvForVariables(map[string]types.VariableType{
+					"someparam": types.IntType,
+				}),
+				"somecaveat",
+				"someparam == 1",
+			),
+			ns.MustCaveatDefinition(
+				caveats.MustEnvForVariables(map[string]types.VariableType{
+					"someparam": types.IntType,
+				}),
+				"somecaveat",
+				"someparam == 1",
+			),
+			[]Delta{},
+		},
+		{
+			"unchanged slightly more complex expression",
+			ns.MustCaveatDefinition(
+				caveats.MustEnvForVariables(map[string]types.VariableType{
+					"someparam": types.IntType,
+				}),
+				"somecaveat",
+				"someparam == {\"a\": 42}.a",
+			),
+			ns.MustCaveatDefinition(
+				caveats.MustEnvForVariables(map[string]types.VariableType{
+					"someparam": types.IntType,
+				}),
+				"somecaveat",
+				"someparam == {\"a\": 42}.a",
+			),
+			[]Delta{},
 		},
 	}
 


### PR DESCRIPTION
By making the serialized caveat expressions stable, the diff should only return a change now when the caveat expr's has actually changed, rather than pretty much always, thus reducing the storage for "changed" caveats

Fixes #1742

We should go back to MarshalVT once https://github.com/planetscale/vtprotobuf/pull/133 has merged