### PR TITLE
Add currently-enabled workflow to release windows

### DIFF
--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -1,0 +1,37 @@
+---
+name: "Release for Windows"
+on:  # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - "*"
+permissions:
+  contents: "write"
+  packages: "write"
+jobs:
+  release-windows:
+    runs-on: "windows-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+      - uses: "authzed/actions/setup-go@main"
+      - uses: "nowsprinting/check-version-format-action@v4"
+        id: "version"
+        with:
+          prefix: "v"
+      - uses: "authzed/actions/docker-login@main"
+        with:
+          quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          dockerhub_token: "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}"
+      - uses: "goreleaser/goreleaser-action@v6"
+        with:
+          distribution: "goreleaser-pro"
+          # NOTE: keep in sync with goreleaser version in other job.
+          # github actions don't allow yaml anchors.
+          version: "v2.3.2"
+          args: "release --clean --config=.goreleaser.windows.yml"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"
+          CHOCOLATEY_API_KEY: "${{ secrets.CHOCOLATEY_API_KEY }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           distribution: "goreleaser-pro"
           # NOTE: keep in sync with goreleaser version in other job.
           # github actions don't allow yaml anchors.
-          version: "2.3.2"
+          version: "v2.3.2"
           args: "release --clean --config=.goreleaser.windows.yml"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -73,7 +73,7 @@ jobs:
           distribution: "goreleaser-pro"
           # NOTE: keep in sync with goreleaser version in other job.
           # github actions don't allow yaml anchors.
-          version: "2.3.2"
+          version: "v2.3.2"
           args: "release --clean"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.goreleaser.windows.yml
+++ b/.goreleaser.windows.yml
@@ -14,7 +14,6 @@ builds:
       - "windows"
     goarch:
       - "amd64"
-      - "arm64"
     mod_timestamp: "{{ .CommitTimestamp }}"
     ldflags:
       - "-s -w"
@@ -27,6 +26,7 @@ archives:
     format_overrides:
       - goos: "windows"
         format: "zip"
+
 chocolateys:
   - name: "spicedb"
     package_source_url: "https://github.com/authzed/spicedb"
@@ -36,6 +36,7 @@ chocolateys:
     url_template: "https://github.com/authzed/spicedb/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     icon_url: "https://authzed.com/favicon.svg"
     copyright: "2024 AuthZed, Inc"
+    authors: "SpiceDB Contributors"
     license_url: "https://github.com/authzed/spicedb/blob/main/LICENSE"
     project_source_url: "https://github.com/authzed/spicedb"
     docs_url: "https://authzed.com/docs"
@@ -48,7 +49,9 @@ chocolateys:
     api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
     source_repo: "https://push.chocolatey.org/"
 checksum:
-  name_template: "checksums.txt"
+  # NOTE: this needs to be different from the main release step
+  # because the main release already generates this file in a separate step.
+  name_template: "windows_checksums.txt"
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 nightly:


### PR DESCRIPTION
Fixes #2053 

## Description
This should get windows releases going.

## Changes
* Add a release workflow github action
* Add a missing `authors` field in the config
* Change checksum filename so it doesn't overlap with primary release

## Testing
See that it's available here: https://community.chocolatey.org/packages/spicedb