### PR TITLE
add continuous checkpointing to Datastore Features

### DIFF
--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -474,12 +474,18 @@ func (cds *crdbDatastore) OfflineFeatures() (*datastore.Features, error) {
 			IntegrityData: datastore.Feature{
 				Status: datastore.FeatureSupported,
 			},
+			ContinuousCheckpointing: datastore.Feature{
+				Status: datastore.FeatureSupported,
+			},
 		}, nil
 	}
 
 	return &datastore.Features{
 		IntegrityData: datastore.Feature{
 			Status: datastore.FeatureUnsupported,
+		},
+		ContinuousCheckpointing: datastore.Feature{
+			Status: datastore.FeatureSupported,
 		},
 	}, nil
 }
@@ -500,7 +506,11 @@ func (cds *crdbDatastore) tableTupleName() string {
 }
 
 func (cds *crdbDatastore) features(ctx context.Context) (*datastore.Features, error) {
-	features := datastore.Features{}
+	features := datastore.Features{
+		ContinuousCheckpointing: datastore.Feature{
+			Status: datastore.FeatureSupported,
+		},
+	}
 	if cds.supportsIntegrity {
 		features.IntegrityData.Status = datastore.FeatureSupported
 	}

--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -320,6 +320,9 @@ func (mdb *memdbDatastore) OfflineFeatures() (*datastore.Features, error) {
 		IntegrityData: datastore.Feature{
 			Status: datastore.FeatureSupported,
 		},
+		ContinuousCheckpointing: datastore.Feature{
+			Status: datastore.FeatureUnsupported,
+		},
 	}, nil
 }
 

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -574,6 +574,9 @@ func (mds *Datastore) OfflineFeatures() (*datastore.Features, error) {
 		IntegrityData: datastore.Feature{
 			Status: datastore.FeatureUnsupported,
 		},
+		ContinuousCheckpointing: datastore.Feature{
+			Status: datastore.FeatureUnsupported,
+		},
 	}, nil
 }
 

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -693,6 +693,9 @@ func (pgd *pgDatastore) OfflineFeatures() (*datastore.Features, error) {
 			IntegrityData: datastore.Feature{
 				Status: datastore.FeatureUnsupported,
 			},
+			ContinuousCheckpointing: datastore.Feature{
+				Status: datastore.FeatureUnsupported,
+			},
 		}, nil
 	}
 
@@ -701,6 +704,9 @@ func (pgd *pgDatastore) OfflineFeatures() (*datastore.Features, error) {
 			Status: datastore.FeatureUnsupported,
 		},
 		IntegrityData: datastore.Feature{
+			Status: datastore.FeatureUnsupported,
+		},
+		ContinuousCheckpointing: datastore.Feature{
 			Status: datastore.FeatureUnsupported,
 		},
 	}, nil

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -320,6 +320,9 @@ func (sd *spannerDatastore) OfflineFeatures() (*datastore.Features, error) {
 		IntegrityData: datastore.Feature{
 			Status: datastore.FeatureUnsupported,
 		},
+		ContinuousCheckpointing: datastore.Feature{
+			Status: datastore.FeatureSupported,
+		},
 	}, nil
 }
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -713,6 +713,11 @@ type Features struct {
 	// Watch is enabled if the underlying datastore can support the Watch api.
 	Watch Feature
 
+	// ContinuousCheckpointing is enabled if the underlying datastore supports continuous checkpointing
+	// via the Watch API. If not supported, clients of the Watch API may expect checkpoints only when
+	// new transactions are committed.
+	ContinuousCheckpointing Feature
+
 	// IntegrityData is enabled if the underlying datastore supports retrieving and storing
 	// integrity information.
 	IntegrityData Feature


### PR DESCRIPTION
this helps consumer understand the behaviour of checkpoints from the datastore without having to know which actual datastore is it talking to.