### PR TITLE
Add a new consistency middleware for full-consistency-only callers

### DIFF
--- a/internal/middleware/consistency/consistency.go
+++ b/internal/middleware/consistency/consistency.go
@@ -21,7 +21,7 @@ import (
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
 
-var ConsistentyCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+var ConsistencyCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Namespace: "spicedb",
 	Subsystem: "middleware",
 	Name:      "consistency_assigned_total",
@@ -90,7 +90,7 @@ func addRevisionToContextFromConsistency(ctx context.Context, req hasConsistency
 	case hasOptionalCursor && withOptionalCursor.GetOptionalCursor() != nil:
 		// Always use the revision encoded in the cursor.
 		if serviceLabel != "" {
-			ConsistentyCounter.WithLabelValues("snapshot", "cursor", serviceLabel).Inc()
+			ConsistencyCounter.WithLabelValues("snapshot", "cursor", serviceLabel).Inc()
 		}
 
 		requestedRev, err := cursor.DecodeToDispatchRevision(withOptionalCursor.GetOptionalCursor(), ds)
@@ -113,7 +113,7 @@ func addRevisionToContextFromConsistency(ctx context.Context, req hasConsistency
 		}
 
 		if serviceLabel != "" {
-			ConsistentyCounter.WithLabelValues("minlatency", source, serviceLabel).Inc()
+			ConsistencyCounter.WithLabelValues("minlatency", source, serviceLabel).Inc()
 		}
 
 		databaseRev, err := ds.OptimizedRevision(ctx)
@@ -125,7 +125,7 @@ func addRevisionToContextFromConsistency(ctx context.Context, req hasConsistency
 	case consistency.GetFullyConsistent():
 		// Fully Consistent: Use the datastore's synchronized revision.
 		if serviceLabel != "" {
-			ConsistentyCounter.WithLabelValues("full", "request", serviceLabel).Inc()
+			ConsistencyCounter.WithLabelValues("full", "request", serviceLabel).Inc()
 		}
 
 		databaseRev, err := ds.HeadRevision(ctx)
@@ -146,14 +146,14 @@ func addRevisionToContextFromConsistency(ctx context.Context, req hasConsistency
 		if pickedRequest {
 			source = "request"
 		}
-		ConsistentyCounter.WithLabelValues("atleast", source, serviceLabel).Inc()
+		ConsistencyCounter.WithLabelValues("atleast", source, serviceLabel).Inc()
 
 		revision = picked
 
 	case consistency.GetAtExactSnapshot() != nil:
 		// Exact snapshot: Use the revision as encoded in the zed token.
 		if serviceLabel != "" {
-			ConsistentyCounter.WithLabelValues("snapshot", "request", serviceLabel).Inc()
+			ConsistencyCounter.WithLabelValues("snapshot", "request", serviceLabel).Inc()
 		}
 
 		requestedRev, err := zedtoken.DecodeRevision(consistency.GetAtExactSnapshot(), ds)

--- a/internal/middleware/consistency/consistency_test.go
+++ b/internal/middleware/consistency/consistency_test.go
@@ -29,7 +29,7 @@ func TestAddRevisionToContextNoneSupplied(t *testing.T) {
 	ds.On("OptimizedRevision").Return(optimized, nil).Once()
 
 	updated := ContextWithHandle(context.Background())
-	err := AddRevisionToContext(updated, &v1.ReadRelationshipsRequest{}, ds)
+	err := AddRevisionToContext(updated, &v1.ReadRelationshipsRequest{}, ds, "somelabel")
 	require.NoError(err)
 
 	rev, _, err := RevisionFromContext(updated)
@@ -52,7 +52,7 @@ func TestAddRevisionToContextMinimizeLatency(t *testing.T) {
 				MinimizeLatency: true,
 			},
 		},
-	}, ds)
+	}, ds, "somelabel")
 	require.NoError(err)
 
 	rev, _, err := RevisionFromContext(updated)
@@ -75,7 +75,7 @@ func TestAddRevisionToContextFullyConsistent(t *testing.T) {
 				FullyConsistent: true,
 			},
 		},
-	}, ds)
+	}, ds, "somelabel")
 	require.NoError(err)
 
 	rev, _, err := RevisionFromContext(updated)
@@ -99,7 +99,7 @@ func TestAddRevisionToContextAtLeastAsFresh(t *testing.T) {
 				AtLeastAsFresh: zedtoken.MustNewFromRevision(exact),
 			},
 		},
-	}, ds)
+	}, ds, "somelabel")
 	require.NoError(err)
 
 	rev, _, err := RevisionFromContext(updated)
