### PR TITLE
reduce build times in CI

### DIFF
--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -54,6 +54,7 @@ func (cds *crdbDatastore) ExampleRetryableError() error {
 }
 
 func TestCRDBDatastoreWithoutIntegrity(t *testing.T) {
+	t.Parallel()
 	b := testdatastore.RunCRDBForTesting(t, "")
 	test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ctx := context.Background()
@@ -72,10 +73,11 @@ func TestCRDBDatastoreWithoutIntegrity(t *testing.T) {
 		})
 
 		return ds, nil
-	}))
+	}), false)
 }
 
 func TestCRDBDatastoreWithFollowerReads(t *testing.T) {
+	t.Parallel()
 	followerReadDelay := time.Duration(4.8 * float64(time.Second))
 	gcWindow := 100 * time.Second
 
@@ -136,6 +138,7 @@ var defaultKeyForTesting = proxy.KeyConfig{
 }
 
 func TestCRDBDatastoreWithIntegrity(t *testing.T) {
+	t.Parallel()
 	b := testdatastore.RunCRDBForTesting(t, "")
 
 	test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
@@ -159,7 +162,7 @@ func TestCRDBDatastoreWithIntegrity(t *testing.T) {
 		})
 
 		return ds, nil
-	}))
+	}), false)
 
 	unwrappedTester := test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ctx := context.Background()
@@ -187,6 +190,7 @@ func TestCRDBDatastoreWithIntegrity(t *testing.T) {
 }
 
 func TestWatchFeatureDetection(t *testing.T) {
+	t.Parallel()
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 	cases := []struct {
@@ -229,7 +233,9 @@ func TestWatchFeatureDetection(t *testing.T) {
 		},
 	}
 	for _, tt := range cases {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
 			adminConn, connStrings := newCRDBWithUser(t, pool)

--- a/internal/datastore/memdb/memdb_test.go
+++ b/internal/datastore/memdb/memdb_test.go
@@ -26,10 +26,12 @@ func (mdbt memDBTest) New(revisionQuantization, _, gcWindow time.Duration, watch
 }
 
 func TestMemdbDatastore(t *testing.T) {
-	test.All(t, memDBTest{})
+	t.Parallel()
+	test.All(t, memDBTest{}, true)
 }
 
 func TestConcurrentWritePanic(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds, err := NewMemdbDatastore(0, 1*time.Hour, 1*time.Hour)
@@ -81,6 +83,7 @@ func TestConcurrentWritePanic(t *testing.T) {
 }
 
 func TestConcurrentWriteRelsError(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	ds, err := NewMemdbDatastore(0, 1*time.Hour, 1*time.Hour)

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -93,14 +93,16 @@ func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestF
 }
 
 func TestMySQLDatastoreDSNWithoutParseTime(t *testing.T) {
+	t.Parallel()
 	_, err := NewMySQLDatastore(context.Background(), "root:password@(localhost:1234)/mysql")
 	require.ErrorContains(t, err, "https://spicedb.dev/d/parse-time-mysql")
 }
 
 func TestMySQL8Datastore(t *testing.T) {
+	t.Parallel()
 	b := testdatastore.RunMySQLForTestingWithOptions(t, testdatastore.MySQLTesterOptions{MigrateForNewDatastore: true}, "")
 	dst := datastoreTester{b: b, t: t}
-	test.AllWithExceptions(t, test.DatastoreTesterFunc(dst.createDatastore), test.WithCategories(test.WatchSchemaCategory, test.WatchCheckpointsCategory))
+	test.AllWithExceptions(t, test.DatastoreTesterFunc(dst.createDatastore), test.WithCategories(test.WatchSchemaCategory, test.WatchCheckpointsCategory), true)
 	additionalMySQLTests(t, b)
 }
 
@@ -660,6 +662,7 @@ func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func TestMySQLMigrations(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 
 	db := datastoreDB(t, false)
@@ -681,6 +684,7 @@ func TestMySQLMigrations(t *testing.T) {
 }
 
 func TestMySQLMigrationsWithPrefix(t *testing.T) {
+	t.Parallel()
 	req := require.New(t)
 
 	prefix := "spicedb_"

--- a/internal/datastore/mysql/migrations/driver.go
+++ b/internal/datastore/mysql/migrations/driver.go
@@ -16,7 +16,6 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	sqlDriver "github.com/go-sql-driver/mysql"
 
-	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/migrate"
 )
 
@@ -57,10 +56,6 @@ func NewMySQLDriverFromDSN(url string, tablePrefix string, credentialsProvider d
 	}
 
 	db := sql.OpenDB(connector)
-	err = sqlDriver.SetLogger(&log.Logger)
-	if err != nil {
-		return nil, fmt.Errorf("unable to set logging to mysql driver: %w", err)
-	}
 	return NewMySQLDriverFromDB(db, tablePrefix), nil
 }
 

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -101,7 +101,7 @@ func testPostgresDatastore(t *testing.T, pc []postgresConfig) {
 					return ds
 				})
 				return ds, nil
-			}))
+			}), false)
 
 			t.Run("TransactionTimestamps", createDatastoreTest(
 				b,
@@ -236,7 +236,7 @@ func testPostgresDatastoreWithoutCommitTimestamps(t *testing.T, pc []postgresCon
 					return ds
 				})
 				return ds, nil
-			}), test.WithCategories(test.WatchCategory))
+			}), test.WithCategories(test.WatchCategory), false)
 		})
 	}
 }

