### PR TITLE
Move caveat loading into a shared runner to reduce overhead in dispatch

### DIFF
--- a/internal/graph/lookupresources2.go
+++ b/internal/graph/lookupresources2.go
@@ -312,6 +312,7 @@ func (crr *CursoredLookupResources2) redispatchOrReportOverDatabaseQuery(
 			rsm := newResourcesSubjectMap2WithCapacity(config.sourceResourceType, uint32(crr.dispatchChunkSize))
 			toBeHandled := make([]itemAndPostCursor[dispatchableResourcesSubjectMap2], 0)
 			currentCursor := queryCursor
+			caveatRunner := caveats.NewCaveatRunner()
 
 			for rel, err := range it {
 				if err != nil {
@@ -323,7 +324,7 @@ func (crr *CursoredLookupResources2) redispatchOrReportOverDatabaseQuery(
 				// If a caveat exists on the relationship, run it and filter the results, marking those that have missing context.
 				if rel.OptionalCaveat != nil && rel.OptionalCaveat.CaveatName != "" {
 					caveatExpr := caveats.CaveatAsExpr(rel.OptionalCaveat)
-					runResult, err := caveats.RunCaveatExpression(ctx, caveatExpr, config.parentRequest.Context.AsMap(), config.reader, caveats.RunCaveatExpressionNoDebugging)
+					runResult, err := caveatRunner.RunCaveatExpression(ctx, caveatExpr, config.parentRequest.Context.AsMap(), config.reader, caveats.RunCaveatExpressionNoDebugging)
 					if err != nil {
 						return nil, err
 					}

--- a/internal/services/v1/debug.go
+++ b/internal/services/v1/debug.go
@@ -92,7 +92,7 @@ func convertCheckTrace(ctx context.Context, caveatContext map[string]any, ct *di
 	var caveatEvalInfo *v1.CaveatEvalInfo
 	if permissionship == v1.CheckDebugTrace_PERMISSIONSHIP_CONDITIONAL_PERMISSION && len(partialResults) == 1 {
 		partialCheckResult := partialResults[0]
-		computedResult, err := cexpr.RunCaveatExpression(ctx, partialCheckResult.Expression, caveatContext, reader, cexpr.RunCaveatExpressionWithDebugInformation)
+		computedResult, err := cexpr.RunSingleCaveatExpression(ctx, partialCheckResult.Expression, caveatContext, reader, cexpr.RunCaveatExpressionWithDebugInformation)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/services/v1/permissions.go
+++ b/internal/services/v1/permissions.go
@@ -668,7 +668,7 @@ func foundSubjectToResolvedSubject(ctx context.Context, foundSubject *dispatch.F
 	if foundSubject.GetCaveatExpression() != nil {
 		permissionship = v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION
 
-		cr, err := cexpr.RunCaveatExpression(ctx, foundSubject.GetCaveatExpression(), caveatContext, ds, cexpr.RunCaveatExpressionNoDebugging)
+		cr, err := cexpr.RunSingleCaveatExpression(ctx, foundSubject.GetCaveatExpression(), caveatContext, ds, cexpr.RunCaveatExpressionNoDebugging)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Rather than re-processing the caveat on each iteration of the relationships loop in LR2, we use a caching loader to only process once per caveat