### PR TITLE
Fix debug traces when caveats use the same param name

### DIFF
--- a/internal/caveats/debug.go
+++ b/internal/caveats/debug.go
@@ -1,0 +1,164 @@
+package caveats
+
+import (
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/authzed/spicedb/pkg/caveats"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
+	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
+)
+
+// BuildDebugInformation returns a human-readable string representation of the given
+// ExpressionResult and a Struct representation of the context values used in the expression.
+func BuildDebugInformation(exprResult ExpressionResult) (string, *structpb.Struct, error) {
+	// If a concrete result, return its information directly.
+	if concrete, ok := exprResult.(*caveats.CaveatResult); ok {
+		exprString, err := concrete.ParentCaveat().ExprString()
+		if err != nil {
+			return "", nil, err
+		}
+
+		contextStruct, err := concrete.ContextStruct()
+		if err != nil {
+			return "", nil, err
+		}
+
+		return exprString, contextStruct, nil
+	}
+
+	// Collect parameters which are shared across expressions.
+	syntheticResult, ok := exprResult.(syntheticResult)
+	if !ok {
+		return "", nil, spiceerrors.MustBugf("unknown ExpressionResult type: %T", exprResult)
+	}
+
+	resultsByParam := mapz.NewMultiMap[string, *caveats.CaveatResult]()
+	if err := collectParameterUsage(syntheticResult, resultsByParam); err != nil {
+		return "", nil, err
+	}
+
+	// Build the synthetic debug information.
+	exprString, contextMap, err := buildDebugInformation(syntheticResult, resultsByParam)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Convert the context map to a struct.
+	contextStruct, err := structpb.NewStruct(contextMap)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return exprString, contextStruct, nil
+}
+
+func buildDebugInformation(sr syntheticResult, resultsByParam *mapz.MultiMap[string, *caveats.CaveatResult]) (string, map[string]any, error) {
+	childExprStrings := make([]string, 0, len(sr.exprResultsForDebug))
+	combinedContext := map[string]any{}
+
+	for _, child := range sr.exprResultsForDebug {
+		if _, ok := child.(*caveats.CaveatResult); ok {
+			childExprString, contextMap, err := buildDebugInformationForConcrete(child.(*caveats.CaveatResult), resultsByParam)
+			if err != nil {
+				return "", nil, err
+			}
+
+			childExprStrings = append(childExprStrings, "("+childExprString+")")
+			maps.Copy(combinedContext, contextMap)
+			continue
+		}
+
+		childExprString, contextMap, err := buildDebugInformation(child.(syntheticResult), resultsByParam)
+		if err != nil {
+			return "", nil, err
+		}
+
+		childExprStrings = append(childExprStrings, "("+childExprString+")")
+		maps.Copy(combinedContext, contextMap)
+	}
+
+	var combinedExprString string
+	switch sr.op {
+	case corev1.CaveatOperation_AND:
+		combinedExprString = strings.Join(childExprStrings, " && ")
+
+	case corev1.CaveatOperation_OR:
+		combinedExprString = strings.Join(childExprStrings, " || ")
+
+	case corev1.CaveatOperation_NOT:
+		if len(childExprStrings) != 1 {
+			return "", nil, spiceerrors.MustBugf("NOT operator must have exactly one child")
+		}
+
+		combinedExprString = "!" + childExprStrings[0]
+
+	default:
+		return "", nil, fmt.Errorf("unknown operator: %v", sr.op)
+	}
+
+	return combinedExprString, combinedContext, nil
+}
+
+func buildDebugInformationForConcrete(cr *caveats.CaveatResult, resultsByParam *mapz.MultiMap[string, *caveats.CaveatResult]) (string, map[string]any, error) {
+	// For each paramter used in the context of the caveat, check if it is shared across multiple
+	// caveats. If so, rewrite the parameter to a unique name.
+	existingContextMap := cr.ContextValues()
+	contextMap := make(map[string]any, len(existingContextMap))
+
+	caveat := *cr.ParentCaveat()
+
+	for paramName, paramValue := range existingContextMap {
+		index := mapz.IndexOfValueInMultimap(resultsByParam, paramName, cr)
+		if resultsByParam.CountOf(paramName) > 1 {
+			newName := paramName + "__" + strconv.Itoa(index)
+			if resultsByParam.Has(newName) {
+				return "", nil, fmt.Errorf("failed to generate unique name for parameter: %s", newName)
+			}
+
+			rewritten, err := caveat.RewriteVariable(paramName, newName)
+			if err != nil {
+				return "", nil, err
+			}
+
+			caveat = rewritten
+			contextMap[newName] = paramValue
+			continue
+		}
+
+		contextMap[paramName] = paramValue
+	}
+
+	exprString, err := caveat.ExprString()
+	if err != nil {
+		return "", nil, err
+	}
+
+	return exprString, contextMap, nil
+}
+
+func collectParameterUsage(sr syntheticResult, resultsByParam *mapz.MultiMap[string, *caveats.CaveatResult]) error {
+	for _, exprResult := range sr.exprResultsForDebug {
+		if concrete, ok := exprResult.(*caveats.CaveatResult); ok {
+			for paramName := range concrete.ContextValues() {
+				resultsByParam.Add(paramName, concrete)
+			}
+		} else {
+			cast, ok := exprResult.(syntheticResult)
+			if !ok {
+				return spiceerrors.MustBugf("unknown ExpressionResult type: %T", exprResult)
+			}
+
+			if err := collectParameterUsage(cast, resultsByParam); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/caveats/debug_test.go
+++ b/internal/caveats/debug_test.go
@@ -1,0 +1,242 @@
+package caveats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/caveats"
+	"github.com/authzed/spicedb/pkg/caveats/types"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+)
+
+func TestBuildDebugInformation(t *testing.T) {
+	tcs := []struct {
+		name               string
+		result             func(t *testing.T) ExpressionResult
+		expectedContext    map[string]any
+		expectedExprString string
+	}{
+		{
+			name:               "basic direct caveat",
+			result:             eval("true", nil),
+			expectedContext:    map[string]any{},
+			expectedExprString: "true",
+		},
+		{
+			name: "basic variable",
+			result: eval("input == 5", map[string]any{
+				"input": 5,
+			}),
+			expectedContext: map[string]any{
+				"input": 5.0,
+			},
+			expectedExprString: "input == 5",
+		},
+		{
+			name: "basic operation",
+			result: eval("input == 5 && input2 == 64", map[string]any{
+				"input":  5,
+				"input2": 64,
+			}),
+			expectedContext: map[string]any{
+				"input":  5.0,
+				"input2": 64.0,
+			},
+			expectedExprString: "input == 5 && input2 == 64",
+		},
+		{
+			name: "nested operation",
+			result: and(
+				eval("input == 5", map[string]any{
+					"input": 5,
+				}),
+				eval("input2 == 64", map[string]any{
+					"input2": 64,
+				}),
+			),
+			expectedContext: map[string]any{
+				"input":  5.0,
+				"input2": 64.0,
+			},
+			expectedExprString: "(input == 5) && (input2 == 64)",
+		},
+		{
+			name: "nested AND operation with name reuse",
+			result: and(
+				eval("input == 5", map[string]any{
+					"input": 5,
+				}),
+				eval("input == 64", map[string]any{
+					"input": 64,
+				}),
+				eval("input == 42", map[string]any{
+					"input": 42,
+				}),
+			),
+			expectedContext: map[string]any{
+				"input__0": 5.0,
+				"input__1": 64.0,
+				"input__2": 42.0,
+			},
+			expectedExprString: "(input__0 == 5) && (input__1 == 64) && (input__2 == 42)",
+		},
+		{
+			name: "nested OR operation with name reuse",
+			result: or(
+				eval("input == 5", map[string]any{
+					"input": 5,
+				}),
+				eval("input == 64", map[string]any{
+					"input": 64,
+				}),
+				eval("input == 42", map[string]any{
+					"input": 42,
+				}),
+			),
+			expectedContext: map[string]any{
+				"input__0": 5.0,
+				"input__1": 64.0,
+				"input__2": 42.0,
+			},
+			expectedExprString: "(input__0 == 5) || (input__1 == 64) || (input__2 == 42)",
+		},
+		{
+			name: "NOT operation ",
+			result: not(
+				eval("input == 5", map[string]any{
+					"input": 5,
+				}),
+			),
+			expectedContext: map[string]any{
+				"input": 5.0,
+			},
+			expectedExprString: "!(input == 5)",
+		},
+		{
+			name: "complex operation with some name reuse",
+			result: and(
+				not(
+					eval("input == 5", map[string]any{
+						"input": 5,
+					}),
+				),
+				or(
+					eval("input == 64", map[string]any{
+						"input": 64,
+					}),
+					eval("input2 == 42", map[string]any{
+						"input2": 42,
+					}),
+				),
+				eval("input3 == 56", map[string]any{
+					"input3": 123,
+				}),
+			),
+			expectedContext: map[string]any{
+				"input__0": 5.0,
+				"input__1": 64.0,
+				"input2":   42.0,
+				"input3":   123.0,
+			},
+			expectedExprString: "(!(input__0 == 5)) && ((input__1 == 64) || (input2 == 42)) && (input3 == 56)",
+		},
+		{
+			name: "nested AND operation with multiple name reuse",
+			result: and(
+				eval("a + b + c == 5", map[string]any{
+					"a": 2,
+					"b": 3,
+					"c": 1200,
+				}),
+				eval("a - b - d == 64", map[string]any{
+					"a": 64,
+					"b": 0,
+					"d": 2400,
+				}),
+			),
+			expectedContext: map[string]any{
+				"a__0": 2.0,
+				"b__0": 3.0,
+				"c":    1200.0,
+				"a__1": 64.0,
+				"b__1": 0.0,
+				"d":    2400.0,
+			},
+			expectedExprString: "(a__0 + b__0 + c == 5) && (a__1 - b__1 - d == 64)",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			exprString, contextStruct, err := BuildDebugInformation(tc.result(t))
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedExprString, exprString)
+			require.Equal(t, tc.expectedContext, contextStruct.AsMap())
+		})
+	}
+}
+
+func and(opFuncs ...func(t *testing.T) ExpressionResult) func(t *testing.T) ExpressionResult {
+	return func(t *testing.T) ExpressionResult {
+		ops := make([]ExpressionResult, 0, len(opFuncs))
+		for _, opFunc := range opFuncs {
+			ops = append(ops, opFunc(t))
+		}
+
+		return syntheticResult{
+			value:               true,
+			op:                  core.CaveatOperation_AND,
+			exprResultsForDebug: ops,
+		}
+	}
+}
+
+func or(opFuncs ...func(t *testing.T) ExpressionResult) func(t *testing.T) ExpressionResult {
+	return func(t *testing.T) ExpressionResult {
+		ops := make([]ExpressionResult, 0, len(opFuncs))
+		for _, opFunc := range opFuncs {
+			ops = append(ops, opFunc(t))
+		}
+
+		return syntheticResult{
+			value:               true,
+			op:                  core.CaveatOperation_OR,
+			exprResultsForDebug: ops,
+		}
+	}
+}
+
+func not(opFuncs ...func(t *testing.T) ExpressionResult) func(t *testing.T) ExpressionResult {
+	return func(t *testing.T) ExpressionResult {
+		ops := make([]ExpressionResult, 0, len(opFuncs))
+		for _, opFunc := range opFuncs {
+			ops = append(ops, opFunc(t))
+		}
+
+		return syntheticResult{
+			value:               true,
+			op:                  core.CaveatOperation_NOT,
+			exprResultsForDebug: ops,
+		}
+	}
+}
+
+func eval(expr string, context map[string]any) func(t *testing.T) ExpressionResult {
+	return func(t *testing.T) ExpressionResult {
+		env := caveats.NewEnvironment()
+
+		for name := range context {
+			require.NoError(t, env.AddVariable(name, types.AnyType))
+		}
+
+		caveat, err := caveats.CompileCaveatWithName(env, expr, "test")
+		require.NoError(t, err)
+
+		result, err := caveats.EvaluateCaveat(caveat, context)
+		require.NoError(t, err)
+
+		return result
+	}
+}

