### PR TITLE
metrics: spicedb_environment_info from telemetry

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -459,7 +459,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 	closeables.AddCloser(gatewayCloser)
 	closeables.AddWithoutError(gatewayServer.Close)
 
-	infoCollector, err := telemetry.SpiceDBClusterInfoCollector(context.TODO(), "environment", c.DatastoreConfig.Engine, ds)
+	infoCollector, err := telemetry.SpiceDBClusterInfoCollector(ctx, "environment", c.DatastoreConfig.Engine, ds)
 	if err != nil {
 		log.Warn().Err(err).Msg("unable to initialize info collector")
 	} else {

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -459,6 +459,15 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 	closeables.AddCloser(gatewayCloser)
 	closeables.AddWithoutError(gatewayServer.Close)
 
+	infoCollector, err := telemetry.SpiceDBClusterInfoCollector(context.TODO(), "environment", c.DatastoreConfig.Engine, ds)
+	if err != nil {
+		log.Warn().Err(err).Msg("unable to initialize info collector")
+	} else {
+		if err := prometheus.Register(infoCollector); err != nil {
+			log.Warn().Err(err).Msg("unable to initialize info collector")
+		}
+	}
+
 	var telemetryRegistry *prometheus.Registry
 
 	reporter := telemetry.DisabledReporter

--- a/pkg/promutil/promutil.go
+++ b/pkg/promutil/promutil.go
@@ -1,0 +1,15 @@
+package promutil
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var _ prometheus.Collector = (CollectorFunc)(nil)
+
+// CollectorFunc is a convenient way to implement a Prometheus Collector
+// without interface boilerplate.
+//
+// This implementation relies on prometheus.DescribeByCollect; familiarize
+// yourself with that documentation before using.
+type CollectorFunc func(ch chan<- prometheus.Metric)
+
+func (c CollectorFunc) Collect(ch chan<- prometheus.Metric) { c(ch) }
+func (c CollectorFunc) Describe(ch chan<- *prometheus.Desc) { prometheus.DescribeByCollect(c, ch) }


### PR DESCRIPTION
This change reuses the logic for `spicedb_telemetry_info` for a metric registered to the default Prometheus registry.

Fixes #2086 