### PR TITLE
Fix serve-devtools command and flags

### DIFF
--- a/pkg/cmd/devtools.go
+++ b/pkg/cmd/devtools.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/cobrautil/v2/cobragrpc"
 	"github.com/jzelinskie/cobrautil/v2/cobrahttp"
+	"github.com/jzelinskie/cobrautil/v2/cobraotel"
 	"github.com/jzelinskie/stringz"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -28,6 +29,7 @@ import (
 	v0svc "github.com/authzed/spicedb/internal/services/v0"
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/termination"
+	"github.com/authzed/spicedb/pkg/runtime"
 )
 
 func RegisterDevtoolsFlags(cmd *cobra.Command) {
@@ -42,6 +44,11 @@ func RegisterDevtoolsFlags(cmd *cobra.Command) {
 	cmd.Flags().String("s3-bucket", "", "s3 bucket name for s3 share store")
 	cmd.Flags().String("s3-endpoint", "", "s3 endpoint for s3 share store")
 	cmd.Flags().String("s3-region", "auto", "s3 region for s3 share store")
+
+	otel := cobraotel.New(cmd.Use)
+	otel.RegisterFlags(cmd.Flags())
+	termination.RegisterFlags(cmd.Flags())
+	runtime.RegisterFlags(cmd.Flags())
 }
 
 func NewDevtoolsCommand(programName string) *cobra.Command {


### PR DESCRIPTION
## Description
This is the same issue that was fixed in #2023 by c529652c8323df5a8add82b3b0c6ee37dc9a0848. Because we reorganized the flagsets in such a way that there are no longer root flags, it meant that every command that was implicitly depending on those root flags started failing. We caught most of them at dev time in #2023 but we didn't notice this one until we went to deploy.

## Changes
* Add missing flag registrations to serve-devtools
## Testing
Review. See that things go green.