### PR TITLE
Bump to most recent version of goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,8 +33,7 @@ jobs:
       - uses: "goreleaser/goreleaser-action@v6"
         with:
           distribution: "goreleaser-pro"
-          # Pinned because of a regression in 2.3.0
-          version: &goreleaser_version "2.2.0"
+          version: &goreleaser_version "2.3.2"
           args: "release --clean --config=.goreleaser.windows.yml"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -71,8 +71,7 @@ jobs:
         id: "goreleaser"
         with:
           distribution: "goreleaser-pro"
-          # Pinned because of a regression in 2.2.0
-          version: "2.2.0"
+          version: "2.3.2"
           args: "release --clean --split --snapshot --single-target --skip=chocolatey"
         env:
           GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -76,6 +76,6 @@ jobs:
         env:
           GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"
       - name: "Obtain container image to scan"
-        run: 'echo "IMAGE_VERSION=$(jq .version dist/linux_amd64/metadata.json --raw-output)" >> $GITHUB_ENV'
+        run: 'echo "IMAGE_VERSION=$(jq .version dist/linux_amd64_v1/metadata.json --raw-output)" >> $GITHUB_ENV'
       - name: "run trivy on release image"
         run: "docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --format table --exit-code 1 --ignore-unfixed --vuln-type os,library --no-progress --severity CRITICAL,HIGH,MEDIUM authzed/spicedb:v${{ env.IMAGE_VERSION }}-amd64"


### PR DESCRIPTION
## Description
The last bit of the version bump saga. We'd pinned to an old version because there was a bug in 2.3.0; the maintainer has since fixed the issue in 2.3.2.

## Changes
Bump to 2.3.2

## Testing
If the security check passes, we're good.