### PR TITLE
introduces ByteSortable method in Revision

### DIFF
--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -279,6 +279,10 @@ type postgresRevision struct {
 	optionalMetadata       map[string]any
 }
 
+func (pr postgresRevision) ByteSortable() bool {
+	return false
+}
+
 func (pr postgresRevision) Equal(rhsRaw datastore.Revision) bool {
 	rhs, ok := rhsRaw.(postgresRevision)
 	return ok && pr.snapshot.Equal(rhs.snapshot)

--- a/internal/datastore/revisions/hlcrevision.go
+++ b/internal/datastore/revisions/hlcrevision.go
@@ -98,6 +98,10 @@ func NewHLCForTime(time time.Time) HLCRevision {
 	return HLCRevision{time.UnixNano(), logicalClockOffset}
 }
 
+func (hlc HLCRevision) ByteSortable() bool {
+	return true
+}
+
 func (hlc HLCRevision) Equal(rhs datastore.Revision) bool {
 	if rhs == datastore.NoRevision {
 		rhs = zeroHLC

--- a/internal/datastore/revisions/timestamprevision.go
+++ b/internal/datastore/revisions/timestamprevision.go
@@ -33,6 +33,10 @@ func parseTimestampRevisionString(revisionStr string) (rev datastore.Revision, e
 	return TimestampRevision(parsed), nil
 }
 
+func (ir TimestampRevision) ByteSortable() bool {
+	return true
+}
+
 func (ir TimestampRevision) Equal(rhs datastore.Revision) bool {
 	if rhs == datastore.NoRevision {
 		rhs = zeroTimestampRevision

--- a/internal/datastore/revisions/txidrevision.go
+++ b/internal/datastore/revisions/txidrevision.go
@@ -27,6 +27,10 @@ func parseTransactionIDRevisionString(revisionStr string) (rev datastore.Revisio
 	return TransactionIDRevision(parsed), nil
 }
 
+func (ir TransactionIDRevision) ByteSortable() bool {
+	return true
+}
+
 func (ir TransactionIDRevision) Equal(rhs datastore.Revision) bool {
 	if rhs == datastore.NoRevision {
 		rhs = zeroTransactionIDRevision

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -817,9 +817,16 @@ type Revision interface {
 
 	// LessThan returns whether the receiver is probably less than the right hand side.
 	LessThan(Revision) bool
+
+	// ByteSortable returns true if the string representation of the Revision is byte sortable, false otherwise.
+	ByteSortable() bool
 }
 
 type nilRevision struct{}
+
+func (nilRevision) ByteSortable() bool {
+	return false
+}
 
 func (nilRevision) Equal(rhs Revision) bool {
 	return rhs == NoRevision


### PR DESCRIPTION
This helps determine if the string representation
of the revision is byte-sortable. This helps
being able to determine if a revision can be
serialized to databases that rely on byte-sorting.