### PR TITLE
security-fix: upgrade go base image to fix new CVE published

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.23.4-alpine3.20 AS spicedb-builder
+FROM golang:1.23.5-alpine3.20 AS spicedb-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 go build -v ./cmd/...
 
-FROM golang:1.23.4-alpine3.20 AS health-probe-builder
+FROM golang:1.23.5-alpine3.20 AS health-probe-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 RUN git clone https://github.com/authzed/grpc-health-probe.git

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,7 +1,7 @@
 # vim: syntax=dockerfile
 ARG BASE=cgr.dev/chainguard/static:latest
 
-FROM golang:1.23.4-alpine3.20 AS health-probe-builder
+FROM golang:1.23.5-alpine3.20 AS health-probe-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 RUN git clone https://github.com/authzed/grpc-health-probe.git


### PR DESCRIPTION
Example workflow failure https://github.com/authzed/spicedb/actions/runs/13012813932/job/36294419304?pr=2212