### PR TITLE
Workaround to snapcraft regression

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,7 +16,10 @@ jobs:
           fetch-depth: 0
       - uses: "authzed/actions/setup-go@main"
       - name: "Install snapcraft"
-        run: "sudo snap install snapcraft --channel=8.x/stable --classic"
+        run: |
+          sudo snap install snapcraft --channel=8.x/stable --classic
+          mkdir -p $HOME/.cache/snapcraft/download
+          mkdir -p $HOME/.cache/snapcraft/stage-packages
       - uses: "authzed/actions/docker-login@main"
         with:
           quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,10 @@ jobs:
         run: 'echo "SpiceDB version must start with `v` and be a semver" && exit 1'
         shell: "bash"
       - name: "Install snapcraft"
-        run: "sudo snap install snapcraft --channel=8.x/stable --classic"
+        run: |
+          sudo snap install snapcraft --channel=8.x/stable --classic
+          mkdir -p $HOME/.cache/snapcraft/download
+          mkdir -p $HOME/.cache/snapcraft/stage-packages
       - uses: "authzed/actions/docker-login@main"
         with:
           quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -56,7 +56,10 @@ jobs:
           username: "${{ env.DOCKERHUB_PUBLIC_USER }}"
           password: "${{ env.DOCKERHUB_PUBLIC_ACCESS_TOKEN }}"
       - name: "Install snapcraft"
-        run: "sudo snap install snapcraft --channel=8.x/stable --classic"
+        run: |
+          sudo snap install snapcraft --channel=8.x/stable --classic
+          mkdir -p $HOME/.cache/snapcraft/download
+          mkdir -p $HOME/.cache/snapcraft/stage-packages
       - uses: "aquasecurity/trivy-action@master"
         with:
           scan-type: "fs"


### PR DESCRIPTION
Workaround to regression after a recent upgrade of Snapcraft in authzed/spicedb#1952

We hit a regression on an old Snapcraft issue.

See:
https://github.com/goreleaser/goreleaser/issues/1715
https://bugs.launchpad.net/snapcraft/+bug/1889741