### PR TITLE
Switch datastore tests to use a larger runner

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -102,7 +102,7 @@ jobs:
 
   datastore:
     name: "Datastore Tests"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "buildjet-8vcpu-ubuntu-2204"
     needs: "paths-filter"
     strategy:
       fail-fast: false


### PR DESCRIPTION
This should hopefully reduce flakes where the database containers are running out of memory and/or CPU, and therefore being killed