### PR TITLE
Updates to tuple helpers

### DIFF
--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -97,7 +97,7 @@ func newDevContextWithDatastore(ctx context.Context, requestContext *devinterfac
 					Message: err.Error(),
 					Source:  devinterface.DeveloperError_RELATIONSHIP,
 					Kind:    devinterface.DeveloperError_PARSE_ERROR,
-					Context: tuple.CoreRelationToString(rel),
+					Context: tuple.CoreRelationToStringWithoutCaveat(rel),
 				})
 			}
 

--- a/pkg/tuple/core.go
+++ b/pkg/tuple/core.go
@@ -19,7 +19,7 @@ func ONRStringToCore(ns, oid, rel string) *core.ObjectAndRelation {
 }
 
 // CoreRelationToString creates a string from a core.RelationTuple.
-func CoreRelationToString(rel *core.RelationTuple) string {
+func CoreRelationToStringWithoutCaveat(rel *core.RelationTuple) string {
 	if rel.Subject.Relation == Ellipsis {
 		return rel.ResourceAndRelation.Namespace + ":" + rel.ResourceAndRelation.ObjectId + "@" + rel.Subject.Namespace + ":" + rel.Subject.ObjectId
 	}

--- a/pkg/tuple/v1.go
+++ b/pkg/tuple/v1.go
@@ -20,6 +20,16 @@ func ParseV1Rel(relString string) (*v1.Relationship, error) {
 	return ToV1Relationship(parsed), nil
 }
 
+// Same as above, but panics if it cannot be parsed. Should only be used in tests.
+func MustParseV1Rel(relString string) (*v1.Relationship, error) {
+	parsed, err := Parse(relString)
+	if err != nil {
+		panic(fmt.Sprintf("could not parse relationship string: %s %s", relString, err))
+	}
+
+	return ToV1Relationship(parsed), nil
+}
+
 // MustV1RelString converts a relationship into a string.  Will panic if
 // the Relationship does not validate.
 func MustV1RelString(rel *v1.Relationship) string {


### PR DESCRIPTION
## Description
Came up the context of authzed/zed#431. The lack of context in the string helper isn't clear from the name, and having a `MustParseV1` function makes writing tests in zed and elsewhere easier.

## Changes
* Rename fn
* Update usage
* Add new helper for tests

## Testing
Review.