### PR TITLE
fix: schema watch causes incorrect delete event for schema changes

### DIFF
--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -455,7 +455,7 @@ func (pgd *pgDatastore) loadNamespaceChanges(ctx context.Context, xmin uint64, x
 		}
 
 		if _, found := filter[createdXID.Uint64]; found {
-			err := tracked.AddChangedDefinition(ctx, txidToRevision[deletedXID.Uint64], loaded)
+			err := tracked.AddChangedDefinition(ctx, txidToRevision[createdXID.Uint64], loaded)
 			if err != nil {
 				return err
 			}
@@ -514,7 +514,7 @@ func (pgd *pgDatastore) loadCaveatChanges(ctx context.Context, xmin uint64, xmax
 		}
 
 		if _, found := filter[createdXID.Uint64]; found {
-			err := tracked.AddChangedDefinition(ctx, txidToRevision[deletedXID.Uint64], loaded)
+			err := tracked.AddChangedDefinition(ctx, txidToRevision[createdXID.Uint64], loaded)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
the computation of schema change events was incorrect due to
the use of the wrong snapshot XID for changed namespaces / caveats.
It manifested itself as a change event, followed by a delete event.