### PR TITLE
Change GC test to always call GC directly

### DIFF
--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -798,8 +798,9 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 			ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 				var err error
 				conn, err = pgx.Connect(ctx, uri)
-				RegisterTypes(conn.TypeMap())
 				require.NoError(err)
+
+				RegisterTypes(conn.TypeMap())
 
 				ds, err := newPostgresDatastore(
 					ctx,

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -208,6 +208,7 @@ func OnlyGCTests(t *testing.T, tester DatastoreTester, concurrent bool) {
 
 	t.Run("TestRevisionGC", runner(tester, RevisionGCTest))
 	t.Run("TestInvalidReads", runner(tester, InvalidReadsTest))
+	t.Run("TestGCProcessRuns", runner(tester, GCProcessRunTest))
 }
 
 // All runs all generic datastore tests on a DatastoreTester.


### PR DESCRIPTION
This should hopefully remove the flaky nature of the test