### PR TITLE
Improve request-id propagation

### DIFF
--- a/internal/graph/context.go
+++ b/internal/graph/context.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/authzed/spicedb/internal/logging"
 	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
+	"github.com/authzed/spicedb/pkg/middleware/requestid"
 )
 
 // branchContext returns a context disconnected from the parent context, but populated with the datastore.
@@ -25,6 +26,8 @@ func branchContext(ctx context.Context) (context.Context, func(cancelErr error))
 	if loggerFromContext != nil {
 		detachedContext = loggerFromContext.WithContext(detachedContext)
 	}
+
+	detachedContext = requestid.PropagateIfExists(ctx, detachedContext)
 
 	return context.WithCancelCause(detachedContext)
 }

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -41,6 +41,7 @@ import (
 	datastorecfg "github.com/authzed/spicedb/pkg/cmd/datastore"
 	"github.com/authzed/spicedb/pkg/cmd/util"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/middleware/requestid"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
@@ -276,6 +277,12 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 			combineddispatch.GrpcDialOpts(
 				grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 				grpc.WithDefaultServiceConfig(hashringConfigJSON),
+				grpc.WithChainUnaryInterceptor(
+					requestid.UnaryClientInterceptor(),
+				),
+				grpc.WithChainStreamInterceptor(
+					requestid.StreamClientInterceptor(),
+				),
 			),
 			combineddispatch.MetricsEnabled(c.DispatchClientMetricsEnabled),
 			combineddispatch.PrometheusSubsystem(c.DispatchClientMetricsPrefix),

--- a/pkg/middleware/requestid/requestid.go
+++ b/pkg/middleware/requestid/requestid.go
@@ -77,7 +77,8 @@ func (r *handleRequestID) fromContextOrGenerate(ctx context.Context) (bool, stri
 	haveRequestID, requestID, md := fromContext(ctx)
 
 	if !haveRequestID && r.generateIfMissing {
-		requestID, haveRequestID = r.requestIDGenerator(), true
+		requestID = r.requestIDGenerator()
+		haveRequestID = true
 
 		// Inject the newly generated request ID into the metadata
 		if md == nil {


### PR DESCRIPTION
SpiceDB supports a custom `request-id` header clients can use to trace requests. It's convenient, for example, when troubleshooting certain requests using `zed permission check --request-id <my-request-id>`.

Unfortunately `request-id` wasn't being properly propagated to:
- `pgx` driver logs for Postgres-based SpiceDB
- dispatched requests

These issues are fixed in this PR, making it possible to filter all the log entries of a request by a custom `request-id`, included those that are part emitted as part of SpiceDB's dispatch mechanism.