### PR TITLE
fixes merge queue not supporting CodeQL

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -14,11 +14,7 @@ jobs:
 
   codeql:
     name: "CodeQL Analyze"
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners
-    # Consider using larger runners for possible analysis time improvements.
+    if: "${{ github.event_name == 'pull_request' }}" # workaround to https://github.com/github/codeql-action/issues/1537
     runs-on: "buildjet-8vcpu-ubuntu-2204"
     timeout-minutes: "${{ (matrix.language == 'swift' && 120) || 360 }}"
     permissions:
@@ -33,50 +29,11 @@ jobs:
       fail-fast: false
       matrix:
         language: ["go"]
-        # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
-        # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-      - name: "Checkout repository"
-        uses: "actions/checkout@v4"
-
-      # Uses centralized Go toolchain version.
+      - uses: "actions/checkout@v4"
       - uses: "authzed/actions/setup-go@main"
-
-      # Initializes the CodeQL tools for scanning.
-      - name: "Initialize CodeQL"
-        uses: "github/codeql-action/init@v3"
-        with:
-          languages: "${{ matrix.language }}"
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
-
-
-      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: "Autobuild"
-        uses: "github/codeql-action/autobuild@v3"
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-      # - run: |
-      #     echo "Run, Build Application using script"
-      #     ./location_of_script_within_repo/buildscript.sh
-
-      - name: "Perform CodeQL Analysis"
-        uses: "github/codeql-action/analyze@v3"
-        with:
-          category: "/language:${{matrix.language}}"
+      - uses: "authzed/actions/codeql@main"
 
   trivy:
     name: "Analyze Code and Docker Image with Trivvy"


### PR DESCRIPTION
see https://github.com/github/codeql-action/issues/1572

also comes full circle and uses centralized
authzed codeQL action since the previous
attempt didn't add anything new other than
checkout v4