### PR TITLE
Use complete sentence in error

### DIFF
--- a/pkg/development/validation.go
+++ b/pkg/development/validation.go
@@ -212,7 +212,7 @@ func validateSubjects(onrKey blocks.ObjectRelation, fs developmentmembership.Fou
 				log.Err(err).Msg("could not cast columnPosition to uint32")
 			}
 			failures = append(failures, &devinterface.DeveloperError{
-				Message: fmt.Sprintf("For object and permission/relation `%s`, subject `%s` found but missing from specified",
+				Message: fmt.Sprintf("For object and permission/relation `%s`, subject `%s` found but not listed in expected subjects",
 					tuple.StringONR(onr),
 					tuple.StringONR(foundSubject.Subject()),
 				),

--- a/pkg/development/wasm/operations_test.go
+++ b/pkg/development/wasm/operations_test.go
@@ -700,7 +700,7 @@ assertFalse: garbage
 			`assertTrue:
 - document:somedoc#view@user:jimmy`,
 			&devinterface.DeveloperError{
-				Message: "For object and permission/relation `document:somedoc#view`, subject `user:jimmy` found but missing from specified",
+				Message: "For object and permission/relation `document:somedoc#view`, subject `user:jimmy` found but not listed in expected subjects",
 				Kind:    devinterface.DeveloperError_EXTRA_RELATIONSHIP_FOUND,
 				Source:  devinterface.DeveloperError_VALIDATION_YAML,
 				Context: "document:somedoc#view",


### PR DESCRIPTION
I found the incomplete sentence confusing, seemed like a bug. Hopefully this will point users towards the "Expected relations" tab where they can fix the error (assuming they're using the playground, otherwise it might be more obvious).