### PR TITLE
postgres watch: checkpoints should move the high watermark revision

### DIFF
--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -201,6 +201,8 @@ func (pgd *pgDatastore) Watch(
 						}) {
 							return
 						}
+
+						currentTxn = *optionalHeadRevision
 					}
 				}
 


### PR DESCRIPTION
In https://github.com/authzed/spicedb/pull/2139 we introduced the emission of checkpoint RevisionChanges when the postgres snapshot moves up out of band (outside of application changes).

The fix missed to also move the locally-cached high watermark revision. As a consequence, on a PG-backed SpiceDB were the pg snapshot does not have an associated SpiceDB transaction, the Watch API will emit checkpoints at the same revision over and over, because its own internal high watermark hasn't moved.

This changes the code so that `currentTxn`, which keeps track of the last checked revision, moves as well with an out-of-band snapshot revision.