### PR TITLE
Add better subject error messages on write/delete validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.18.3
 )
 
+require github.com/lithammer/fuzzysearch v1.1.8
+
 require (
 	cloud.google.com/go/auth v0.4.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1288,6 +1288,8 @@ github.com/leonklingele/grouper v1.1.2 h1:o1ARBDLOmmasUaNDesWqWCIFH3u7hoFlM84Yrj
 github.com/leonklingele/grouper v1.1.2/go.mod h1:6D0M/HVkhs2yRKRFZUoGjeDy7EZTfFBE9gl4kjmIGkA=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lithammer/fuzzysearch v1.1.8 h1:/HIuJnjHuXS8bKaiTMeeDlW2/AyIWk2brx1V8LFgLN4=
+github.com/lithammer/fuzzysearch v1.1.8/go.mod h1:IdqeyBClc3FFqSzYq/MXESsS4S0FsZ5ajtkr5xPLts4=
 github.com/lthibault/jitterbug v2.0.0+incompatible h1:qouq51IKzlMx25+15jbxhC/d79YyTj0q6XFoptNqaUw=
 github.com/lthibault/jitterbug v2.0.0+incompatible/go.mod h1:2l7akWd27PScEs6YkjyUVj/8hKgNhbbQ3KiJgJtlf6o=
 github.com/lufeee/execinquery v1.2.1 h1:hf0Ems4SHcUGBxpGN7Jz78z1ppVkP/837ZlETPCEtOM=

--- a/internal/relationships/validation.go
+++ b/internal/relationships/validation.go
@@ -209,7 +209,7 @@ func ValidateOneRelationship(
 		}
 
 		if isAllowed != typesystem.AllowedRelationValid {
-			return NewInvalidSubjectTypeError(rel, relationToCheck)
+			return NewInvalidSubjectTypeError(rel, relationToCheck, resourceTS)
 		}
 
 	case rule == ValidateRelationshipForDeletion && caveat == nil:
@@ -221,7 +221,7 @@ func ValidateOneRelationship(
 			}
 
 			if isAllowed != typesystem.PublicSubjectAllowed {
-				return NewInvalidSubjectTypeError(rel, relationToCheck)
+				return NewInvalidSubjectTypeError(rel, relationToCheck, resourceTS)
 			}
 		} else {
 			isAllowed, err := resourceTS.IsAllowedDirectRelation(rel.ResourceAndRelation.Relation, rel.Subject.Namespace, rel.Subject.Relation)
@@ -230,7 +230,7 @@ func ValidateOneRelationship(
 			}
 
 			if isAllowed != typesystem.DirectRelationValid {
-				return NewInvalidSubjectTypeError(rel, relationToCheck)
+				return NewInvalidSubjectTypeError(rel, relationToCheck, resourceTS)
 			}
 		}
 

--- a/internal/relationships/validation_test.go
+++ b/internal/relationships/validation_test.go
@@ -195,6 +195,50 @@ func TestValidateRelationshipOperations(t *testing.T) {
 			core.RelationTupleUpdate_DELETE,
 			"subjects of type `user` are not allowed on relation `resource#viewer2`",
 		},
+		{
+			"write of an uncaveated subject when a caveat is required",
+			`
+			definition user {}
+
+			caveat somecaveat(somecondition int) {
+				somecondition == 42
+			}
+
+			definition resource {
+				relation viewer: user with somecaveat
+			}`,
+			"resource:foo#viewer@user:tom",
+			core.RelationTupleUpdate_CREATE,
+			"subjects of type `user` are not allowed on relation `resource#viewer` without one of the following caveats: somecaveat",
+		},
+		{
+			"did you mean test",
+			`
+			definition user {}
+
+			definition usr {}
+
+			definition resource {
+				relation viewer: user
+			}`,
+			"resource:foo#viewer@usr:tom",
+			core.RelationTupleUpdate_CREATE,
+			"subjects of type `usr` are not allowed on relation `resource#viewer`; did you mean `user`?",
+		},
+		{
+			"did you mean subrelation test",
+			`
+			definition user {
+				relation member: user
+			}
+
+			definition resource {
+				relation viewer: user#member
+			}`,
+			"resource:foo#viewer@user:tom",
+			core.RelationTupleUpdate_CREATE,
+			"subjects of type `user` are not allowed on relation `resource#viewer`; did you mean `user#member`?",
+		},
 	}
 
 	for _, tc := range tcs {

--- a/pkg/development/wasm/operations_test.go
+++ b/pkg/development/wasm/operations_test.go
@@ -333,7 +333,7 @@ func TestCheckOperation(t *testing.T) {
 			tuple.MustParse("resource:someobj#view@user:foo"),
 			nil,
 			&devinterface.DeveloperError{
-				Message: "subjects of type `user` are not allowed on relation `resource#viewer`",
+				Message: "subjects of type `user` are not allowed on relation `resource#viewer` without one of the following caveats: somecaveat",
 				Kind:    devinterface.DeveloperError_INVALID_SUBJECT_TYPE,
 				Source:  devinterface.DeveloperError_RELATIONSHIP,
 				Context: "resource:someobj#viewer@user:foo",


### PR DESCRIPTION
Fixes #1939

Examples:

```subjects of type `user` are not allowed on relation `resource#viewer` without one of the following caveats: somecaveat```

```subjects of type `user` are not allowed on relation `resource#viewer`; did you mean `user#member`?```