### PR TITLE
Update compiler to consume local imports

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Lint"
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - "!dependabot/*"
@@ -20,7 +20,7 @@ jobs:
       - name: "Check Licenses"
         uses: "authzed/actions/go-license-check@main"
         with:
-          ignore: "buf.build" # Has no license information
+          ignore: "buf.build"  # Has no license information
 
   go-lint:
     name: "Lint Go"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Security"
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - "!dependabot/*"
@@ -16,7 +16,7 @@ env:
 jobs:
   codeql:
     name: "CodeQL Analyze"
-    if: "${{ github.event_name == 'pull_request' }}" # workaround to https://github.com/github/codeql-action/issues/1537
+    if: "${{ github.event_name == 'pull_request' }}"  # workaround to https://github.com/github/codeql-action/issues/1537
     runs-on: "buildjet-8vcpu-ubuntu-2204"
     timeout-minutes: "${{ (matrix.language == 'swift' && 120) || 360 }}"
     permissions:

--- a/internal/services/integrationtesting/testconfigs/caveatmultiplebranchessamerel.yaml
+++ b/internal/services/integrationtesting/testconfigs/caveatmultiplebranchessamerel.yaml
@@ -1,3 +1,4 @@
+---
 schema: >-
   definition user {}
 

--- a/pkg/composableschemadsl/compiler/importer-test/README.md
+++ b/pkg/composableschemadsl/compiler/importer-test/README.md
@@ -1,0 +1,5 @@
+# Test Structure
+
+Every folder should have a `root.zed`. This is the target for compilation.
+
+Every folder will have an `expected.zed`, which is the output of the compilation process.

