### PR TITLE
Handle circular and duplicate imports

### DIFF
--- a/pkg/composableschemadsl/compiler/importer-test/circular-import/expected.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/circular-import/expected.zed
@@ -1,0 +1,8 @@
+definition user {}
+
+definition persona {}
+
+definition resource {
+	relation viewer: user
+	permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/circular-import/root.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/circular-import/root.zed
@@ -1,0 +1,6 @@
+from .subjects import user
+
+definition resource {
+  relation viewer: user
+  permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/circular-import/subjects.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/circular-import/subjects.zed
@@ -1,0 +1,3 @@
+from .user import user
+
+definition persona {}

--- a/pkg/composableschemadsl/compiler/importer-test/circular-import/user.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/circular-import/user.zed
@@ -1,0 +1,3 @@
+from .subjects import persona
+
+definition user {}

--- a/pkg/composableschemadsl/compiler/importer-test/diamond-shaped/expected.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/diamond-shaped/expected.zed
@@ -1,0 +1,8 @@
+definition user {}
+
+definition persona {}
+
+definition resource {
+	relation viewer: user
+	permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/diamond-shaped/left.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/diamond-shaped/left.zed
@@ -1,0 +1,1 @@
+from .subjects import user

--- a/pkg/composableschemadsl/compiler/importer-test/diamond-shaped/right.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/diamond-shaped/right.zed
@@ -1,0 +1,1 @@
+from .subjects import persona

--- a/pkg/composableschemadsl/compiler/importer-test/diamond-shaped/root.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/diamond-shaped/root.zed
@@ -1,0 +1,7 @@
+from .left import user
+from .right import persona
+
+definition resource {
+  relation viewer: user
+  permission view = viewer
+}

--- a/pkg/composableschemadsl/compiler/importer-test/diamond-shaped/subjects.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/diamond-shaped/subjects.zed
@@ -1,0 +1,2 @@
+definition user {}
+definition persona {}

--- a/pkg/composableschemadsl/compiler/importer.go
+++ b/pkg/composableschemadsl/compiler/importer.go
@@ -13,12 +13,19 @@ import (
 )
 
 type importContext struct {
-	pathSegments []string
-	sourceFolder string
-	names        *mapz.Set[string]
+	pathSegments         []string
+	sourceFolder         string
+	names                *mapz.Set[string]
+	locallyVisitedFiles  *mapz.Set[string]
+	globallyVisitedFiles *mapz.Set[string]
 }
 
 const SchemaFileSuffix = ".zed"
+
+type ErrCircularImport struct {
+	error
+	filePath string
+}
 
 func importFile(importContext importContext) (*CompiledSchema, error) {
 	relativeFilepath := constructFilePath(importContext.pathSegments)
@@ -26,25 +33,55 @@ func importFile(importContext importContext) (*CompiledSchema, error) {
 
 	newSourceFolder := filepath.Dir(filePath)
 
-	var schemaBytes []byte
+	currentLocallyVisitedFiles := importContext.locallyVisitedFiles.Copy()
+
+	if ok := currentLocallyVisitedFiles.Add(filePath); !ok {
+		// If we've already visited the file on this particular branch walk, it's
+		// a circular import issue.
+		return nil, &ErrCircularImport{
+			error:    fmt.Errorf("circular import detected: %s has been visited on this branch", filePath),
+			filePath: filePath,
+		}
+	}
+
+	if ok := importContext.globallyVisitedFiles.Add(filePath); !ok {
+		// If the file has already been visited, we short-circuit the import process
+		// by not reading the schema file in and compiling a schema with an empty string.
+		// This prevents duplicate definitions from ending up in the output, as well
+		// as preventing circular imports.
+		log.Debug().Str("filepath", filePath).Msg("file %s has already been visited in another part of the walk")
+		return compileImpl(InputSchema{
+			Source:       input.Source(filePath),
+			SchemaString: "",
+		},
+			compilationContext{
+				existingNames:        importContext.names,
+				locallyVisitedFiles:  currentLocallyVisitedFiles,
+				globallyVisitedFiles: importContext.globallyVisitedFiles,
+			},
+			AllowUnprefixedObjectType(),
+			SourceFolder(newSourceFolder),
+		)
+	}
+
 	schemaBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read schema file: %w", err)
 	}
 	log.Trace().Str("schema", string(schemaBytes)).Str("file", filePath).Msg("read schema from file")
 
-	compiled, err := compileImpl(InputSchema{
+	return compileImpl(InputSchema{
 		Source:       input.Source(filePath),
 		SchemaString: string(schemaBytes),
 	},
-		importContext.names,
+		compilationContext{
+			existingNames:        importContext.names,
+			locallyVisitedFiles:  currentLocallyVisitedFiles,
+			globallyVisitedFiles: importContext.globallyVisitedFiles,
+		},
 		AllowUnprefixedObjectType(),
 		SourceFolder(newSourceFolder),
 	)
-	if err != nil {
-		return nil, err
-	}
-	return compiled, nil
 }
 
 func constructFilePath(segments []string) string {


### PR DESCRIPTION
## Description
Circular imports are a normal problem in an import system. This handles them, along with imports via multiple paths, by keeping a global registry of visited files and warning and short-circuiting when a file is visited multiple times.

## Notes
This is a fairly naive implementation for the time being. One thing that we have going for us is that a schema is entirely static - there's no logic to run at import time, so import order doesn't particularly matter.

## Changes
* Add test cases for circular imports and imports via multiple paths
* Refactor `compileImpl` to take a compilation context and add visited files to that context
* Track visited files in the importer

## Testing
Review. See that things go green. Suggest any test cases I haven't thought of.