### PR TITLE
Implement support for metadata associated with read-write transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,6 +110,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/Yiling-J/theine-go v0.4.1
 	github.com/ccoveille/go-safecast v1.1.0
 	github.com/gosimple/slug v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -654,6 +654,8 @@ github.com/IBM/pgxpoolprometheus v1.1.1/go.mod h1:GFJDkHbidFfB2APbhBTSy2X4PKH3bL
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/KimMachineGun/automemlimit v0.6.1 h1:ILa9j1onAAMadBsyyUJv5cack8Y1WT26yLj/V+ulKp8=
 github.com/KimMachineGun/automemlimit v0.6.1/go.mod h1:T7xYht7B8r6AG/AqFcUdc7fzd2bIdBKmepfP2S1svPY=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
 github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=

--- a/internal/datastore/crdb/migrations/zz_migration.0008_add_transaction_metadata_table.go
+++ b/internal/datastore/crdb/migrations/zz_migration.0008_add_transaction_metadata_table.go
@@ -1,0 +1,88 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/Masterminds/semver"
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	// ttl_expiration_expression support was added in CRDB v22.2, but the E2E tests
+	// use v21.2.
+	addTransactionMetadataTableQueryWithBasicTTL = `
+		CREATE TABLE transaction_metadata (
+			key UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			expires_at TIMESTAMPTZ,
+			metadata JSONB
+		) WITH (ttl_expire_after = '1d');
+	`
+
+	addTransactionMetadataTableQuery = `
+		CREATE TABLE transaction_metadata (
+			key UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			expires_at TIMESTAMPTZ,
+			metadata JSONB
+		) WITH (ttl_expiration_expression = 'expires_at', ttl_job_cron = '@daily');
+	`
+
+	// See: https://www.cockroachlabs.com/docs/stable/changefeed-messages#prevent-changefeeds-from-emitting-row-level-ttl-deletes
+	// for why we set ttl_disable_changefeed_replication = 'true'. This isn't stricly necessary as the Watch API will ignore the
+	// deletions of these metadata rows, but no reason to even have it in the changefeed.
+	// NOTE: This only applies on CRDB v24 and later.
+	addTransactionMetadataTableQueryWithTTLIgnore = `
+		CREATE TABLE transaction_metadata (
+			key UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			expires_at TIMESTAMPTZ,
+			metadata JSONB
+		) WITH (ttl_expiration_expression = 'expires_at', ttl_job_cron = '@daily', ttl_disable_changefeed_replication = 'true');
+	`
+)
+
+func init() {
+	err := CRDBMigrations.Register("add-transaction-metadata-table", "add-integrity-relationtuple-table", addTransactionMetadataTable, noAtomicMigration)
+	if err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}
+
+func addTransactionMetadataTable(ctx context.Context, conn *pgx.Conn) error {
+	row := conn.QueryRow(ctx, "select version()")
+	var fullVersionString string
+	if err := row.Scan(&fullVersionString); err != nil {
+		return err
+	}
+
+	re, err := regexp.Compile(semver.SemVerRegex)
+	if err != nil {
+		return fmt.Errorf("failed to compile regex: %w", err)
+	}
+
+	version := re.FindString(fullVersionString)
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return fmt.Errorf("failed to parse version %q: %w", version, err)
+	}
+
+	if v.Major() < 22 {
+		return fmt.Errorf("unsupported version %q", version)
+	}
+
+	// v22.1 doesn't support `ttl_expiration_expression`; it was added in v22.2.
+	if v.Major() == 22 && v.Minor() == 1 {
+		_, err := conn.Exec(ctx, addTransactionMetadataTableQueryWithBasicTTL)
+		return err
+	}
+
+	// `ttl_disable_changefeed_replication`	was added in v24.
+	if v.Major() < 24 {
+		_, err := conn.Exec(ctx, addTransactionMetadataTableQuery)
+		return err
+	}
+
+	// v24 and later
+	_, err = conn.Exec(ctx, addTransactionMetadataTableQueryWithTTLIgnore)
+	return err
+}

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -640,7 +640,7 @@ func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
 	// Transaction timestamp should not be stored in system time zone
 	tx, err := db.BeginTx(ctx, nil)
 	req.NoError(err)
