### PR TITLE
Remove unnecessary branch from limit logic

### DIFF
--- a/internal/graph/limits.go
+++ b/internal/graph/limits.go
@@ -49,11 +49,6 @@ func (lt *limitTracker) prepareForPublishing() bool {
 		return false
 	}
 
-	if lt.currentLimit == 1 {
-		lt.currentLimit = 0
-		return true
-	}
-
 	// otherwise, remove the element from the limit.
 	lt.currentLimit--
 	return true


### PR DESCRIPTION
## Description
It seems like it's a vestige of when there was additional logic in this file - otherwise the `== 0` case handles the decrementing properly.

## Changes
* Remove special handling of `== 1` case.
## Testing
Review. See that tests pass.