### PR TITLE
Update CLA link in `CONTRIBUTING.md` to point to v2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ In order to protect the project, all contributors are required to sign our [Cont
 
 The signing process has been automated by [CLA Assistant][cla-assistant] during the Pull Request review process and only requires responding with a comment acknowledging the agreement.
 
-[cla]: https://github.com/authzed/cla/blob/main/v1/icla.md
+[cla]: https://github.com/authzed/cla/blob/main/v2/icla.md
 [cla-assistant]: https://github.com/cla-assistant/cla-assistant
 
 ## Common tasks


### PR DESCRIPTION
A new version of the CLA was published in https://github.com/authzed/cla/commit/6a6a2954c3503f6df66a5aaa7bb72866da0e5efe but is not reflected in `CONTRIBUTING.md`. This updates the link to point to the new CLA.

Addresses https://github.com/authzed/spicedb/issues/1917