### PR TITLE
fix HCLRevision mismatch on zero logical clock

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -67,6 +67,9 @@ jobs:
           format: "table"
           exit-code: "1"
           severity: "CRITICAL,HIGH,MEDIUM"
+        env:
+          TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db"
+          TRIVY_JAVA_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-java-db"
       - uses: "goreleaser/goreleaser-action@v6"
         id: "goreleaser"
         with:

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -251,11 +251,13 @@ func TestWatchingCacheFallbackToStandardCache(t *testing.T) {
 	require.NoError(t, wcache.startSync(context.Background()))
 
 	// Ensure the namespace is not found, but is cached in the fallback caching layer.
-	_, _, err = wcache.SnapshotReader(rev("1")).ReadNamespaceByName(context.Background(), "somenamespace")
+	r := rev("1")
+	_, _, err = wcache.SnapshotReader(r).ReadNamespaceByName(context.Background(), "somenamespace")
 	require.ErrorAs(t, err, &datastore.ErrNamespaceNotFound{})
 	require.False(t, wcache.namespaceCache.inFallbackMode)
 
-	entry, ok := c.Get("n:somenamespace@1")
+	expectedKey := cache.StringKey("n:somenamespace@" + r.String())
+	entry, ok := c.Get(expectedKey)
 	require.True(t, ok)
 	require.NotNil(t, entry.notFound)
 

--- a/internal/datastore/revisions/commonrevision_test.go
+++ b/internal/datastore/revisions/commonrevision_test.go
@@ -151,7 +151,7 @@ func TestRevisionComparison(t *testing.T) {
 
 func TestRevisionBidirectionalParsing(t *testing.T) {
 	tcs := []string{
-		"1", "2", "42", "192747564535", "1.0000000004", "1.0000000002", "1.0000000042", "-1235",
+		"1.0000000000", "2.0000000000", "42.0000000000", "192747564535.0000000000", "1.0000000004", "1.0000000002", "1.0000000042", "-1235.0000000000",
 	}
 
 	for _, tc := range tcs {
@@ -223,11 +223,11 @@ func TestTransactionIDRevisionParsing(t *testing.T) {
 
 func TestHLCRevisionParsing(t *testing.T) {
 	tcs := map[string]bool{
-		"1":                              false,
-		"2":                              false,
-		"42":                             false,
-		"1257894000000000000":            false,
-		"-1":                             false,
+		"1.0000000000":                   false,
+		"2.0000000000":                   false,
+		"42.0000000000":                  false,
+		"1257894000000000000.0000000000": false,
+		"-1.0000000000":                  false,
 		"1.0000000004":                   false,
 		"9223372036854775807.0000000004": false,
 	}

--- a/internal/datastore/revisions/hlcrevision.go
+++ b/internal/datastore/revisions/hlcrevision.go
@@ -39,7 +39,7 @@ func parseHLCRevisionString(revisionStr string) (datastore.Revision, error) {
 		if err != nil {
 			return datastore.NoRevision, fmt.Errorf("invalid revision string: %q", revisionStr)
 		}
-		return HLCRevision{timestamp, 0}, nil
+		return HLCRevision{timestamp, logicalClockOffset}, nil
 	}
 
 	if len(pieces) != 2 {
@@ -65,6 +65,7 @@ func parseHLCRevisionString(revisionStr string) (datastore.Revision, error) {
 	if err != nil {
 		return datastore.NoRevision, spiceerrors.MustBugf("could not cast logicalclock to uint32: %v", err)
 	}
+
 	return HLCRevision{timestamp, uintLogicalClock + logicalClockOffset}, nil
 }
 
@@ -90,7 +91,7 @@ func NewForHLC(decimal decimal.Decimal) (HLCRevision, error) {
 
 // NewHLCForTime creates a new revision for the given time.
 func NewHLCForTime(time time.Time) HLCRevision {
-	return HLCRevision{time.UnixNano(), 0}
+	return HLCRevision{time.UnixNano(), logicalClockOffset}
 }
 
 func (hlc HLCRevision) Equal(rhs datastore.Revision) bool {
@@ -121,10 +122,6 @@ func (hlc HLCRevision) LessThan(rhs datastore.Revision) bool {
 }
 
 func (hlc HLCRevision) String() string {
-	if hlc.logicalclock == 0 {
-		return strconv.FormatInt(hlc.time, 10)
-	}
-
 	logicalClockString := strconv.FormatInt(int64(hlc.logicalclock)-int64(logicalClockOffset), 10)
 	return strconv.FormatInt(hlc.time, 10) + "." + strings.Repeat("0", logicalClockLength-len(logicalClockString)) + logicalClockString
 }
@@ -134,15 +131,11 @@ func (hlc HLCRevision) TimestampNanoSec() int64 {
 }
 
 func (hlc HLCRevision) InexactFloat64() float64 {
-	if hlc.logicalclock == 0 {
-		return float64(hlc.time)
-	}
-
 	return float64(hlc.time) + float64(hlc.logicalclock-logicalClockOffset)/math.Pow10(logicalClockLength)
 }
 
 func (hlc HLCRevision) ConstructForTimestamp(timestamp int64) WithTimestampRevision {
-	return HLCRevision{timestamp, 0}
+	return HLCRevision{timestamp, logicalClockOffset}
 }
 
 func (hlc HLCRevision) AsDecimal() (decimal.Decimal, error) {

--- a/internal/datastore/revisions/hlcrevision.go
+++ b/internal/datastore/revisions/hlcrevision.go
@@ -56,9 +56,13 @@ func parseHLCRevisionString(revisionStr string) (datastore.Revision, error) {
 	}
 
 	paddedLogicalClockStr := pieces[1] + strings.Repeat("0", logicalClockLength-len(pieces[1]))
-	logicalclock, err := strconv.ParseUint(paddedLogicalClockStr, 10, 32)
+	logicalclock, err := strconv.ParseUint(paddedLogicalClockStr, 10, 64)
 	if err != nil {
 		return datastore.NoRevision, fmt.Errorf("invalid revision string: %q", revisionStr)
+	}
+
+	if logicalclock > math.MaxUint32 {
+		return datastore.NoRevision, spiceerrors.MustBugf("received logical lock that exceeds MaxUint32 (%d > %d): revision %q", logicalclock, math.MaxUint32, revisionStr)
 	}
 
 	uintLogicalClock, err := safecast.ToUint32(logicalclock)

--- a/internal/datastore/revisions/hlcrevision_test.go
+++ b/internal/datastore/revisions/hlcrevision_test.go
@@ -289,6 +289,13 @@ func TestHLCToFromDecimal(t *testing.T) {
 	}
 }
 
+func TestFailsIfLogicalClockExceedsMaxUin32(t *testing.T) {
+	expectedError := "received logical lock that exceeds MaxUint32 (9999999999 > 4294967295): revision \"0.9999999999\""
+	require.PanicsWithValue(t, expectedError, func() {
+		_, _ = HLCRevisionFromString("0.9999999999")
+	})
+}
+
 func BenchmarkHLCParsing(b *testing.B) {
 	tcs := []string{
 		"1",

--- a/internal/datastore/revisions/hlcrevision_test.go
+++ b/internal/datastore/revisions/hlcrevision_test.go
@@ -80,7 +80,6 @@ func TestConstructForTimestamp(t *testing.T) {
 		t.Run(strconv.Itoa(int(input)), func(t *testing.T) {
 			rev := zeroHLC
 			withTimestamp := rev.ConstructForTimestamp(input)
-			withTimestamp.String()
 			require.Equal(t, output, withTimestamp.String())
 			require.Equal(t, input, withTimestamp.TimestampNanoSec())
 		})


### PR DESCRIPTION
While working on https://github.com/authzed/spicedb/pull/2120, I detected something I wasn't expecting: when comparing the revision out of the datastore write, and what came out of Watch API, the revisions were different.
We use `SHOW COMMIT TIMESTAMP` to retrieve a CRDB [transaction timestamp](https://github.com/cockroachdb/cockroach/pull/80848). The value coming out of the `update` field in change streams had the same value, but the difference was the notation: one included the logical clock, the other didn't, but logical clocks were the same (zero):

- revision generated out of the transaction in `readTransactionCommitRev` uses `NewForHLC(hlcNow)`, which takes a `Decimal`. This in turn calls `decimal.String()`, which returns a number stripped out of the decimal part if it's zero.
- revision obtained out of the changefeeds uses `revisions.HLCRevisionFromString(details.Updated)`, and `details.Updated` always comes with the decimal part, even when it's zero

Both timestamps were the same, but had a different string representation, and led to a different `HCLRevision` logical lock, hence `.Equal()` method failing.

The problem originates in the use of the offset to represent the logical part of the clock. The representation of "zero" wasn't being used consistently, and in some parts of the code the revision was initialized with logical clock of zero, when it needed the offset padding.

⚠️ One of the consequences of this change is that moving forward string representation of the revision will be _longer_ as it will always include the logical clock (when using `HLCRevision`, that is, which only applies to CRDB). This means caches that append the revision to keys will be longer.