### PR TITLE
Implement parsing of local imports

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -72,7 +72,7 @@ jobs:
         with:
           distribution: "goreleaser-pro"
           version: "2.3.2"
-          args: "release --clean --split --snapshot --single-target --skip=chocolatey"
+          args: "release --clean --split --snapshot --single-target"
         env:
           GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"
       - name: "Obtain container image to scan"

--- a/pkg/composableschemadsl/dslshape/dslshape.go
+++ b/pkg/composableschemadsl/dslshape/dslshape.go
@@ -35,6 +35,8 @@ const (
 	NodeTypeNilExpression // A nil keyword
 
 	NodeTypeCaveatTypeReference // A type reference for a caveat parameter.
+
+	NodeTypeImport
 )
 
 const (
@@ -188,4 +190,12 @@ const (
 	//
 	NodeExpressionPredicateLeftExpr  = "left-expr"
 	NodeExpressionPredicateRightExpr = "right-expr"
+
+	//
+	// NodeTypeImport
+	//
+	// TODO: still need to figure out what form this should take - full path? relative path?
+	NodeImportPredicateSource         = "import-source"
+	NodeImportPredicatePathSegment    = "path-segment"
+	NodeImportPredicateDefinitionName = "imported-definition"
 )

--- a/pkg/composableschemadsl/dslshape/zz_generated.nodetype_string.go
+++ b/pkg/composableschemadsl/dslshape/zz_generated.nodetype_string.go
@@ -27,11 +27,12 @@ func _() {
 	_ = x[NodeTypeIdentifier-16]
 	_ = x[NodeTypeNilExpression-17]
 	_ = x[NodeTypeCaveatTypeReference-18]
+	_ = x[NodeTypeImport-19]
 }
 
-const _NodeType_name = "NodeTypeErrorNodeTypeFileNodeTypeCommentNodeTypeDefinitionNodeTypeCaveatDefinitionNodeTypeCaveatParameterNodeTypeCaveatExpressionNodeTypeRelationNodeTypePermissionNodeTypeTypeReferenceNodeTypeSpecificTypeReferenceNodeTypeCaveatReferenceNodeTypeUnionExpressionNodeTypeIntersectExpressionNodeTypeExclusionExpressionNodeTypeArrowExpressionNodeTypeIdentifierNodeTypeNilExpressionNodeTypeCaveatTypeReference"
+const _NodeType_name = "NodeTypeErrorNodeTypeFileNodeTypeCommentNodeTypeDefinitionNodeTypeCaveatDefinitionNodeTypeCaveatParameterNodeTypeCaveatExpressionNodeTypeRelationNodeTypePermissionNodeTypeTypeReferenceNodeTypeSpecificTypeReferenceNodeTypeCaveatReferenceNodeTypeUnionExpressionNodeTypeIntersectExpressionNodeTypeExclusionExpressionNodeTypeArrowExpressionNodeTypeIdentifierNodeTypeNilExpressionNodeTypeCaveatTypeReferenceNodeTypeImport"
 
-var _NodeType_index = [...]uint16{0, 13, 25, 40, 58, 82, 105, 129, 145, 163, 184, 213, 236, 259, 286, 313, 336, 354, 375, 402}
+var _NodeType_index = [...]uint16{0, 13, 25, 40, 58, 82, 105, 129, 145, 163, 184, 213, 236, 259, 286, 313, 336, 354, 375, 402, 416}
 
 func (i NodeType) String() string {
 	if i < 0 || i >= NodeType(len(_NodeType_index)-1) {

--- a/pkg/composableschemadsl/lexer/lex_def.go
+++ b/pkg/composableschemadsl/lexer/lex_def.go
@@ -78,6 +78,8 @@ var keywords = map[string]struct{}{
 	"permission": {},
 	"nil":        {},
 	"with":       {},
+	"from":       {},
+	"import":     {},
 }
 
 // IsKeyword returns whether the specified input string is a reserved keyword.

--- a/pkg/composableschemadsl/parser/parser_test.go
+++ b/pkg/composableschemadsl/parser/parser_test.go
@@ -122,6 +122,13 @@ func TestParser(t *testing.T) {
 		{"arrow illegal operations test", "arrowillegalops"},
 		{"arrow illegal function test", "arrowillegalfunc"},
 		{"caveat with keyword parameter test", "caveatwithkeywordparam"},
+		{"local imports test", "localimport"},
+		{"local imports with keyword in import path test", "localimport_import_path_with_keyword"},
+		{"local imports with keyword in identifiers test", "localimport_keyword_in_identifiers"},
+		{"local imports with malformed identifiers set test", "localimport_malformed_identifier_set"},
+		{"local imports with malformed import path test", "localimport_malformed_import_path"},
+		{"local imports with path missing leading period test", "localimport_path_missing_leading_period"},
+		{"local imports with typo in import separator test", "localimport_typo_in_import_separator"},
 	}
 
 	for _, test := range parserTests {

--- a/pkg/composableschemadsl/parser/tests/localimport.zed
+++ b/pkg/composableschemadsl/parser/tests/localimport.zed
@@ -1,0 +1,7 @@
+from .path.to.user import user, persona
+
+definition resource {
+    relation user: user
+    relation persona: persona
+    permission view = user + persona
+}

--- a/pkg/composableschemadsl/parser/tests/localimport.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/localimport.zed.expected
@@ -1,0 +1,96 @@
+NodeTypeFile
+  end-rune = 155
+  input-source = local imports test
+  start-rune = 0
+  child-node =>
+    NodeTypeImport
+      end-rune = 39
+      input-source = local imports test
+      start-rune = 0
+      imported-definition =>
+        NodeTypeIdentifier
+          end-rune = 29
+          identifier-value = user
+          input-source = local imports test
+          start-rune = 26
+        NodeTypeIdentifier
+          end-rune = 38
+          identifier-value = persona
+          input-source = local imports test
+          start-rune = 32
+      path-segment =>
+        NodeTypeIdentifier
+          end-rune = 9
+          identifier-value = path
+          input-source = local imports test
+          start-rune = 6
+        NodeTypeIdentifier
+          end-rune = 12
+          identifier-value = to
+          input-source = local imports test
+          start-rune = 11
+        NodeTypeIdentifier
+          end-rune = 17
+          identifier-value = user
+          input-source = local imports test
+          start-rune = 14
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 154
+      input-source = local imports test
+      start-rune = 41
+      child-node =>
+        NodeTypeRelation
+          end-rune = 85
+          input-source = local imports test
+          relation-name = user
+          start-rune = 67
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 85
+              input-source = local imports test
+              start-rune = 82
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 85
+                  input-source = local imports test
+                  start-rune = 82
+                  type-name = user
+        NodeTypeRelation
+          end-rune = 115
+          input-source = local imports test
+          relation-name = persona
+          start-rune = 91
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 115
+              input-source = local imports test
+              start-rune = 109
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 115
+                  input-source = local imports test
+                  start-rune = 109
+                  type-name = persona
+        NodeTypePermission
+          end-rune = 152
+          input-source = local imports test
+          relation-name = view
+          start-rune = 121
+          compute-expression =>
+            NodeTypeUnionExpression
+              end-rune = 152
+              input-source = local imports test
+              start-rune = 139
+              left-expr =>
+                NodeTypeIdentifier
+                  end-rune = 142
+                  identifier-value = user
+                  input-source = local imports test
+                  start-rune = 139
+              right-expr =>
+                NodeTypeIdentifier
+                  end-rune = 152
+                  identifier-value = persona
+                  input-source = local imports test
+                  start-rune = 146

--- a/pkg/composableschemadsl/parser/tests/localimport_import_path_with_keyword.zed
+++ b/pkg/composableschemadsl/parser/tests/localimport_import_path_with_keyword.zed
@@ -1,0 +1,7 @@
+from .path.definition.user import user, persona
+
+definition resource {
+    relation user: user
+    relation persona: persona
+    permission view = user + persona
+}

--- a/pkg/composableschemadsl/parser/tests/localimport_import_path_with_keyword.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/localimport_import_path_with_keyword.zed.expected
@@ -1,0 +1,50 @@
+NodeTypeFile
+  end-rune = 20
+  input-source = local imports with keyword in import path test
+  start-rune = 0
+  child-node =>
+    NodeTypeImport
+      end-rune = 10
+      input-source = local imports with keyword in import path test
+      start-rune = 0
+      child-node =>
+        NodeTypeError
+          end-rune = 10
+          error-message = Expected keyword import, found token TokenTypeKeyword
+          error-source = definition
+          input-source = local imports with keyword in import path test
+          start-rune = 11
+      path-segment =>
+        NodeTypeIdentifier
+          end-rune = 9
+          identifier-value = path
+          input-source = local imports with keyword in import path test
+          start-rune = 6
+        NodeTypeIdentifier
+          end-rune = 10
+          input-source = local imports with keyword in import path test
+          start-rune = 11
+          child-node =>
+            NodeTypeError
+              end-rune = 10
+              error-message = Expected identifier, found token TokenTypeKeyword
+              error-source = definition
+              input-source = local imports with keyword in import path test
+              start-rune = 11
+    NodeTypeDefinition
+      end-rune = 20
+      input-source = local imports with keyword in import path test
+      start-rune = 11
+      child-node =>
+        NodeTypeError
+          end-rune = 20
+          error-message = Expected identifier, found token TokenTypePeriod
+          error-source = .
+          input-source = local imports with keyword in import path test
+          start-rune = 21
+    NodeTypeError
+      end-rune = 20
+      error-message = Unexpected token at root level: TokenTypePeriod
+      error-source = .
+      input-source = local imports with keyword in import path test
+      start-rune = 21

--- a/pkg/composableschemadsl/parser/tests/localimport_keyword_in_identifiers.zed
+++ b/pkg/composableschemadsl/parser/tests/localimport_keyword_in_identifiers.zed
@@ -1,0 +1,7 @@
+from .path.to.user import user, caveat
+
+definition resource {
+    relation user: user
+    relation persona: persona
+    permission view = user + persona
+}

--- a/pkg/composableschemadsl/parser/tests/localimport_keyword_in_identifiers.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/localimport_keyword_in_identifiers.zed.expected
@@ -1,0 +1,114 @@
+NodeTypeFile
+  end-rune = 154
+  input-source = local imports with keyword in identifiers test
+  start-rune = 0
+  child-node =>
+    NodeTypeImport
+      end-rune = 30
+      input-source = local imports with keyword in identifiers test
+      start-rune = 0
+      imported-definition =>
+        NodeTypeIdentifier
+          end-rune = 29
+          identifier-value = user
+          input-source = local imports with keyword in identifiers test
+          start-rune = 26
+        NodeTypeIdentifier
+          end-rune = 30
+          input-source = local imports with keyword in identifiers test
+          start-rune = 32
+          child-node =>
+            NodeTypeError
+              end-rune = 30
+              error-message = Expected identifier, found token TokenTypeKeyword
+              error-source = caveat
+              input-source = local imports with keyword in identifiers test
+              start-rune = 32
+      path-segment =>
+        NodeTypeIdentifier
+          end-rune = 9
+          identifier-value = path
+          input-source = local imports with keyword in identifiers test
+          start-rune = 6
+        NodeTypeIdentifier
+          end-rune = 12
+          identifier-value = to
+          input-source = local imports with keyword in identifiers test
+          start-rune = 11
+        NodeTypeIdentifier
+          end-rune = 17
+          identifier-value = user
+          input-source = local imports with keyword in identifiers test
+          start-rune = 14
+    NodeTypeCaveatDefinition
+      end-rune = 37
+      input-source = local imports with keyword in identifiers test
+      start-rune = 32
+      child-node =>
+        NodeTypeError
+          end-rune = 37
+          error-message = Expected identifier, found token TokenTypeSyntheticSemicolon
+          error-source = 
+
+          input-source = local imports with keyword in identifiers test
+          start-rune = 38
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 153
+      input-source = local imports with keyword in identifiers test
+      start-rune = 40
+      child-node =>
+        NodeTypeRelation
+          end-rune = 84
+          input-source = local imports with keyword in identifiers test
+          relation-name = user
+          start-rune = 66
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 84
+              input-source = local imports with keyword in identifiers test
+              start-rune = 81
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 84
+                  input-source = local imports with keyword in identifiers test
+                  start-rune = 81
+                  type-name = user
+        NodeTypeRelation
+          end-rune = 114
+          input-source = local imports with keyword in identifiers test
+          relation-name = persona
+          start-rune = 90
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 114
+              input-source = local imports with keyword in identifiers test
+              start-rune = 108
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 114
+                  input-source = local imports with keyword in identifiers test
+                  start-rune = 108
+                  type-name = persona
+        NodeTypePermission
+          end-rune = 151
+          input-source = local imports with keyword in identifiers test
+          relation-name = view
+          start-rune = 120
+          compute-expression =>
+            NodeTypeUnionExpression
+              end-rune = 151
+              input-source = local imports with keyword in identifiers test
+              start-rune = 138
+              left-expr =>
+                NodeTypeIdentifier
+                  end-rune = 141
+                  identifier-value = user
+                  input-source = local imports with keyword in identifiers test
+                  start-rune = 138
+              right-expr =>
+                NodeTypeIdentifier
+                  end-rune = 151
+                  identifier-value = persona
+                  input-source = local imports with keyword in identifiers test
+                  start-rune = 145

--- a/pkg/composableschemadsl/parser/tests/localimport_malformed_identifier_set.zed
+++ b/pkg/composableschemadsl/parser/tests/localimport_malformed_identifier_set.zed
@@ -1,0 +1,7 @@
+from .path.to.user import user,
+
+definition resource {
+    relation user: user
+    relation persona: persona
+    permission view = user + persona
+}

--- a/pkg/composableschemadsl/parser/tests/localimport_malformed_identifier_set.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/localimport_malformed_identifier_set.zed.expected
@@ -1,0 +1,102 @@
+NodeTypeFile
+  end-rune = 147
+  input-source = local imports with malformed identifiers set test
+  start-rune = 0
+  child-node =>
+    NodeTypeImport
+      end-rune = 30
+      input-source = local imports with malformed identifiers set test
+      start-rune = 0
+      imported-definition =>
+        NodeTypeIdentifier
+          end-rune = 29
+          identifier-value = user
+          input-source = local imports with malformed identifiers set test
+          start-rune = 26
+        NodeTypeIdentifier
+          end-rune = 30
+          input-source = local imports with malformed identifiers set test
+          start-rune = 33
+          child-node =>
+            NodeTypeError
+              end-rune = 30
+              error-message = Expected identifier, found token TokenTypeKeyword
+              error-source = definition
+              input-source = local imports with malformed identifiers set test
+              start-rune = 33
+      path-segment =>
+        NodeTypeIdentifier
+          end-rune = 9
+          identifier-value = path
+          input-source = local imports with malformed identifiers set test
+          start-rune = 6
+        NodeTypeIdentifier
+          end-rune = 12
+          identifier-value = to
+          input-source = local imports with malformed identifiers set test
+          start-rune = 11
+        NodeTypeIdentifier
+          end-rune = 17
+          identifier-value = user
+          input-source = local imports with malformed identifiers set test
+          start-rune = 14
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 146
+      input-source = local imports with malformed identifiers set test
+      start-rune = 33
+      child-node =>
+        NodeTypeRelation
+          end-rune = 77
+          input-source = local imports with malformed identifiers set test
+          relation-name = user
+          start-rune = 59
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 77
+              input-source = local imports with malformed identifiers set test
+              start-rune = 74
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 77
+                  input-source = local imports with malformed identifiers set test
+                  start-rune = 74
+                  type-name = user
+        NodeTypeRelation
+          end-rune = 107
+          input-source = local imports with malformed identifiers set test
+          relation-name = persona
+          start-rune = 83
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 107
+              input-source = local imports with malformed identifiers set test
+              start-rune = 101
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 107
+                  input-source = local imports with malformed identifiers set test
+                  start-rune = 101
+                  type-name = persona
+        NodeTypePermission
+          end-rune = 144
+          input-source = local imports with malformed identifiers set test
+          relation-name = view
+          start-rune = 113
+          compute-expression =>
+            NodeTypeUnionExpression
+              end-rune = 144
+              input-source = local imports with malformed identifiers set test
+              start-rune = 131
+              left-expr =>
+                NodeTypeIdentifier
+                  end-rune = 134
+                  identifier-value = user
+                  input-source = local imports with malformed identifiers set test
+                  start-rune = 131
+              right-expr =>
+                NodeTypeIdentifier
+                  end-rune = 144
+                  identifier-value = persona
+                  input-source = local imports with malformed identifiers set test
+                  start-rune = 138

--- a/pkg/composableschemadsl/parser/tests/localimport_malformed_import_path.zed
+++ b/pkg/composableschemadsl/parser/tests/localimport_malformed_import_path.zed
@@ -1,0 +1,7 @@
+from .path.to. import user, persona
+
+definition resource {
+    relation user: user
+    relation persona: persona
+    permission view = user + persona
+}

--- a/pkg/composableschemadsl/parser/tests/localimport_malformed_import_path.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/localimport_malformed_import_path.zed.expected
@@ -1,0 +1,102 @@
+NodeTypeFile
+  end-rune = 151
+  input-source = local imports with malformed import path test
+  start-rune = 0
+  child-node =>
+    NodeTypeImport
+      end-rune = 35
+      input-source = local imports with malformed import path test
+      start-rune = 0
+      imported-definition =>
+        NodeTypeIdentifier
+          end-rune = 25
+          identifier-value = user
+          input-source = local imports with malformed import path test
+          start-rune = 22
+        NodeTypeIdentifier
+          end-rune = 34
+          identifier-value = persona
+          input-source = local imports with malformed import path test
+          start-rune = 28
+      path-segment =>
+        NodeTypeIdentifier
+          end-rune = 9
+          identifier-value = path
+          input-source = local imports with malformed import path test
+          start-rune = 6
+        NodeTypeIdentifier
+          end-rune = 12
+          identifier-value = to
+          input-source = local imports with malformed import path test
+          start-rune = 11
+        NodeTypeIdentifier
+          end-rune = 13
+          input-source = local imports with malformed import path test
+          start-rune = 15
+          child-node =>
+            NodeTypeError
+              end-rune = 13
+              error-message = Expected identifier, found token TokenTypeKeyword
+              error-source = import
+              input-source = local imports with malformed import path test
+              start-rune = 15
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 150
+      input-source = local imports with malformed import path test
+      start-rune = 37
+      child-node =>
+        NodeTypeRelation
+          end-rune = 81
+          input-source = local imports with malformed import path test
+          relation-name = user
+          start-rune = 63
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 81
+              input-source = local imports with malformed import path test
+              start-rune = 78
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 81
+                  input-source = local imports with malformed import path test
+                  start-rune = 78
+                  type-name = user
+        NodeTypeRelation
+          end-rune = 111
+          input-source = local imports with malformed import path test
+          relation-name = persona
+          start-rune = 87
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 111
+              input-source = local imports with malformed import path test
+              start-rune = 105
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 111
+                  input-source = local imports with malformed import path test
+                  start-rune = 105
+                  type-name = persona
+        NodeTypePermission
+          end-rune = 148
+          input-source = local imports with malformed import path test
+          relation-name = view
+          start-rune = 117
+          compute-expression =>
+            NodeTypeUnionExpression
+              end-rune = 148
+              input-source = local imports with malformed import path test
+              start-rune = 135
+              left-expr =>
+                NodeTypeIdentifier
+                  end-rune = 138
+                  identifier-value = user
+                  input-source = local imports with malformed import path test
+                  start-rune = 135
+              right-expr =>
+                NodeTypeIdentifier
+                  end-rune = 148
+                  identifier-value = persona
+                  input-source = local imports with malformed import path test
+                  start-rune = 142

--- a/pkg/composableschemadsl/parser/tests/localimport_path_missing_leading_period.zed
+++ b/pkg/composableschemadsl/parser/tests/localimport_path_missing_leading_period.zed
@@ -1,0 +1,7 @@
+from path.to.user import user, persona
+
+definition resource {
+    relation user: user
+    relation persona: persona
+    permission view = user + persona
+}

--- a/pkg/composableschemadsl/parser/tests/localimport_path_missing_leading_period.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/localimport_path_missing_leading_period.zed.expected
@@ -1,0 +1,22 @@
+NodeTypeFile
+  end-rune = 3
+  input-source = local imports with path missing leading period test
+  start-rune = 0
+  child-node =>
+    NodeTypeImport
+      end-rune = 3
+      input-source = local imports with path missing leading period test
+      start-rune = 0
+      child-node =>
+        NodeTypeError
+          end-rune = 3
+          error-message = Expected one of: [TokenTypePeriod], found: TokenTypeIdentifier
+          error-source = path
+          input-source = local imports with path missing leading period test
+          start-rune = 5
+    NodeTypeError
+      end-rune = 3
+      error-message = Unexpected token at root level: TokenTypeIdentifier
+      error-source = path
+      input-source = local imports with path missing leading period test
+      start-rune = 5

--- a/pkg/composableschemadsl/parser/tests/localimport_typo_in_import_separator.zed
+++ b/pkg/composableschemadsl/parser/tests/localimport_typo_in_import_separator.zed
@@ -1,0 +1,7 @@
+from .path.to.user impoort user, persona
+
+definition resource {
+    relation user: user
+    relation persona: persona
+    permission view = user + persona
+}

--- a/pkg/composableschemadsl/parser/tests/localimport_typo_in_import_separator.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/localimport_typo_in_import_separator.zed.expected
@@ -1,0 +1,38 @@
+NodeTypeFile
+  end-rune = 17
+  input-source = local imports with typo in import separator test
+  start-rune = 0
+  child-node =>
+    NodeTypeImport
+      end-rune = 17
+      input-source = local imports with typo in import separator test
+      start-rune = 0
+      child-node =>
+        NodeTypeError
+          end-rune = 17
+          error-message = Expected keyword import, found token TokenTypeIdentifier
+          error-source = impoort
+          input-source = local imports with typo in import separator test
+          start-rune = 19
+      path-segment =>
+        NodeTypeIdentifier
+          end-rune = 9
+          identifier-value = path
+          input-source = local imports with typo in import separator test
+          start-rune = 6
+        NodeTypeIdentifier
+          end-rune = 12
+          identifier-value = to
+          input-source = local imports with typo in import separator test
+          start-rune = 11
+        NodeTypeIdentifier
+          end-rune = 17
+          identifier-value = user
+          input-source = local imports with typo in import separator test
+          start-rune = 14
+    NodeTypeError
+      end-rune = 17
+      error-message = Unexpected token at root level: TokenTypeIdentifier
+      error-source = impoort
+      input-source = local imports with typo in import separator test
+      start-rune = 19


### PR DESCRIPTION
Part of #1437 

## Description
A first step in implementing the composable schema proposal. This implements the relative import syntax in the parser.

## Changes
* Add a new test with the desired local import syntax
* Add `from` and `import` as keywords
* Add new import node type and predicates for it
* Add parser logic to consume import syntax
* Add generated test output
* Fix trivy usage so that we don't hit rate limits
## Testing
Review. See that tests are green.