--- a/internal/caveats/run_test.go
+++ b/internal/caveats/run_test.go
@@ -61,7 +61,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			true,
 			nil,
-			"first == 42",
+			`(first == 42) || (second == "hello")`,
 		},
 		{
 			"non-short circuited or",
@@ -75,7 +75,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			true,
 			nil,
-			`second == "hello"`,
+			`(first == 42) || (second == "hello")`,
 		},
 		{
 			"false or",
@@ -89,7 +89,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			nil,
-			`first == 42 || second == "hello"`,
+			`(first == 42) || (second == "hello")`,
 		},
 		{
 			"short circuited and",
@@ -102,7 +102,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			nil,
-			"first == 42",
+			`(first == 42) && (second == "hello")`,
 		},
 		{
 			"non-short circuited and",
@@ -116,7 +116,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			nil,
-			"first == 42",
+			`(first == 42) && (second == "hello")`,
 		},
 		{
 			"false or",
@@ -130,7 +130,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			nil,
-			`second == "hello"`,
+			`(first == 42) && (second == "hello")`,
 		},
 		{
 			"inversion",
@@ -162,7 +162,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			nil,
-			`first == 42 || second == "hello"`,
+			`((first == 42) || (second == "hello")) && (!(third))`,
 		},
 		{
 			"nested true",
@@ -182,7 +182,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			true,
 			nil,
-			`first == 42 && !(third)`,
+			`((first == 42) || (second == "hello")) && (!(third))`,
 		},
 		{
 			"missing context on left side of and branch, right branch is true",
@@ -195,7 +195,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			[]string{"first"},
-			`first == 42 && second == "hello"`,
+			`(first == 42) && (second == "hello")`,
 		},
 		{
 			"missing context on right side of and branch, left branch is true",
@@ -208,7 +208,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			[]string{"second"},
-			`first == 42 && second == "hello"`,
+			`(first == 42) && (second == "hello")`,
 		},
 		{
 			"missing context on left side of or branch, right branch is true",
@@ -221,7 +221,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			true,
 			nil,
-			`second == "hello"`,
+			`(first == 42) || (second == "hello")`,
 		},
 		{
 			"missing context on right side of or branch, left branch is true",
@@ -234,7 +234,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			true,
 			nil,
-			`first == 42`,
+			`(first == 42) || (second == "hello")`,
 		},
 		{
 			"missing context on left side of and branch, right branch is false",
@@ -247,7 +247,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			nil,
-			`second == "hello"`,
+			`(first == 42) && (second == "hello")`,
 		},
 		{
 			"missing context on right side of and branch, left branch is false",
@@ -260,7 +260,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			nil,
-			`first == 42`,
+			`(first == 42) && (second == "hello")`,
 		},
 		{
 			"missing context on left side of or branch, right branch is false",
@@ -273,7 +273,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			[]string{"first"},
-			`first == 42 || second == "hello"`,
+			`(first == 42) || (second == "hello")`,
 		},
 		{
 			"missing context on right side of or branch, left branch is false",
@@ -286,7 +286,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			[]string{"second"},
-			`first == 42 || second == "hello"`,
+			`(first == 42) || (second == "hello")`,
 		},
 		{
 			"missing context on both sides of and branch",
@@ -297,7 +297,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			map[string]any{},
 			false,
 			[]string{"first", "second"},
-			`first == 42 && second == "hello"`,
+			`(first == 42) && (second == "hello")`,
 		},
 		{
 			"missing context on both sides of or branch",
@@ -308,7 +308,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			map[string]any{},
 			false,
 			[]string{"first", "second"},
-			`first == 42 || second == "hello"`,
+			`(first == 42) || (second == "hello")`,
 		},
 		{
 			"missing context under invert",
@@ -333,7 +333,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			[]string{"first"},
-			`!(first == 42) && second == "hello"`,
+			`(!(first == 42)) && (second == "hello")`,
 		},
 		{
 			"missing context with invert under and with true left branch",
@@ -348,7 +348,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			[]string{"first"},
-			`second == "hello" && !(first == 42)`,
+			`(second == "hello") && (!(first == 42))`,
 		},
 		{
 			"missing context with invert under and with false right branch",
@@ -363,7 +363,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			nil,
-			`second == "hello"`,
+			`(!(first == 42)) && (second == "hello")`,
 		},
 		{
 			"missing context with invert under and with false left branch",
@@ -378,7 +378,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			nil,
-			`second == "hello"`,
+			`(second == "hello") && (!(first == 42))`,
 		},
 		{
 			"missing context with invert under or with true right branch",
@@ -393,7 +393,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			true,
 			nil,
-			`second == "hello"`,
+			`(!(first == 42)) || (second == "hello")`,
 		},
 		{
 			"missing context with invert under or with true left branch",
@@ -408,7 +408,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			true,
 			nil,
-			`second == "hello"`,
+			`(second == "hello") || (!(first == 42))`,
 		},
 		{
 			"missing context with invert under or with false right branch",
@@ -423,7 +423,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			[]string{"first"},
-			`!(first == 42) || second == "hello"`,
+			`(!(first == 42)) || (second == "hello")`,
 		},
 		{
 			"missing context with invert under or with false left branch",
@@ -438,7 +438,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			},
 			false,
 			[]string{"first"},
