### PR TITLE
adjust pg revision timestamps

### DIFF
--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -170,8 +170,8 @@ func parseRevisionProto(revisionStr string) (datastore.Revision, error) {
 			xmax:    uint64(xminInt + decoded.RelativeXmax),
 			xipList: xips,
 		},
-		optionalTxID:      xid8{Uint64: decoded.OptionalTxid, Valid: decoded.OptionalTxid != 0},
-		optionalTimestamp: decoded.OptionalTimestamp,
+		optionalTxID:           xid8{Uint64: decoded.OptionalTxid, Valid: decoded.OptionalTxid != 0},
+		optionalNanosTimestamp: decoded.OptionalTimestamp,
 	}, nil
 }
 
@@ -248,9 +248,9 @@ func createNewTransaction(ctx context.Context, tx pgx.Tx) (newXID xid8, newSnaps
 }
 
 type postgresRevision struct {
-	snapshot          pgSnapshot
-	optionalTxID      xid8
-	optionalTimestamp uint64
+	snapshot               pgSnapshot
+	optionalTxID           xid8
+	optionalNanosTimestamp uint64
 }
 
 func (pr postgresRevision) Equal(rhsRaw datastore.Revision) bool {
@@ -298,14 +298,14 @@ func (pr postgresRevision) OptionalTransactionID() (xid8, bool) {
 	return pr.optionalTxID, true
 }
 
-// OptionalTimestamp returns a unix epoch timestamp representing the time at which the transaction committed as
-// defined by the Postgres primary. This is not guaranteed to be monotonically increasing.
-func (pr postgresRevision) OptionalTimestamp() (uint64, bool) {
-	if pr.optionalTimestamp == 0 {
+// OptionalNanosTimestamp returns a unix epoch timestamp in nanos representing the time at which the transaction committed
+// as defined by the Postgres primary. This is not guaranteed to be monotonically increasing
+func (pr postgresRevision) OptionalNanosTimestamp() (uint64, bool) {
+	if pr.optionalNanosTimestamp == 0 {
 		return 0, false
 	}
 
-	return pr.optionalTimestamp, true
+	return pr.optionalNanosTimestamp, true
 }
 
 // MarshalBinary creates a version of the snapshot that uses relative encoding

--- a/internal/datastore/postgres/revisions_test.go
+++ b/internal/datastore/postgres/revisions_test.go
@@ -87,8 +87,8 @@ func TestRevisionSerDe(t *testing.T) {
 func TestTxIDTimestampAvailable(t *testing.T) {
 	testTimestamp := uint64(time.Now().Unix())
 	snapshot := snap(0, 5, 1)
-	pgr := postgresRevision{snapshot: snapshot, optionalTxID: newXid8(1), optionalTimestamp: testTimestamp}
-	receivedTimestamp, ok := pgr.OptionalTimestamp()
+	pgr := postgresRevision{snapshot: snapshot, optionalTxID: newXid8(1), optionalNanosTimestamp: testTimestamp}
+	receivedTimestamp, ok := pgr.OptionalNanosTimestamp()
 	require.True(t, ok)
 	require.Equal(t, receivedTimestamp, testTimestamp)
 	txid, ok := pgr.OptionalTransactionID()
@@ -96,7 +96,7 @@ func TestTxIDTimestampAvailable(t *testing.T) {
 	require.Equal(t, newXid8(1), txid)
 
 	anotherRev := postgresRevision{snapshot: snapshot}
-	_, ok = anotherRev.OptionalTimestamp()
+	_, ok = anotherRev.OptionalNanosTimestamp()
 	require.False(t, ok)
 	_, ok = anotherRev.OptionalTransactionID()
 	require.False(t, ok)

--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -152,7 +152,11 @@ func (pgd *pgDatastore) Watch(
 				// transactions.
 				currentTxn = newTxns[len(newTxns)-1]
 				for _, newTx := range newTxns {
-					currentTxn = postgresRevision{snapshot: currentTxn.snapshot.markComplete(newTx.optionalTxID.Uint64)}
+					currentTxn = postgresRevision{
+						snapshot:               currentTxn.snapshot.markComplete(newTx.optionalTxID.Uint64),
+						optionalTxID:           currentTxn.optionalTxID,
+						optionalNanosTimestamp: currentTxn.optionalNanosTimestamp,
+					}
 				}
 
 				// If checkpoints were requested, output a checkpoint. While the Postgres datastore does not
@@ -201,9 +205,9 @@ func (pgd *pgDatastore) getNewRevisions(ctx context.Context, afterTX postgresRev
 			}
 
 			ids = append(ids, postgresRevision{
-				snapshot:          nextSnapshot.markComplete(nextXID.Uint64),
-				optionalTxID:      nextXID,
-				optionalTimestamp: uint64(timestamp.Unix()),
+				snapshot:               nextSnapshot.markComplete(nextXID.Uint64),
+				optionalTxID:           nextXID,
+				optionalNanosTimestamp: uint64(timestamp.UnixNano()),
 			})
 		}
 		if rows.Err() != nil {


### PR DESCRIPTION
two follow up changes to https://github.com/authzed/spicedb/pull/1951
- the unit is nanos, to align it with the resolution of the inexact float64 provided by the CRDB HCL revision
- also provide timestamp and transaction ID values with checkpoint revisions, which were not being delivered via the Datastore Watch API