### PR TITLE
introduce emission strategy into CockroachDB Watch API

### DIFF
--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -499,6 +499,9 @@ func (cds *crdbDatastore) OfflineFeatures() (*datastore.Features, error) {
 			ContinuousCheckpointing: datastore.Feature{
 				Status: datastore.FeatureSupported,
 			},
+			WatchEmitsImmediately: datastore.Feature{
+				Status: datastore.FeatureSupported,
+			},
 		}, nil
 	}
 
@@ -507,6 +510,9 @@ func (cds *crdbDatastore) OfflineFeatures() (*datastore.Features, error) {
 			Status: datastore.FeatureUnsupported,
 		},
 		ContinuousCheckpointing: datastore.Feature{
+			Status: datastore.FeatureSupported,
+		},
+		WatchEmitsImmediately: datastore.Feature{
 			Status: datastore.FeatureSupported,
 		},
 	}, nil
@@ -530,6 +536,9 @@ func (cds *crdbDatastore) tableTupleName() string {
 func (cds *crdbDatastore) features(ctx context.Context) (*datastore.Features, error) {
 	features := datastore.Features{
 		ContinuousCheckpointing: datastore.Feature{
+			Status: datastore.FeatureSupported,
+		},
+		WatchEmitsImmediately: datastore.Feature{
 			Status: datastore.FeatureSupported,
 		},
 	}

--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -334,6 +334,9 @@ func (mdb *memdbDatastore) OfflineFeatures() (*datastore.Features, error) {
 		ContinuousCheckpointing: datastore.Feature{
 			Status: datastore.FeatureUnsupported,
 		},
+		WatchEmitsImmediately: datastore.Feature{
+			Status: datastore.FeatureUnsupported,
+		},
 	}, nil
 }
 

--- a/internal/datastore/memdb/watch.go
+++ b/internal/datastore/memdb/watch.go
@@ -23,6 +23,12 @@ func (mdb *memdbDatastore) Watch(ctx context.Context, ar datastore.Revision, opt
 	updates := make(chan *datastore.RevisionChanges, watchBufferLength)
 	errs := make(chan error, 1)
 
+	if options.EmissionStrategy == datastore.EmitImmediatelyStrategy {
+		close(updates)
+		errs <- errors.New("emit immediately strategy is unsupported in MemDB")
+		return updates, errs
+	}
+
 	watchBufferWriteTimeout := options.WatchBufferWriteTimeout
 	if watchBufferWriteTimeout == 0 {
 		watchBufferWriteTimeout = mdb.watchBufferWriteTimeout

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -607,6 +607,9 @@ func (mds *Datastore) OfflineFeatures() (*datastore.Features, error) {
 		ContinuousCheckpointing: datastore.Feature{
 			Status: datastore.FeatureUnsupported,
 		},
+		WatchEmitsImmediately: datastore.Feature{
+			Status: datastore.FeatureUnsupported,
+		},
 	}, nil
 }
 

--- a/internal/datastore/mysql/watch.go
+++ b/internal/datastore/mysql/watch.go
@@ -30,7 +30,14 @@ func (mds *Datastore) Watch(ctx context.Context, afterRevisionRaw datastore.Revi
 	errs := make(chan error, 1)
 
 	if options.Content&datastore.WatchSchema == datastore.WatchSchema {
+		close(updates)
 		errs <- errors.New("schema watch unsupported in MySQL")
+		return updates, errs
+	}
+
+	if options.EmissionStrategy == datastore.EmitImmediatelyStrategy {
+		close(updates)
+		errs <- errors.New("emit immediately strategy is unsupported in MySQL")
 		return updates, errs
 	}
 

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -697,6 +697,9 @@ func (pgd *pgDatastore) OfflineFeatures() (*datastore.Features, error) {
 			ContinuousCheckpointing: datastore.Feature{
 				Status: datastore.FeatureUnsupported,
 			},
+			WatchEmitsImmediately: datastore.Feature{
+				Status: datastore.FeatureUnsupported,
+			},
 		}, nil
 	}
 

--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -74,7 +74,14 @@ func (pgd *pgDatastore) Watch(
 	errs := make(chan error, 1)
 
 	if !pgd.watchEnabled {
+		close(updates)
 		errs <- datastore.NewWatchDisabledErr("postgres must be run with track_commit_timestamp=on for watch to be enabled. See https://spicedb.dev/d/enable-watch-api-postgres")
+		return updates, errs
+	}
+
+	if options.EmissionStrategy == datastore.EmitImmediatelyStrategy {
+		close(updates)
+		errs <- errors.New("emit immediately strategy is unsupported in Postgres")
 		return updates, errs
 	}
 

--- a/internal/datastore/spanner/spanner.go
+++ b/internal/datastore/spanner/spanner.go
@@ -356,6 +356,9 @@ func (sd *spannerDatastore) OfflineFeatures() (*datastore.Features, error) {
 		ContinuousCheckpointing: datastore.Feature{
 			Status: datastore.FeatureSupported,
 		},
+		WatchEmitsImmediately: datastore.Feature{
+			Status: datastore.FeatureUnsupported,
+		},
 	}, nil
 }
 

--- a/internal/datastore/spanner/watch.go
+++ b/internal/datastore/spanner/watch.go
@@ -61,6 +61,12 @@ func (sd *spannerDatastore) Watch(ctx context.Context, afterRevision datastore.R
 	updates := make(chan *datastore.RevisionChanges, watchBufferLength)
 	errs := make(chan error, 1)
 
+	if opts.EmissionStrategy == datastore.EmitImmediatelyStrategy {
+		close(updates)
+		errs <- errors.New("emit immediately strategy is unsupported in Spanner")
+		return updates, errs
+	}
+
 	go sd.watch(ctx, afterRevision, opts, updates, errs)
 
 	return updates, errs

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -180,6 +180,7 @@ func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories, 
 		t.Run("TestWatchWithTouch", runner(tester, WatchWithTouchTest))
 		t.Run("TestWatchWithDelete", runner(tester, WatchWithDeleteTest))
 		t.Run("TestWatchWithMetadata", runner(tester, WatchWithMetadataTest))
+		t.Run("TestWatchEmissionStrategy", runner(tester, WatchEmissionStrategyTest))
 	}
 
 	if !except.Watch() && !except.WatchSchema() {


### PR DESCRIPTION
depends on https://github.com/authzed/spicedb/pull/2122
introduces `WatchOptions.EmissionStrategy` to handle limitations of CockroachDB changefeeds.

In CRDB, checkpointing for a span only occurs once its catch-up scan completes. As a result, resolved timestamps for the changefeed won't be emitted until all spans have been checkpointed and moved past the initial high-water mark.
Unfortunately, no workarounds exist to make the changefeed emit resolved timestamps during a catch-up scan. This is a known issue on CRL's radar.

This is important because, without checkpoints, it means changes are accumulated in memory, and depending on the use case can lead to increased memory pressure and out-of-memory errors

This commit introduces a new change emission strategy option into WatchOptions:
- `EmitWhenCheckpointedStrategy` is the original strategy, which accumulates until a checkpoint is emitted.
- `EmitImmediatelyStrategy` is the new strategy that streams changes right away. It's important to note that makes the client responsible of:
  - deduplicating changes
  - ordering revisions
  - accumulate changes until a checkpoint is emitted

Essentially the client is responsible for doing all the work that used to be done with the `Change` struct helper.

For every other datastore, calling Watch API with `EmitImmediatelyStrategy` will return an error. We don't consider there is an evident need at the moment for other data stores. Once we've proven this strategy is viable in production workloads, we will study implementing a Watch API strategy that buffers to disk to address out-of-memory issues, and potentially deprecate the emit immediately strategy in favor of one that does all the heavy lifting for the client.