### PR TITLE
Fix/bulk loader nullstring

### DIFF
--- a/internal/datastore/postgres/common/bulk.go
+++ b/internal/datastore/postgres/common/bulk.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/jackc/pgx/v5"
 
@@ -29,11 +28,10 @@ func (tg *tupleSourceAdapter) Next() bool {
 
 // Values returns the values for the current row.
 func (tg *tupleSourceAdapter) Values() ([]any, error) {
-	var caveatName sql.NullString
+	var caveatName string
 	var caveatContext map[string]any
 	if tg.current.Caveat != nil {
-		caveatName.String = tg.current.Caveat.CaveatName
-		caveatName.Valid = true
+		caveatName = tg.current.Caveat.CaveatName
 		caveatContext = tg.current.Caveat.Context.AsMap()
 	}
 

--- a/internal/datastore/postgres/readwrite.go
+++ b/internal/datastore/postgres/readwrite.go
@@ -725,9 +725,7 @@ func exactRelationshipDifferentCaveatClause(r *core.RelationTuple) sq.And {
 			colUsersetRelation:  r.Subject.Relation,
 		},
 		sq.Or{
-			sq.NotEq{
-				colCaveatContextName: caveatName,
-			},
+			sq.Expr(fmt.Sprintf(`%s IS DISTINCT FROM ?`, colCaveatContextName), caveatName),
 			sq.NotEq{
 				colCaveatContext: caveatContext,
 			},

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -140,6 +140,7 @@ func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories) 
 	t.Run("TestBulkUploadErrors", func(t *testing.T) { BulkUploadErrorsTest(t, tester) })
 	t.Run("TestBulkUploadAlreadyExistsError", func(t *testing.T) { BulkUploadAlreadyExistsErrorTest(t, tester) })
 	t.Run("TestBulkUploadAlreadyExistsSameCallError", func(t *testing.T) { BulkUploadAlreadyExistsSameCallErrorTest(t, tester) })
+	t.Run("BulkUploadEditCaveat", func(t *testing.T) { BulkUploadEditCaveat(t, tester) })
 
 	if !except.Stats() {
 		t.Run("TestStats", func(t *testing.T) { StatsTest(t, tester) })


### PR DESCRIPTION
Fixes #1938 and also fixes problems like it in the future by using `IS DISTINCT FROM`instead of `<>` to compare a potential null value field. (This will make it so that already bulk loaded relations will work correctly).