### PR TITLE
Register common flags with helper

### DIFF
--- a/pkg/cmd/datastore.go
+++ b/pkg/cmd/datastore.go
@@ -12,6 +12,7 @@ import (
 	"github.com/authzed/spicedb/pkg/cmd/datastore"
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/termination"
+	"github.com/authzed/spicedb/pkg/cmd/util"
 	dspkg "github.com/authzed/spicedb/pkg/datastore"
 )
 
@@ -35,12 +36,14 @@ func NewDatastoreCommand(programName string) (*cobra.Command, error) {
 	if err := datastore.RegisterDatastoreFlagsWithPrefix(gcCmd.Flags(), "", cfg); err != nil {
 		return nil, err
 	}
+	util.RegisterCommonFlags(gcCmd)
 	datastoreCmd.AddCommand(gcCmd)
 
 	repairCmd := NewRepairDatastoreCommand(programName, cfg)
 	if err := datastore.RegisterDatastoreFlagsWithPrefix(repairCmd.Flags(), "", cfg); err != nil {
 		return nil, err
 	}
+	util.RegisterCommonFlags(repairCmd)
 	datastoreCmd.AddCommand(repairCmd)
 
 	headCmd := NewHeadCommand(programName)

--- a/pkg/cmd/devtools.go
+++ b/pkg/cmd/devtools.go
@@ -17,7 +17,6 @@ import (
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/cobrautil/v2/cobragrpc"
 	"github.com/jzelinskie/cobrautil/v2/cobrahttp"
-	"github.com/jzelinskie/cobrautil/v2/cobraotel"
 	"github.com/jzelinskie/stringz"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -29,7 +28,7 @@ import (
 	v0svc "github.com/authzed/spicedb/internal/services/v0"
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/termination"
-	"github.com/authzed/spicedb/pkg/runtime"
+	"github.com/authzed/spicedb/pkg/cmd/util"
 )
 
 func RegisterDevtoolsFlags(cmd *cobra.Command) {
@@ -45,10 +44,7 @@ func RegisterDevtoolsFlags(cmd *cobra.Command) {
 	cmd.Flags().String("s3-endpoint", "", "s3 endpoint for s3 share store")
 	cmd.Flags().String("s3-region", "auto", "s3 region for s3 share store")
 
-	otel := cobraotel.New(cmd.Use)
-	otel.RegisterFlags(cmd.Flags())
-	termination.RegisterFlags(cmd.Flags())
-	runtime.RegisterFlags(cmd.Flags())
+	util.RegisterCommonFlags(cmd)
 }
 
 func NewDevtoolsCommand(programName string) *cobra.Command {

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/jzelinskie/cobrautil/v2"
-	"github.com/jzelinskie/cobrautil/v2/cobraotel"
 	"github.com/spf13/cobra"
 
 	crdbmigrations "github.com/authzed/spicedb/internal/datastore/crdb/migrations"
@@ -17,9 +16,9 @@ import (
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/termination"
+	"github.com/authzed/spicedb/pkg/cmd/util"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/migrate"
-	"github.com/authzed/spicedb/pkg/runtime"
 )
 
 func RegisterMigrateFlags(cmd *cobra.Command) {
@@ -32,10 +31,7 @@ func RegisterMigrateFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint64("migration-backfill-batch-size", 1000, "number of items to migrate per iteration of a datastore backfill")
 	cmd.Flags().Duration("migration-timeout", 1*time.Hour, "defines a timeout for the execution of the migration, set to 1 hour by default")
 
-	otel := cobraotel.New("spicedb")
-	otel.RegisterFlags(cmd.Flags())
-	termination.RegisterFlags(cmd.Flags())
-	runtime.RegisterFlags(cmd.Flags())
+	util.RegisterCommonFlags(cmd)
 }
 
 func NewMigrateCommand(programName string) *cobra.Command {
@@ -149,6 +145,7 @@ func runMigration[D migrate.Driver[C, T], C any, T any](
 
 func RegisterHeadFlags(cmd *cobra.Command) {
 	cmd.Flags().String("datastore-engine", "postgres", fmt.Sprintf(`type of datastore to initialize (%s)`, datastore.EngineOptions()))
+	util.RegisterCommonFlags(cmd)
 }
 
 func NewHeadCommand(programName string) *cobra.Command {

--- a/pkg/cmd/testing.go
+++ b/pkg/cmd/testing.go
@@ -3,14 +3,12 @@ package cmd
 import (
 	"context"
 
-	"github.com/jzelinskie/cobrautil/v2/cobraotel"
 	"github.com/spf13/cobra"
 
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/termination"
 	"github.com/authzed/spicedb/pkg/cmd/testserver"
 	"github.com/authzed/spicedb/pkg/cmd/util"
-	"github.com/authzed/spicedb/pkg/runtime"
 )
 
 func RegisterTestingFlags(cmd *cobra.Command, config *testserver.Config) {
@@ -32,9 +30,7 @@ func RegisterTestingFlags(cmd *cobra.Command, config *testserver.Config) {
 	cmd.Flags().Uint32Var(&config.MaxLookupResourcesLimit, "max-lookup-resources-limit", 1000, "maximum number of resources that can be looked up in a single request")
 	cmd.Flags().Uint32Var(&config.MaxBulkExportRelationshipsLimit, "max-bulk-export-relationships-limit", 10_000, "maximum number of relationships that can be exported in a single request")
 	cmd.Flags().BoolVar(&config.EnableExperimentalLookupResources, "enable-experimental-lookup-resources", false, "enables the experimental version of the lookup resources API")
-	otel := cobraotel.New("spicedb")
-	otel.RegisterFlags(cmd.Flags())
-	runtime.RegisterFlags(cmd.Flags())
+	util.RegisterCommonFlags(cmd)
 }
 
 func NewTestingCommand(programName string, config *testserver.Config) *cobra.Command {

--- a/pkg/cmd/util/util.go
+++ b/pkg/cmd/util/util.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/jzelinskie/cobrautil/v2/cobraotel"
 	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -31,6 +32,8 @@ import (
 
 	"github.com/authzed/spicedb/internal/grpchelpers"
 	log "github.com/authzed/spicedb/internal/logging"
+	"github.com/authzed/spicedb/pkg/cmd/termination"
+	"github.com/authzed/spicedb/pkg/runtime"
 	"github.com/authzed/spicedb/pkg/x509util"
 )
 
@@ -448,3 +451,14 @@ func (d *disabledHTTPServer) ListenAndServe() error {
 }
 
 func (d *disabledHTTPServer) Close() {}
+
+// Registers flags that are common to many commands.
+// NOTE: these used to be registered in the root command
+// so that they were shared across all commands, but this
+// made it difficult to organize the flags, so we lifted them here.
+func RegisterCommonFlags(cmd *cobra.Command) {
+	otel := cobraotel.New("spicedb")
+	otel.RegisterFlags(cmd.Flags())
+	termination.RegisterFlags(cmd.Flags())
+	runtime.RegisterFlags(cmd.Flags())
+}


### PR DESCRIPTION
## Description
We missed registering the common flags on a handful of the datastore commands. This fixes that and also centralizes the registration logic into a single helper function.

## Changes
* Add util to register common flags
* Use that util where needed

## Testing
Review. See that `./spicedb head` works (among others).