### PR TITLE
Changes to address flaky DB tests

### DIFF
--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -92,13 +92,11 @@ func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestF
 }
 
 func TestMySQLDatastoreDSNWithoutParseTime(t *testing.T) {
-	t.Parallel()
 	_, err := NewMySQLDatastore(context.Background(), "root:password@(localhost:1234)/mysql")
 	require.ErrorContains(t, err, "https://spicedb.dev/d/parse-time-mysql")
 }
 
 func TestMySQL8Datastore(t *testing.T) {
-	t.Parallel()
 	b := testdatastore.RunMySQLForTestingWithOptions(t, testdatastore.MySQLTesterOptions{MigrateForNewDatastore: true}, "")
 	dst := datastoreTester{b: b, t: t}
 	test.AllWithExceptions(t, test.DatastoreTesterFunc(dst.createDatastore), test.WithCategories(test.WatchSchemaCategory, test.WatchCheckpointsCategory), true)
@@ -665,7 +663,6 @@ func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
 }
 
 func TestMySQLMigrations(t *testing.T) {
-	t.Parallel()
 	req := require.New(t)
 
 	db := datastoreDB(t, false)
@@ -687,7 +684,6 @@ func TestMySQLMigrations(t *testing.T) {
 }
 
 func TestMySQLMigrationsWithPrefix(t *testing.T) {
-	t.Parallel()
 	req := require.New(t)
 
 	prefix := "spicedb_"

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -16,14 +16,10 @@ import (
 )
 
 func TestPostgresDatastore(t *testing.T) {
-	t.Parallel()
-
 	testPostgresDatastore(t, postgresConfigs)
 }
 
 func TestPostgresDatastoreWithoutCommitTimestamps(t *testing.T) {
-	t.Parallel()
-
 	testPostgresDatastoreWithoutCommitTimestamps(t, postgresConfigs)
 }
 

--- a/internal/testserver/datastore/crdb.go
+++ b/internal/testserver/datastore/crdb.go
@@ -52,6 +52,7 @@ func RunCRDBForTesting(t testing.TB, bridgeNetworkName string) RunningEngineForT
 		creds:    "root:fake",
 	}
 	t.Cleanup(func() {
+		require.NoError(t, builder.conn.Close(context.Background()))
 		require.NoError(t, pool.Purge(resource))
 	})
 

--- a/internal/testserver/datastore/mysql.go
+++ b/internal/testserver/datastore/mysql.go
@@ -72,6 +72,7 @@ func RunMySQLForTestingWithOptions(t testing.TB, options MySQLTesterOptions, bri
 		options: options,
 	}
 	t.Cleanup(func() {
+		require.NoError(t, builder.db.Close())
 		require.NoError(t, pool.Purge(resource))
 	})
 


### PR DESCRIPTION
1) Add additional logging when the flake occurs
2) Remove parallel from the PG tests, as they seem to be causing the PG containers to die
3) Make sure to cleanup connections