### PR TITLE
Improve handling of watch errors

### DIFF
--- a/internal/datastore/common/sqlerrors.go
+++ b/internal/datastore/common/sqlerrors.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// IsCancellationError determines if an error returned by pgx has been caused by context cancellation.
+func IsCancellationError(err error) bool {
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		err.Error() == "conn closed" { // conns are sometimes closed async upon cancellation
+		return true
+	}
+	return false
+}
+
+// IsResettableError returns whether the given error is a resettable error.
+func IsResettableError(err error) bool {
+	// detect when an error is likely due to a node taken out of service
+	if strings.Contains(err.Error(), "broken pipe") ||
+		strings.Contains(err.Error(), "unexpected EOF") ||
+		strings.Contains(err.Error(), "conn closed") ||
+		strings.Contains(err.Error(), "connection refused") ||
+		strings.Contains(err.Error(), "connection reset by peer") {
+		return true
+	}
+
+	return false
+}

--- a/internal/datastore/crdb/watch.go
+++ b/internal/datastore/crdb/watch.go
@@ -160,6 +160,11 @@ func (cds *crdbDatastore) watch(
 			return
 		}
 
+		if strings.Contains(err.Error(), "must be after replica GC threshold") {
+			errs <- datastore.NewInvalidRevisionErr(afterRevision, datastore.RevisionStale)
+			return
+		}
+
 		if pool.IsResettableError(ctx, err) || pool.IsRetryableError(ctx, err) {
 			errs <- datastore.NewWatchTemporaryErr(err)
 			return

--- a/internal/datastore/mysql/watch.go
+++ b/internal/datastore/mysql/watch.go
@@ -147,8 +147,12 @@ func (mds *Datastore) loadChanges(
 
 	rows, err := mds.db.QueryContext(ctx, sql, args...)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		if errors.Is(ctx.Err(), context.Canceled) {
 			err = datastore.NewWatchCanceledErr()
+		} else if common.IsCancellationError(err) {
+			err = datastore.NewWatchCanceledErr()
+		} else if common.IsResettableError(err) {
+			err = datastore.NewWatchTemporaryErr(err)
 		}
 		return
 	}

--- a/internal/datastore/postgres/common/pgx.go
+++ b/internal/datastore/postgres/common/pgx.go
@@ -75,7 +75,7 @@ func ConfigurePGXLogger(connConfig *pgx.ConnConfig) {
 			// log cancellation and serialization errors at debug level
 			if errArg, ok := data["err"]; ok {
 				err, ok := errArg.(error)
-				if ok && (IsCancellationError(err) || IsSerializationError(err)) {
+				if ok && (common.IsCancellationError(err) || IsSerializationError(err)) {
 					logger.Log(ctx, tracelog.LogLevelDebug, msg, data)
 					return
 				}
@@ -118,16 +118,6 @@ func truncateLargeSQL(data map[string]any) {
 			data["args"] = argsSlice[:maxSQLArgsLen]
 		}
 	}
-}
-
-// IsCancellationError determines if an error returned by pgx has been caused by context cancellation.
-func IsCancellationError(err error) bool {
-	if errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) ||
-		err.Error() == "conn closed" { // conns are sometimes closed async upon cancellation
-		return true
-	}
-	return false
 }
 
 func IsSerializationError(err error) bool {

--- a/internal/datastore/spanner/watch.go
+++ b/internal/datastore/spanner/watch.go
@@ -94,6 +94,16 @@ func (sd *spannerDatastore) watch(
 			return
 		}
 
+		if common.IsCancellationError(err) {
+			errs <- datastore.NewWatchCanceledErr()
+			return
+		}
+
+		if common.IsResettableError(err) {
+			errs <- datastore.NewWatchTemporaryErr(err)
+			return
+		}
+
 		errs <- err
 	}
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -651,6 +651,15 @@ type ReadOnlyDatastore interface {
 	// Watch notifies the caller about changes to the datastore, based on the specified options.
 	//
 	// All events following afterRevision will be sent to the caller.
+	//
+	// Errors returned will fall into a few classes:
+	// - WatchDisconnectedError - the watch has fallen too far behind and has been disconnected.
+	// - WatchCanceledError     - the watch was canceled by the caller.
+	// - WatchDisabledError     - the watch is disabled by being unsupported by the datastore.
+	// - WatchRetryableError    - the watch is retryable, and the caller may retry after some backoff time.
+	// - InvalidRevisionError   - the revision specified has passed the datastore's watch history window and
+	//                            the watch cannot be retried.
+	// - Other errors 			- the watch should not be retried due to a fatal error.
 	Watch(ctx context.Context, afterRevision Revision, options WatchOptions) (<-chan RevisionChanges, <-chan error)
 
 	// ReadyState returns a state indicating whether the datastore is ready to accept data.


### PR DESCRIPTION
Adds more cases where retryable error is returned and adds a too-stale error for CRDB

A followup will add too-stale for the other datastores