-	txID, err := ds.(*Datastore).createNewTransaction(ctx, tx)
+	txID, err := ds.(*Datastore).createNewTransaction(ctx, tx, nil)
 	req.NoError(err)
 	err = tx.Commit()
 	req.NoError(err)

--- a/internal/datastore/mysql/migrations/zz_migration.0009_add_metadata_to_transaction_table.go
+++ b/internal/datastore/mysql/migrations/zz_migration.0009_add_metadata_to_transaction_table.go
@@ -1,0 +1,18 @@
+package migrations
+
+import "fmt"
+
+func addMetadataToTransactionTable(t *tables) string {
+	return fmt.Sprintf(`ALTER TABLE %s
+		ADD COLUMN metadata BLOB NULL DEFAULT NULL;`,
+		t.RelationTupleTransaction(),
+	)
+}
+
+func init() {
+	mustRegisterMigration("add_metadata_to_transaction_table", "add_relationship_counters_table", noNonatomicMigration,
+		newStatementBatch(
+			addMetadataToTransactionTable,
+		).execute,
+	)
+}

--- a/internal/datastore/mysql/query_builder.go
+++ b/internal/datastore/mysql/query_builder.go
@@ -9,8 +9,8 @@ import (
 // QueryBuilder captures all parameterizable queries used
 // by the MySQL datastore implementation
 type QueryBuilder struct {
-	GetLastRevision  sq.SelectBuilder
-	GetRevisionRange sq.SelectBuilder
+	GetLastRevision   sq.SelectBuilder
+	LoadRevisionRange sq.SelectBuilder
 
 	WriteNamespaceQuery        sq.InsertBuilder
 	ReadNamespaceQuery         sq.SelectBuilder
@@ -43,7 +43,7 @@ func NewQueryBuilder(driver *migrations.MySQLDriver) *QueryBuilder {
 
 	// transaction builders
 	builder.GetLastRevision = getLastRevision(driver.RelationTupleTransaction())
-	builder.GetRevisionRange = getRevisionRange(driver.RelationTupleTransaction())
+	builder.LoadRevisionRange = loadRevisionRange(driver.RelationTupleTransaction())
 
 	// namespace builders
 	builder.WriteNamespaceQuery = writeNamespace(driver.Namespace())
@@ -99,8 +99,8 @@ func getLastRevision(tableTransaction string) sq.SelectBuilder {
 	return sb.Select("MAX(id)").From(tableTransaction).Limit(1)
 }
 
-func getRevisionRange(tableTransaction string) sq.SelectBuilder {
-	return sb.Select("MIN(id)", "MAX(id)").From(tableTransaction)
+func loadRevisionRange(tableTransaction string) sq.SelectBuilder {
+	return sb.Select(colID, colMetadata).From(tableTransaction)
 }
 
 func readCounter(tableRelationshipCounters string) sq.SelectBuilder {

--- a/internal/datastore/mysql/readwrite.go
+++ b/internal/datastore/mysql/readwrite.go
@@ -50,10 +50,10 @@ type mysqlReadWriteTXN struct {
 	newTxnID       uint64
 }
 
-// caveatContextWrapper is used to marshall maps into MySQLs JSON data type
-type caveatContextWrapper map[string]any
+// structpbWrapper is used to marshall maps into MySQLs JSON data type
+type structpbWrapper map[string]any
 
-func (cc *caveatContextWrapper) Scan(val any) error {
+func (cc *structpbWrapper) Scan(val any) error {
 	v, ok := val.([]byte)
 	if !ok {
 		return fmt.Errorf("unsupported type: %T", v)
@@ -61,7 +61,7 @@ func (cc *caveatContextWrapper) Scan(val any) error {
 	return json.Unmarshal(v, &cc)
 }
 
-func (cc *caveatContextWrapper) Value() (driver.Value, error) {
+func (cc *structpbWrapper) Value() (driver.Value, error) {
 	return json.Marshal(&cc)
 }
 
@@ -221,7 +221,7 @@ func (rwt *mysqlReadWriteTXN) WriteRelationships(ctx context.Context, mutations 
 		}
 
 		var caveatName string
-		var caveatContext caveatContextWrapper
+		var caveatContext structpbWrapper
 
 		tupleIdsToDelete := make([]int64, 0, len(clauses))
 		for rows.Next() {
@@ -282,7 +282,7 @@ func (rwt *mysqlReadWriteTXN) WriteRelationships(ctx context.Context, mutations 
 		tpl := mut.Tuple
 
 		var caveatName string
-		var caveatContext caveatContextWrapper
+		var caveatContext structpbWrapper
 		if tpl.Caveat != nil {
 			caveatName = tpl.Caveat.CaveatName
 			caveatContext = tpl.Caveat.Context.AsMap()
@@ -503,7 +503,7 @@ func (rwt *mysqlReadWriteTXN) BulkLoad(ctx context.Context, iter datastore.BulkW
 			}
 
 			var caveatName string
-			var caveatContext caveatContextWrapper
+			var caveatContext structpbWrapper
 			if tpl.Caveat != nil {
 				caveatName = tpl.Caveat.CaveatName
 				caveatContext = tpl.Caveat.Context.AsMap()

--- a/internal/datastore/postgres/migrations/zz_migration.0019_add_metadata_to_transaction_table.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0019_add_metadata_to_transaction_table.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const addMetadataToTransactionTable = `ALTER TABLE relation_tuple_transaction ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'`
+
+func init() {
+	if err := DatabaseMigrations.Register("add-metadata-to-transaction-table", "create-relationships-counters-table",
+		func(ctx context.Context, conn *pgx.Conn) error {
+			if _, err := conn.Exec(ctx, addMetadataToTransactionTable); err != nil {
+				return fmt.Errorf("failed to add metadata to transaction table: %w", err)
+			}
+			return nil
+		},
+		noTxMigration); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -440,7 +440,7 @@ func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
 	tx, err := pgd.writePool.Begin(ctx)
 	require.NoError(err)
 
-	txXID, _, err := createNewTransaction(ctx, tx)
+	txXID, _, err := createNewTransaction(ctx, tx, nil)
 	require.NoError(err)
 
 	err = tx.Commit(ctx)

--- a/internal/datastore/spanner/migrations/zz_migration.0010_add_transaction_metadata_table.go
+++ b/internal/datastore/spanner/migrations/zz_migration.0010_add_transaction_metadata_table.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	"context"
+
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+)
+
+const (
+	// NOTE: We use 2 days here because Spanner only supports deletion policies at intervals of days.
+	// See: https://cloud.google.com/spanner/docs/ttl/working-with-ttl#create
+	addTransactionMetadataTable = `CREATE TABLE transaction_metadata (
+			transaction_tag STRING(36) NOT NULL,
+			created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP()),
+			metadata JSON
+		) PRIMARY KEY (transaction_tag),
+		ROW DELETION POLICY (OLDER_THAN(created_at, INTERVAL 2 DAY))
+	`
+)
+
+func init() {
+	if err := SpannerMigrations.Register("add-transaction-metadata-table", "add-relationship-counter-table", func(ctx context.Context, w Wrapper) error {
+		updateOp, err := w.adminClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+			Database: w.client.DatabaseName(),
+			Statements: []string{
+				addTransactionMetadataTable,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		return updateOp.Wait(ctx)
+	}, nil); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}

--- a/internal/datastore/spanner/schema.go
+++ b/internal/datastore/spanner/schema.go
@@ -30,6 +30,10 @@ const (
 	colCounterSerializedFilter   = "serialized_filter"
 	colCounterCurrentCount       = "current_count"
 	colCounterUpdatedAtTimestamp = "updated_at_timestamp"
+
+	tableTransactionMetadata = "transaction_metadata"
+	colTransactionTag        = "transaction_tag"
+	colMetadata              = "metadata"
 )
 
 var allRelationshipCols = []string{

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/authzed/spicedb/pkg/tuple"
 
@@ -61,6 +62,9 @@ type RevisionChanges struct {
 	// up until and including the Revision and that no additional schema updates can
 	// have occurred before this point.
 	IsCheckpoint bool
+
+	// Metadata is the metadata associated with the revision, if any.
+	Metadata *structpb.Struct
 }
 
 func (rc *RevisionChanges) MarshalZerologObject(e *zerolog.Event) {

--- a/pkg/datastore/options/options.go
+++ b/pkg/datastore/options/options.go
@@ -1,6 +1,8 @@
 package options
 
 import (
+	"google.golang.org/protobuf/types/known/structpb"
+
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
@@ -51,7 +53,8 @@ type ResourceRelation struct {
 // RWTOptions are options that can affect the way a read-write transaction is
 // executed.
 type RWTOptions struct {
-	DisableRetries bool `debugmap:"visible"`
+	DisableRetries bool             `debugmap:"visible"`
+	Metadata       *structpb.Struct `debugmap:"visible"`
 }
 
 // DeleteOptions are the options that can affect the results of a delete relationships

--- a/pkg/datastore/options/zz_generated.query_options.go
+++ b/pkg/datastore/options/zz_generated.query_options.go
@@ -4,6 +4,7 @@ package options
 import (
 	defaults "github.com/creasty/defaults"
 	helpers "github.com/ecordell/optgen/helpers"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
 type QueryOptionsOption func(q *QueryOptions)
@@ -192,6 +193,7 @@ func NewRWTOptionsWithOptionsAndDefaults(opts ...RWTOptionsOption) *RWTOptions {
 func (r *RWTOptions) ToOption() RWTOptionsOption {
 	return func(to *RWTOptions) {
 		to.DisableRetries = r.DisableRetries
+		to.Metadata = r.Metadata
 	}
 }
 
@@ -199,6 +201,7 @@ func (r *RWTOptions) ToOption() RWTOptionsOption {
 func (r RWTOptions) DebugMap() map[string]any {
 	debugMap := map[string]any{}
 	debugMap["DisableRetries"] = helpers.DebugValue(r.DisableRetries, false)
+	debugMap["Metadata"] = helpers.DebugValue(r.Metadata, false)
 	return debugMap
 }
 
@@ -222,5 +225,12 @@ func (r *RWTOptions) WithOptions(opts ...RWTOptionsOption) *RWTOptions {
 func WithDisableRetries(disableRetries bool) RWTOptionsOption {
 	return func(r *RWTOptions) {
 		r.DisableRetries = disableRetries
+	}
+}
+
+// WithMetadata returns an option that can set Metadata on a RWTOptions
+func WithMetadata(metadata *structpb.Struct) RWTOptionsOption {
+	return func(r *RWTOptions) {
+		r.Metadata = metadata
 	}
 }

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -162,6 +162,7 @@ func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories) 
 		t.Run("TestCaveatedRelationshipWatch", func(t *testing.T) { CaveatedRelationshipWatchTest(t, tester) })
 		t.Run("TestWatchWithTouch", func(t *testing.T) { WatchWithTouchTest(t, tester) })
 		t.Run("TestWatchWithDelete", func(t *testing.T) { WatchWithDeleteTest(t, tester) })
+		t.Run("TestWatchWithMetadata", func(t *testing.T) { WatchWithMetadataTest(t, tester) })
 	}
 
 	if !except.Watch() && !except.WatchSchema() {


### PR DESCRIPTION
This will allow callers of APIs such as WriteRelationships and DeleteRelationships to assign metadata to the transaction that will be mirrored back out in the Watch API, to provide a means for correlating updates

First part of #966

Each datastore has a different means of correlating between the transaction and the associated change(s) coming out of the watch API:

- Memdb: The metadata is stored on the changes struct
- Postgres: A `metadata` column was added to the transactions table
- MySQL: A `metadata` column was added to the transactions table
- Spanner: A transaction tag is used to correlate the transaction and the metadata is stored in an auto-GC-ing table, indexed by the transaction tag
- CRDB: A row is inserted into a metadata table as part of the transaction, which includes the metadata. When seen at the same revision as the other changes, the metadata becomes correlated with that transaction. The rows are set to auto-GC after a period of time in CRDB >= v22