### PR TITLE
Fix bulk export of relationships with caveats

### DIFF
--- a/internal/services/v1/experimental_test.go
+++ b/internal/services/v1/experimental_test.go
@@ -74,7 +74,7 @@ func TestBulkImportRelationships(t *testing.T) {
 
 						for i := uint64(0); i < batchSize; i++ {
 							if withCaveats {
-								batch = append(batch, relWithCaveat(
+								batch = append(batch, mustRelWithCaveatAndContext(
 									tf.DocumentNS.Name,
 									strconv.Itoa(batchNum)+"_"+strconv.FormatUint(i, 10),
 									"caveated_viewer",
@@ -82,6 +82,7 @@ func TestBulkImportRelationships(t *testing.T) {
 									strconv.FormatUint(i, 10),
 									"",
 									"test",
+									map[string]any{"secret": strconv.FormatUint(i, 10)},
 								))
 							} else {
 								batch = append(batch, rel(
@@ -177,6 +178,8 @@ func TestBulkExportRelationships(t *testing.T) {
 		{tf.FolderNS.Name, "owner"},
 		{tf.DocumentNS.Name, "editor"},
 		{tf.FolderNS.Name, "editor"},
+		{tf.DocumentNS.Name, "caveated_viewer"},
+		{tf.DocumentNS.Name, "expiring_viewer"},
 	}
 
 	totalToWrite := 1_000
@@ -184,16 +187,9 @@ func TestBulkExportRelationships(t *testing.T) {
 	batch := make([]*v1.Relationship, totalToWrite)
 	for i := range batch {
 		nsAndRel := nsAndRels[i%len(nsAndRels)]
-		rel := rel(
-			nsAndRel.namespace,
-			strconv.Itoa(i),
-			nsAndRel.relation,
-			tf.UserNS.Name,
-			strconv.Itoa(i),
-			"",
-		)
-		batch[i] = rel
-		expectedRels.Add(tuple.MustV1RelString(rel))
+		v1rel := relationshipForBulkTesting(nsAndRel, i)
+		batch[i] = v1rel
+		expectedRels.Add(tuple.MustV1RelString(v1rel))
 	}
 
 	ctx := context.Background()
@@ -280,7 +276,7 @@ func TestBulkExportRelationshipsWithFilter(t *testing.T) {
 			&v1.RelationshipFilter{
 				ResourceType: tf.DocumentNS.Name,
 			},
-			500,
+			625,
 		},
 		{
 			"filter by resource ID",
@@ -302,7 +298,7 @@ func TestBulkExportRelationshipsWithFilter(t *testing.T) {
 				ResourceType:             tf.DocumentNS.Name,
 				OptionalResourceIdPrefix: "1",
 			},
-			55,
+			69,
 		},
 		{
 			"filter by invalid resource type",
@@ -335,31 +331,26 @@ func TestBulkExportRelationshipsWithFilter(t *testing.T) {
 				{tf.FolderNS.Name, "owner"},
 				{tf.DocumentNS.Name, "editor"},
 				{tf.FolderNS.Name, "editor"},
+				{tf.DocumentNS.Name, "caveated_viewer"},
+				{tf.DocumentNS.Name, "expiring_viewer"},
 			}
 
 			expectedRels := set.NewStringSetWithSize(1000)
 			batch := make([]*v1.Relationship, 1000)
 			for i := range batch {
 				nsAndRel := nsAndRels[i%len(nsAndRels)]
-				rel := rel(
-					nsAndRel.namespace,
-					strconv.Itoa(i),
-					nsAndRel.relation,
-					tf.UserNS.Name,
-					strconv.Itoa(i),
-					"",
-				)
-				batch[i] = rel
+				v1rel := relationshipForBulkTesting(nsAndRel, i)
+				batch[i] = v1rel
 
 				if tc.filter != nil {
 					filter, err := datastore.RelationshipsFilterFromPublicFilter(tc.filter)
 					require.NoError(err)
-					if !filter.Test(tuple.FromV1Relationship(rel)) {
+					if !filter.Test(tuple.FromV1Relationship(v1rel)) {
 						continue
 					}
 				}
 
-				expectedRels.Add(tuple.MustV1RelString(rel))
+				expectedRels.Add(tuple.MustV1RelString(v1rel))
 			}
 
 			require.Equal(tc.expectedCount, expectedRels.Size())

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -670,6 +671,72 @@ func relWithCaveat(resType, resID, relation, subType, subID, subRel, caveatName 
 			CaveatName: caveatName,
 		},
 	}
+}
+
+func mustRelWithCaveatAndContext(resType, resID, relation, subType, subID, subRel, caveatName string, context map[string]any) *v1.Relationship {
+	sctx, err := structpb.NewStruct(context)
+	if err != nil {
+		panic(err)
+	}
+
+	return &v1.Relationship{
+		Resource: &v1.ObjectReference{
+			ObjectType: resType,
+			ObjectId:   resID,
+		},
+		Relation: relation,
+		Subject: &v1.SubjectReference{
+			Object: &v1.ObjectReference{
+				ObjectType: subType,
+				ObjectId:   subID,
+			},
+			OptionalRelation: subRel,
+		},
+		OptionalCaveat: &v1.ContextualizedCaveat{
+			CaveatName: caveatName,
+			Context:    sctx,
+		},
+	}
+}
+
+func relationshipForBulkTesting(nsAndRel struct {
+	namespace string
+	relation  string
+}, i int,
+) *v1.Relationship {
+	if nsAndRel.relation == "caveated_viewer" {
+		return mustRelWithCaveatAndContext(
+			nsAndRel.namespace,
+			strconv.Itoa(i),
+			nsAndRel.relation,
+			tf.UserNS.Name,
+			strconv.Itoa(i),
+			"",
+			"test",
+			map[string]any{"secret": strconv.Itoa(i)},
+		)
+	}
+
+	if nsAndRel.relation == "expiring_viewer" {
+		return relWithExpiration(
+			nsAndRel.namespace,
+			strconv.Itoa(i),
+			nsAndRel.relation,
+			tf.UserNS.Name,
+			strconv.Itoa(i),
+			"",
+			time.Now().Add(time.Hour),
+		)
+	}
+
+	return rel(
+		nsAndRel.namespace,
+		strconv.Itoa(i),
+		nsAndRel.relation,
+		tf.UserNS.Name,
+		strconv.Itoa(i),
+		"",
+	)
 }
 
 func TestInvalidWriteRelationship(t *testing.T) {


### PR DESCRIPTION
The structs change made the export not properly copy the caveats