-			`second == "hello" || !(first == 42)`,
+			`(second == "hello") || (!(first == 42))`,
 		},
 	}
 
@@ -491,14 +491,8 @@ func TestRunCaveatExpressions(t *testing.T) {
 						require.False(t, result.IsPartial())
 					}
 
-					_, err = result.ContextStruct()
-					require.NoError(t, err)
-
-					_, err = result.ExpressionString()
-					require.NoError(t, err)
-
 					if debugOption == caveats.RunCaveatExpressionWithDebugInformation {
-						exprString, err := result.ExpressionString()
+						exprString, _, err := caveats.BuildDebugInformation(result)
 						require.NoError(t, err)
 						require.NotEmpty(t, exprString)
 						require.Equal(t, tc.expectedExprString, exprString)

--- a/internal/graph/computed/computecheck_test.go
+++ b/internal/graph/computed/computecheck_test.go
@@ -3,6 +3,7 @@ package computed_test
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -842,7 +843,11 @@ func TestComputeCheckWithCaveats(t *testing.T) {
 						require.Equal(t, v1.ResourceCheckResult_Membership_name[int32(r.member)], v1.ResourceCheckResult_Membership_name[int32(result.Membership)], "mismatch for %s with context %v", r.check, r.context)
 
 						if result.Membership == v1.ResourceCheckResult_CAVEATED_MEMBER {
-							require.Equal(t, r.expectedMissingFields, result.MissingExprFields)
+							foundFields := result.MissingExprFields
+							sort.Strings(foundFields)
+							sort.Strings(r.expectedMissingFields)
+
+							require.Equal(t, r.expectedMissingFields, foundFields)
 						}
 					}
 				})

