### PR TITLE
Integrate updates to cobrautil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/johannesboyne/gofakes3 v0.0.0-20230914150226-f005f5cc03aa
-	github.com/jzelinskie/cobrautil/v2 v2.0.0-20240816002907-ef0e64d7f25b
+	github.com/jzelinskie/cobrautil/v2 v2.0.0-20240819150235-f7fe73942d0f
 	github.com/jzelinskie/persistent v0.0.0-20230816160542-1205ef8f0e15
 	github.com/jzelinskie/stringz v0.0.3
 	github.com/lthibault/jitterbug v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1250,6 +1250,8 @@ github.com/jzelinskie/cobrautil/v2 v2.0.0-20240813173937-98b79ae0b499 h1:dXbwn1p
 github.com/jzelinskie/cobrautil/v2 v2.0.0-20240813173937-98b79ae0b499/go.mod h1:jsl6cEF6BT3UeQoSLreA7G0sZXemoI5XNqyxzWCohbE=
 github.com/jzelinskie/cobrautil/v2 v2.0.0-20240816002907-ef0e64d7f25b h1:dUjc3twJXVQ7FILS1+KhHilbM7LQwIvVgH4E7h0AwTA=
 github.com/jzelinskie/cobrautil/v2 v2.0.0-20240816002907-ef0e64d7f25b/go.mod h1:jsl6cEF6BT3UeQoSLreA7G0sZXemoI5XNqyxzWCohbE=
+github.com/jzelinskie/cobrautil/v2 v2.0.0-20240819150235-f7fe73942d0f h1:+WgAZQQXj+X8lcJdwcrQpD89Zd9ekdauOK3hWl3FkPU=
+github.com/jzelinskie/cobrautil/v2 v2.0.0-20240819150235-f7fe73942d0f/go.mod h1:jsl6cEF6BT3UeQoSLreA7G0sZXemoI5XNqyxzWCohbE=
 github.com/jzelinskie/persistent v0.0.0-20230816160542-1205ef8f0e15 h1:lFr5Krrc4LESaXK9yW15IQMZ4p2bZGw/+71Z1dV6tuk=
 github.com/jzelinskie/persistent v0.0.0-20230816160542-1205ef8f0e15/go.mod h1:gGiXKQUcSfUdRciTcDSuLGLZLLFSIjt1xNTE90WHDSI=
 github.com/jzelinskie/stringz v0.0.3 h1:0GhG3lVMYrYtIvRbxvQI6zqRTT1P1xyQlpa0FhfUXas=

--- a/pkg/cmd/server/defaults.go
+++ b/pkg/cmd/server/defaults.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/fatih/color"
 	"github.com/go-logr/zerologr"
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
@@ -72,7 +73,12 @@ func DefaultPreRunE(programName string) cobrautil.CobraRunFunc {
 				logging.SetGlobalLogger(logger)
 			}),
 		).RunE(),
-		cobraproclimits.SetMemLimitRunE(),
+		// NOTE: These need to be declared after the logger to access
+		// the logging context.
+		// NOTE: The default memlimit is 0.9. Our assumption is that SpiceDB
+		// will be the only thing consuming memory in its context, and if
+		// this needs to be configurable we can do that as a future step.
+		cobraproclimits.SetMemLimitRunE(memlimit.WithRatio(1.0)),
 		cobraproclimits.SetProcLimitRunE(),
 		cobraotel.New("spicedb",
 			cobraotel.WithLogger(zerologr.New(&logging.Logger)),


### PR DESCRIPTION
## Description
This pulls in jzelinskie/cobrautil#58 which fixes a bug and also explicitly configures the memlimit to 100% of available memory, which will be desirable for most SpiceDB use cases.

## Changes
* Bump versions
* Add explicit memlimit configuration
* Add some notes
## Testing
Review. See that things go green.