@@ -123,7 +123,7 @@ func TestAddRevisionToContextAtValidExactSnapshot(t *testing.T) {
 				AtExactSnapshot: zedtoken.MustNewFromRevision(exact),
 			},
 		},
-	}, ds)
+	}, ds, "somelabel")
 	require.NoError(err)
 
 	rev, _, err := RevisionFromContext(updated)
@@ -147,7 +147,7 @@ func TestAddRevisionToContextAtInvalidExactSnapshot(t *testing.T) {
 				AtExactSnapshot: zedtoken.MustNewFromRevision(zero),
 			},
 		},
-	}, ds)
+	}, ds, "somelabel")
 	require.Error(err)
 	ds.AssertExpectations(t)
 }
@@ -181,7 +181,7 @@ func TestAddRevisionToContextWithCursor(t *testing.T) {
 			},
 		},
 		OptionalCursor: cursor,
-	}, ds)
+	}, ds, "somelabel")
 	require.NoError(err)
 
 	// ensure we get back `optimized` from the cursor

--- a/internal/middleware/consistency/forcefull.go
+++ b/internal/middleware/consistency/forcefull.go
@@ -52,7 +52,7 @@ func setFullConsistencyRevisionToContext(ctx context.Context, req interface{}, d
 	switch req.(type) {
 	case hasConsistency:
 		if serviceLabel != "" {
-			ConsistentyCounter.WithLabelValues("full", "request", serviceLabel).Inc()
+			ConsistencyCounter.WithLabelValues("full", "request", serviceLabel).Inc()
 		}
 
 		databaseRev, err := ds.HeadRevision(ctx)

--- a/internal/middleware/consistency/forcefull.go
+++ b/internal/middleware/consistency/forcefull.go
@@ -1,0 +1,66 @@
+package consistency
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc"
+
+	datastoremw "github.com/authzed/spicedb/internal/middleware/datastore"
+	"github.com/authzed/spicedb/pkg/datastore"
+)
+
+// ForceFullConsistencyUnaryServerInterceptor returns a new unary server interceptor that enforces full consistency
+// for all requests, except for those in the bypassServiceWhitelist.
+func ForceFullConsistencyUnaryServerInterceptor(serviceLabel string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		for bypass := range bypassServiceWhitelist {
+			if strings.HasPrefix(info.FullMethod, bypass) {
+				return handler(ctx, req)
+			}
+		}
+		ds := datastoremw.MustFromContext(ctx)
+		newCtx := ContextWithHandle(ctx)
+		if err := setFullConsistencyRevisionToContext(newCtx, req, ds, serviceLabel); err != nil {
+			return nil, err
+		}
+
+		return handler(newCtx, req)
+	}
+}
+
+// ForceFullConsistencyStreamServerInterceptor returns a new stream server interceptor that enforces full consistency
+// for all requests, except for those in the bypassServiceWhitelist.
+func ForceFullConsistencyStreamServerInterceptor(serviceLabel string) grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		for bypass := range bypassServiceWhitelist {
+			if strings.HasPrefix(info.FullMethod, bypass) {
+				return handler(srv, stream)
+			}
+		}
+		wrapper := &recvWrapper{stream, ContextWithHandle(stream.Context()), serviceLabel, setFullConsistencyRevisionToContext}
+		return handler(srv, wrapper)
+	}
+}
+
+func setFullConsistencyRevisionToContext(ctx context.Context, req interface{}, ds datastore.Datastore, serviceLabel string) error {
+	handle := ctx.Value(revisionKey)
+	if handle == nil {
+		return nil
+	}
+
+	switch req.(type) {
+	case hasConsistency:
+		if serviceLabel != "" {
+			ConsistentyCounter.WithLabelValues("full", "request", serviceLabel).Inc()
+		}
+
+		databaseRev, err := ds.HeadRevision(ctx)
+		if err != nil {
+			return rewriteDatastoreError(ctx, err)
+		}
+		handle.(*revisionHandle).revision = databaseRev
+	}
+
+	return nil
+}