--- a/pkg/composableschemadsl/compiler/importer-test/nested-local-with-hop/expected.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/nested-local-with-hop/expected.zed
@@ -1,0 +1,6 @@
+definition user {}
+
+definition resource {
+	relation viewer: user
+	permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/nested-local-with-hop/root.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/nested-local-with-hop/root.zed
@@ -1,0 +1,6 @@
+from .transitive.transitive import user
+
+definition resource {
+  relation viewer: user
+  permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/nested-local-with-hop/transitive/transitive.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/nested-local-with-hop/transitive/transitive.zed
@@ -1,0 +1,1 @@
+from .user.user import user

--- a/pkg/composableschemadsl/compiler/importer-test/nested-local-with-hop/transitive/user/user.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/nested-local-with-hop/transitive/user/user.zed
@@ -1,0 +1,1 @@
+definition user {}

--- a/pkg/composableschemadsl/compiler/importer-test/nested-local/expected.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/nested-local/expected.zed
@@ -1,0 +1,6 @@
+definition user {}
+
+definition resource {
+	relation viewer: user
+	permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/nested-local/root.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/nested-local/root.zed
@@ -1,0 +1,6 @@
+from .user.user import user
+
+definition resource {
+  relation viewer: user
+  permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/nested-local/user/user.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/nested-local/user/user.zed
@@ -1,0 +1,1 @@
+definition user {}

--- a/pkg/composableschemadsl/compiler/importer-test/nested-two-layer-local/definitions/user/user.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/nested-two-layer-local/definitions/user/user.zed
@@ -1,0 +1,1 @@
+definition user {}

--- a/pkg/composableschemadsl/compiler/importer-test/nested-two-layer-local/expected.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/nested-two-layer-local/expected.zed
@@ -1,0 +1,6 @@
+definition user {}
+
+definition resource {
+	relation viewer: user
+	permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/nested-two-layer-local/root.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/nested-two-layer-local/root.zed
@@ -1,0 +1,6 @@
+from .definitions.user.user import user
+
+definition resource {
+  relation viewer: user
+  permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/simple-local-with-hop/expected.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/simple-local-with-hop/expected.zed
@@ -1,0 +1,6 @@
+definition user {}
+
+definition resource {
+	relation viewer: user
+	permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/simple-local-with-hop/indirection.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/simple-local-with-hop/indirection.zed
@@ -1,0 +1,1 @@
+from .user import user

--- a/pkg/composableschemadsl/compiler/importer-test/simple-local-with-hop/root.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/simple-local-with-hop/root.zed
@@ -1,0 +1,6 @@
+from .indirection import user
+
+definition resource {
+  relation viewer: user
+  permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/simple-local-with-hop/user.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/simple-local-with-hop/user.zed
@@ -1,0 +1,1 @@
+definition user {}

--- a/pkg/composableschemadsl/compiler/importer-test/simple-local/expected.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/simple-local/expected.zed
@@ -1,0 +1,6 @@
+definition user {}
+
+definition resource {
+	relation viewer: user
+	permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/simple-local/root.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/simple-local/root.zed
@@ -1,0 +1,6 @@
+from .user import user
+
+definition resource {
+  relation viewer: user
+  permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/simple-local/user.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/simple-local/user.zed
@@ -1,0 +1,1 @@
+definition user {}

--- a/pkg/composableschemadsl/compiler/importer.go
+++ b/pkg/composableschemadsl/compiler/importer.go
@@ -1,0 +1,52 @@
+package compiler
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/authzed/spicedb/pkg/composableschemadsl/input"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
+)
+
+type importContext struct {
+	pathSegments []string
+	sourceFolder string
+	names        *mapz.Set[string]
+}
+
+const SchemaFileSuffix = ".zed"
+
+func importFile(importContext importContext) (*CompiledSchema, error) {
+	relativeFilepath := constructFilePath(importContext.pathSegments)
+	filePath := path.Join(importContext.sourceFolder, relativeFilepath)
+
+	newSourceFolder := filepath.Dir(filePath)
+
+	var schemaBytes []byte
+	schemaBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read schema file: %w", err)
+	}
+	log.Trace().Str("schema", string(schemaBytes)).Str("file", filePath).Msg("read schema from file")
+
+	compiled, err := compileImpl(InputSchema{
+		Source:       input.Source(filePath),
+		SchemaString: string(schemaBytes),
+	},
+		importContext.names,
+		AllowUnprefixedObjectType(),
+		SourceFolder(newSourceFolder),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return compiled, nil
+}
+
+func constructFilePath(segments []string) string {
+	return path.Join(segments...) + SchemaFileSuffix
+}

--- a/pkg/composableschemadsl/compiler/importer_test.go
+++ b/pkg/composableschemadsl/compiler/importer_test.go
@@ -1,0 +1,91 @@
+package compiler_test
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/composableschemadsl/compiler"
+	"github.com/authzed/spicedb/pkg/composableschemadsl/generator"
+	"github.com/authzed/spicedb/pkg/composableschemadsl/input"
+)
+
+type importerTest struct {
+	name   string
+	folder string
+}
+
+func (it *importerTest) input() string {
+	b, err := os.ReadFile(fmt.Sprintf("importer-test/%s/root.zed", it.folder))
+	if err != nil {
+		panic(err)
+	}
+
+	return string(b)
+}
+
+func (it *importerTest) relativePath() string {
+	return fmt.Sprintf("importer-test/%s", it.folder)
+}
+
+func (it *importerTest) expected() string {
+	b, err := os.ReadFile(fmt.Sprintf("importer-test/%s/expected.zed", it.folder))
+	if err != nil {
+		panic(err)
+	}
+
+	return string(b)
+}
+
+func (it *importerTest) writeExpected(schema string) {
+	err := os.WriteFile(fmt.Sprintf("importer-test/%s/expected.zed", it.folder), []byte(schema), 0o_600)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestImporter(t *testing.T) {
+	workingDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	importerTests := []importerTest{
+		{"simple local import", "simple-local"},
+		{"simple local import with transitive hop", "simple-local-with-hop"},
+		{"nested local import", "nested-local"},
+		{"nested local import with transitive hop", "nested-local-with-hop"},
+		{"nested local two layers deep import", "nested-two-layer-local"},
+	}
+
+	for _, test := range importerTests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			sourceFolder := path.Join(workingDir, test.relativePath())
+
+			inputSchema := test.input()
+
+			compiled, err := compiler.Compile(compiler.InputSchema{
+				Source:       input.Source("schema"),
+				SchemaString: inputSchema,
+			}, compiler.AllowUnprefixedObjectType(),
+				compiler.SourceFolder(sourceFolder))
+			require.NoError(t, err)
+
+			generated, _, err := generator.GenerateSchema(compiled.OrderedDefinitions)
+			require.NoError(t, err)
+
+			if os.Getenv("REGEN") == "true" {
+				test.writeExpected(generated)
+			} else {
+				expected := test.expected()
+				if !assert.Equal(t, expected, generated, test.name) {
+					t.Log(generated)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Part of getting composable schemas implemented. This actually implements the traversal.

## Notes
This is intentionally incremental, and is not intended to be the release candidate. Future work includes:

* Import cycle tracking
* Only including requested imports (rather than all imports)

## Changes
* Plumb an `existingNames` value through the compiler so that it can track the definitions it's already seen
* Add file importer logic
* Implement import logic the translator
## Testing
Review. See that tests go green.