### PR TITLE
Ensure datastore containers do not auto-restart

### DIFF
--- a/internal/testserver/datastore/crdb.go
+++ b/internal/testserver/datastore/crdb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
 
 	crdbmigrations "github.com/authzed/spicedb/internal/datastore/crdb/migrations"
@@ -44,6 +45,10 @@ func RunCRDBForTesting(t testing.TB, bridgeNetworkName string) RunningEngineForT
 		Tag:        CRDBTestVersionTag,
 		Cmd:        []string{"start-single-node", "--insecure", "--max-offset=50ms"},
 		NetworkID:  bridgeNetworkName,
+	}, func(config *docker.HostConfig) {
+		// set AutoRemove to true so that stopped container goes away by itself
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
 	})
 	require.NoError(t, err)
 

--- a/internal/testserver/datastore/mysql.go
+++ b/internal/testserver/datastore/mysql.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
 
 	"github.com/authzed/spicedb/internal/datastore/mysql/migrations"
@@ -64,6 +65,10 @@ func RunMySQLForTestingWithOptions(t testing.TB, options MySQLTesterOptions, bri
 		// increase max connections (default 151) to accommodate tests using the same docker container
 		Cmd:       []string{"--max-connections=500"},
 		NetworkID: bridgeNetworkName,
+	}, func(config *docker.HostConfig) {
+		// set AutoRemove to true so that stopped container goes away by itself
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
 	})
 	require.NoError(t, err)
 

--- a/internal/testserver/datastore/postgres.go
+++ b/internal/testserver/datastore/postgres.go
@@ -81,6 +81,10 @@ func RunPostgresForTestingWithCommitTimestamps(t testing.TB, bridgeNetworkName s
 		ExposedPorts: []string{POSTGRES_TEST_PORT + "/tcp"},
 		NetworkID:    bridgeNetworkName,
 		Cmd:          cmd,
+	}, func(config *docker.HostConfig) {
+		// set AutoRemove to true so that stopped container goes away by itself
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
 	})
 	require.NoError(t, err)
 

--- a/internal/testserver/datastore/spanner.go
+++ b/internal/testserver/datastore/spanner.go
@@ -16,6 +16,7 @@ import (
 	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
 	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
 
 	"github.com/authzed/spicedb/internal/datastore/spanner/migrations"
@@ -41,6 +42,10 @@ func RunSpannerForTesting(t testing.TB, bridgeNetworkName string, targetMigratio
 		Tag:          "1.5.11",
 		ExposedPorts: []string{"9010/tcp"},
 		NetworkID:    bridgeNetworkName,
+	}, func(config *docker.HostConfig) {
+		// set AutoRemove to true so that stopped container goes away by itself
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
If they run out of memory or CPU and are therefore killed, the test should fail for that reason, rather than the container restarting and then us seeing a "database does not exist" error. This will help us run down any problems earlier.