### PR TITLE
Make sure to escape underscores in resource ID prefix matches in filters

### DIFF
--- a/internal/datastore/common/sql.go
+++ b/internal/datastore/common/sql.go
@@ -290,6 +290,9 @@ func (sqf SchemaQueryFilterer) FilterWithResourceIDPrefix(prefix string) (Schema
 		return sqf, spiceerrors.MustBugf("prefix cannot be empty")
 	}
 
+	prefix = strings.ReplaceAll(prefix, `\`, `\\`)
+	prefix = strings.ReplaceAll(prefix, "_", `\_`)
+
 	sqf.queryBuilder = sqf.queryBuilder.Where(sq.Like{sqf.schema.colObjectID: prefix + "%"})
 	sqf.tracerAttributes = append(sqf.tracerAttributes, ObjIDKey.String(prefix+"*"))
 

--- a/pkg/datastore/test/tuples.go
+++ b/pkg/datastore/test/tuples.go
@@ -1069,6 +1069,34 @@ func QueryRelationshipsWithVariousFiltersTest(t *testing.T, tester DatastoreTest
 			expected:      []string{"document:first#viewer@user:tom"},
 		},
 		{
+			name: "resource id prefix with underscore",
+			filter: datastore.RelationshipsFilter{
+				OptionalResourceIDPrefix: "first_",
+			},
+			relationships: []string{
+				"document:first#viewer@user:tom",
+				"document:first_foo#viewer@user:tom",
+				"document:first_bar#viewer@user:tom",
+				"document:firstmeh#viewer@user:tom",
+				"document:second#viewer@user:tom",
+			},
+			expected: []string{"document:first_foo#viewer@user:tom", "document:first_bar#viewer@user:tom"},
+		},
+		{
+			name: "resource id prefix with multiple underscores",
+			filter: datastore.RelationshipsFilter{
+				OptionalResourceIDPrefix: "first_f_",
+			},
+			relationships: []string{
+				"document:first#viewer@user:tom",
+				"document:first_f_oo#viewer@user:tom",
+				"document:first_bar#viewer@user:tom",
+				"document:firstmeh#viewer@user:tom",
+				"document:second#viewer@user:tom",
+			},
+			expected: []string{"document:first_f_oo#viewer@user:tom"},
+		},
+		{
 			name: "resource id different prefix",
 			filter: datastore.RelationshipsFilter{
 				OptionalResourceIDPrefix: "s",


### PR DESCRIPTION
Otherwise, it can make the query much slower and match unexpected relationships