### PR TITLE
fixes CRDB watch implementation accumulating past updates

### DIFF
--- a/internal/datastore/common/changes.go
+++ b/internal/datastore/common/changes.go
@@ -145,9 +145,9 @@ func (ch *Changes[R, K]) SetRevisionMetadata(ctx context.Context, rev R, metadat
 		return err
 	}
 
-	if len(record.metadata) > 0 {
-		return spiceerrors.MustBugf("metadata already set for revision")
-	}
+	spiceerrors.DebugAssert(func() bool {
+		return len(record.metadata) == 0 || maps.Equal(record.metadata, metadata)
+	}, "found different metadata for revision %v", rev)
 
 	maps.Copy(record.metadata, metadata)
 	return nil

--- a/internal/datastore/revisions/hlcrevision.go
+++ b/internal/datastore/revisions/hlcrevision.go
@@ -93,6 +93,12 @@ func NewHLCForTime(time time.Time) HLCRevision {
 	return HLCRevision{time.UnixNano(), 0}
 }
 
+// IsValid returns true if the revision is valid. A valid revision has a timestamp greater than 0,
+// versus an empty revision.
+func (hlc HLCRevision) IsValid() bool {
+	return hlc.time > 0
+}
+
 func (hlc HLCRevision) Equal(rhs datastore.Revision) bool {
 	if rhs == datastore.NoRevision {
 		rhs = zeroHLC


### PR DESCRIPTION
when the timestamp to start emitting updates from
is way in the past, CRDB will not emit checkpoints.

As a consequence, every update in the w.r.t to the moment the changefeed was created will accumulate
in memory and OOM the process with a large enough
backlog.

The proposed solution is to compute one checkpoint from the real-time stream of updates, and then use that as the high-watermark for the backlog of
changes from the past. We need to emit all the updates before we can emit a checkpoint, so downstream callers would have to handle it accordingly.