### PR TITLE
Reorganize serve flags into flagsets

### DIFF
--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/authzed/spicedb/internal/datastore/crdb"
@@ -159,7 +158,7 @@ type Config struct {
 }
 
 // RegisterDatastoreFlags adds datastore flags to a cobra command.
-func RegisterDatastoreFlags(cmd *cobra.Command, flagset *pflag.FlagSet, opts *Config) error {
+func RegisterDatastoreFlags(flagset *pflag.FlagSet, opts *Config) error {
 	return RegisterDatastoreFlagsWithPrefix(flagset, "", opts)
 }
 

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -159,8 +159,8 @@ type Config struct {
 }
 
 // RegisterDatastoreFlags adds datastore flags to a cobra command.
-func RegisterDatastoreFlags(cmd *cobra.Command, opts *Config) error {
-	return RegisterDatastoreFlagsWithPrefix(cmd.Flags(), "", opts)
+func RegisterDatastoreFlags(cmd *cobra.Command, flagset *pflag.FlagSet, opts *Config) error {
+	return RegisterDatastoreFlagsWithPrefix(flagset, "", opts)
 }
 
 // RegisterDatastoreFlagsWithPrefix adds datastore flags to a cobra command, with each flag prefixed with the provided

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/jzelinskie/cobrautil/v2"
+	"github.com/jzelinskie/cobrautil/v2/cobraotel"
 	"github.com/spf13/cobra"
 
 	crdbmigrations "github.com/authzed/spicedb/internal/datastore/crdb/migrations"
@@ -30,6 +31,9 @@ func RegisterMigrateFlags(cmd *cobra.Command) {
 	cmd.Flags().String("datastore-mysql-table-prefix", "", "prefix to add to the name of all mysql database tables")
 	cmd.Flags().Uint64("migration-backfill-batch-size", 1000, "number of items to migrate per iteration of a datastore backfill")
 	cmd.Flags().Duration("migration-timeout", 1*time.Hour, "defines a timeout for the execution of the migration, set to 1 hour by default")
+
+	otel := cobraotel.New(cmd.Use)
+	otel.RegisterFlags(cmd.Flags())
 	termination.RegisterFlags(cmd.Flags())
 	runtime.RegisterFlags(cmd.Flags())
 }

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -32,7 +32,7 @@ func RegisterMigrateFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint64("migration-backfill-batch-size", 1000, "number of items to migrate per iteration of a datastore backfill")
 	cmd.Flags().Duration("migration-timeout", 1*time.Hour, "defines a timeout for the execution of the migration, set to 1 hour by default")
 
-	otel := cobraotel.New(cmd.Use)
+	otel := cobraotel.New("spicedb")
 	otel.RegisterFlags(cmd.Flags())
 	termination.RegisterFlags(cmd.Flags())
 	runtime.RegisterFlags(cmd.Flags())

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/migrate"
+	"github.com/authzed/spicedb/pkg/runtime"
 )
 
 func RegisterMigrateFlags(cmd *cobra.Command) {
@@ -29,6 +30,8 @@ func RegisterMigrateFlags(cmd *cobra.Command) {
 	cmd.Flags().String("datastore-mysql-table-prefix", "", "prefix to add to the name of all mysql database tables")
 	cmd.Flags().Uint64("migration-backfill-batch-size", 1000, "number of items to migrate per iteration of a datastore backfill")
 	cmd.Flags().Duration("migration-timeout", 1*time.Hour, "defines a timeout for the execution of the migration, set to 1 hour by default")
+	termination.RegisterFlags(cmd.Flags())
+	runtime.RegisterFlags(cmd.Flags())
 }
 
 func NewMigrateCommand(programName string) *cobra.Command {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -4,15 +4,12 @@ import (
 	"fmt"
 
 	"github.com/jzelinskie/cobrautil/v2"
-	"github.com/jzelinskie/cobrautil/v2/cobraotel"
 	"github.com/jzelinskie/cobrautil/v2/cobrazerolog"
 	"github.com/spf13/cobra"
 
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/cmd/server"
-	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/releases"
-	"github.com/authzed/spicedb/pkg/runtime"
 )
 
 func RegisterRootFlags(cmd *cobra.Command) error {
@@ -22,15 +19,7 @@ func RegisterRootFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to register zerolog flag completion: %w", err)
 	}
 
-	ot := cobraotel.New(cmd.Use)
-	ot.RegisterFlags(cmd.PersistentFlags())
-	if err := ot.RegisterFlagCompletion(cmd); err != nil {
-		return fmt.Errorf("failed to register otel flag completion: %w", err)
-	}
-
 	releases.RegisterFlags(cmd.PersistentFlags())
-	termination.RegisterFlags(cmd.PersistentFlags())
-	runtime.RegisterFlags(cmd.PersistentFlags())
 
 	return nil
 }

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -128,8 +128,6 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	namespaceCacheFlags.DurationVar(&config.SchemaWatchHeartbeat, "datastore-schema-watch-heartbeat", 1*time.Second, "heartbeat time on the schema watch in the datastore (if supported). 0 means to default to the datastore's minimum.")
 	server.MustRegisterCacheFlags(namespaceCacheFlags, "ns-cache", &config.NamespaceCacheConfig, namespaceCacheDefaults)
 
-	// Flags for parsing and validating schemas.
-	cmd.Flags().BoolVar(&config.SchemaPrefixesRequired, "schema-prefixes-required", false, "require prefixes on all object definitions in schemas")
 
 	dispatchFlags := nfs.FlagSet(BoldBlue("Dispatch"))
 	// Flags for configuring the dispatch server
@@ -169,7 +167,8 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 
 	observabilityFlags := nfs.FlagSet(BoldBlue("Observability"))
 	// Flags for observability and profiling
-	otel := cobraotel.New(cmd.Use)
+	// NOTE: cobraotel.New takes service name as an arg rather than command name.
+	otel := cobraotel.New("spicedb")
 	otel.RegisterFlags(observabilityFlags)
 	runtime.RegisterFlags(observabilityFlags)
 
@@ -186,6 +185,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	miscellaneousFlags := nfs.FlagSet(BoldBlue("Miscellaneous"))
 	// Flags for things that don't neatly fit into another bucket
 	termination.RegisterFlags(miscellaneousFlags)
+	miscellaneousFlags.BoolVar(&config.SchemaPrefixesRequired, "schema-prefixes-required", false, "require prefixes on all object definitions in schemas")
 
 	// Flags for misc services
 

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jzelinskie/cobrautil/v2"
+	"github.com/jzelinskie/cobrautil/v2/cobraotel"
 	"github.com/spf13/cobra"
 
 	"github.com/authzed/spicedb/internal/telemetry"
@@ -12,6 +14,7 @@ import (
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/cmd/util"
+	"github.com/authzed/spicedb/pkg/runtime"
 )
 
 const PresharedKeyFlag = "grpc-preshared-key"
@@ -50,115 +53,141 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	config.DispatchClusterMetricsEnabled = true
 	config.DispatchClientMetricsEnabled = true
 
+	nfs := cobrautil.NewNamedFlagSets(cmd)
+
+	grpcFlagSet := nfs.FlagSet("gRPC")
 	// Flags for logging
-	cmd.Flags().BoolVar(&config.EnableRequestLogs, "grpc-log-requests-enabled", false, "logs API request payloads")
-	cmd.Flags().BoolVar(&config.EnableResponseLogs, "grpc-log-responses-enabled", false, "logs API response payloads")
+	grpcFlagSet.BoolVar(&config.EnableRequestLogs, "grpc-log-requests-enabled", false, "logs API request payloads")
+	grpcFlagSet.BoolVar(&config.EnableResponseLogs, "grpc-log-responses-enabled", false, "logs API response payloads")
 
 	// Flags for the gRPC API server
-	util.RegisterGRPCServerFlags(cmd.Flags(), &config.GRPCServer, "grpc", "gRPC", ":50051", true)
-	cmd.Flags().StringSliceVar(&config.PresharedSecureKey, PresharedKeyFlag, []string{}, "preshared key(s) to require for authenticated requests")
-	cmd.Flags().DurationVar(&config.ShutdownGracePeriod, "grpc-shutdown-grace-period", 0*time.Second, "amount of time after receiving sigint to continue serving")
-	if err := cmd.MarkFlagRequired(PresharedKeyFlag); err != nil {
+	util.RegisterGRPCServerFlags(grpcFlagSet, &config.GRPCServer, "grpc", "gRPC", ":50051", true)
+	grpcFlagSet.StringSliceVar(&config.PresharedSecureKey, PresharedKeyFlag, []string{}, "preshared key(s) to require for authenticated requests")
+	grpcFlagSet.DurationVar(&config.ShutdownGracePeriod, "grpc-shutdown-grace-period", 0*time.Second, "amount of time after receiving sigint to continue serving")
+	if err := cobra.MarkFlagRequired(grpcFlagSet, PresharedKeyFlag); err != nil {
 		return fmt.Errorf("failed to mark flag as required: %w", err)
 	}
 
-	// Flags for the datastore
-	if err := datastore.RegisterDatastoreFlags(cmd, &config.DatastoreConfig); err != nil {
-		return err
-	}
-
-	// Flags for configuring the API usage of the datastore
-	cmd.Flags().Uint64Var(&config.MaxDatastoreReadPageSize, "max-datastore-read-page-size", 1_000, "limit on the maximum page size that we will load into memory from the datastore at one time")
-
-	// Flags for the namespace cache
-	cmd.Flags().Duration("ns-cache-expiration", 1*time.Minute, "amount of time a namespace entry should remain cached")
-	if err := cmd.Flags().MarkHidden("ns-cache-expiration"); err != nil {
+	// Flags for HTTP gateway
+	httpFlags := nfs.FlagSet("HTTP")
+	util.RegisterHTTPServerFlags(httpFlags, &config.HTTPGateway, "http", "gateway", ":8443", false)
+	httpFlags.StringVar(&config.HTTPGatewayUpstreamAddr, "http-upstream-override-addr", "", "Override the upstream to point to a different gRPC server")
+	if err := httpFlags.MarkHidden("http-upstream-override-addr"); err != nil {
 		return fmt.Errorf("failed to mark flag as hidden: %w", err)
 	}
-	server.MustRegisterCacheFlags(cmd.Flags(), "ns-cache", &config.NamespaceCacheConfig, namespaceCacheDefaults)
+	httpFlags.StringVar(&config.HTTPGatewayUpstreamTLSCertPath, "http-upstream-override-tls-cert-path", "", "Override the upstream TLS certificate")
+	if err := httpFlags.MarkHidden("http-upstream-override-tls-cert-path"); err != nil {
+		return fmt.Errorf("failed to mark flag as hidden: %w", err)
+	}
+	httpFlags.BoolVar(&config.HTTPGatewayCorsEnabled, "http-cors-enabled", false, "DANGEROUS: Enable CORS on the http gateway")
+	if err := httpFlags.MarkHidden("http-cors-enabled"); err != nil {
+		return fmt.Errorf("failed to mark flag as hidden: %w", err)
+	}
+	httpFlags.StringSliceVar(&config.HTTPGatewayCorsAllowedOrigins, "http-cors-allowed-origins", []string{"*"}, "Set CORS allowed origins for http gateway, defaults to all origins")
+	if err := httpFlags.MarkHidden("http-cors-allowed-origins"); err != nil {
+		return fmt.Errorf("failed to mark flag as hidden: %w", err)
+	}
 
-	cmd.Flags().BoolVar(&config.EnableExperimentalWatchableSchemaCache, "enable-experimental-watchable-schema-cache", false, "enables the experimental schema cache which makes use of the Watch API for automatic updates")
-	cmd.Flags().DurationVar(&config.SchemaWatchHeartbeat, "datastore-schema-watch-heartbeat", 1*time.Second, "heartbeat time on the schema watch in the datastore (if supported). 0 means to default to the datastore's minimum.")
+	apiFlags := nfs.FlagSet("SpiceDB API")
+	// Flags for configuring API behavior
+	// In a future version these will probably be prefixed.
+	apiFlags.Uint16Var(&config.MaximumPreconditionCount, "update-relationships-max-preconditions-per-call", 1000, "maximum number of preconditions allowed for WriteRelationships and DeleteRelationships calls")
+	// TODO: this one should maybe not live in API?
+	apiFlags.Uint64Var(&config.MaxDatastoreReadPageSize, "max-datastore-read-page-size", 1_000, "limit on the maximum page size that we will load into memory from the datastore at one time")
+	apiFlags.BoolVar(&config.DisableV1SchemaAPI, "disable-v1-schema-api", false, "disables the V1 schema API")
+	apiFlags.BoolVar(&config.DisableVersionResponse, "disable-version-response", false, "disables version response support in the API")
+	apiFlags.Uint16Var(&config.MaximumUpdatesPerWrite, "write-relationships-max-updates-per-call", 1000, "maximum number of updates allowed for WriteRelationships calls")
+	apiFlags.IntVar(&config.MaxCaveatContextSize, "max-caveat-context-size", 4096, "maximum allowed size of request caveat context in bytes. A value of zero or less means no limit")
+	apiFlags.IntVar(&config.MaxRelationshipContextSize, "max-relationship-context-size", 25000, "maximum allowed size of the context to be stored in a relationship")
+	apiFlags.DurationVar(&config.StreamingAPITimeout, "streaming-api-response-delay-timeout", 30*time.Second, "max duration time elapsed between messages sent by the server-side to the client (responses) before the stream times out")
+	apiFlags.DurationVar(&config.WatchHeartbeat, "watch-api-heartbeat", 1*time.Second, "heartbeat time on the watch in the API. 0 means to default to the datastore's minimum.")
+	apiFlags.Uint32Var(&config.MaxReadRelationshipsLimit, "max-read-relationships-limit", 1000, "maximum number of relationships that can be read in a single request")
+	apiFlags.Uint32Var(&config.MaxDeleteRelationshipsLimit, "max-delete-relationships-limit", 1000, "maximum number of relationships that can be deleted in a single request")
+	apiFlags.Uint32Var(&config.MaxLookupResourcesLimit, "max-lookup-resources-limit", 1000, "maximum number of resources that can be looked up in a single request")
+	apiFlags.Uint32Var(&config.MaxBulkExportRelationshipsLimit, "max-bulk-export-relationships-limit", 10_000, "maximum number of relationships that can be exported in a single request")
+
+	datastoreFlags := nfs.FlagSet("Datastore")
+	// Flags for the datastore
+	if err := datastore.RegisterDatastoreFlags(cmd, datastoreFlags, &config.DatastoreConfig); err != nil {
+		return err
+	}
+	// TODO: should this be under datastore or api?
+	datastoreFlags.DurationVar(&config.SchemaWatchHeartbeat, "datastore-schema-watch-heartbeat", 1*time.Second, "heartbeat time on the schema watch in the datastore (if supported). 0 means to default to the datastore's minimum.")
+
+	namespaceCacheFlags := nfs.FlagSet("Namespace Cache")
+	// Flags for the namespace cache
+	namespaceCacheFlags.Duration("ns-cache-expiration", 1*time.Minute, "amount of time a namespace entry should remain cached")
+	if err := namespaceCacheFlags.MarkHidden("ns-cache-expiration"); err != nil {
+		return fmt.Errorf("failed to mark flag as hidden: %w", err)
+	}
+	server.MustRegisterCacheFlags(namespaceCacheFlags, "ns-cache", &config.NamespaceCacheConfig, namespaceCacheDefaults)
+
 
 	// Flags for parsing and validating schemas.
 	cmd.Flags().BoolVar(&config.SchemaPrefixesRequired, "schema-prefixes-required", false, "require prefixes on all object definitions in schemas")
 
-	// Flags for HTTP gateway
-	util.RegisterHTTPServerFlags(cmd.Flags(), &config.HTTPGateway, "http", "gateway", ":8443", false)
-	cmd.Flags().StringVar(&config.HTTPGatewayUpstreamAddr, "http-upstream-override-addr", "", "Override the upstream to point to a different gRPC server")
-	if err := cmd.Flags().MarkHidden("http-upstream-override-addr"); err != nil {
-		return fmt.Errorf("failed to mark flag as hidden: %w", err)
-	}
-	cmd.Flags().StringVar(&config.HTTPGatewayUpstreamTLSCertPath, "http-upstream-override-tls-cert-path", "", "Override the upstream TLS certificate")
-	if err := cmd.Flags().MarkHidden("http-upstream-override-tls-cert-path"); err != nil {
-		return fmt.Errorf("failed to mark flag as hidden: %w", err)
-	}
-	cmd.Flags().BoolVar(&config.HTTPGatewayCorsEnabled, "http-cors-enabled", false, "DANGEROUS: Enable CORS on the http gateway")
-	if err := cmd.Flags().MarkHidden("http-cors-enabled"); err != nil {
-		return fmt.Errorf("failed to mark flag as hidden: %w", err)
-	}
-	cmd.Flags().StringSliceVar(&config.HTTPGatewayCorsAllowedOrigins, "http-cors-allowed-origins", []string{"*"}, "Set CORS allowed origins for http gateway, defaults to all origins")
-	if err := cmd.Flags().MarkHidden("http-cors-allowed-origins"); err != nil {
-		return fmt.Errorf("failed to mark flag as hidden: %w", err)
-	}
-
+	dispatchFlags := nfs.FlagSet("Dispatch")
 	// Flags for configuring the dispatch server
-	util.RegisterGRPCServerFlags(cmd.Flags(), &config.DispatchServer, "dispatch-cluster", "dispatch", ":50053", false)
-	server.MustRegisterCacheFlags(cmd.Flags(), "dispatch-cache", &config.DispatchCacheConfig, dispatchCacheDefaults)
-	server.MustRegisterCacheFlags(cmd.Flags(), "dispatch-cluster-cache", &config.ClusterDispatchCacheConfig, dispatchClusterCacheDefaults)
+	util.RegisterGRPCServerFlags(dispatchFlags, &config.DispatchServer, "dispatch-cluster", "dispatch", ":50053", false)
+	server.MustRegisterCacheFlags(dispatchFlags, "dispatch-cache", &config.DispatchCacheConfig, dispatchCacheDefaults)
+	server.MustRegisterCacheFlags(dispatchFlags, "dispatch-cluster-cache", &config.ClusterDispatchCacheConfig, dispatchClusterCacheDefaults)
 
 	// Flags for configuring dispatch requests
-	cmd.Flags().Uint16Var(&config.DispatchChunkSize, "dispatch-chunk-size", 100, "maximum number of object IDs in a dispatched request")
-	cmd.Flags().Uint32Var(&config.DispatchMaxDepth, "dispatch-max-depth", 50, "maximum recursion depth for nested calls")
-	cmd.Flags().StringVar(&config.DispatchUpstreamAddr, "dispatch-upstream-addr", "", "upstream grpc address to dispatch to")
-	cmd.Flags().StringVar(&config.DispatchUpstreamCAPath, "dispatch-upstream-ca-path", "", "local path to the TLS CA used when connecting to the dispatch cluster")
-	cmd.Flags().DurationVar(&config.DispatchUpstreamTimeout, "dispatch-upstream-timeout", 60*time.Second, "maximum duration of a dispatch call an upstream cluster before it times out")
+	dispatchFlags.Uint16Var(&config.DispatchChunkSize, "dispatch-chunk-size", 100, "maximum number of object IDs in a dispatched request")
+	dispatchFlags.Uint32Var(&config.DispatchMaxDepth, "dispatch-max-depth", 50, "maximum recursion depth for nested calls")
+	dispatchFlags.StringVar(&config.DispatchUpstreamAddr, "dispatch-upstream-addr", "", "upstream grpc address to dispatch to")
+	dispatchFlags.StringVar(&config.DispatchUpstreamCAPath, "dispatch-upstream-ca-path", "", "local path to the TLS CA used when connecting to the dispatch cluster")
+	dispatchFlags.DurationVar(&config.DispatchUpstreamTimeout, "dispatch-upstream-timeout", 60*time.Second, "maximum duration of a dispatch call an upstream cluster before it times out")
 
-	cmd.Flags().Uint16Var(&config.GlobalDispatchConcurrencyLimit, "dispatch-concurrency-limit", 50, "maximum number of parallel goroutines to create for each request or subrequest")
+	dispatchFlags.Uint16Var(&config.GlobalDispatchConcurrencyLimit, "dispatch-concurrency-limit", 50, "maximum number of parallel goroutines to create for each request or subrequest")
 
-	cmd.Flags().Uint16Var(&config.DispatchConcurrencyLimits.Check, "dispatch-check-permission-concurrency-limit", 0, "maximum number of parallel goroutines to create for each check request or subrequest. defaults to --dispatch-concurrency-limit")
-	cmd.Flags().Uint16Var(&config.DispatchConcurrencyLimits.LookupResources, "dispatch-lookup-resources-concurrency-limit", 0, "maximum number of parallel goroutines to create for each lookup resources request or subrequest. defaults to --dispatch-concurrency-limit")
-	cmd.Flags().Uint16Var(&config.DispatchConcurrencyLimits.LookupSubjects, "dispatch-lookup-subjects-concurrency-limit", 0, "maximum number of parallel goroutines to create for each lookup subjects request or subrequest. defaults to --dispatch-concurrency-limit")
-	cmd.Flags().Uint16Var(&config.DispatchConcurrencyLimits.ReachableResources, "dispatch-reachable-resources-concurrency-limit", 0, "maximum number of parallel goroutines to create for each reachable resources request or subrequest. defaults to --dispatch-concurrency-limit")
+	dispatchFlags.Uint16Var(&config.DispatchConcurrencyLimits.Check, "dispatch-check-permission-concurrency-limit", 0, "maximum number of parallel goroutines to create for each check request or subrequest. defaults to --dispatch-concurrency-limit")
+	dispatchFlags.Uint16Var(&config.DispatchConcurrencyLimits.LookupResources, "dispatch-lookup-resources-concurrency-limit", 0, "maximum number of parallel goroutines to create for each lookup resources request or subrequest. defaults to --dispatch-concurrency-limit")
+	dispatchFlags.Uint16Var(&config.DispatchConcurrencyLimits.LookupSubjects, "dispatch-lookup-subjects-concurrency-limit", 0, "maximum number of parallel goroutines to create for each lookup subjects request or subrequest. defaults to --dispatch-concurrency-limit")
+	dispatchFlags.Uint16Var(&config.DispatchConcurrencyLimits.ReachableResources, "dispatch-reachable-resources-concurrency-limit", 0, "maximum number of parallel goroutines to create for each reachable resources request or subrequest. defaults to --dispatch-concurrency-limit")
 
-	cmd.Flags().Uint16Var(&config.DispatchHashringReplicationFactor, "dispatch-hashring-replication-factor", 100, "set the replication factor of the consistent hasher used for the dispatcher")
-	cmd.Flags().Uint8Var(&config.DispatchHashringSpread, "dispatch-hashring-spread", 1, "set the spread of the consistent hasher used for the dispatcher")
+	dispatchFlags.Uint16Var(&config.DispatchHashringReplicationFactor, "dispatch-hashring-replication-factor", 100, "set the replication factor of the consistent hasher used for the dispatcher")
+	dispatchFlags.Uint8Var(&config.DispatchHashringSpread, "dispatch-hashring-spread", 1, "set the spread of the consistent hasher used for the dispatcher")
 
-	cmd.Flags().StringToStringVar(&config.DispatchSecondaryUpstreamAddrs, "experimental-dispatch-secondary-upstream-addrs", nil, "secondary upstream addresses for dispatches, each with a name")
-	cmd.Flags().StringToStringVar(&config.DispatchSecondaryUpstreamExprs, "experimental-dispatch-secondary-upstream-exprs", nil, "map from request type (currently supported: `check`) to its associated CEL expression, which returns the secondary upstream(s) to be used for the request")
-
-	// Flags for configuring API behavior
-	cmd.Flags().BoolVar(&config.DisableV1SchemaAPI, "disable-v1-schema-api", false, "disables the V1 schema API")
-	cmd.Flags().BoolVar(&config.DisableVersionResponse, "disable-version-response", false, "disables version response support in the API")
-	cmd.Flags().Uint16Var(&config.MaximumUpdatesPerWrite, "write-relationships-max-updates-per-call", 1000, "maximum number of updates allowed for WriteRelationships calls")
-	cmd.Flags().Uint16Var(&config.MaximumPreconditionCount, "update-relationships-max-preconditions-per-call", 1000, "maximum number of preconditions allowed for WriteRelationships and DeleteRelationships calls")
-	cmd.Flags().IntVar(&config.MaxCaveatContextSize, "max-caveat-context-size", 4096, "maximum allowed size of request caveat context in bytes. A value of zero or less means no limit")
-	cmd.Flags().IntVar(&config.MaxRelationshipContextSize, "max-relationship-context-size", 25000, "maximum allowed size of the context to be stored in a relationship")
-	cmd.Flags().DurationVar(&config.StreamingAPITimeout, "streaming-api-response-delay-timeout", 30*time.Second, "max duration time elapsed between messages sent by the server-side to the client (responses) before the stream times out")
-	cmd.Flags().DurationVar(&config.WatchHeartbeat, "watch-api-heartbeat", 1*time.Second, "heartbeat time on the watch in the API. 0 means to default to the datastore's minimum.")
-
-	cmd.Flags().Uint32Var(&config.MaxReadRelationshipsLimit, "max-read-relationships-limit", 1000, "maximum number of relationships that can be read in a single request")
-	cmd.Flags().Uint32Var(&config.MaxDeleteRelationshipsLimit, "max-delete-relationships-limit", 1000, "maximum number of relationships that can be deleted in a single request")
-	cmd.Flags().Uint32Var(&config.MaxLookupResourcesLimit, "max-lookup-resources-limit", 1000, "maximum number of resources that can be looked up in a single request")
-	cmd.Flags().Uint32Var(&config.MaxBulkExportRelationshipsLimit, "max-bulk-export-relationships-limit", 10_000, "maximum number of relationships that can be exported in a single request")
-	cmd.Flags().BoolVar(&config.EnableExperimentalLookupResources, "enable-experimental-lookup-resources", false, "enables the experimental version of the lookup resources API")
 
 	cmd.Flags().BoolVar(&config.V1SchemaAdditiveOnly, "testing-only-schema-additive-writes", false, "append new definitions to the existing schema, rather than overwriting it")
 	if err := cmd.Flags().MarkHidden("testing-only-schema-additive-writes"); err != nil {
 		return fmt.Errorf("failed to mark flag as required: %w", err)
 	}
 
+	experimentalFlags := nfs.FlagSet("Experimental")
+	// Flags for experimental features
+	experimentalFlags.BoolVar(&config.EnableExperimentalLookupResources, "enable-experimental-lookup-resources", false, "enables the experimental version of the lookup resources API")
+	experimentalFlags.BoolVar(&config.EnableExperimentalWatchableSchemaCache, "enable-experimental-watchable-schema-cache", false, "enables the experimental schema cache which makes use of the Watch API for automatic updates")
+	// TODO: these two could reasonably be put in either the Dispatch group or the Experimental group. Is there a preference?
+	experimentalFlags.StringToStringVar(&config.DispatchSecondaryUpstreamAddrs, "experimental-dispatch-secondary-upstream-addrs", nil, "secondary upstream addresses for dispatches, each with a name")
+	experimentalFlags.StringToStringVar(&config.DispatchSecondaryUpstreamExprs, "experimental-dispatch-secondary-upstream-exprs", nil, "map from request type (currently supported: `check`) to its associated CEL expression, which returns the secondary upstream(s) to be used for the request")
+
+	observabilityFlags := nfs.FlagSet("Observability")
+	// Flags for observability and profiling
+	otel := cobraotel.New(cmd.Use)
+	otel.RegisterFlags(observabilityFlags)
+	runtime.RegisterFlags(observabilityFlags)
+
+	metricsFlags := nfs.FlagSet("Metrics Server")
+	// Flags for metrics
+	util.RegisterHTTPServerFlags(metricsFlags, &config.MetricsAPI, "metrics", "metrics", ":9090", true)
+
+	telemetryFlags := nfs.FlagSet("Telemetry")
+	// Flags for telemetry
+	telemetryFlags.StringVar(&config.TelemetryEndpoint, "telemetry-endpoint", telemetry.DefaultEndpoint, "endpoint to which telemetry is reported, empty string to disable")
+	telemetryFlags.StringVar(&config.TelemetryCAOverridePath, "telemetry-ca-override-path", "", "TODO")
+	telemetryFlags.DurationVar(&config.TelemetryInterval, "telemetry-interval", telemetry.DefaultInterval, "approximate period between telemetry reports, minimum 1 minute")
+
+	miscellaneousFlags := nfs.FlagSet("Miscellaneous")
+	// Flags for things that don't neatly fit into another bucket
+	termination.RegisterFlags(miscellaneousFlags)
+
 	// Flags for misc services
-	util.RegisterHTTPServerFlags(cmd.Flags(), &config.MetricsAPI, "metrics", "metrics", ":9090", true)
 
 	if err := util.RegisterDeprecatedHTTPServerFlags(cmd, "dashboard", "dashboard"); err != nil {
 		return err
 	}
-
-	// Flags for telemetry
-	cmd.Flags().StringVar(&config.TelemetryEndpoint, "telemetry-endpoint", telemetry.DefaultEndpoint, "endpoint to which telemetry is reported, empty string to disable")
-	cmd.Flags().StringVar(&config.TelemetryCAOverridePath, "telemetry-ca-override-path", "", "TODO")
-	cmd.Flags().DurationVar(&config.TelemetryInterval, "telemetry-interval", telemetry.DefaultInterval, "approximate period between telemetry reports, minimum 1 minute")
 
 	return nil
 }

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -122,7 +122,6 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	}
 	server.MustRegisterCacheFlags(namespaceCacheFlags, "ns-cache", &config.NamespaceCacheConfig, namespaceCacheDefaults)
 
-
 	// Flags for parsing and validating schemas.
 	cmd.Flags().BoolVar(&config.SchemaPrefixesRequired, "schema-prefixes-required", false, "require prefixes on all object definitions in schemas")
 
@@ -148,7 +147,6 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 
 	dispatchFlags.Uint16Var(&config.DispatchHashringReplicationFactor, "dispatch-hashring-replication-factor", 100, "set the replication factor of the consistent hasher used for the dispatcher")
 	dispatchFlags.Uint8Var(&config.DispatchHashringSpread, "dispatch-hashring-spread", 1, "set the spread of the consistent hasher used for the dispatcher")
-
 
 	cmd.Flags().BoolVar(&config.V1SchemaAdditiveOnly, "testing-only-schema-additive-writes", false, "append new definitions to the existing schema, rather than overwriting it")
 	if err := cmd.Flags().MarkHidden("testing-only-schema-additive-writes"); err != nil {

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -180,7 +180,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	telemetryFlags := nfs.FlagSet(BoldBlue("Telemetry"))
 	// Flags for telemetry
 	telemetryFlags.StringVar(&config.TelemetryEndpoint, "telemetry-endpoint", telemetry.DefaultEndpoint, "endpoint to which telemetry is reported, empty string to disable")
-	telemetryFlags.StringVar(&config.TelemetryCAOverridePath, "telemetry-ca-override-path", "", "TODO")
+	telemetryFlags.StringVar(&config.TelemetryCAOverridePath, "telemetry-ca-override-path", "", "path to a custom CA to use with the telemetry endpoint")
 	telemetryFlags.DurationVar(&config.TelemetryInterval, "telemetry-interval", telemetry.DefaultInterval, "approximate period between telemetry reports, minimum 1 minute")
 
 	miscellaneousFlags := nfs.FlagSet(BoldBlue("Miscellaneous"))

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -128,7 +128,6 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	namespaceCacheFlags.DurationVar(&config.SchemaWatchHeartbeat, "datastore-schema-watch-heartbeat", 1*time.Second, "heartbeat time on the schema watch in the datastore (if supported). 0 means to default to the datastore's minimum.")
 	server.MustRegisterCacheFlags(namespaceCacheFlags, "ns-cache", &config.NamespaceCacheConfig, namespaceCacheDefaults)
 
-
 	dispatchFlags := nfs.FlagSet(BoldBlue("Dispatch"))
 	// Flags for configuring the dispatch server
 	util.RegisterGRPCServerFlags(dispatchFlags, &config.DispatchServer, "dispatch-cluster", "dispatch", ":50053", false)

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -192,6 +192,10 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 		return err
 	}
 
+	// Attach the created flagsets to the command - they're created but not registered
+	// until this function is called.
+	nfs.AddFlagSets(cmd)
+
 	return nil
 }
 

--- a/pkg/cmd/testing.go
+++ b/pkg/cmd/testing.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"context"
 
+	"github.com/jzelinskie/cobrautil/v2/cobraotel"
 	"github.com/spf13/cobra"
 
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/cmd/testserver"
 	"github.com/authzed/spicedb/pkg/cmd/util"
+	"github.com/authzed/spicedb/pkg/runtime"
 )
 
 func RegisterTestingFlags(cmd *cobra.Command, config *testserver.Config) {
@@ -30,6 +32,9 @@ func RegisterTestingFlags(cmd *cobra.Command, config *testserver.Config) {
 	cmd.Flags().Uint32Var(&config.MaxLookupResourcesLimit, "max-lookup-resources-limit", 1000, "maximum number of resources that can be looked up in a single request")
 	cmd.Flags().Uint32Var(&config.MaxBulkExportRelationshipsLimit, "max-bulk-export-relationships-limit", 10_000, "maximum number of relationships that can be exported in a single request")
 	cmd.Flags().BoolVar(&config.EnableExperimentalLookupResources, "enable-experimental-lookup-resources", false, "enables the experimental version of the lookup resources API")
+	otel := cobraotel.New(cmd.Use)
+	otel.RegisterFlags(cmd.Flags())
+	runtime.RegisterFlags(cmd.Flags())
 }
 
 func NewTestingCommand(programName string, config *testserver.Config) *cobra.Command {

--- a/pkg/cmd/testing.go
+++ b/pkg/cmd/testing.go
@@ -32,7 +32,7 @@ func RegisterTestingFlags(cmd *cobra.Command, config *testserver.Config) {
 	cmd.Flags().Uint32Var(&config.MaxLookupResourcesLimit, "max-lookup-resources-limit", 1000, "maximum number of resources that can be looked up in a single request")
 	cmd.Flags().Uint32Var(&config.MaxBulkExportRelationshipsLimit, "max-bulk-export-relationships-limit", 10_000, "maximum number of relationships that can be exported in a single request")
 	cmd.Flags().BoolVar(&config.EnableExperimentalLookupResources, "enable-experimental-lookup-resources", false, "enables the experimental version of the lookup resources API")
-	otel := cobraotel.New(cmd.Use)
+	otel := cobraotel.New("spicedb")
 	otel.RegisterFlags(cmd.Flags())
 	runtime.RegisterFlags(cmd.Flags())
 }


### PR DESCRIPTION
## Description
The flags on `spicedb serve --help` are numerous. It makes parsing through them to figure out which ones are relevant and which ones you need pretty difficult.  This is the first step towards addressing that - we organize the flags into flagsets which provides a bit of logical and visual grouping.

## Changes
Gonna annotate.

## Testing
Review. `./spicedb serve --help` and see that all of the expected flags are present and that they are organized more nicely.