### PR TITLE
Move unlock call to a background context in GC

### DIFF
--- a/internal/datastore/mysql/gc.go
+++ b/internal/datastore/mysql/gc.go
@@ -33,8 +33,8 @@ func (mds *Datastore) LockForGCRun(ctx context.Context) (bool, error) {
 	return mds.tryAcquireLock(ctx, gcRunLock)
 }
 
-func (mds *Datastore) UnlockAfterGCRun(ctx context.Context) error {
-	return mds.releaseLock(ctx, gcRunLock)
+func (mds *Datastore) UnlockAfterGCRun() error {
+	return mds.releaseLock(context.Background(), gcRunLock)
 }
 
 func (mds *Datastore) Now(ctx context.Context) (time.Time, error) {

--- a/internal/datastore/postgres/gc.go
+++ b/internal/datastore/postgres/gc.go
@@ -25,8 +25,8 @@ func (pgd *pgDatastore) LockForGCRun(ctx context.Context) (bool, error) {
 	return pgd.tryAcquireLock(ctx, gcRunLock)
 }
 
-func (pgd *pgDatastore) UnlockAfterGCRun(ctx context.Context) error {
-	return pgd.releaseLock(ctx, gcRunLock)
+func (pgd *pgDatastore) UnlockAfterGCRun() error {
+	return pgd.releaseLock(context.Background(), gcRunLock)
 }
 
 func (pgd *pgDatastore) HasGCRun() bool {


### PR DESCRIPTION
This ensures that if the GC operation times out, the unlock still can run