### PR TITLE
LookupResources Postgres query optimization

### DIFF
--- a/internal/datastore/common/sql.go
+++ b/internal/datastore/common/sql.go
@@ -148,6 +148,7 @@ type nameAndValue struct {
 }
 
 func (sqf SchemaQueryFilterer) After(cursor *core.RelationTuple, order options.SortOrder) SchemaQueryFilterer {
+	// NOTE: The ordering of these columns can affect query performance, be aware when changing.
 	columnsAndValues := map[options.SortOrder][]nameAndValue{
 		options.ByResource: {
 			{
@@ -177,9 +178,6 @@ func (sqf SchemaQueryFilterer) After(cursor *core.RelationTuple, order options.S
 				sqf.schema.colUsersetObjectID, cursor.Subject.ObjectId,
 			},
 			{
-				sqf.schema.colUsersetRelation, cursor.Subject.Relation,
-			},
-			{
 				sqf.schema.colNamespace, cursor.ResourceAndRelation.Namespace,
 			},
 			{
@@ -187,6 +185,9 @@ func (sqf SchemaQueryFilterer) After(cursor *core.RelationTuple, order options.S
 			},
 			{
 				sqf.schema.colRelation, cursor.ResourceAndRelation.Relation,
+			},
+			{
+				sqf.schema.colUsersetRelation, cursor.Subject.Relation,
 			},
 		},
 	}[order]

--- a/internal/datastore/common/sql_test.go
+++ b/internal/datastore/common/sql_test.go
@@ -621,8 +621,8 @@ func TestSchemaQueryFilterer(t *testing.T) {
 					OptionalSubjectType: "somesubjectype",
 				}).After(tuple.MustParse("someresourcetype:foo#viewer@user:bar"), options.BySubject)
 			},
-			"SELECT * WHERE ((subject_ns = ?)) AND (subject_object_id,subject_relation,ns,object_id,relation) > (?,?,?,?,?)",
-			[]any{"somesubjectype", "bar", "...", "someresourcetype", "foo", "viewer"},
+			"SELECT * WHERE ((subject_ns = ?)) AND (subject_object_id,ns,object_id,relation,subject_relation) > (?,?,?,?,?)",
+			[]any{"somesubjectype", "bar", "someresourcetype", "foo", "viewer", "..."},
 			map[string]int{
 				"subject_ns": 1,
 			},
@@ -635,8 +635,8 @@ func TestSchemaQueryFilterer(t *testing.T) {
 					OptionalSubjectIds:  []string{"foo"},
 				}).After(tuple.MustParse("someresourcetype:someresource#viewer@user:bar"), options.BySubject)
 			},
-			"SELECT * WHERE ((subject_ns = ? AND subject_object_id IN (?))) AND (subject_relation,ns,object_id,relation) > (?,?,?,?)",
-			[]any{"somesubjectype", "foo", "...", "someresourcetype", "someresource", "viewer"},
+			"SELECT * WHERE ((subject_ns = ? AND subject_object_id IN (?))) AND (ns,object_id,relation,subject_relation) > (?,?,?,?)",
+			[]any{"somesubjectype", "foo", "someresourcetype", "someresource", "viewer", "..."},
 			map[string]int{"subject_ns": 1, "subject_object_id": 1},
 		},
 		{
@@ -647,8 +647,8 @@ func TestSchemaQueryFilterer(t *testing.T) {
 					OptionalSubjectIds:  []string{"foo", "bar"},
 				}).After(tuple.MustParse("someresourcetype:someresource#viewer@user:next"), options.BySubject)
 			},
-			"SELECT * WHERE ((subject_ns = ? AND subject_object_id IN (?, ?))) AND (subject_object_id,subject_relation,ns,object_id,relation) > (?,?,?,?,?)",
-			[]any{"somesubjectype", "foo", "bar", "next", "...", "someresourcetype", "someresource", "viewer"},
+			"SELECT * WHERE ((subject_ns = ? AND subject_object_id IN (?, ?))) AND (subject_object_id,ns,object_id,relation,subject_relation) > (?,?,?,?,?)",
+			[]any{"somesubjectype", "foo", "bar", "next", "someresourcetype", "someresource", "viewer", "..."},
 			map[string]int{"subject_ns": 1, "subject_object_id": 2},
 		},
 	}


### PR DESCRIPTION
Fixes potential slow reverse lookup queries when using Postgres by changing the order of the columns being compared in the cursor. By comparing the numerical IDs before the string relations, the query is able to short-circuit sooner and return faster.