### PR TITLE
do not return backward incompatible `--explain` debug info in trailer

### DIFF
--- a/internal/services/v1/debug_test.go
+++ b/internal/services/v1/debug_test.go
@@ -482,7 +482,8 @@ func TestCheckPermissionWithDebug(t *testing.T) {
 					encodedDebugInfo, err := responsemeta.GetResponseTrailerMetadataOrNil(trailer, responsemeta.DebugInformation)
 					req.NoError(err)
 
-					req.NotNil(encodedDebugInfo)
+					// DebugInfo No longer comes as part of the trailer
+					req.Nil(encodedDebugInfo)
 
 					debugInfo := checkResp.DebugTrace
 					req.NotEmpty(debugInfo.SchemaUsed)

--- a/internal/services/v1/permissions.go
+++ b/internal/services/v1/permissions.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/authzed/authzed-go/pkg/requestmeta"
-	"github.com/authzed/authzed-go/pkg/responsemeta"
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/jzelinskie/stringz"
 	"google.golang.org/grpc/codes"
@@ -106,14 +105,6 @@ func (ps *permissionServer) CheckPermission(ctx context.Context, req *v1.CheckPe
 			return nil, ps.rewriteError(ctx, cerr)
 		}
 		debugTrace = converted
-
-		// TODO(jschorr): Remove this once the trailer is not longer used by anyone.
-		serr := responsemeta.SetResponseTrailerMetadata(ctx, map[responsemeta.ResponseMetadataTrailerKey]string{
-			responsemeta.DebugInformation: `{"note": "debug information has been moved into the response object. See https://spicedb.dev/d/check-traces"}`,
-		})
-		if serr != nil {
-			return nil, ps.rewriteError(ctx, serr)
-		}
 	}
 
 	if err != nil {

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -293,7 +293,7 @@ func TestCheckPermissions(t *testing.T) {
 								require.NoError(err)
 
 								if debug {
-									require.NotNil(encodedDebugInfo)
+									require.Nil(encodedDebugInfo)
 
 									debugInfo := checkResp.DebugTrace
 									require.NotNil(debugInfo.Check)
@@ -342,7 +342,8 @@ func TestCheckPermissionWithDebugInfo(t *testing.T) {
 	encodedDebugInfo, err := responsemeta.GetResponseTrailerMetadataOrNil(trailer, responsemeta.DebugInformation)
 	require.NoError(err)
 
-	require.NotNil(encodedDebugInfo)
+	// debug info is returned empty to make sure clients are not broken with backward incompatible payloads
+	require.Nil(encodedDebugInfo)
 
 	debugInfo := checkResp.DebugTrace
 	require.GreaterOrEqual(len(debugInfo.Check.GetSubProblems().Traces), 1)


### PR DESCRIPTION
Previous change caused `zed` to fail to parse `--explain` trailer. This means new release causes clients to miss debug info trailer, but seems better than breaking them with an incompatible message.