### PR TITLE
Remove warning for an arrow referencing a relation in its own namespace

### DIFF
--- a/pkg/development/warningdefs.go
+++ b/pkg/development/warningdefs.go
@@ -196,6 +196,11 @@ var lintArrowReferencingRelation = ttuCheck{
 		}
 
 		for _, subjectType := range allowedSubjectTypes {
+			// Skip for arrow referencing relations in the same namespace.
+			if subjectType.Namespace == ts.Namespace().Name {
+				continue
+			}
+
 			nts, err := ts.TypeSystemForNamespace(ctx, subjectType.Namespace)
 			if err != nil {
 				return nil, err

--- a/pkg/development/warnings_test.go
+++ b/pkg/development/warnings_test.go
@@ -202,6 +202,18 @@ func TestWarnings(t *testing.T) {
 				SourceCode: "view",
 			},
 		},
+		{
+			name: "arrow referencing relation in the same namespace",
+			schema: `definition user {}
+
+			definition document {
+				relation parent: document
+				relation viewer: user
+				permission view = parent->viewer
+			}
+			`,
+			expectedWarning: nil,
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
This is less risky of causing issues than referencing an external relation, so disable the warning in this case