### PR TITLE
Import request ID metadata key from `authzed-go`

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.1
 
 require (
-	github.com/authzed/authzed-go v0.11.1
+	github.com/authzed/authzed-go v0.11.2-0.20240320204618-9622b72a72c6
 	github.com/authzed/grpcutil v0.0.0-20240123092924-129dc0a6a6e1
 	github.com/authzed/spicedb v1.29.5
 	github.com/brianvoe/gofakeit/v6 v6.23.2

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -22,8 +22,8 @@ github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9 h1:goHVqTbFX3AIo0tzGr14pgfAW2ZfPChKO21Z9MGf/gk=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
-github.com/authzed/authzed-go v0.11.1 h1:N5CoDgF3Y28oESncviWEa7quGcrpXwe2KbYR4WCeg0M=
-github.com/authzed/authzed-go v0.11.1/go.mod h1:w3Q8IbTR2raCDGIWCj2UHXxhQuhmpRPYNRutZjgUkXM=
+github.com/authzed/authzed-go v0.11.2-0.20240320204618-9622b72a72c6 h1:zpdDybjx+3fyTf7UU2F6y/rkZuiylhUcNhkvewqn2Gs=
+github.com/authzed/authzed-go v0.11.2-0.20240320204618-9622b72a72c6/go.mod h1:w3Q8IbTR2raCDGIWCj2UHXxhQuhmpRPYNRutZjgUkXM=
 github.com/authzed/cel-go v0.17.5 h1:lfpkNrR99B5QRHg5qdG9oLu/kguVlZC68VJuMk8tH9Y=
 github.com/authzed/cel-go v0.17.5/go.mod h1:XL/zEq5hKGVF8aOdMbG7w+BQPihLjY2W8N+UIygDA2I=
 github.com/authzed/grpcutil v0.0.0-20240123092924-129dc0a6a6e1 h1:zBfQzia6Hz45pJBeURTrv1b6HezmejB6UmiGuBilHZM=

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/IBM/pgxpoolprometheus v1.1.1
 	github.com/Masterminds/squirrel v1.5.4
-	github.com/authzed/authzed-go v0.11.1
+	github.com/authzed/authzed-go v0.11.2-0.20240320204618-9622b72a72c6
 	github.com/authzed/cel-go v0.17.5
 	github.com/authzed/consistent v0.1.0
 	github.com/authzed/grpcutil v0.0.0-20240123092924-129dc0a6a6e1

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/ashanbrown/forbidigo v1.6.0 h1:D3aewfM37Yb3pxHujIPSpTf6oQk9sc9WZi8ger
 github.com/ashanbrown/forbidigo v1.6.0/go.mod h1:Y8j9jy9ZYAEHXdu723cUlraTqbzjKF1MUyfOKL+AjcU=
 github.com/ashanbrown/makezero v1.1.1 h1:iCQ87C0V0vSyO+M9E/FZYbu65auqH0lnsOkf5FcB28s=
 github.com/ashanbrown/makezero v1.1.1/go.mod h1:i1bJLCRSCHOcOa9Y6MyF2FTfMZMFdHvxKHxgO5Z1axI=
-github.com/authzed/authzed-go v0.11.1 h1:N5CoDgF3Y28oESncviWEa7quGcrpXwe2KbYR4WCeg0M=
-github.com/authzed/authzed-go v0.11.1/go.mod h1:w3Q8IbTR2raCDGIWCj2UHXxhQuhmpRPYNRutZjgUkXM=
+github.com/authzed/authzed-go v0.11.2-0.20240320204618-9622b72a72c6 h1:zpdDybjx+3fyTf7UU2F6y/rkZuiylhUcNhkvewqn2Gs=
+github.com/authzed/authzed-go v0.11.2-0.20240320204618-9622b72a72c6/go.mod h1:w3Q8IbTR2raCDGIWCj2UHXxhQuhmpRPYNRutZjgUkXM=
 github.com/authzed/cel-go v0.17.5 h1:lfpkNrR99B5QRHg5qdG9oLu/kguVlZC68VJuMk8tH9Y=
 github.com/authzed/cel-go v0.17.5/go.mod h1:XL/zEq5hKGVF8aOdMbG7w+BQPihLjY2W8N+UIygDA2I=
 github.com/authzed/consistent v0.1.0 h1:tlh1wvKoRbjRhMm2P+X5WQQyR54SRoS4MyjLOg17Mp8=

--- a/pkg/middleware/requestid/requestid.go
+++ b/pkg/middleware/requestid/requestid.go
@@ -5,6 +5,7 @@ import (
 
 	log "github.com/authzed/spicedb/internal/logging"
 
+	"github.com/authzed/authzed-go/pkg/requestmeta"
 	"github.com/authzed/authzed-go/pkg/responsemeta"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/rs/xid"
@@ -12,8 +13,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// MetadataKey is the key in which request IDs are passed to metadata.
-const MetadataKey = "x-request-id"
+const metadataKey = string(requestmeta.RequestIDKey)
 
 // Option instances control how the middleware is initialized.
 type Option func(*handleRequestID)
@@ -47,7 +47,7 @@ func (r *handleRequestID) ServerReporter(ctx context.Context, _ interceptors.Cal
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
 		var requestIDs []string
-		requestIDs, haveRequestID = md[MetadataKey]
+		requestIDs, haveRequestID = md[metadataKey]
 		if haveRequestID {
 			requestID = requestIDs[0]
 		}
@@ -61,12 +61,12 @@ func (r *handleRequestID) ServerReporter(ctx context.Context, _ interceptors.Cal
 			md = metadata.New(nil)
 		}
 
-		md.Set(MetadataKey, requestID)
+		md.Set(metadataKey, requestID)
 		ctx = metadata.NewIncomingContext(ctx, md)
 	}
 
 	if haveRequestID {
-		ctx = metadata.AppendToOutgoingContext(ctx, MetadataKey, requestID)
+		ctx = metadata.AppendToOutgoingContext(ctx, metadataKey, requestID)
 		err := responsemeta.SetResponseHeaderMetadata(ctx, map[responsemeta.ResponseMetadataHeaderKey]string{
 			responsemeta.RequestID: requestID,
 		})


### PR DESCRIPTION
Aligns the code with how we import other gRPC metadata keys from `authzed-go`.