### PR TITLE
Introducing SpiceDB Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
     <a href="https://twitter.com/authzed"><img alt="twitter badge" src="https://img.shields.io/badge/twitter-@authzed-1d9bf0.svg?style=flat-square"></a>
     &nbsp;
     <a href="https://www.linkedin.com/company/authzed/"><img alt="linkedin badge" src="https://img.shields.io/badge/linkedin-+authzed-2D65BC.svg?style=flat-square"></a>
+    &nbsp;
+    <a href="https://gurubase.io/g/spicedb"><img alt="gurubase badge" src="https://img.shields.io/badge/gurubase-Ask%20SpiceDB%20Guru-006BFF"></a>
+    
 </p>
 
 ## What is SpiceDB?


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [SpiceDB Guru](https://gurubase.io/g/spicedb) to Gurubase. SpiceDB Guru uses the data from this repo and data from the [docs](https://authzed.com/docs/spicedb/getting-started/discovering-spicedb) to answer questions by leveraging the LLM.

In this PR, I showcased the "SpiceDB Guru", which highlights that SpiceDB now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable SpiceDB Guru in Gurubase, just let me know that's totally fine.