### PR TITLE
cmd/server: log dispatching at debug level

### DIFF
--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -303,7 +303,7 @@ func newCRDBWithUser(t *testing.T, pool *dockertest.Pool) (adminConn *pgx.Conn, 
 	require.NoError(t, rootCertFile.Close())
 
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "cockroachdb/cockroach",
+		Repository: "mirror.gcr.io/cockroachdb/cockroach",
 		Tag:        testdatastore.CRDBTestVersionTag,
 		Cmd:        []string{"start-single-node", "--certs-dir", "/certs", "--accept-sql-without-tls"},
 		Mounts:     []string{certDir + ":/certs"},

--- a/internal/testserver/datastore/crdb.go
+++ b/internal/testserver/datastore/crdb.go
@@ -40,7 +40,7 @@ func RunCRDBForTesting(t testing.TB, bridgeNetworkName string) RunningEngineForT
 	name := fmt.Sprintf("crds-%s", uuid.New().String())
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Name:       name,
-		Repository: "cockroachdb/cockroach",
+		Repository: "mirror.gcr.io/cockroachdb/cockroach",
 		Tag:        CRDBTestVersionTag,
 		Cmd:        []string{"start-single-node", "--insecure", "--max-offset=50ms"},
 		NetworkID:  bridgeNetworkName,

--- a/internal/testserver/datastore/mysql.go
+++ b/internal/testserver/datastore/mysql.go
@@ -58,7 +58,7 @@ func RunMySQLForTestingWithOptions(t testing.TB, options MySQLTesterOptions, bri
 	name := fmt.Sprintf("mysql-%s", uuid.New().String())
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Name:       name,
-		Repository: "mysql",
+		Repository: "mirror.gcr.io/library/mysql",
 		Tag:        containerImageTag,
 		Env:        []string{"MYSQL_ROOT_PASSWORD=secret"},
 		// increase max connections (default 151) to accommodate tests using the same docker container

--- a/internal/testserver/datastore/postgres.go
+++ b/internal/testserver/datastore/postgres.go
@@ -69,7 +69,7 @@ func RunPostgresForTestingWithCommitTimestamps(t testing.TB, bridgeNetworkName s
 
 	postgres, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Name:       postgresContainerHostname,
-		Repository: "postgres",
+		Repository: "mirror.gcr.io/library/postgres",
 		Tag:        pgVersion,
 		Env: []string{
 			"POSTGRES_USER=" + POSTGRES_TEST_USER,
@@ -173,7 +173,7 @@ func (b *postgresTester) runPgbouncerForTesting(t testing.TB, pool *dockertest.P
 
 	pgbouncer, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Name:       pgbouncerContainerHostname,
-		Repository: "edoburu/pgbouncer",
+		Repository: "mirror.gcr.io/edoburu/pgbouncer",
 		Tag:        "latest",
 		Env: []string{
 			"DB_USER=" + POSTGRES_TEST_USER,


### PR DESCRIPTION
Prior to this change, dispatch logs can become VERY noisy and most use cases don't necessitate them.