### PR TITLE
Remove now-unused windows workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,39 +8,6 @@ permissions:
   contents: "write"
   packages: "write"
 jobs:
-  goreleaser-windows:
-    runs-on: "windows-latest"
-    steps:
-      - uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 0
-      - uses: "authzed/actions/setup-go@main"
-      - uses: "nowsprinting/check-version-format-action@v4"
-        id: "version"
-        with:
-          prefix: "v"
-      - name: "Fail for an invalid version (windows)"
-        if: "${{ !startsWith(github.ref_name, 'v') || steps.version.outputs.is_valid != 'true' }}"
-        run: 'echo "SpiceDB version must start with `v` and be a semver" && exit 1'
-        shell: "bash"
-      - uses: "authzed/actions/docker-login@main"
-        with:
-          quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          dockerhub_token: "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}"
-      - uses: "docker/setup-qemu-action@v3"
-      - uses: "docker/setup-buildx-action@v3"
-      - uses: "goreleaser/goreleaser-action@v6"
-        with:
-          distribution: "goreleaser-pro"
-          # NOTE: keep in sync with goreleaser version in other job.
-          # github actions don't allow yaml anchors.
-          version: "v2.3.2"
-          args: "release --clean --config=.goreleaser.windows.yml"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"
-          CHOCOLATEY_API_KEY: "${{ secrets.CHOCOLATEY_API_KEY }}"
   goreleaser:
     runs-on: "buildjet-4vcpu-ubuntu-2204"
     steps:


### PR DESCRIPTION
## Description
This is superseded by what's in https://github.com/authzed/spicedb/blob/main/.github/workflows/release-windows.yaml, which uses a different runner and a different mechanism. I forgot to clean this up in the context of #2087.

## Changes
* Remove now-unused windows release flow
## Testing
Review.