### PR TITLE
adds index to support efficient querying of Watch API

### DIFF
--- a/internal/datastore/postgres/migrations/zz_migration.0020_add_watch_api_index.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0020_add_watch_api_index.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const addWatchAPIIndexToRelationTupleTable = `CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_watch_index ON relation_tuple (created_xid);`
+
+func init() {
+	if err := DatabaseMigrations.Register("add-watch-api-index-to-relation-tuple-table", "add-metadata-to-transaction-table",
+		func(ctx context.Context, conn *pgx.Conn) error {
+			if _, err := conn.Exec(ctx, addWatchAPIIndexToRelationTupleTable); err != nil {
+				return fmt.Errorf("failed to add watch API index to relation tuple table: %w", err)
+			}
+			return nil
+		},
+		noTxMigration); err != nil {
+		panic("failed to register migration: " + err.Error())
+	}
+}


### PR DESCRIPTION
we identified Watch API was causing a full table scan on large postgres-backed SpiceDB, overloading the database.

This commit adds an index that reduces the execution time of relationship changes to be emitted via Watch API by more than three orders of magnitude on tables with several gigabytes worth of data.