### PR TITLE
Make all and any into keywords

### DIFF
--- a/pkg/composableschemadsl/lexer/lex_def.go
+++ b/pkg/composableschemadsl/lexer/lex_def.go
@@ -80,6 +80,8 @@ var keywords = map[string]struct{}{
 	"with":       {},
 	"from":       {},
 	"import":     {},
+	"all":        {},
+	"any":        {},
 }
 
 // IsKeyword returns whether the specified input string is a reserved keyword.

--- a/pkg/composableschemadsl/lexer/lex_test.go
+++ b/pkg/composableschemadsl/lexer/lex_test.go
@@ -57,6 +57,14 @@ var lexerTests = []lexerTest{
 	{"minus", "-", []Lexeme{{TokenTypeMinus, 0, "-", ""}, tEOF}},
 
 	{"keyword", "definition", []Lexeme{{TokenTypeKeyword, 0, "definition", ""}, tEOF}},
+	{"keyword", "caveat", []Lexeme{{TokenTypeKeyword, 0, "caveat", ""}, tEOF}},
+	{"keyword", "relation", []Lexeme{{TokenTypeKeyword, 0, "relation", ""}, tEOF}},
+	{"keyword", "permission", []Lexeme{{TokenTypeKeyword, 0, "permission", ""}, tEOF}},
+	{"keyword", "nil", []Lexeme{{TokenTypeKeyword, 0, "nil", ""}, tEOF}},
+	{"keyword", "with", []Lexeme{{TokenTypeKeyword, 0, "with", ""}, tEOF}},
+	{"keyword", "from", []Lexeme{{TokenTypeKeyword, 0, "from", ""}, tEOF}},
+	{"keyword", "import", []Lexeme{{TokenTypeKeyword, 0, "import", ""}, tEOF}},
+	{"keyword", "all", []Lexeme{{TokenTypeKeyword, 0, "all", ""}, tEOF}},
 	{"keyword", "nil", []Lexeme{{TokenTypeKeyword, 0, "nil", ""}, tEOF}},
 	{"identifier", "define", []Lexeme{{TokenTypeIdentifier, 0, "define", ""}, tEOF}},
 	{"typepath", "foo/bar", []Lexeme{
@@ -251,7 +259,7 @@ var lexerTests = []lexerTest{
 	{"dot access", "foo.all(something)", []Lexeme{
 		{TokenTypeIdentifier, 0, "foo", ""},
 		{TokenTypePeriod, 0, ".", ""},
-		{TokenTypeIdentifier, 0, "all", ""},
+		{TokenTypeKeyword, 0, "all", ""},
 		{TokenTypeLeftParen, 0, "(", ""},
 		{TokenTypeIdentifier, 0, "something", ""},
 		{TokenTypeRightParen, 0, ")", ""},

--- a/pkg/composableschemadsl/parser/parser_impl.go
+++ b/pkg/composableschemadsl/parser/parser_impl.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/authzed/spicedb/pkg/composableschemadsl/dslshape"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/input"
@@ -195,6 +196,27 @@ func (p *sourceParser) tryConsumeKeyword(keyword string) bool {
 
 	p.consumeToken()
 	return true
+}
+
+// consumeKeywords consumes any of a set of keywords or adds an error node
+func (p *sourceParser) consumeKeywords(keywords ...string) (string, bool) {
+	keyword, ok := p.tryConsumeKeywords(keywords...)
+	if !ok {
+		p.emitErrorf("Expected one of keywords %s; found token %v", strings.Join(keywords, ", "), p.currentToken.Kind)
+		return "", false
+	}
+	return keyword, true
+}
+
+// tryConsumeKeyword attempts to consume one of a set of expected keyword tokens.
+func (p *sourceParser) tryConsumeKeywords(keywords ...string) (string, bool) {
+	for _, keyword := range keywords {
+		if p.isKeyword(keyword) {
+			p.consumeToken()
+			return keyword, true
+		}
+	}
+	return "", false
 }
 
 // cosumeIdentifier consumes an expected identifier token or adds an error node.

--- a/pkg/composableschemadsl/parser/tests/arrowillegalfunc.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/arrowillegalfunc.zed.expected
@@ -1,32 +1,32 @@
 NodeTypeFile
-  end-rune = 48
+  end-rune = 45
   input-source = arrow illegal function test
   start-rune = 0
   child-node =>
     NodeTypeDefinition
       definition-name = resource
-      end-rune = 48
+      end-rune = 45
       input-source = arrow illegal function test
       start-rune = 0
       child-node =>
         NodeTypePermission
-          end-rune = 48
+          end-rune = 45
           input-source = arrow illegal function test
           relation-name = view
           start-rune = 26
           child-node =>
             NodeTypeError
-              end-rune = 48
-              error-message = Expected 'any' or 'all' for arrow function, found: foo
-              error-source = (
+              end-rune = 45
+              error-message = Expected one of keywords any, all; found token TokenTypeIdentifier
+              error-source = foo
               input-source = arrow illegal function test
-              start-rune = 49
+              start-rune = 46
             NodeTypeError
-              end-rune = 48
-              error-message = Expected right hand expression, found: TokenTypeLeftParen
-              error-source = (
+              end-rune = 45
+              error-message = Expected right hand expression, found: TokenTypeIdentifier
+              error-source = foo
               input-source = arrow illegal function test
-              start-rune = 49
+              start-rune = 46
           compute-expression =>
             NodeTypeIdentifier
               end-rune = 44
@@ -34,14 +34,14 @@ NodeTypeFile
               input-source = arrow illegal function test
               start-rune = 44
         NodeTypeError
-          end-rune = 48
-          error-message = Expected end of statement or definition, found: TokenTypeLeftParen
-          error-source = (
+          end-rune = 45
+          error-message = Expected end of statement or definition, found: TokenTypeIdentifier
+          error-source = foo
           input-source = arrow illegal function test
-          start-rune = 49
+          start-rune = 46
     NodeTypeError
-      end-rune = 48
-      error-message = Unexpected token at root level: TokenTypeLeftParen
-      error-source = (
+      end-rune = 45
+      error-message = Unexpected token at root level: TokenTypeIdentifier
+      error-source = foo
       input-source = arrow illegal function test
-      start-rune = 49
+      start-rune = 46


### PR DESCRIPTION
## Description
One of the things that we wanted to do with the new schema version. `any` and `all` should be keywords befitting their use in intersection arrow syntax, but we didn't want to break existing usages; we're making the breaking change now.

## Changes
* Add `any` and `all` to keyword list
* Add `consumeKeywords` impl function to capture getting one of a set of keywords
* Update caveat parsing code to allow for `any` as a keyword in type logic
* Update test case to reflect new error messaging
* Update lexer tests and make keyword tests exhaustive
## Testing
Review. See that things are green.