### PR TITLE
Fix data type for pg_class relcount

### DIFF
--- a/internal/datastore/postgres/stats.go
+++ b/internal/datastore/postgres/stats.go
@@ -57,7 +57,7 @@ func (pgd *pgDatastore) Statistics(ctx context.Context) (datastore.Stats, error)
 
 	var uniqueID string
 	var nsDefs []datastore.RevisionedNamespace
-	var relCount int64
+	var relCount float64
 	if err := pgx.BeginTxFunc(ctx, pgd.readPool, pgd.readTxOptions, func(tx pgx.Tx) error {
 		if pgd.analyzeBeforeStatistics {
 			if _, err := tx.Exec(ctx, "ANALYZE "+tableTuple); err != nil {


### PR DESCRIPTION
It is a float4. See: https://www.postgresql.org/docs/current/catalog-pg-class.html

Fixes #2045