--- a/internal/services/integrationtesting/cert_test.go
+++ b/internal/services/integrationtesting/cert_test.go
@@ -148,7 +148,7 @@ func TestCertRotation(t *testing.T) {
 					},
 					{
 						Name:       "consistency",
-						Middleware: consistency.UnaryServerInterceptor(),
+						Middleware: consistency.UnaryServerInterceptor("testing"),
 					},
 					{
 						Name:       "servicespecific",
@@ -167,7 +167,7 @@ func TestCertRotation(t *testing.T) {
 					},
 					{
 						Name:       "consistency",
-						Middleware: consistency.StreamServerInterceptor(),
+						Middleware: consistency.StreamServerInterceptor("testing"),
 					},
 					{
 						Name:       "servicespecific",

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -104,7 +104,7 @@ func NewTestServerWithConfigAndDatastore(require *require.Assertions,
 					},
 					{
 						Name:       "consistency",
-						Middleware: consistency.UnaryServerInterceptor(),
+						Middleware: consistency.UnaryServerInterceptor("testserver"),
 					},
 					{
 						Name:       "servicespecific",
@@ -127,7 +127,7 @@ func NewTestServerWithConfigAndDatastore(require *require.Assertions,
 					},
 					{
 						Name:       "consistency",
-						Middleware: consistency.StreamServerInterceptor(),
+						Middleware: consistency.StreamServerInterceptor("testserver"),
 					},
 					{
 						Name:       "servicespecific",

--- a/pkg/cmd/server/defaults.go
+++ b/pkg/cmd/server/defaults.go
@@ -186,6 +186,7 @@ type MiddlewareOption struct {
 	EnableRequestLog        bool                `debugmap:"visible"`
 	EnableResponseLog       bool                `debugmap:"visible"`
 	DisableGRPCHistogram    bool                `debugmap:"visible"`
+	MiddlewareServiceLabel  string              `debugmap:"visible"`
 
 	unaryDatastoreMiddleware  *ReferenceableMiddleware[grpc.UnaryServerInterceptor]  `debugmap:"hidden"`
 	streamDatastoreMiddleware *ReferenceableMiddleware[grpc.StreamServerInterceptor] `debugmap:"hidden"`
@@ -341,7 +342,7 @@ func DefaultUnaryMiddleware(opts MiddlewareOption) (*MiddlewareChain[grpc.UnaryS
 		NewUnaryMiddleware().
 			WithName(DefaultInternalMiddlewareConsistency).
 			WithInternal(true).
-			WithInterceptor(consistencymw.UnaryServerInterceptor()).
+			WithInterceptor(consistencymw.UnaryServerInterceptor(opts.MiddlewareServiceLabel)).
 			Done(),
 
 		NewUnaryMiddleware().
@@ -415,7 +416,7 @@ func DefaultStreamingMiddleware(opts MiddlewareOption) (*MiddlewareChain[grpc.St
 		NewStreamMiddleware().
 			WithName(DefaultInternalMiddlewareConsistency).
 			WithInternal(true).
-			WithInterceptor(consistencymw.StreamServerInterceptor()).
+			WithInterceptor(consistencymw.StreamServerInterceptor(opts.MiddlewareServiceLabel)).
 			Done(),
 
 		NewStreamMiddleware().

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -59,6 +59,7 @@ type Config struct {
 	PresharedSecureKey     []string              `debugmap:"sensitive"`
 	ShutdownGracePeriod    time.Duration         `debugmap:"visible"`
 	DisableVersionResponse bool                  `debugmap:"visible"`
+	ServerName             string                `debugmap:"visible"`
 
 	// GRPC Gateway config
 	HTTPGateway                    util.HTTPServerConfig `debugmap:"visible"`
@@ -376,6 +377,11 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		watchServiceOption = services.WatchServiceDisabled
 	}
 
+	serverName := c.ServerName
+	if serverName == "" {
+		serverName = "spicedb"
+	}
+
 	opts := MiddlewareOption{
 		log.Logger,
 		c.GRPCAuthFunc,
@@ -384,6 +390,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		c.EnableRequestLogs,
 		c.EnableResponseLogs,
 		c.DisableGRPCLatencyHistogram,
+		serverName,
 		nil,
 		nil,
 	}

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -231,7 +231,7 @@ func TestModifyUnaryMiddleware(t *testing.T) {
 		},
 	}}
 
-	opt := MiddlewareOption{logging.Logger, nil, false, nil, false, false, false, nil, nil}
+	opt := MiddlewareOption{logging.Logger, nil, false, nil, false, false, false, "testing", nil, nil}
 	opt = opt.WithDatastore(nil)
 
 	defaultMw, err := DefaultUnaryMiddleware(opt)
@@ -259,7 +259,7 @@ func TestModifyStreamingMiddleware(t *testing.T) {
 		},
 	}}
 
-	opt := MiddlewareOption{logging.Logger, nil, false, nil, false, false, false, nil, nil}
+	opt := MiddlewareOption{logging.Logger, nil, false, nil, false, false, false, "testing", nil, nil}
 	opt = opt.WithDatastore(nil)
 
 	defaultMw, err := DefaultStreamingMiddleware(opt)

--- a/pkg/cmd/server/zz_generated.middlewareoption.go
+++ b/pkg/cmd/server/zz_generated.middlewareoption.go
@@ -40,6 +40,7 @@ func (m *MiddlewareOption) ToOption() MiddlewareOptionOption {
 		to.EnableRequestLog = m.EnableRequestLog
 		to.EnableResponseLog = m.EnableResponseLog
 		to.DisableGRPCHistogram = m.DisableGRPCHistogram
+		to.MiddlewareServiceLabel = m.MiddlewareServiceLabel
 		to.unaryDatastoreMiddleware = m.unaryDatastoreMiddleware
 		to.streamDatastoreMiddleware = m.streamDatastoreMiddleware
 	}
@@ -52,6 +53,7 @@ func (m MiddlewareOption) DebugMap() map[string]any {
 	debugMap["EnableRequestLog"] = helpers.DebugValue(m.EnableRequestLog, false)
 	debugMap["EnableResponseLog"] = helpers.DebugValue(m.EnableResponseLog, false)
 	debugMap["DisableGRPCHistogram"] = helpers.DebugValue(m.DisableGRPCHistogram, false)
+	debugMap["MiddlewareServiceLabel"] = helpers.DebugValue(m.MiddlewareServiceLabel, false)
 	return debugMap
 }
 
@@ -117,5 +119,12 @@ func WithEnableResponseLog(enableResponseLog bool) MiddlewareOptionOption {
 func WithDisableGRPCHistogram(disableGRPCHistogram bool) MiddlewareOptionOption {
 	return func(m *MiddlewareOption) {
 		m.DisableGRPCHistogram = disableGRPCHistogram
+	}
+}
+
+// WithMiddlewareServiceLabel returns an option that can set MiddlewareServiceLabel on a MiddlewareOption
+func WithMiddlewareServiceLabel(middlewareServiceLabel string) MiddlewareOptionOption {
+	return func(m *MiddlewareOption) {
+		m.MiddlewareServiceLabel = middlewareServiceLabel
 	}
 }

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -43,6 +43,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.PresharedSecureKey = c.PresharedSecureKey
 		to.ShutdownGracePeriod = c.ShutdownGracePeriod
 		to.DisableVersionResponse = c.DisableVersionResponse
+		to.ServerName = c.ServerName
 		to.HTTPGateway = c.HTTPGateway
 		to.HTTPGatewayUpstreamAddr = c.HTTPGatewayUpstreamAddr
 		to.HTTPGatewayUpstreamTLSCertPath = c.HTTPGatewayUpstreamTLSCertPath
@@ -110,6 +111,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["PresharedSecureKey"] = helpers.SensitiveDebugValue(c.PresharedSecureKey)
 	debugMap["ShutdownGracePeriod"] = helpers.DebugValue(c.ShutdownGracePeriod, false)
 	debugMap["DisableVersionResponse"] = helpers.DebugValue(c.DisableVersionResponse, false)
+	debugMap["ServerName"] = helpers.DebugValue(c.ServerName, false)
 	debugMap["HTTPGateway"] = helpers.DebugValue(c.HTTPGateway, false)
 	debugMap["HTTPGatewayUpstreamAddr"] = helpers.DebugValue(c.HTTPGatewayUpstreamAddr, false)
 	debugMap["HTTPGatewayUpstreamTLSCertPath"] = helpers.DebugValue(c.HTTPGatewayUpstreamTLSCertPath, false)
@@ -220,6 +222,13 @@ func WithShutdownGracePeriod(shutdownGracePeriod time.Duration) ConfigOption {
 func WithDisableVersionResponse(disableVersionResponse bool) ConfigOption {
 	return func(c *Config) {
 		c.DisableVersionResponse = disableVersionResponse
+	}
+}
+
+// WithServerName returns an option that can set ServerName on a Config
+func WithServerName(serverName string) ConfigOption {
+	return func(c *Config) {
+		c.ServerName = serverName
 	}
 }
 

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -158,11 +158,11 @@ func (dc *DevContext) RunV1InMemoryService() (*grpc.ClientConn, func(), error) {
 	s := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			datastoremw.UnaryServerInterceptor(dc.Datastore),
-			consistency.UnaryServerInterceptor(),
+			consistency.UnaryServerInterceptor("development"),
 		),
 		grpc.ChainStreamInterceptor(
 			datastoremw.StreamServerInterceptor(dc.Datastore),
-			consistency.StreamServerInterceptor(),
+			consistency.StreamServerInterceptor("development"),
 		),
 	)
 	ps := v1svc.NewPermissionsServer(dc.Dispatcher, v1svc.PermissionsServerConfig{


### PR DESCRIPTION
Also adds a service label onto the metrics generated to allow for disambiguation where SpiceDB might be embedded