--- a/internal/services/v1/debug.go
+++ b/internal/services/v1/debug.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"cmp"
 	"context"
-	"fmt"
 	"slices"
 	"strings"
 
@@ -111,12 +110,7 @@ func convertCheckTrace(ctx context.Context, caveatContext map[string]any, ct *di
 			}
 		}
 
-		contextStruct, err := computedResult.ContextStruct()
-		if err != nil {
-			return nil, fmt.Errorf("could not serialize context: %w. please report this error", err)
-		}
-
-		exprString, err := computedResult.ExpressionString()
+		exprString, contextStruct, err := cexpr.BuildDebugInformation(computedResult)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/caveats/eval.go
+++ b/pkg/caveats/eval.go
@@ -70,6 +70,11 @@ func (cr CaveatResult) ExpressionString() (string, error) {
 	return cr.parentCaveat.ExprString()
 }
 
+// ParentCaveat returns the caveat that was evaluated to produce this result.
+func (cr CaveatResult) ParentCaveat() *CompiledCaveat {
+	return cr.parentCaveat
+}
+
 // MissingVarNames returns the name(s) of the missing variables.
 func (cr CaveatResult) MissingVarNames() ([]string, error) {
 	if !cr.isPartial {

--- a/pkg/caveats/replacer/inlining.go
+++ b/pkg/caveats/replacer/inlining.go
@@ -1,0 +1,171 @@
+// Modified version of https://github.com/authzed/cel-go/blob/b707d132d96bb5450df92d138860126bf03f805f/cel/inlining.go
+// which changes it so variable replacement is always done without cel.bind calls. See
+// the "CHANGED" below.
+//
+// Original Copyright notice:
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replacer
+
+import (
+	"github.com/authzed/cel-go/cel"
+	"github.com/authzed/cel-go/common/ast"
+	"github.com/authzed/cel-go/common/containers"
+	"github.com/authzed/cel-go/common/operators"
+	"github.com/authzed/cel-go/common/overloads"
+	"github.com/authzed/cel-go/common/types"
+	"github.com/authzed/cel-go/common/types/traits"
+)
+
+// InlineVariable holds a variable name to be matched and an AST representing
+// the expression graph which should be used to replace it.
+type InlineVariable struct {
+	name  string
+	alias string
+	def   *ast.AST
+}
+
+// Name returns the qualified variable or field selection to replace.
+func (v *InlineVariable) Name() string {
+	return v.name
+}
+
+// Alias returns the alias to use when performing cel.bind() calls during inlining.
+func (v *InlineVariable) Alias() string {
+	return v.alias
+}
+
+// Expr returns the inlined expression value.
+func (v *InlineVariable) Expr() ast.Expr {
+	return v.def.Expr()
+}
+
+// Type indicates the inlined expression type.
+func (v *InlineVariable) Type() *cel.Type {
+	return v.def.GetType(v.def.Expr().ID())
+}
+
+// newInlineVariable declares a variable name to be replaced by a checked expression.
+func newInlineVariable(name string, definition *cel.Ast) *InlineVariable {
+	return newInlineVariableWithAlias(name, name, definition)
+}
+
+// newInlineVariableWithAlias declares a variable name to be replaced by a checked expression.
+// If the variable occurs more than once, the provided alias will be used to replace the expressions
+// where the variable name occurs.
+func newInlineVariableWithAlias(name, alias string, definition *cel.Ast) *InlineVariable {
+	return &InlineVariable{name: name, alias: alias, def: definition.NativeRep()}
+}
+
+// newModifiedInliningOptimizer creates and optimizer which replaces variables with expression definitions.
+func newModifiedInliningOptimizer(inlineVars ...*InlineVariable) cel.ASTOptimizer {
+	return &inliningOptimizer{variables: inlineVars}
+}
+
+type inliningOptimizer struct {
+	variables []*InlineVariable
+}
+
+func (opt *inliningOptimizer) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *ast.AST {
+	root := ast.NavigateAST(a)
+	for _, inlineVar := range opt.variables {
+		matches := ast.MatchDescendants(root, opt.matchVariable(inlineVar.Name()))
+		// Skip cases where the variable isn't in the expression graph
+		if len(matches) == 0 {
+			continue
+		}
+
+		// CHANGED: *ALWAYS* do a direct replacement of the expression sub-graph.
+		for _, match := range matches {
+			// Copy the inlined AST expr and source info.
+			copyExpr := ctx.CopyASTAndMetadata(inlineVar.def)
+			opt.inlineExpr(ctx, match, copyExpr, inlineVar.Type())
+		}
+	}
+	return a
+}
+
+// inlineExpr replaces the current expression with the inlined one, unless the location of the inlining
+// happens within a presence test, e.g. has(a.b.c) -> inline alpha for a.b.c in which case an attempt is
+// made to determine whether the inlined value can be presence or existence tested.
+func (opt *inliningOptimizer) inlineExpr(ctx *cel.OptimizerContext, prev ast.NavigableExpr, inlined ast.Expr, inlinedType *cel.Type) {
+	switch prev.Kind() {
+	case ast.SelectKind:
+		sel := prev.AsSelect()
+		if !sel.IsTestOnly() {
+			ctx.UpdateExpr(prev, inlined)
+			return
+		}
+		opt.rewritePresenceExpr(ctx, prev, inlined, inlinedType)
+	default:
+		ctx.UpdateExpr(prev, inlined)
+	}
+}
+
+// rewritePresenceExpr converts the inlined expression, when it occurs within a has() macro, to type-safe
+// expression appropriate for the inlined type, if possible.
+//
+// If the rewrite is not possible an error is reported at the inline expression site.
+func (opt *inliningOptimizer) rewritePresenceExpr(ctx *cel.OptimizerContext, prev, inlined ast.Expr, inlinedType *cel.Type) {
+	// If the input inlined expression is not a select expression it won't work with the has()
+	// macro. Attempt to rewrite the presence test in terms of the typed input, otherwise error.
+	if inlined.Kind() == ast.SelectKind {
+		presenceTest, hasMacro := ctx.NewHasMacro(prev.ID(), inlined)
+		ctx.UpdateExpr(prev, presenceTest)
+		ctx.SetMacroCall(prev.ID(), hasMacro)
+		return
+	}
+
+	ctx.ClearMacroCall(prev.ID())
+	if inlinedType.IsAssignableType(cel.NullType) {
+		ctx.UpdateExpr(prev,
+			ctx.NewCall(operators.NotEquals,
+				inlined,
+				ctx.NewLiteral(types.NullValue),
+			))
+		return
+	}
+	if inlinedType.HasTrait(traits.SizerType) {
+		ctx.UpdateExpr(prev,
+			ctx.NewCall(operators.NotEquals,
+				ctx.NewMemberCall(overloads.Size, inlined),
+				ctx.NewLiteral(types.IntZero),
+			))
+		return
+	}
+	ctx.ReportErrorAtID(prev.ID(), "unable to inline expression type %v into presence test", inlinedType)
+}
+
+// matchVariable matches simple identifiers, select expressions, and presence test expressions
+// which match the (potentially) qualified variable name provided as input.
+//
+// Note, this function does not support inlining against select expressions which includes optional
+// field selection. This may be a future refinement.
+func (opt *inliningOptimizer) matchVariable(varName string) ast.ExprMatcher {
+	return func(e ast.NavigableExpr) bool {
+		if e.Kind() == ast.IdentKind && e.AsIdent() == varName {
+			return true
+		}
+		if e.Kind() == ast.SelectKind {
+			sel := e.AsSelect()
+			// While the `ToQualifiedName` call could take the select directly, this
+			// would skip presence tests from possible matches, which we would like
+			// to include.
+			qualName, found := containers.ToQualifiedName(sel.Operand())
+			return found && qualName+"."+sel.FieldName() == varName
+		}
+		return false
+	}
+}

--- a/pkg/caveats/replacer/replacer.go
+++ b/pkg/caveats/replacer/replacer.go
@@ -1,0 +1,25 @@
+package replacer
+
+import (
+	"fmt"
+
+	"github.com/authzed/cel-go/cel"
+)
+
+func ReplaceVariable(e *cel.Env, existingAst *cel.Ast, oldVarName string, newVarName string) (*cel.Ast, error) {
+	newExpr, iss := e.Compile(newVarName)
+	if iss.Err() != nil {
+		return nil, fmt.Errorf("failed to compile new variable name: %w", iss.Err())
+	}
+
+	inlinedVars := []*InlineVariable{}
+	inlinedVars = append(inlinedVars, newInlineVariable(oldVarName, newExpr))
+
+	opt := cel.NewStaticOptimizer(newModifiedInliningOptimizer(inlinedVars...))
+	optimized, iss := opt.Optimize(e, existingAst)
+	if iss.Err() != nil {
+		return nil, fmt.Errorf("failed to optimize: %w", iss.Err())
+	}
+
+	return optimized, nil
+}

--- a/pkg/genutil/mapz/multimap.go
+++ b/pkg/genutil/mapz/multimap.go
@@ -103,6 +103,27 @@ func (mm MultiMap[T, Q]) Values() []Q {
 	return values
 }
 
+// CountOf returns the number of values stored for the given key.
+func (mm MultiMap[T, Q]) CountOf(key T) int {
+	return len(mm.items[key])
+}
+
+// IndexOfValueInMultimap returns the index of the value in the map for the given key.
+func IndexOfValueInMultimap[T comparable, Q comparable](mm *MultiMap[T, Q], key T, value Q) int {
+	values, ok := mm.items[key]
+	if !ok {
+		return -1
+	}
+
+	for i, v := range values {
+		if v == value {
+			return i
+		}
+	}
+
+	return -1
+}
+
 // AsReadOnly returns a read-only *copy* of the mulitmap.
 func (mm *MultiMap[T, Q]) AsReadOnly() ReadOnlyMultimap[T, Q] {
 	return readOnlyMultimap[T, Q]{


### PR DESCRIPTION
This is done by renaming the parameters in the shared context map and rewriting the expression in the debug trace