### PR TITLE
add schemaFile to ValidationFile

### DIFF
--- a/pkg/validationfile/fileformat.go
+++ b/pkg/validationfile/fileformat.go
@@ -39,6 +39,9 @@ type ValidationFile struct {
 	// ValidationTuples are the validation tuples, in tuple string syntax.
 	// Deprecated: only for internal use. Use `relationships`.
 	ValidationTuples []string `yaml:"validation_tuples"`
+
+	// Schema file represents the path specified for the schema file
+	SchemaFile string `yaml:"schemaFile"`
 }
 
 // ParseAssertionsBlock parses the given contents as an assertions block.

--- a/pkg/validationfile/fileformat_test.go
+++ b/pkg/validationfile/fileformat_test.go
@@ -101,6 +101,18 @@ validation:
 	}
 }
 
+func TestDecodeValidationFileWithoutSchema(t *testing.T) {
+	_, err := DecodeValidationFile([]byte(`schemaFile: >-
+  someschemafilehere.zed
+
+relationships: >-
+  document:firstdoc#writer@user:tom
+`))
+	errWithSource, ok := spiceerrors.AsWithSourceError(err)
+	require.False(t, ok)
+	require.Nil(t, errWithSource)
+}
+
 func TestDecodeRelationshipsErrorLineNumber(t *testing.T) {
 	_, err := DecodeValidationFile([]byte(`schema: >-
   definition user {}


### PR DESCRIPTION
Related authzed/zed#453

Added `schemaFile` to ValidationFile which could be used to specify path of the schema.