### PR TITLE
makes it possible to compare datastore-specific revisions with datastore.NoRevision

### DIFF
--- a/internal/datastore/revisions/timestamprevision.go
+++ b/internal/datastore/revisions/timestamprevision.go
@@ -11,6 +11,8 @@ import (
 // TimestampRevision is a revision that is a timestamp.
 type TimestampRevision int64
 
+var zeroTimestampRevision = TimestampRevision(0)
+
 // NewForTime creates a new revision for the given time.
 func NewForTime(time time.Time) TimestampRevision {
 	return TimestampRevision(time.UnixNano())
@@ -31,16 +33,28 @@ func parseTimestampRevisionString(revisionStr string) (rev datastore.Revision, e
 	return TimestampRevision(parsed), nil
 }
 
-func (ir TimestampRevision) Equal(other datastore.Revision) bool {
-	return int64(ir) == int64(other.(TimestampRevision))
+func (ir TimestampRevision) Equal(rhs datastore.Revision) bool {
+	if rhs == datastore.NoRevision {
+		rhs = zeroTimestampRevision
+	}
+
+	return int64(ir) == int64(rhs.(TimestampRevision))
 }
 
-func (ir TimestampRevision) GreaterThan(other datastore.Revision) bool {
-	return int64(ir) > int64(other.(TimestampRevision))
+func (ir TimestampRevision) GreaterThan(rhs datastore.Revision) bool {
+	if rhs == datastore.NoRevision {
+		rhs = zeroTimestampRevision
+	}
+
+	return int64(ir) > int64(rhs.(TimestampRevision))
 }
 
-func (ir TimestampRevision) LessThan(other datastore.Revision) bool {
-	return int64(ir) < int64(other.(TimestampRevision))
+func (ir TimestampRevision) LessThan(rhs datastore.Revision) bool {
+	if rhs == datastore.NoRevision {
+		rhs = zeroTimestampRevision
+	}
+
+	return int64(ir) < int64(rhs.(TimestampRevision))
 }
 
 func (ir TimestampRevision) TimestampNanoSec() int64 {

--- a/internal/datastore/revisions/timestamprevision_test.go
+++ b/internal/datastore/revisions/timestamprevision_test.go
@@ -1,0 +1,17 @@
+package revisions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestZeroTimestampRevision(t *testing.T) {
+	require.False(t, TimestampRevision(0).LessThan(zeroTimestampRevision))
+	require.True(t, TimestampRevision(0).Equal(zeroTimestampRevision))
+	require.False(t, TimestampRevision(0).GreaterThan(zeroTimestampRevision))
+
+	require.False(t, TimestampRevision(1).LessThan(zeroTimestampRevision))
+	require.False(t, TimestampRevision(1).Equal(zeroTimestampRevision))
+	require.True(t, TimestampRevision(1).GreaterThan(zeroTimestampRevision))
+}

--- a/internal/datastore/revisions/txidrevision.go
+++ b/internal/datastore/revisions/txidrevision.go
@@ -10,6 +10,8 @@ import (
 // TransactionIDRevision is a revision that is a transaction ID.
 type TransactionIDRevision uint64
 
+var zeroTransactionIDRevision = TransactionIDRevision(0)
+
 // NewForTransactionID creates a new revision for the given transaction ID.
 func NewForTransactionID(transactionID uint64) TransactionIDRevision {
 	return TransactionIDRevision(transactionID)
@@ -25,16 +27,28 @@ func parseTransactionIDRevisionString(revisionStr string) (rev datastore.Revisio
 	return TransactionIDRevision(parsed), nil
 }
 
-func (ir TransactionIDRevision) Equal(other datastore.Revision) bool {
-	return uint64(ir) == uint64(other.(TransactionIDRevision))
+func (ir TransactionIDRevision) Equal(rhs datastore.Revision) bool {
+	if rhs == datastore.NoRevision {
+		rhs = zeroTransactionIDRevision
+	}
+
+	return uint64(ir) == uint64(rhs.(TransactionIDRevision))
 }
 
-func (ir TransactionIDRevision) GreaterThan(other datastore.Revision) bool {
-	return uint64(ir) > uint64(other.(TransactionIDRevision))
+func (ir TransactionIDRevision) GreaterThan(rhs datastore.Revision) bool {
+	if rhs == datastore.NoRevision {
+		rhs = zeroTransactionIDRevision
+	}
+
+	return uint64(ir) > uint64(rhs.(TransactionIDRevision))
 }
 
-func (ir TransactionIDRevision) LessThan(other datastore.Revision) bool {
-	return uint64(ir) < uint64(other.(TransactionIDRevision))
+func (ir TransactionIDRevision) LessThan(rhs datastore.Revision) bool {
+	if rhs == datastore.NoRevision {
+		rhs = zeroTransactionIDRevision
+	}
+
+	return uint64(ir) < uint64(rhs.(TransactionIDRevision))
 }
 
 func (ir TransactionIDRevision) TransactionID() uint64 {

--- a/internal/datastore/revisions/txidrevision_test.go
+++ b/internal/datastore/revisions/txidrevision_test.go
@@ -1,0 +1,17 @@
+package revisions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestZeroTransactionIDRevision(t *testing.T) {
+	require.False(t, TransactionIDRevision(0).LessThan(zeroTransactionIDRevision))
+	require.True(t, TransactionIDRevision(0).Equal(zeroTransactionIDRevision))
+	require.False(t, TransactionIDRevision(0).GreaterThan(zeroTransactionIDRevision))
+
+	require.False(t, TransactionIDRevision(1).LessThan(zeroTransactionIDRevision))
+	require.False(t, TransactionIDRevision(1).Equal(zeroTransactionIDRevision))
+	require.True(t, TransactionIDRevision(1).GreaterThan(zeroTransactionIDRevision))
+}


### PR DESCRIPTION
This is more ergonomic on the client side, so it does not force the client to check for nil revisions and instead always return `datastore.NoRevision` when there are errors computing a revision.