### PR TITLE
refactor bulk export relationships logic

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -73,4 +73,4 @@ jobs:
       - name: "Obtain container image to scan"
         run: 'echo "IMAGE_VERSION=$(jq .version dist/linux_amd64/metadata.json --raw-output)" >> $GITHUB_ENV'
       - name: "run trivy on release image"
-        run: "docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --format table --exit-code 1 --ignore-unfixed --vuln-type os,library --no-progress --severity CRITICAL,HIGH,MEDIUM authzed/spicedb:v${{ env.IMAGE_VERSION }}-amd64"
+        run: "docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.50.4 image --format table --exit-code 1 --ignore-unfixed --vuln-type os,library --no-progress --severity CRITICAL,HIGH,MEDIUM authzed/spicedb:v${{ env.IMAGE_VERSION }}-amd64"

--- a/internal/services/shared/errors.go
+++ b/internal/services/shared/errors.go
@@ -118,6 +118,10 @@ type ConfigForErrors struct {
 	MaximumAPIDepth uint32
 }
 
+func RewriteErrorWithoutConfig(ctx context.Context, err error) error {
+	return RewriteError(ctx, err, nil)
+}
+
 func RewriteError(ctx context.Context, err error, config *ConfigForErrors) error {
 	// Check if the error can be directly used.
 	if _, ok := status.FromError(err); ok {


### PR DESCRIPTION
for a potential future use that bypasses the gRPC server

note: trivy build started failing because it flagged the spicedb image built by goreleaser as containing CVEs, because it's parsing the version in the ldflags, and infers its 0.0.1, which is the version the currently being generated in this pipeline. This was probably introduced by trivy 0.51.0, when it started parsing go binaries ldflags: https://github.com/aquasecurity/trivy/pull/6564. The right way to address this would be to generate the correct version, or something that does not follow semver.