### PR TITLE
Implement partials syntax parsing

### DIFF
--- a/pkg/composableschemadsl/dslshape/dslshape.go
+++ b/pkg/composableschemadsl/dslshape/dslshape.go
@@ -37,6 +37,8 @@ const (
 	NodeTypeCaveatTypeReference // A type reference for a caveat parameter.
 
 	NodeTypeImport
+	NodeTypePartial
+	NodeTypePartialReference // A location where a partial is referenced
 )
 
 const (
@@ -195,4 +197,14 @@ const (
 	// NodeTypeImport
 	//
 	NodeImportPredicatePath = "import-path"
+
+	//
+	// NodeTypePartial
+	//
+	NodePartialPredicateName = "partial-name"
+
+	//
+	// NodeTypePartialReference
+	//
+	NodePartialReferencePredicateName = "partial-reference-name"
 )

--- a/pkg/composableschemadsl/dslshape/zz_generated.nodetype_string.go
+++ b/pkg/composableschemadsl/dslshape/zz_generated.nodetype_string.go
@@ -28,11 +28,13 @@ func _() {
 	_ = x[NodeTypeNilExpression-17]
 	_ = x[NodeTypeCaveatTypeReference-18]
 	_ = x[NodeTypeImport-19]
+	_ = x[NodeTypePartial-20]
+	_ = x[NodeTypePartialReference-21]
 }
 
-const _NodeType_name = "NodeTypeErrorNodeTypeFileNodeTypeCommentNodeTypeDefinitionNodeTypeCaveatDefinitionNodeTypeCaveatParameterNodeTypeCaveatExpressionNodeTypeRelationNodeTypePermissionNodeTypeTypeReferenceNodeTypeSpecificTypeReferenceNodeTypeCaveatReferenceNodeTypeUnionExpressionNodeTypeIntersectExpressionNodeTypeExclusionExpressionNodeTypeArrowExpressionNodeTypeIdentifierNodeTypeNilExpressionNodeTypeCaveatTypeReferenceNodeTypeImport"
+const _NodeType_name = "NodeTypeErrorNodeTypeFileNodeTypeCommentNodeTypeDefinitionNodeTypeCaveatDefinitionNodeTypeCaveatParameterNodeTypeCaveatExpressionNodeTypeRelationNodeTypePermissionNodeTypeTypeReferenceNodeTypeSpecificTypeReferenceNodeTypeCaveatReferenceNodeTypeUnionExpressionNodeTypeIntersectExpressionNodeTypeExclusionExpressionNodeTypeArrowExpressionNodeTypeIdentifierNodeTypeNilExpressionNodeTypeCaveatTypeReferenceNodeTypeImportNodeTypePartialNodeTypePartialReference"
 
-var _NodeType_index = [...]uint16{0, 13, 25, 40, 58, 82, 105, 129, 145, 163, 184, 213, 236, 259, 286, 313, 336, 354, 375, 402, 416}
+var _NodeType_index = [...]uint16{0, 13, 25, 40, 58, 82, 105, 129, 145, 163, 184, 213, 236, 259, 286, 313, 336, 354, 375, 402, 416, 431, 455}
 
 func (i NodeType) String() string {
 	if i < 0 || i >= NodeType(len(_NodeType_index)-1) {

--- a/pkg/composableschemadsl/lexer/lex_def.go
+++ b/pkg/composableschemadsl/lexer/lex_def.go
@@ -81,6 +81,7 @@ var keywords = map[string]struct{}{
 	"import":     {},
 	"all":        {},
 	"any":        {},
+	"partial":    {},
 }
 
 // IsKeyword returns whether the specified input string is a reserved keyword.

--- a/pkg/composableschemadsl/lexer/lex_test.go
+++ b/pkg/composableschemadsl/lexer/lex_test.go
@@ -65,6 +65,7 @@ var lexerTests = []lexerTest{
 	{"keyword", "import", []Lexeme{{TokenTypeKeyword, 0, "import", ""}, tEOF}},
 	{"keyword", "all", []Lexeme{{TokenTypeKeyword, 0, "all", ""}, tEOF}},
 	{"keyword", "nil", []Lexeme{{TokenTypeKeyword, 0, "nil", ""}, tEOF}},
+	{"keyword", "partial", []Lexeme{{TokenTypeKeyword, 0, "partial", ""}, tEOF}},
 	{"identifier", "define", []Lexeme{{TokenTypeIdentifier, 0, "define", ""}, tEOF}},
 	{"typepath", "foo/bar", []Lexeme{
 		{TokenTypeIdentifier, 0, "foo", ""},

--- a/pkg/composableschemadsl/parser/parser_test.go
+++ b/pkg/composableschemadsl/parser/parser_test.go
@@ -128,6 +128,11 @@ func TestParser(t *testing.T) {
 		{"local imports with unterminated string on import test", "localimport_with_unterminated_string"},
 		{"local imports with mismatched quotes on import test", "localimport_with_mismatched_quotes"},
 		{"local imports with keyword in import path test", "localimport_import_path_with_keyword"},
+		{"top-level block with unrecognized keyword", "nonsense_top_level_block"},
+		{"partials happy path", "partials"},
+		{"partials with malformed partial reference", "partials_with_malformed_partial_reference"},
+		{"partials with malformed reference splat", "partials_with_malformed_reference_splat"},
+		{"partials with malformed partial block", "partials_with_malformed_partial_block"},
 	}
 
 	for _, test := range parserTests {

--- a/pkg/composableschemadsl/parser/tests/nonsense_top_level_block.zed
+++ b/pkg/composableschemadsl/parser/tests/nonsense_top_level_block.zed
@@ -1,0 +1,4 @@
+nonsense thing {
+  relation: user
+  permission view = user
+}

--- a/pkg/composableschemadsl/parser/tests/nonsense_top_level_block.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/nonsense_top_level_block.zed.expected
@@ -1,0 +1,11 @@
+NodeTypeFile
+  end-rune = -1
+  input-source = top-level block with unrecognized keyword
+  start-rune = 0
+  child-node =>
+    NodeTypeError
+      end-rune = -1
+      error-message = Unexpected token at root level: TokenTypeIdentifier
+      error-source = nonsense
+      input-source = top-level block with unrecognized keyword
+      start-rune = 0

--- a/pkg/composableschemadsl/parser/tests/partials.zed
+++ b/pkg/composableschemadsl/parser/tests/partials.zed
@@ -1,0 +1,10 @@
+partial view_partial {
+  relation user: user
+  permission view = user
+}
+
+definition user {}
+
+definition resource {
+  ...view_partial
+}

--- a/pkg/composableschemadsl/parser/tests/partials.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/partials.zed.expected
@@ -1,0 +1,54 @@
+NodeTypeFile
+  end-rune = 134
+  input-source = partials happy path
+  start-rune = 0
+  child-node =>
+    NodeTypePartial
+      end-rune = 70
+      input-source = partials happy path
+      partial-name = view_partial
+      start-rune = 0
+      child-node =>
+        NodeTypeRelation
+          end-rune = 43
+          input-source = partials happy path
+          relation-name = user
+          start-rune = 25
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 43
+              input-source = partials happy path
+              start-rune = 40
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 43
+                  input-source = partials happy path
+                  start-rune = 40
+                  type-name = user
+        NodeTypePermission
+          end-rune = 68
+          input-source = partials happy path
+          relation-name = view
+          start-rune = 47
+          compute-expression =>
+            NodeTypeIdentifier
+              end-rune = 68
+              identifier-value = user
+              input-source = partials happy path
+              start-rune = 65
+    NodeTypeDefinition
+      definition-name = user
+      end-rune = 90
+      input-source = partials happy path
+      start-rune = 73
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 133
+      input-source = partials happy path
+      start-rune = 93
+      child-node =>
+        NodeTypePartialReference
+          end-rune = 131
+          input-source = partials happy path
+          partial-reference-name = view_partial
+          start-rune = 117

--- a/pkg/composableschemadsl/parser/tests/partials_with_malformed_partial_block.zed
+++ b/pkg/composableschemadsl/parser/tests/partials_with_malformed_partial_block.zed
@@ -1,0 +1,10 @@
+partial view_partial {
+  relation user: user
+  permission view = user
+
+
+definition user {}
+
+definition resource {
+  ...view_partial
+}

--- a/pkg/composableschemadsl/parser/tests/partials_with_malformed_partial_block.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/partials_with_malformed_partial_block.zed.expected
@@ -1,0 +1,60 @@
+NodeTypeFile
+  end-rune = 133
+  input-source = partials with malformed partial block
+  start-rune = 0
+  child-node =>
+    NodeTypePartial
+      end-rune = 69
+      input-source = partials with malformed partial block
+      partial-name = view_partial
+      start-rune = 0
+      child-node =>
+        NodeTypeRelation
+          end-rune = 43
+          input-source = partials with malformed partial block
+          relation-name = user
+          start-rune = 25
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 43
+              input-source = partials with malformed partial block
+              start-rune = 40
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 43
+                  input-source = partials with malformed partial block
+                  start-rune = 40
+                  type-name = user
+        NodeTypePermission
+          end-rune = 68
+          input-source = partials with malformed partial block
+          relation-name = view
+          start-rune = 47
+          compute-expression =>
+            NodeTypeIdentifier
+              end-rune = 68
+              identifier-value = user
+              input-source = partials with malformed partial block
+              start-rune = 65
+        NodeTypeError
+          end-rune = 69
+          error-message = Expected end of statement or definition, found: TokenTypeKeyword
+          error-source = definition
+          input-source = partials with malformed partial block
+          start-rune = 72
+    NodeTypeDefinition
+      definition-name = user
+      end-rune = 89
+      input-source = partials with malformed partial block
+      start-rune = 72
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 132
+      input-source = partials with malformed partial block
+      start-rune = 92
+      child-node =>
+        NodeTypePartialReference
+          end-rune = 130
+          input-source = partials with malformed partial block
+          partial-reference-name = view_partial
+          start-rune = 116

--- a/pkg/composableschemadsl/parser/tests/partials_with_malformed_partial_reference.zed
+++ b/pkg/composableschemadsl/parser/tests/partials_with_malformed_partial_reference.zed
@@ -1,0 +1,10 @@
+partial view_partial {
+  relation user: user
+  permission view = user
+}
+
+definition user {}
+
+definition resource {
+  ...view_partial and_something_else
+}

--- a/pkg/composableschemadsl/parser/tests/partials_with_malformed_partial_reference.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/partials_with_malformed_partial_reference.zed.expected
@@ -1,0 +1,66 @@
+NodeTypeFile
+  end-rune = 131
+  input-source = partials with malformed partial reference
+  start-rune = 0
+  child-node =>
+    NodeTypePartial
+      end-rune = 70
+      input-source = partials with malformed partial reference
+      partial-name = view_partial
+      start-rune = 0
+      child-node =>
+        NodeTypeRelation
+          end-rune = 43
+          input-source = partials with malformed partial reference
+          relation-name = user
+          start-rune = 25
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 43
+              input-source = partials with malformed partial reference
+              start-rune = 40
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 43
+                  input-source = partials with malformed partial reference
+                  start-rune = 40
+                  type-name = user
+        NodeTypePermission
+          end-rune = 68
+          input-source = partials with malformed partial reference
+          relation-name = view
+          start-rune = 47
+          compute-expression =>
+            NodeTypeIdentifier
+              end-rune = 68
+              identifier-value = user
+              input-source = partials with malformed partial reference
+              start-rune = 65
+    NodeTypeDefinition
+      definition-name = user
+      end-rune = 90
+      input-source = partials with malformed partial reference
+      start-rune = 73
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 131
+      input-source = partials with malformed partial reference
+      start-rune = 93
+      child-node =>
+        NodeTypePartialReference
+          end-rune = 131
+          input-source = partials with malformed partial reference
+          partial-reference-name = view_partial
+          start-rune = 117
+        NodeTypeError
+          end-rune = 131
+          error-message = Expected end of statement or definition, found: TokenTypeIdentifier
+          error-source = and_something_else
+          input-source = partials with malformed partial reference
+          start-rune = 133
+    NodeTypeError
+      end-rune = 131
+      error-message = Unexpected token at root level: TokenTypeIdentifier
+      error-source = and_something_else
+      input-source = partials with malformed partial reference
+      start-rune = 133

--- a/pkg/composableschemadsl/parser/tests/partials_with_malformed_reference_splat.zed
+++ b/pkg/composableschemadsl/parser/tests/partials_with_malformed_reference_splat.zed
@@ -1,0 +1,10 @@
+partial view_partial {
+  relation user: user
+  permission view = user
+}
+
+definition user {}
+
+definition resource {
+  ..view_partial
+}

--- a/pkg/composableschemadsl/parser/tests/partials_with_malformed_reference_splat.zed.expected
+++ b/pkg/composableschemadsl/parser/tests/partials_with_malformed_reference_splat.zed.expected
@@ -1,0 +1,61 @@
+NodeTypeFile
+  end-rune = 113
+  input-source = partials with malformed reference splat
+  start-rune = 0
+  child-node =>
+    NodeTypePartial
+      end-rune = 70
+      input-source = partials with malformed reference splat
+      partial-name = view_partial
+      start-rune = 0
+      child-node =>
+        NodeTypeRelation
+          end-rune = 43
+          input-source = partials with malformed reference splat
+          relation-name = user
+          start-rune = 25
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 43
+              input-source = partials with malformed reference splat
+              start-rune = 40
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 43
+                  input-source = partials with malformed reference splat
+                  start-rune = 40
+                  type-name = user
+        NodeTypePermission
+          end-rune = 68
+          input-source = partials with malformed reference splat
+          relation-name = view
+          start-rune = 47
+          compute-expression =>
+            NodeTypeIdentifier
+              end-rune = 68
+              identifier-value = user
+              input-source = partials with malformed reference splat
+              start-rune = 65
+    NodeTypeDefinition
+      definition-name = user
+      end-rune = 90
+      input-source = partials with malformed reference splat
+      start-rune = 73
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 113
+      input-source = partials with malformed reference splat
+      start-rune = 93
+      child-node =>
+        NodeTypeError
+          end-rune = 113
+          error-message = Expected end of statement or definition, found: TokenTypePeriod
+          error-source = .
+          input-source = partials with malformed reference splat
+          start-rune = 117
+    NodeTypeError
+      end-rune = 113
+      error-message = Unexpected token at root level: TokenTypePeriod
+      error-source = .
+      input-source = partials with malformed reference splat
+      start-rune = 117


### PR DESCRIPTION
## Description
Part of the MVP of composable schema support. This implements the parsing part of a partials syntax, which can be used to decompose a schema within definitions.

## Changes
* Add `partial` as a keyword
* Implement parsing of partials blocks
* Implement parsing of partial references
* Add tests