### PR TITLE
Small changes around node IDs and trace IDs

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel"
@@ -128,7 +127,7 @@ func (cc *ConcurrentChecker) Check(ctx context.Context, req ValidatedCheckReques
 	if debugInfo == nil {
 		debugInfo = &v1.DebugInformation{
 			Check: &v1.CheckDebugTrace{
-				TraceId:  uuid.NewString(),
+				TraceId:  NewTraceID(),
 				SourceId: nodeID,
 			},
 		}
@@ -1328,7 +1327,7 @@ func combineResponseMetadata(ctx context.Context, existing *v1.ResponseMeta, res
 
 	debugInfo := &v1.DebugInformation{
 		Check: &v1.CheckDebugTrace{
-			TraceId:  uuid.NewString(),
+			TraceId:  NewTraceID(),
 			SourceId: nodeID,
 		},
 	}

--- a/internal/graph/traceid.go
+++ b/internal/graph/traceid.go
@@ -1,0 +1,13 @@
+package graph
+
+import (
+	"github.com/google/uuid"
+)
+
+// NewTraceID generates a new trace ID. The trace IDs will only be unique with
+// a single dispatch request tree and should not be used for any other purpose.
+// This function currently uses the UUID library to generate a new trace ID,
+// which means it should not be invoked from performance-critical code paths.
+func NewTraceID() string {
+	return uuid.NewString()
+}

--- a/internal/services/v1/bulkcheck.go
+++ b/internal/services/v1/bulkcheck.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/google/uuid"
 	"github.com/jzelinskie/stringz"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -199,7 +198,7 @@ func (bc *bulkChecker) checkBulkPermissions(ctx context.Context, req *v1.CheckBu
 							},
 							Results:  localResults,
 							Duration: durationpb.New(time.Duration(0)),
-							TraceId:  uuid.New().String(),
+							TraceId:  graph.NewTraceID(),
 							SourceId: debugInfo.Check.SourceId,
 						},
 					}


### PR DESCRIPTION
1) Moves the default node ID to use a hash in case the hostname has anything sensitive in it
2) Moves the trace ID generation to a single method, in case we choose to change its implementation in the future to something less intensive to run