### PR TITLE
Correct version requirement for datastore repair

### DIFF
--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -468,7 +468,7 @@ func (pgd *pgDatastore) RepairOperations() []datastore.RepairOperation {
 	return []datastore.RepairOperation{
 		{
 			Name:        repairTransactionIDsOperation,
-			Description: "Brings the Postgres database up to the expected transaction ID (Postgres v14+ only)",
+			Description: "Brings the Postgres database up to the expected transaction ID (Postgres v15+ only)",
 		},
 	}
 }


### PR DESCRIPTION
The `spicedb datastore repair transaction-ids` command requires Postgres v15+ to succeed.