### PR TITLE
move to ubicloud runners for extra concurrency

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,7 +15,7 @@ env:
   DOCKERHUB_PUBLIC_USER: "spicedbgithubactions"
 jobs:
   paths-filter:
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     outputs:
       codechange: "${{ steps.code-filter.outputs.codechange }}"
       protochange: "${{ steps.proto-filter.outputs.protochange }}"
@@ -45,7 +45,7 @@ jobs:
               - "go.mod"
   build:
     name: "Build Binary & Image"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-4"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -62,7 +62,7 @@ jobs:
 
   unit:
     name: "Unit"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-4"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -74,7 +74,7 @@ jobs:
 
   integration:
     name: "Integration Tests"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-4"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -90,7 +90,7 @@ jobs:
 
   datastore:
     name: "Datastore Tests"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-4"
     needs: "paths-filter"
     strategy:
       fail-fast: false
@@ -120,7 +120,7 @@ jobs:
 
   e2e:
     name: "E2E"
-    runs-on: "buildjet-8vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-8"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -171,7 +171,7 @@ jobs:
           path: "e2e/newenemy/*.log"
   analyzers-unit-tests:
     name: "Analyzers Unit Tests"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -185,7 +185,7 @@ jobs:
         run: "go run mage.go test:analyzers"
   development:
     name: "WASM Tests"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -197,7 +197,7 @@ jobs:
 
   protobuf:
     name: "Generate Protobufs"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.protochange == 'true'

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   cla:
     name: "Check Signature"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     steps:
       - uses: "authzed/actions/cla-check@main"
         with:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       - "checks_requested"
 jobs:
   triage:
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     steps:
       - uses: "actions/labeler@v3"
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   go-lint:
     name: "Lint Go"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-4"
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"
@@ -26,7 +26,7 @@ jobs:
 
   extra-lint:
     name: "Lint YAML & Markdown"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     steps:
       - uses: "actions/checkout@v3"
       - name: "Lint Everything Else"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -15,7 +15,7 @@ jobs:
   codeql:
     name: "CodeQL Analyze"
     if: "${{ github.event_name == 'pull_request' }}" # workaround to https://github.com/github/codeql-action/issues/1537
-    runs-on: "buildjet-8vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-8"
     timeout-minutes: "${{ (matrix.language == 'swift' && 120) || 360 }}"
     permissions:
       # required for all workflows
@@ -37,7 +37,7 @@ jobs:
 
   trivy:
     name: "Analyze Code and Docker Image with Trivvy"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/setup-go@main"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     name: "Build WASM"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     steps:
       - uses: "actions/checkout@v3"
         with:


### PR DESCRIPTION
Moves GH Action runner from BuildJet to Ubicloud which gives us:
- cheaper rates
- more concurrency