--- a/internal/datastore/proxy/observable_test.go
+++ b/internal/datastore/proxy/observable_test.go
@@ -20,7 +20,7 @@ func (obs observableTest) New(revisionQuantization, _, gcWindow time.Duration, w
 }
 
 func TestObservableProxy(t *testing.T) {
-	test.All(t, observableTest{})
+	test.All(t, observableTest{}, true)
 }
 
 func (p *observableProxy) ExampleRetryableError() error {

--- a/internal/datastore/proxy/schemacaching/estimatedsize_test.go
+++ b/internal/datastore/proxy/schemacaching/estimatedsize_test.go
@@ -91,6 +91,8 @@ func TestEstimatedDefinitionSizes(t *testing.T) {
 			for _, caveatDef := range fullyResolved.CaveatDefinitions {
 				caveatDef := caveatDef
 				t.Run("caveat "+caveatDef.Name, func(t *testing.T) {
+					t.Parallel()
+
 					serialized, _ := caveatDef.MarshalVT()
 					sizevt := caveatDef.SizeVT()
 					estimated := estimatedCaveatDefinitionSize(sizevt)

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -28,6 +28,8 @@ func (sd *spannerDatastore) ExampleRetryableError() error {
 }
 
 func TestSpannerDatastore(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	b := testdatastore.RunSpannerForTesting(t, "", "head")
 
@@ -43,7 +45,7 @@ func TestSpannerDatastore(t *testing.T) {
 			return ds
 		})
 		return ds, nil
-	}), test.WithCategories(test.GCCategory, test.WatchCategory, test.StatsCategory))
+	}), test.WithCategories(test.GCCategory, test.WatchCategory, test.StatsCategory), true)
 
 	t.Run("TestFakeStats", createDatastoreTest(
 		b,

--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/internal/datastore/memdb"
@@ -30,7 +29,7 @@ import (
 var ONR = tuple.ObjectAndRelation
 
 func TestSimpleCheck(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	type expected struct {
 		relation string
@@ -119,6 +118,7 @@ func TestSimpleCheck(t *testing.T) {
 				userset := userset
 				expected := expected
 				t.Run(name, func(t *testing.T) {
+					t.Parallel()
 					require := require.New(t)
 
 					ctx, dispatch, revision := newLocalDispatcher(t)
@@ -150,6 +150,7 @@ func TestSimpleCheck(t *testing.T) {
 }
 
 func TestMaxDepth(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
@@ -182,6 +183,7 @@ func TestMaxDepth(t *testing.T) {
 }
 
 func TestCheckMetadata(t *testing.T) {
+	t.Parallel()
 	type expected struct {
 		relation              string
 		isMember              bool
@@ -287,6 +289,7 @@ func TestCheckMetadata(t *testing.T) {
 }
 
 func TestCheckPermissionOverSchema(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name                      string
 		schema                    string
@@ -1370,6 +1373,7 @@ func addFrame(trace *v1.CheckDebugTrace, foundFrames *mapz.Set[string]) {
 }
 
 func TestCheckDebugging(t *testing.T) {
+	t.Parallel()
 	type expectedFrame struct {
 		resourceType *core.RelationReference
 		resourceIDs  []string
@@ -1482,6 +1486,7 @@ func TestCheckDebugging(t *testing.T) {
 }
 
 func TestCheckWithHints(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name                   string
 		schema                 string
@@ -1853,6 +1858,7 @@ func TestCheckWithHints(t *testing.T) {
 }
 
 func TestCheckHintsPartialApplication(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	dispatcher := NewLocalOnlyDispatcher(10, 100)
@@ -1898,6 +1904,7 @@ func TestCheckHintsPartialApplication(t *testing.T) {
 }
 
 func TestCheckHintsPartialApplicationOverArrow(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	dispatcher := NewLocalOnlyDispatcher(10, 100)

--- a/internal/dispatch/graph/dispatch_test.go
+++ b/internal/dispatch/graph/dispatch_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestDispatchChunking(t *testing.T) {
+	t.Parallel()
 	schema := `
 		definition user {
 			relation self: user
@@ -35,6 +36,7 @@ func TestDispatchChunking(t *testing.T) {
 	ctx, dispatcher, revision := newLocalDispatcherWithSchemaAndRels(t, schema, append(enabled, resources...))
 
 	t.Run("check", func(t *testing.T) {
+		t.Parallel()
 		for _, tpl := range resources[:1] {
 			checkResult, err := dispatcher.DispatchCheck(ctx, &v1.DispatchCheckRequest{
 				ResourceRelation: RR(tpl.ResourceAndRelation.Namespace, "view"),
@@ -55,6 +57,8 @@ func TestDispatchChunking(t *testing.T) {
 	})
 
 	t.Run("lookup-resources", func(t *testing.T) {
+		t.Parallel()
+
 		for _, tpl := range resources[:1] {
 			stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupResourcesResponse](ctx)
 			err := dispatcher.DispatchLookupResources(&v1.DispatchLookupResourcesRequest{
@@ -75,6 +79,8 @@ func TestDispatchChunking(t *testing.T) {
 	})
 
 	t.Run("lookup-subjects", func(t *testing.T) {
+		t.Parallel()
+
 		for _, tpl := range resources[:1] {
 			stream := dispatch.NewCollectingDispatchStream[*v1.DispatchLookupSubjectsResponse](ctx)
 

--- a/internal/dispatch/graph/expand_test.go
+++ b/internal/dispatch/graph/expand_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -137,7 +136,7 @@ var (
 )
 
 func TestExpand(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	testCases := []struct {
 		start                 *core.ObjectAndRelation
@@ -275,7 +274,7 @@ func onrExpr(onr *core.ObjectAndRelation) ast.Expr {
 }
 
 func TestMaxDepthExpand(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	require := require.New(t)
 
@@ -306,7 +305,7 @@ func TestMaxDepthExpand(t *testing.T) {
 }
 
 func TestExpandOverSchema(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	testCases := []struct {
 		name          string

--- a/internal/dispatch/graph/graph_test.go
+++ b/internal/dispatch/graph/graph_test.go
@@ -13,11 +13,14 @@ import (
 )
 
 func TestUnwrapStatusError(t *testing.T) {
+	t.Parallel()
+
 	err := rewriteError(context.Background(), graph.NewCheckFailureErr(status.Error(codes.Canceled, "canceled")))
 	grpcutil.RequireStatus(t, codes.Canceled, err)
 }
 
 func TestConcurrencyLimitsWithOverallDefaultLimit(t *testing.T) {
+	t.Parallel()
 	cl := ConcurrencyLimits{}
 	require.Equal(t, uint16(0), cl.Check)
 	require.Equal(t, uint16(0), cl.LookupResources)
@@ -38,6 +41,7 @@ func TestConcurrencyLimitsWithOverallDefaultLimit(t *testing.T) {
 }
 
 func TestSharedConcurrencyLimits(t *testing.T) {
+	t.Parallel()
 	cl := SharedConcurrencyLimits(42)
 	require.Equal(t, uint16(42), cl.Check)
 	require.Equal(t, uint16(42), cl.LookupResources)

--- a/internal/dispatch/graph/lookupresources2_test.go
+++ b/internal/dispatch/graph/lookupresources2_test.go
@@ -21,13 +21,11 @@ import (
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
-	"github.com/authzed/spicedb/pkg/testutil"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
 func TestSimpleLookupResources2(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
-
+	// FIXME marking this parallel makes goleak detect a leaked goroutine
 	testCases := []struct {
 		start                 *core.RelationReference
 		target                *core.ObjectAndRelation
@@ -159,7 +157,7 @@ func TestSimpleLookupResources2(t *testing.T) {
 }
 
 func TestSimpleLookupResourcesWithCursor2(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	for _, tc := range []struct {
 		subject        string
@@ -242,7 +240,7 @@ func TestSimpleLookupResourcesWithCursor2(t *testing.T) {
 }
 
 func TestLookupResourcesCursorStability2(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	require := require.New(t)
 	ctx, dispatcher, revision := newLocalDispatcher(t)
@@ -309,6 +307,7 @@ func processResults2(stream *dispatch.CollectingDispatchStream[*v1.DispatchLooku
 }
 
 func TestMaxDepthLookup2(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
@@ -338,6 +337,7 @@ func TestMaxDepthLookup2(t *testing.T) {
 }
 
 func TestLookupResources2OverSchemaWithCursors(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name                string
 		schema              string
@@ -682,9 +682,11 @@ func TestLookupResources2OverSchemaWithCursors(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			for _, pageSize := range []int{0, 104, 1023} {
 				pageSize := pageSize
 				t.Run(fmt.Sprintf("ps-%d_", pageSize), func(t *testing.T) {
+					t.Parallel()
 					require := require.New(t)
 
 					dispatcher := NewLocalOnlyDispatcher(10, 100)
@@ -741,10 +743,11 @@ func TestLookupResources2OverSchemaWithCursors(t *testing.T) {
 					}
 
 					foundResourceIDsSlice := foundResourceIDs.AsSlice()
+					expectedResourceIDs := slices.Clone(tc.expectedResourceIDs)
 					slices.Sort(foundResourceIDsSlice)
-					slices.Sort(tc.expectedResourceIDs)
+					slices.Sort(expectedResourceIDs)
 
-					require.Equal(tc.expectedResourceIDs, foundResourceIDsSlice)
+					require.Equal(expectedResourceIDs, foundResourceIDsSlice)
 				})
 			}
 		})
@@ -752,7 +755,7 @@ func TestLookupResources2OverSchemaWithCursors(t *testing.T) {
 }
 
 func TestLookupResources2ImmediateTimeout(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Parallel()
 
 	require := require.New(t)
 
@@ -787,7 +790,7 @@ func TestLookupResources2ImmediateTimeout(t *testing.T) {
 }
 
 func TestLookupResources2WithError(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Parallel()
 
 	require := require.New(t)
 
@@ -822,7 +825,7 @@ func TestLookupResources2WithError(t *testing.T) {
 }
 
 func TestLookupResources2EnsureCheckHints(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Parallel()
 
 	tcs := []struct {
 		name          string

--- a/internal/dispatch/graph/lookupresources_test.go
+++ b/internal/dispatch/graph/lookupresources_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ccoveille/go-safecast"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	"github.com/authzed/spicedb/internal/datastore/memdb"
 	"github.com/authzed/spicedb/internal/dispatch"
@@ -18,7 +17,6 @@ import (
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
-	"github.com/authzed/spicedb/pkg/testutil"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
@@ -39,7 +37,7 @@ func resolvedRes(resourceID string) *v1.ResolvedResource {
 }
 
 func TestSimpleLookupResources(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	testCases := []struct {
 		start                 *core.RelationReference
@@ -166,7 +164,7 @@ func TestSimpleLookupResources(t *testing.T) {
 }
 
 func TestSimpleLookupResourcesWithCursor(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	for _, tc := range []struct {
 		subject        string
@@ -245,7 +243,7 @@ func TestSimpleLookupResourcesWithCursor(t *testing.T) {
 }
 
 func TestLookupResourcesCursorStability(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	require := require.New(t)
 	ctx, dispatcher, revision := newLocalDispatcher(t)
@@ -307,6 +305,7 @@ func processResults(stream *dispatch.CollectingDispatchStream[*v1.DispatchLookup
 }
 
 func TestMaxDepthLookup(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
@@ -389,6 +388,7 @@ func genResourceIds(resourceName string, number int) []string {
 }
 
 func TestLookupResourcesOverSchemaWithCursors(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name                string
 		schema              string
@@ -597,9 +597,11 @@ func TestLookupResourcesOverSchemaWithCursors(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			for _, pageSize := range []int{0, 104, 1023} {
 				pageSize := pageSize
 				t.Run(fmt.Sprintf("ps-%d_", pageSize), func(t *testing.T) {
+					t.Parallel()
 					require := require.New(t)
 
 					dispatcher := NewLocalOnlyDispatcher(10, 100)
@@ -646,10 +648,11 @@ func TestLookupResourcesOverSchemaWithCursors(t *testing.T) {
 					}
 
 					foundResourceIDsSlice := foundResourceIDs.AsSlice()
+					expectedResourceIDs := slices.Clone(tc.expectedResourceIDs)
 					slices.Sort(foundResourceIDsSlice)
-					slices.Sort(tc.expectedResourceIDs)
+					slices.Sort(expectedResourceIDs)
 
-					require.Equal(tc.expectedResourceIDs, foundResourceIDsSlice)
+					require.Equal(expectedResourceIDs, foundResourceIDsSlice)
 				})
 			}
 		})
@@ -657,7 +660,7 @@ func TestLookupResourcesOverSchemaWithCursors(t *testing.T) {
 }
 
 func TestLookupResourcesImmediateTimeout(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	require := require.New(t)
 
@@ -690,7 +693,7 @@ func TestLookupResourcesImmediateTimeout(t *testing.T) {
 }
 
 func TestLookupResourcesWithError(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	require := require.New(t)
 

--- a/internal/dispatch/graph/lookupsubjects_test.go
+++ b/internal/dispatch/graph/lookupsubjects_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	"github.com/authzed/spicedb/internal/caveats"
 	"github.com/authzed/spicedb/internal/datastore/common"
@@ -19,7 +18,6 @@ import (
 	itestutil "github.com/authzed/spicedb/internal/testutil"
 	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
-	"github.com/authzed/spicedb/pkg/testutil"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
@@ -32,7 +30,7 @@ var (
 )
 
 func TestSimpleLookupSubjects(t *testing.T) {
-	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	t.Parallel()
 
 	testCases := []struct {
 		resourceType     string
@@ -194,6 +192,7 @@ func TestSimpleLookupSubjects(t *testing.T) {
 }
 
 func TestLookupSubjectsMaxDepth(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
 
 	rawDS, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
@@ -224,6 +223,7 @@ func TestLookupSubjectsMaxDepth(t *testing.T) {
 }
 
 func TestLookupSubjectsDispatchCount(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		resourceType          string
 		resourceID            string
@@ -277,6 +277,7 @@ func TestLookupSubjectsDispatchCount(t *testing.T) {
 }
 
 func TestLookupSubjectsOverSchema(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name          string
 		schema        string

--- a/internal/dispatch/graph/package_test.go
+++ b/internal/dispatch/graph/package_test.go
@@ -1,0 +1,14 @@
+package graph
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+
+	"github.com/authzed/spicedb/pkg/testutil"
+)
+
+// done so we can do t.Parallel() and still use goleak
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+}

--- a/internal/dispatch/remote/cluster_test.go
+++ b/internal/dispatch/remote/cluster_test.go
@@ -236,6 +236,7 @@ func TestCheckSecondaryDispatch(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			conn := connectionForDispatching(t, &fakeDispatchSvc{dispatchCount: 1, sleepTime: tc.primarySleepTime})
 			secondaryConn := connectionForDispatching(t, &fakeDispatchSvc{dispatchCount: 2, sleepTime: 0 * time.Millisecond})
 

--- a/internal/relationships/validation_test.go
+++ b/internal/relationships/validation_test.go
@@ -242,7 +242,9 @@ func TestValidateRelationshipOperations(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			req := require.New(t)
 
 			ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)

--- a/internal/services/integrationtesting/cert_test.go
+++ b/internal/services/integrationtesting/cert_test.go
@@ -36,6 +36,8 @@ import (
 )
 
 func TestCertRotation(t *testing.T) {
+	t.Parallel()
+
 	const (
 		// length of time the initial cert is valid
 		initialValidDuration = 3 * time.Second

--- a/internal/services/integrationtesting/consistency_datastore_test.go
+++ b/internal/services/integrationtesting/consistency_datastore_test.go
@@ -38,6 +38,11 @@ func TestConsistencyPerDatastore(t *testing.T) {
 				filePath := filePath
 
 				t.Run(path.Base(filePath), func(t *testing.T) {
+					// FIXME errors arise if spanner is run in parallel
+					if engineID != "spanner" {
+						t.Parallel()
+					}
+
 					rde := testdatastore.RunDatastoreEngine(t, engineID)
 					ds := rde.NewDatastore(t, config.DatastoreConfigInitFunc(t,
 						dsconfig.WithWatchBufferLength(0),
@@ -67,6 +72,7 @@ func TestConsistencyPerDatastore(t *testing.T) {
 						}
 
 						t.Run(tester.Name(), func(t *testing.T) {
+							t.Parallel()
 							runAssertions(t, vctx)
 						})
 					}

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -55,6 +55,7 @@ func TestConsistency(t *testing.T) {
 		filePath := filePath
 
 		t.Run(path.Base(filePath), func(t *testing.T) {
+			t.Parallel()
 			for _, dispatcherKind := range []string{"local", "caching"} {
 				dispatcherKind := dispatcherKind
 

--- a/internal/services/integrationtesting/ops_test.go
+++ b/internal/services/integrationtesting/ops_test.go
@@ -120,6 +120,8 @@ func (dr deleteCaveatedRelationship) Execute(tester opsTester) error {
 }
 
 func TestSchemaAndRelationshipsOperations(t *testing.T) {
+	t.Parallel()
+
 	tcs := []schemaTestCase{
 		// Test: write a basic, valid schema.
 		{
@@ -751,6 +753,7 @@ func TestSchemaAndRelationshipsOperations(t *testing.T) {
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			for _, testerName := range []string{"v1"} {
 				testerName := testerName
 				t.Run(testerName, func(t *testing.T) {

--- a/internal/services/v1/experimental_test.go
+++ b/internal/services/v1/experimental_test.go
@@ -51,7 +51,9 @@ func TestBulkImportRelationships(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			conn, cleanup, _, _ := testserver.NewTestServer(require, 0, memdb.DisableGC, true, tf.StandardDatastoreWithSchema)
@@ -300,6 +302,7 @@ func TestBulkExportRelationshipsWithFilter(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			conn, cleanup, _, _ := testserver.NewTestServer(require, 0, memdb.DisableGC, true, tf.StandardDatastoreWithSchema)

--- a/internal/taskrunner/preloadedtaskrunner_test.go
+++ b/internal/taskrunner/preloadedtaskrunner_test.go
@@ -14,8 +14,13 @@ import (
 	"go.uber.org/goleak"
 )
 
+// done so we can do t.Parallel() and still use goleak
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
 func TestPreloadedTaskRunnerCompletesAllTasks(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	t.Parallel()
 
 	tr := NewPreloadedTaskRunner(context.Background(), 2, 5)
 	wg := sync.WaitGroup{}
@@ -38,7 +43,7 @@ func TestPreloadedTaskRunnerCompletesAllTasks(t *testing.T) {
 }
 
 func TestPreloadedTaskRunnerCancelsEarlyDueToError(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	t.Parallel()
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -76,7 +81,7 @@ func TestPreloadedTaskRunnerCancelsEarlyDueToError(t *testing.T) {
 }
 
 func TestPreloadedTaskRunnerCancelsEarlyDueToCancel(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	t.Parallel()
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -115,7 +120,7 @@ func TestPreloadedTaskRunnerCancelsEarlyDueToCancel(t *testing.T) {
 }
 
 func TestPreloadedTaskRunnerReturnsError(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	t.Parallel()
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -154,7 +159,7 @@ func TestPreloadedTaskRunnerReturnsError(t *testing.T) {
 }
 
 func TestPreloadedTaskRunnerEmpty(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	t.Parallel()
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)

--- a/internal/testutil/subjects_test.go
+++ b/internal/testutil/subjects_test.go
@@ -22,6 +22,8 @@ var (
 )
 
 func TestCompareSubjects(t *testing.T) {
+	t.Parallel()
+
 	tcs := []struct {
 		first              *v1.FoundSubject
 		second             *v1.FoundSubject

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -23,17 +23,27 @@ func (t Test) All() error {
 	return nil
 }
 
-// Runs the unit tests and generates a coverage report
-func (Test) UnitCover() error {
-	mg.Deps(Test{}.Unit)
+// UnitCover Runs the unit tests and generates a coverage report
+func (t Test) UnitCover() error {
+	if err := t.unit(true); err != nil {
+		return err
+	}
 	fmt.Println("Running coverage...")
 	return sh.RunV("go", "tool", "cover", "-html=coverage.txt")
 }
 
 // Unit Runs the unit tests
-func (Test) Unit() error {
+func (t Test) Unit() error {
+	return t.unit(false)
+}
+
+func (Test) unit(coverage bool) error {
 	fmt.Println("running unit tests")
-	return goTest("./...", "-tags", "ci,skipintegrationtests", "-race", "-timeout", "10m", "-covermode=atomic", "-count=1", "-coverprofile=coverage.txt")
+	args := []string{"-tags", "ci,skipintegrationtests", "-race", "-timeout", "10m", "-count=1"}
+	if coverage {
+		args = append(args, "-covermode=atomic", "-coverprofile=coverage.txt")
+	}
+	return goTest("./...", args...)
 }
 
 // Image Run tests that run the built image

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -9,6 +9,8 @@ import (
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/spf13/cobra"
 
+	sqlDriver "github.com/go-sql-driver/mysql"
+
 	crdbmigrations "github.com/authzed/spicedb/internal/datastore/crdb/migrations"
 	mysqlmigrations "github.com/authzed/spicedb/internal/datastore/mysql/migrations"
 	"github.com/authzed/spicedb/internal/datastore/postgres/migrations"
@@ -109,6 +111,12 @@ func migrateRun(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
+		}
+
+		// Do this outside NewMySQLDriverFromDSN to avoid races on MySQL datastore tests
+		err = sqlDriver.SetLogger(&log.Logger)
+		if err != nil {
+			return fmt.Errorf("unable to set logging to mysql driver: %w", err)
 		}
 
 		migrationDriver, err := mysqlmigrations.NewMySQLDriverFromDSN(dbURL, tablePrefix, credentialsProvider)

--- a/pkg/datastore/pagination/iterator_test.go
+++ b/pkg/datastore/pagination/iterator_test.go
@@ -142,7 +142,9 @@ func TestPaginatedIterator(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(fmt.Sprintf("%d/%d-%d", tc.pageSize, tc.totalRelationships, tc.order), func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			tpls := make([]*core.RelationTuple, 0, tc.totalRelationships)

--- a/pkg/schemadsl/compiler/compiler_test.go
+++ b/pkg/schemadsl/compiler/compiler_test.go
@@ -21,6 +21,8 @@ var (
 )
 
 func TestCompile(t *testing.T) {
+	t.Parallel()
+
 	type compileTest struct {
 		name          string
 		objectPrefix  ObjectPrefixOption
@@ -977,6 +979,7 @@ func TestCompile(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 			compiled, err := Compile(InputSchema{
 				input.Source(test.name), test.input,
@@ -1056,6 +1059,8 @@ func filterSourcePositions(m protoreflect.Message) {
 }
 
 func TestSkipValidation(t *testing.T) {
+	t.Parallel()
+
 	_, err := Compile(InputSchema{"test", `definition a/def {}`}, AllowUnprefixedObjectType())
 	require.Error(t, err)
 
@@ -1064,6 +1069,8 @@ func TestSkipValidation(t *testing.T) {
 }
 
 func TestSuperLargeCaveatCompile(t *testing.T) {
+	t.Parallel()
+
 	b, err := os.ReadFile("../parser/tests/superlarge.zed")
 	if err != nil {
 		panic(err)

--- a/pkg/schemadsl/parser/parser_test.go
+++ b/pkg/schemadsl/parser/parser_test.go
@@ -127,6 +127,7 @@ func TestParser(t *testing.T) {
 	for _, test := range parserTests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			root := Parse(createAstNode, input.Source(test.name), test.input())
 			parseTree := getParseTree((root).(*testNode), 0)
 			assert := assert.New(t)


### PR DESCRIPTION
optimized tests with various changes. 40% improvement in CI in some cases.

- datastore tests now run parallel. CRDB and Postgres had issues so it's disabled parallelization there
- Parallelized integrity / no integrity tests in CRDB
- removed code coverage by default in unit tests - was not being used
- added `t.Parallel()` in the unit tests taking the longest

# before
![image](https://github.com/user-attachments/assets/a0d2f532-9a30-4cf9-8c50-b4ccc15a0d01)

# after
![image](https://github.com/user-attachments/assets/748e774f-636c-485c-a32e-74f7a20d9497)

