### PR TITLE
CheckBulkPermissions

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.1
 
 require (
-	github.com/authzed/authzed-go v0.10.2-0.20240206183056-781a5f5d1b3c
+	github.com/authzed/authzed-go v0.10.2-0.20240312180602-9b3947de5a3d
 	github.com/authzed/grpcutil v0.0.0-20240123092924-129dc0a6a6e1
 	github.com/authzed/spicedb v1.29.1
 	github.com/brianvoe/gofakeit/v6 v6.23.2

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -20,8 +20,8 @@ github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9 h1:goHVqTbFX3AIo0tzGr14pgfAW2ZfPChKO21Z9MGf/gk=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
-github.com/authzed/authzed-go v0.10.2-0.20240206183056-781a5f5d1b3c h1:w71KppS/+mCDkNXR8vmwXGVt/1dLt+axcIq+qK7f7To=
-github.com/authzed/authzed-go v0.10.2-0.20240206183056-781a5f5d1b3c/go.mod h1:bS4eeTw/ZpCunZHePrt1MAcvOggAwL8Djh8cx+CR33g=
+github.com/authzed/authzed-go v0.10.2-0.20240312180602-9b3947de5a3d h1:hzo0UIaYtLyJsEdCrM05k1k2YZHqPAyMpHL7rq37j5Q=
+github.com/authzed/authzed-go v0.10.2-0.20240312180602-9b3947de5a3d/go.mod h1:2cnND+OBSxz1DpVfaQBKtdobTiaX2qAlj7k9eNr/pM4=
 github.com/authzed/cel-go v0.17.5 h1:lfpkNrR99B5QRHg5qdG9oLu/kguVlZC68VJuMk8tH9Y=
 github.com/authzed/cel-go v0.17.5/go.mod h1:XL/zEq5hKGVF8aOdMbG7w+BQPihLjY2W8N+UIygDA2I=
 github.com/authzed/grpcutil v0.0.0-20240123092924-129dc0a6a6e1 h1:zBfQzia6Hz45pJBeURTrv1b6HezmejB6UmiGuBilHZM=

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/IBM/pgxpoolprometheus v1.1.1
 	github.com/Masterminds/squirrel v1.5.4
-	github.com/authzed/authzed-go v0.10.2-0.20240206183056-781a5f5d1b3c
+	github.com/authzed/authzed-go v0.10.2-0.20240312180602-9b3947de5a3d
 	github.com/authzed/cel-go v0.17.5
 	github.com/authzed/consistent v0.1.0
 	github.com/authzed/grpcutil v0.0.0-20240123092924-129dc0a6a6e1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/ashanbrown/forbidigo v1.6.0 h1:D3aewfM37Yb3pxHujIPSpTf6oQk9sc9WZi8ger
 github.com/ashanbrown/forbidigo v1.6.0/go.mod h1:Y8j9jy9ZYAEHXdu723cUlraTqbzjKF1MUyfOKL+AjcU=
 github.com/ashanbrown/makezero v1.1.1 h1:iCQ87C0V0vSyO+M9E/FZYbu65auqH0lnsOkf5FcB28s=
 github.com/ashanbrown/makezero v1.1.1/go.mod h1:i1bJLCRSCHOcOa9Y6MyF2FTfMZMFdHvxKHxgO5Z1axI=
-github.com/authzed/authzed-go v0.10.2-0.20240206183056-781a5f5d1b3c h1:w71KppS/+mCDkNXR8vmwXGVt/1dLt+axcIq+qK7f7To=
-github.com/authzed/authzed-go v0.10.2-0.20240206183056-781a5f5d1b3c/go.mod h1:bS4eeTw/ZpCunZHePrt1MAcvOggAwL8Djh8cx+CR33g=
+github.com/authzed/authzed-go v0.10.2-0.20240312180602-9b3947de5a3d h1:hzo0UIaYtLyJsEdCrM05k1k2YZHqPAyMpHL7rq37j5Q=
+github.com/authzed/authzed-go v0.10.2-0.20240312180602-9b3947de5a3d/go.mod h1:2cnND+OBSxz1DpVfaQBKtdobTiaX2qAlj7k9eNr/pM4=
 github.com/authzed/cel-go v0.17.5 h1:lfpkNrR99B5QRHg5qdG9oLu/kguVlZC68VJuMk8tH9Y=
 github.com/authzed/cel-go v0.17.5/go.mod h1:XL/zEq5hKGVF8aOdMbG7w+BQPihLjY2W8N+UIygDA2I=
 github.com/authzed/consistent v0.1.0 h1:tlh1wvKoRbjRhMm2P+X5WQQyR54SRoS4MyjLOg17Mp8=

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -385,7 +385,7 @@ func validateLookupResources(t *testing.T, vctx validationContext) {
 							requireSameSets(t, maps.Keys(accessibleResources), maps.Keys(resolvedResources))
 
 							// Ensure that every returned concrete object Checks directly.
-							bulkCheckItems := make([]*v1.BulkCheckPermissionRequestItem, 0, len(resolvedResources))
+							checkBulkItems := make([]*v1.CheckBulkPermissionsRequestItem, 0, len(resolvedResources))
 							expectedBulkPermissions := map[string]v1.CheckPermissionResponse_Permissionship{}
 
 							for _, resolvedResource := range resolvedResources {
@@ -420,7 +420,7 @@ func validateLookupResources(t *testing.T, vctx validationContext) {
 									permissionship,
 								)
 
-								bulkCheckItems = append(bulkCheckItems, &v1.BulkCheckPermissionRequestItem{
+								checkBulkItems = append(checkBulkItems, &v1.CheckBulkPermissionsRequestItem{
 									Resource: &v1.ObjectReference{
 										ObjectType: resourceRelation.Namespace,
 										ObjectId:   resolvedResource.ResourceObjectId,
@@ -437,8 +437,8 @@ func validateLookupResources(t *testing.T, vctx validationContext) {
 							}
 
 							// Ensure they are all found via bulk check as well.
-							results, err := vctx.serviceTester.BulkCheck(context.Background(),
-								bulkCheckItems,
+							results, err := vctx.serviceTester.CheckBulk(context.Background(),
+								checkBulkItems,
 								vctx.revision,
 							)
 							require.NoError(t, err)

--- a/internal/services/v1/bulkcheck.go
+++ b/internal/services/v1/bulkcheck.go
@@ -1,0 +1,251 @@
+package v1
+
+import (
+	"context"
+	"sync"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/jzelinskie/stringz"
+	"google.golang.org/grpc/status"
+
+	"github.com/authzed/spicedb/internal/dispatch"
+	"github.com/authzed/spicedb/internal/graph"
+	"github.com/authzed/spicedb/internal/graph/computed"
+	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
+	"github.com/authzed/spicedb/internal/middleware/usagemetrics"
+	"github.com/authzed/spicedb/internal/namespace"
+	"github.com/authzed/spicedb/internal/services/shared"
+	"github.com/authzed/spicedb/internal/taskrunner"
+	"github.com/authzed/spicedb/pkg/genutil"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
+	"github.com/authzed/spicedb/pkg/genutil/slicez"
+	"github.com/authzed/spicedb/pkg/middleware/consistency"
+	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
+)
+
+// bulkChecker contains the logic to allow ExperimentalService/BulkCheckPermission and
+// PermissionsService/CheckBulkPermissions to share the same implementation.
+type bulkChecker struct {
+	maxAPIDepth          uint32
+	maxCaveatContextSize int
+	maxConcurrency       uint16
+
+	dispatch dispatch.Dispatcher
+}
+
+func (bc *bulkChecker) checkBulkPermissions(ctx context.Context, req *v1.CheckBulkPermissionsRequest) (*v1.CheckBulkPermissionsResponse, error) {
+	atRevision, checkedAt, err := consistency.RevisionFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(req.Items) > maxBulkCheckCount {
+		return nil, NewExceedsMaximumChecksErr(uint64(len(req.Items)), maxBulkCheckCount)
+	}
+
+	// Compute a hash for each requested item and record its index(es) for the items, to be used for sorting of results.
+	itemCount, err := genutil.EnsureUInt32(len(req.Items))
+	if err != nil {
+		return nil, err
+	}
+
+	itemIndexByHash := mapz.NewMultiMapWithCap[string, int](itemCount)
+	for index, item := range req.Items {
+		itemHash, err := computeCheckBulkPermissionsItemHash(item)
+		if err != nil {
+			return nil, err
+		}
+
+		itemIndexByHash.Add(itemHash, index)
+	}
+
+	// Identify checks with same permission+subject over different resources and group them. This is doable because
+	// the dispatching system already internally supports this kind of batching for performance.
+	groupedItems, err := groupItems(ctx, groupingParameters{
+		atRevision:           atRevision,
+		maxCaveatContextSize: bc.maxCaveatContextSize,
+		maximumAPIDepth:      bc.maxAPIDepth,
+	}, req.Items)
+	if err != nil {
+		return nil, err
+	}
+
+	bulkResponseMutex := sync.Mutex{}
+
+	tr := taskrunner.NewPreloadedTaskRunner(ctx, bc.maxConcurrency, len(groupedItems))
+
+	respMetadata := &dispatchv1.ResponseMeta{
+		DispatchCount:       1,
+		CachedDispatchCount: 0,
+		DepthRequired:       1,
+		DebugInfo:           nil,
+	}
+	usagemetrics.SetInContext(ctx, respMetadata)
+
+	orderedPairs := make([]*v1.CheckBulkPermissionsPair, len(req.Items))
+
+	addPair := func(pair *v1.CheckBulkPermissionsPair) error {
+		pairItemHash, err := computeCheckBulkPermissionsItemHash(pair.Request)
+		if err != nil {
+			return err
+		}
+
+		found, ok := itemIndexByHash.Get(pairItemHash)
+		if !ok {
+			return spiceerrors.MustBugf("missing expected item hash")
+		}
+
+		for _, index := range found {
+			orderedPairs[index] = pair
+		}
+
+		return nil
+	}
+
+	appendResultsForError := func(params *computed.CheckParameters, resourceIDs []string, err error) error {
+		rewritten := shared.RewriteError(ctx, err, &shared.ConfigForErrors{
+			MaximumAPIDepth: bc.maxAPIDepth,
+		})
+		statusResp, ok := status.FromError(rewritten)
+		if !ok {
+			// If error is not a gRPC Status, fail the entire bulk check request.
+			return err
+		}
+
+		bulkResponseMutex.Lock()
+		defer bulkResponseMutex.Unlock()
+
+		for _, resourceID := range resourceIDs {
+			reqItem, err := requestItemFromResourceAndParameters(params, resourceID)
+			if err != nil {
+				return err
+			}
+
+			if err := addPair(&v1.CheckBulkPermissionsPair{
+				Request: reqItem,
+				Response: &v1.CheckBulkPermissionsPair_Error{
+					Error: statusResp.Proto(),
+				},
+			}); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	appendResultsForCheck := func(params *computed.CheckParameters, resourceIDs []string, metadata *dispatchv1.ResponseMeta, results map[string]*dispatchv1.ResourceCheckResult) error {
+		bulkResponseMutex.Lock()
+		defer bulkResponseMutex.Unlock()
+
+		for _, resourceID := range resourceIDs {
+			reqItem, err := requestItemFromResourceAndParameters(params, resourceID)
+			if err != nil {
+				return err
+			}
+
+			if err := addPair(&v1.CheckBulkPermissionsPair{
+				Request:  reqItem,
+				Response: pairItemFromCheckResult(results[resourceID]),
+			}); err != nil {
+				return err
+			}
+		}
+
+		respMetadata.DispatchCount += metadata.DispatchCount
+		respMetadata.CachedDispatchCount += metadata.CachedDispatchCount
+		return nil
+	}
+
+	for _, group := range groupedItems {
+		group := group
+
+		slicez.ForEachChunk(group.resourceIDs, MaxBulkCheckDispatchChunkSize, func(resourceIDs []string) {
+			tr.Add(func(ctx context.Context) error {
+				ds := datastoremw.MustFromContext(ctx).SnapshotReader(atRevision)
+
+				// Ensure the check namespaces and relations are valid.
+				err := namespace.CheckNamespaceAndRelations(ctx,
+					[]namespace.TypeAndRelationToCheck{
+						{
+							NamespaceName: group.params.ResourceType.Namespace,
+							RelationName:  group.params.ResourceType.Relation,
+							AllowEllipsis: false,
+						},
+						{
+							NamespaceName: group.params.Subject.Namespace,
+							RelationName:  stringz.DefaultEmpty(group.params.Subject.Relation, graph.Ellipsis),
+							AllowEllipsis: true,
+						},
+					}, ds)
+				if err != nil {
+					return appendResultsForError(group.params, resourceIDs, err)
+				}
+
+				// Call bulk check to compute the check result(s) for the resource ID(s).
+				rcr, metadata, err := computed.ComputeBulkCheck(ctx, bc.dispatch, *group.params, resourceIDs)
+				if err != nil {
+					return appendResultsForError(group.params, resourceIDs, err)
+				}
+
+				return appendResultsForCheck(group.params, resourceIDs, metadata, rcr)
+			})
+		})
+	}
+
+	// Run the checks in parallel.
+	if err := tr.StartAndWait(); err != nil {
+		return nil, err
+	}
+
+	return &v1.CheckBulkPermissionsResponse{CheckedAt: checkedAt, Pairs: orderedPairs}, nil
+}
+
+func toCheckBulkPermissionsRequest(req *v1.BulkCheckPermissionRequest) *v1.CheckBulkPermissionsRequest {
+	items := make([]*v1.CheckBulkPermissionsRequestItem, len(req.Items))
+	for i, item := range req.Items {
+		items[i] = &v1.CheckBulkPermissionsRequestItem{
+			Resource:   item.Resource,
+			Permission: item.Permission,
+			Subject:    item.Subject,
+			Context:    item.Context,
+		}
+	}
+
+	return &v1.CheckBulkPermissionsRequest{Items: items}
+}
+
+func toBulkCheckPermissionResponse(resp *v1.CheckBulkPermissionsResponse) *v1.BulkCheckPermissionResponse {
+	pairs := make([]*v1.BulkCheckPermissionPair, len(resp.Pairs))
+	for i, pair := range resp.Pairs {
+		pairs[i] = &v1.BulkCheckPermissionPair{}
+		pairs[i].Request = &v1.BulkCheckPermissionRequestItem{
+			Resource:   pair.Request.Resource,
+			Permission: pair.Request.Permission,
+			Subject:    pair.Request.Subject,
+			Context:    pair.Request.Context,
+		}
+
+		switch t := pair.Response.(type) {
+		case *v1.CheckBulkPermissionsPair_Item:
+			pairs[i].Response = &v1.BulkCheckPermissionPair_Item{
+				Item: &v1.BulkCheckPermissionResponseItem{
+					Permissionship:    t.Item.Permissionship,
+					PartialCaveatInfo: t.Item.PartialCaveatInfo,
+				},
+			}
+		case *v1.CheckBulkPermissionsPair_Error:
+			pairs[i].Response = &v1.BulkCheckPermissionPair_Error{
+				Error: t.Error,
+			}
+		default:
+			panic("unknown CheckBulkPermissionResponse pair response type")
+		}
+	}
+
+	return &v1.BulkCheckPermissionResponse{
+		CheckedAt: resp.CheckedAt,
+		Pairs:     pairs,
+	}
+}

--- a/internal/services/v1/grouping.go
+++ b/internal/services/v1/grouping.go
@@ -23,13 +23,13 @@ type groupingParameters struct {
 	maxCaveatContextSize int
 }
 
-// groupItems takes a slice of BulkCheckPermissionRequestItem and groups them based
+// groupItems takes a slice of CheckBulkPermissionsRequestItem and groups them based
 // on using the same permission, subject type, subject id, and caveat.
-func groupItems(ctx context.Context, params groupingParameters, items []*v1.BulkCheckPermissionRequestItem) (map[string]*groupedCheckParameters, error) {
+func groupItems(ctx context.Context, params groupingParameters, items []*v1.CheckBulkPermissionsRequestItem) (map[string]*groupedCheckParameters, error) {
 	res := make(map[string]*groupedCheckParameters)
 
 	for _, item := range items {
-		hash, err := computeBulkCheckPermissionItemHashWithoutResourceID(item)
+		hash, err := computeCheckBulkPermissionsItemHashWithoutResourceID(item)
 		if err != nil {
 			return nil, err
 		}
@@ -41,7 +41,7 @@ func groupItems(ctx context.Context, params groupingParameters, items []*v1.Bulk
 			}
 
 			res[hash] = &groupedCheckParameters{
-				params:      checkParametersFromBulkCheckPermissionRequestItem(item, params, caveatContext),
+				params:      checkParametersFromCheckBulkPermissionsRequestItem(item, params, caveatContext),
 				resourceIDs: []string{item.Resource.ObjectId},
 			}
 		} else {
@@ -52,8 +52,8 @@ func groupItems(ctx context.Context, params groupingParameters, items []*v1.Bulk
 	return res, nil
 }
 
-func checkParametersFromBulkCheckPermissionRequestItem(
-	bc *v1.BulkCheckPermissionRequestItem,
+func checkParametersFromCheckBulkPermissionsRequestItem(
+	bc *v1.CheckBulkPermissionsRequestItem,
 	params groupingParameters,
 	caveatContext map[string]any,
 ) *computed.CheckParameters {

--- a/internal/services/v1/grouping_test.go
+++ b/internal/services/v1/grouping_test.go
@@ -179,10 +179,10 @@ func TestGroupItems(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			var items []*v1.BulkCheckPermissionRequestItem
+			var items []*v1.CheckBulkPermissionsRequestItem
 			for _, r := range tt.requests {
 				rel := tuple.ParseRel(r)
-				item := &v1.BulkCheckPermissionRequestItem{
+				item := &v1.CheckBulkPermissionsRequestItem{
 					Resource:   rel.Resource,
 					Permission: rel.Relation,
 					Subject:    rel.Subject,
@@ -256,7 +256,7 @@ func TestCaveatContextSizeLimitIsEnforced(t *testing.T) {
 		maximumAPIDepth:      1,
 	}
 	rel := tuple.ParseRel(`document:1#view@user:1[somecaveat:{"hey": "bud"}]`)
-	items := []*v1.BulkCheckPermissionRequestItem{
+	items := []*v1.CheckBulkPermissionsRequestItem{
 		{
 			Resource:   rel.Resource,
 			Permission: rel.Relation,

--- a/internal/services/v1/hash.go
+++ b/internal/services/v1/hash.go
@@ -11,8 +11,8 @@ import (
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
-func computeBulkCheckPermissionItemHashWithoutResourceID(req *v1.BulkCheckPermissionRequestItem) (string, error) {
-	return computeCallHash("v1.bulkcheckpermissionrequestitem", nil, map[string]any{
+func computeCheckBulkPermissionsItemHashWithoutResourceID(req *v1.CheckBulkPermissionsRequestItem) (string, error) {
+	return computeCallHash("v1.checkbulkpermissionsrequestitem", nil, map[string]any{
 		"resource-type":    req.Resource.ObjectType,
 		"permission":       req.Permission,
 		"subject-type":     req.Subject.Object.ObjectType,
@@ -22,8 +22,8 @@ func computeBulkCheckPermissionItemHashWithoutResourceID(req *v1.BulkCheckPermis
 	})
 }
 
-func computeBulkCheckPermissionItemHash(req *v1.BulkCheckPermissionRequestItem) (string, error) {
-	return computeCallHash("v1.bulkcheckpermissionrequestitem", nil, map[string]any{
+func computeCheckBulkPermissionsItemHash(req *v1.CheckBulkPermissionsRequestItem) (string, error) {
+	return computeCallHash("v1.checkbulkpermissionsrequestitem", nil, map[string]any{
 		"resource-type":    req.Resource.ObjectType,
 		"resource-id":      req.Resource.ObjectId,
 		"permission":       req.Permission,

--- a/internal/services/v1/hash_test.go
+++ b/internal/services/v1/hash_test.go
@@ -398,15 +398,15 @@ func TestLRHashStability(t *testing.T) {
 	}
 }
 
-func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
+func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 	tcs := []struct {
 		name         string
-		request      *v1.BulkCheckPermissionRequestItem
+		request      *v1.CheckBulkPermissionsRequestItem
 		expectedHash string
 	}{
 		{
 			"basic bulk check item",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -419,11 +419,11 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"4fe0404757f60c7b",
+			"f518629690bd9dc0",
 		},
 		{
 			"different resource ID, should still be the same hash",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid2",
@@ -436,11 +436,11 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"4fe0404757f60c7b",
+			"f518629690bd9dc0",
 		},
 		{
 			"basic bulk check item - transcribed letter",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resourc",
 					ObjectId:   "esomeid",
@@ -453,11 +453,11 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"9aa5ad05571cf7aa",
+			"60f1e177297e915e",
 		},
 		{
 			"different resource type",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource2",
 					ObjectId:   "someid",
@@ -470,11 +470,11 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"7e48b1946d209d19",
+			"5117abaee3adf638",
 		},
 		{
 			"different permission",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -487,11 +487,11 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"55001a108b0e1857",
+			"716f7be27e600292",
 		},
 		{
 			"different subject type",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -504,11 +504,11 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"f913ec03a38259ff",
+			"7cb5945314ccbdce",
 		},
 		{
 			"different subject id",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -521,11 +521,11 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"70ff03c2e3f8598c",
+			"b24ecacf87fd0bb8",
 		},
 		{
 			"different subject relation",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -539,11 +539,11 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 					OptionalRelation: "foo",
 				},
 			},
-			"0bd57e3aa9d48e1e",
+			"ee8c34ab206c80d7",
 		},
 		{
 			"with context",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -564,11 +564,11 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 					return s
 				}(),
 			},
-			"f7ae307d940c4984",
+			"7a5b1fec3cbed446",
 		},
 		{
 			"with different context",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -589,7 +589,7 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 					return s
 				}(),
 			},
-			"d0ce3e8b8a7b8b5a",
+			"f17da513a6207c30",
 		},
 	}
 
@@ -599,22 +599,22 @@ func TestBulkCheckPermissionItemWithoutResourceIDHashStability(t *testing.T) {
 			verr := tc.request.Validate()
 			require.NoError(t, verr)
 
-			hash, err := computeBulkCheckPermissionItemHashWithoutResourceID(tc.request)
+			hash, err := computeCheckBulkPermissionsItemHashWithoutResourceID(tc.request)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedHash, hash)
 		})
 	}
 }
 
-func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
+func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 	tcs := []struct {
 		name         string
-		request      *v1.BulkCheckPermissionRequestItem
+		request      *v1.CheckBulkPermissionsRequestItem
 		expectedHash string
 	}{
 		{
 			"basic bulk check item",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -627,11 +627,11 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"29a0970e6e288823",
+			"5edbb3bbb8079754",
 		},
 		{
 			"different resource ID, should be a different hash",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid2",
@@ -644,11 +644,11 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"994a3681c5ed2ac3",
+			"e6711064500e65ba",
 		},
 		{
 			"basic bulk check item - transcribed letter",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resourc",
 					ObjectId:   "esomeid",
@@ -661,11 +661,11 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"ba4cdd3258637028",
+			"8cda00b7188572b7",
 		},
 		{
 			"different resource type",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource2",
 					ObjectId:   "someid",
@@ -678,11 +678,11 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"dbc6b81a0746e406",
+			"51df43a69e51d3b0",
 		},
 		{
 			"different permission",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -695,11 +695,11 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"cbb6d9b04f0f03bf",
+			"62aaa50b2821130d",
 		},
 		{
 			"different subject type",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -712,11 +712,11 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"ed3c04de90075403",
+			"82a445d3ffc0823a",
 		},
 		{
 			"different subject id",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -729,11 +729,11 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"3042f00fc2bb4dbc",
+			"d3d624a310fa7781",
 		},
 		{
 			"different subject relation",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -747,11 +747,11 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 					OptionalRelation: "foo",
 				},
 			},
-			"4839071c4b9804ac",
+			"a9d96f0572caef89",
 		},
 		{
 			"with context",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -772,11 +772,11 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 					return s
 				}(),
 			},
-			"ecd2be822056deff",
+			"94dea3fccff039ed",
 		},
 		{
 			"with different context",
-			&v1.BulkCheckPermissionRequestItem{
+			&v1.CheckBulkPermissionsRequestItem{
 				Resource: &v1.ObjectReference{
 					ObjectType: "resource",
 					ObjectId:   "someid",
@@ -797,7 +797,7 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 					return s
 				}(),
 			},
-			"bc0be3336cc9ae97",
+			"7ffdedbe12d578ee",
 		},
 	}
 
@@ -807,7 +807,7 @@ func TestBulkCheckPermissionItemWIDHashStability(t *testing.T) {
 			verr := tc.request.Validate()
 			require.NoError(t, verr)
 
-			hash, err := computeBulkCheckPermissionItemHash(tc.request)
+			hash, err := computeCheckBulkPermissionsItemHash(tc.request)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedHash, hash)
 		})

--- a/internal/services/v1/metadata_test.go
+++ b/internal/services/v1/metadata_test.go
@@ -48,6 +48,25 @@ func TestAllMethodsReturnMetadata(t *testing.T) {
 				require.NoError(t, err)
 				return trailer
 			},
+			"CheckBulkPermissions": func(t *testing.T, client v1.PermissionsServiceClient) metadata.MD {
+				var trailer metadata.MD
+				_, err := client.CheckBulkPermissions(ctx, &v1.CheckBulkPermissionsRequest{
+					Consistency: &v1.Consistency{
+						Requirement: &v1.Consistency_AtLeastAsFresh{
+							AtLeastAsFresh: zedtoken.MustNewFromRevision(revision),
+						},
+					},
+					Items: []*v1.CheckBulkPermissionsRequestItem{
+						{
+							Resource:   obj("document", "masterplan"),
+							Permission: "view",
+							Subject:    sub("user", "eng_lead", ""),
+						},
+					},
+				}, grpc.Trailer(&trailer))
+				require.NoError(t, err)
+				return trailer
+			},
 			"DeleteRelationships": func(t *testing.T, client v1.PermissionsServiceClient) metadata.MD {
 				var trailer metadata.MD
 				_, err := client.DeleteRelationships(ctx, &v1.DeleteRelationshipsRequest{


### PR DESCRIPTION
Adds the `PermissionsService/CheckBulkPermissions` API method. This promotes the existing `ExperimentalService/BulkCheckPermission` API out of the experimental service, but does not remove the old method to ensure backwards compatibility.

To reduce code duplication, this refactors the bulk permission checking logic into a shared component that can be used by both the old and new methods. The old method performs protobuf message conversion on the input, passes the inputs to the shared method, and then converts the output.

Resolves #1791 