### PR TITLE
Add composable schema test syntax parsing

### DIFF
--- a/pkg/composableschemadsl/dslshape/dslshape.go
+++ b/pkg/composableschemadsl/dslshape/dslshape.go
@@ -37,6 +37,15 @@ const (
 	NodeTypeCaveatTypeReference // A type reference for a caveat parameter.
 
 	NodeTypeImport
+
+	NodeTypeTest
+	NodeTypeTestRelations
+	NodeTypeTestRelation
+	NodeTypeTestObject
+	NodeTypeTestPermission
+	NodeTypeTestNegativePermission
+	NodeTypeTestAssertions
+	NodeTypeTestExpected
 )
 
 const (
@@ -198,4 +207,11 @@ const (
 	NodeImportPredicateSource         = "import-source"
 	NodeImportPredicatePathSegment    = "path-segment"
 	NodeImportPredicateDefinitionName = "imported-definition"
+
+	NodeTestPredicateName = "test-name"
+
+	NodeTestObjectPredicateObjectType = "object-type"
+	NodeTestObjectPredicateObjectID = "object-id"
+	// Used for both positive and negative permissions
+	NodeTestRelationPermissionPredicateName = "permission-name"
 )

--- a/pkg/composableschemadsl/lexer/lex_def.go
+++ b/pkg/composableschemadsl/lexer/lex_def.go
@@ -82,6 +82,13 @@ var keywords = map[string]struct{}{
 	"import":     {},
 	"all":        {},
 	"any":        {},
+	// Test keywords
+	"test": {},
+	"relationships": {},
+	"assertions": {},
+	"expected": {},
+	"is": {},
+	"of": {},
 }
 
 // IsKeyword returns whether the specified input string is a reserved keyword.


### PR DESCRIPTION
Fixes #2129 

## Description
Part of the composable schema implementation. This is just the parsing; compilation and execution of the tests will come in a later PR.

## Changes
TODO

## Testing
TODO