### PR TITLE
Implement definition requests

### DIFF
--- a/pkg/composableschemadsl/compiler/importer-test/simple-local-with-extra-def/expected.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/simple-local-with-extra-def/expected.zed
@@ -1,0 +1,6 @@
+definition user {}
+
+definition resource {
+	relation viewer: user
+	permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/simple-local-with-extra-def/root.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/simple-local-with-extra-def/root.zed
@@ -1,0 +1,6 @@
+from .user import user
+
+definition resource {
+  relation viewer: user
+  permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/simple-local-with-extra-def/user.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/simple-local-with-extra-def/user.zed
@@ -1,0 +1,9 @@
+definition user {}
+
+// This shouldn't be present in the output
+definition persona {}
+
+// Nor should this
+caveat only_on_tuesday(day_of_week string) {
+  day_of_week == 'tuesday'
+}

--- a/pkg/composableschemadsl/compiler/importer_test.go
+++ b/pkg/composableschemadsl/compiler/importer_test.go
@@ -55,6 +55,7 @@ func TestImporter(t *testing.T) {
 	importerTests := []importerTest{
 		{"simple local import", "simple-local"},
 		{"simple local import with transitive hop", "simple-local-with-hop"},
+		{"simple local import with extra def", "simple-local-with-extra-def"},
 		{"nested local import", "nested-local"},
 		{"nested local import with transitive hop", "nested-local-with-hop"},
 		{"nested local two layers deep import", "nested-two-layer-local"},


### PR DESCRIPTION
Merge after #2116 

## Description
In #2116, one of the unimplemented features was filtering down the imported objects to the set of requested objects. This implements that behavior.

## Changes
* Add filtering logic in the importer
* Pull requested definitions out in the translator
* Add tests
## Testing
Review. See that things are green.