### PR TITLE
Support follower read delay flag with Postgres and MySQL datastores

### DIFF
--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -230,12 +230,18 @@ func newMySQLDatastore(ctx context.Context, uri string, replicaIndex int, option
 		quantizationPeriodNanos = 1
 	}
 
+	followerReadDelayNanos := config.followerReadDelay.Nanoseconds()
+	if followerReadDelayNanos < 0 {
+		followerReadDelayNanos = 0
+	}
+
 	revisionQuery := fmt.Sprintf(
 		querySelectRevision,
 		colID,
 		driver.RelationTupleTransaction(),
 		colTimestamp,
 		quantizationPeriodNanos,
+		followerReadDelayNanos,
 	)
 
 	validTransactionQuery := fmt.Sprintf(

--- a/internal/datastore/mysql/options.go
+++ b/internal/datastore/mysql/options.go
@@ -28,6 +28,8 @@ const (
 	defaultFilterMaximumIDCount              = 100
 	defaultColumnOptimizationOption          = common.ColumnOptimizationOptionNone
 	defaultExpirationDisabled                = false
+	// no follower delay by default, it should only be set if using read replicas
+	defaultFollowerReadDelay = 0
 )
 
 type mysqlOptions struct {
@@ -36,6 +38,7 @@ type mysqlOptions struct {
 	gcInterval                  time.Duration
 	gcMaxOperationTime          time.Duration
 	maxRevisionStalenessPercent float64
+	followerReadDelay           time.Duration
 	watchBufferLength           uint16
 	watchBufferWriteTimeout     time.Duration
 	tablePrefix                 string
@@ -77,6 +80,7 @@ func generateConfig(options []Option) (mysqlOptions, error) {
 		filterMaximumIDCount:        defaultFilterMaximumIDCount,
 		columnOptimizationOption:    defaultColumnOptimizationOption,
 		expirationDisabled:          defaultExpirationDisabled,
+		followerReadDelay:           defaultFollowerReadDelay,
 	}
 
 	for _, option := range options {
@@ -135,6 +139,14 @@ func MaxRevisionStalenessPercent(stalenessPercent float64) Option {
 	return func(mo *mysqlOptions) {
 		mo.maxRevisionStalenessPercent = stalenessPercent
 	}
+}
+
+// FollowerReadDelay is the amount of time to round down the current time when
+// reading from a read replica is expected.
+//
+// This value defaults to 0 seconds.
+func FollowerReadDelay(delay time.Duration) Option {
+	return func(mo *mysqlOptions) { mo.followerReadDelay = delay }
 }
 
 // GCWindow is the maximum age of a passed revision that will be considered

--- a/internal/datastore/mysql/revisions.go
+++ b/internal/datastore/mysql/revisions.go
@@ -30,10 +30,11 @@ const (
 	//   %[2] Relationship tuple transaction table
 	//   %[3] Name of timestamp column
 	//   %[4] Quantization period (in nanoseconds)
+	//   %[5] Follower read delay (in nanoseconds)
 	querySelectRevision = `SELECT COALESCE((
 			SELECT MIN(%[1]s)
 			FROM   %[2]s
-			WHERE  %[3]s >= FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(UTC_TIMESTAMP(6)) * 1000000000 / %[4]d) * %[4]d / 1000000000)
+			WHERE  %[3]s >= FROM_UNIXTIME(FLOOR((UNIX_TIMESTAMP(UTC_TIMESTAMP(6)) * 1000000000 - %[5]d) / %[4]d) * %[4]d / 1000000000)
 		), (
 			SELECT MAX(%[1]s)
 			FROM   %[2]s

--- a/internal/datastore/postgres/options.go
+++ b/internal/datastore/postgres/options.go
@@ -19,6 +19,7 @@ type postgresOptions struct {
 	watchBufferLength       uint16
 	watchBufferWriteTimeout time.Duration
 	revisionQuantization    time.Duration
+	followerReadDelay       time.Duration
 	gcWindow                time.Duration
 	gcInterval              time.Duration
 	gcMaxOperationTime      time.Duration
@@ -74,6 +75,8 @@ const (
 	defaultColumnOptimizationOption          = common.ColumnOptimizationOptionNone
 	defaultIncludeQueryParametersInTraces    = false
 	defaultExpirationDisabled                = false
+	// no follower delay by default, it should only be set if using read replicas
+	defaultFollowerReadDelay = 0
 )
 
 // Option provides the facility to configure how clients within the
@@ -99,6 +102,7 @@ func generateConfig(options []Option) (postgresOptions, error) {
 		columnOptimizationOption:       defaultColumnOptimizationOption,
 		includeQueryParametersInTraces: defaultIncludeQueryParametersInTraces,
 		expirationDisabled:             defaultExpirationDisabled,
+		followerReadDelay:              defaultFollowerReadDelay,
 	}
 
 	for _, option := range options {
@@ -279,6 +283,14 @@ func WatchBufferWriteTimeout(watchBufferWriteTimeout time.Duration) Option {
 // This value defaults to 5 seconds.
 func RevisionQuantization(quantization time.Duration) Option {
 	return func(po *postgresOptions) { po.revisionQuantization = quantization }
+}
+
+// FollowerReadDelay is the amount of time to round down the current time when
+// reading from a read replica is expected.
+//
+// This value defaults to 0 seconds.
+func FollowerReadDelay(delay time.Duration) Option {
+	return func(po *postgresOptions) { po.followerReadDelay = delay }
 }
 
 // MaxRevisionStalenessPercent is the amount of time, expressed as a percentage of

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -295,6 +295,12 @@ func newPostgresDatastore(
 	if quantizationPeriodNanos < 1 {
 		quantizationPeriodNanos = 1
 	}
+
+	followerReadDelayNanos := config.followerReadDelay.Nanoseconds()
+	if followerReadDelayNanos < 0 {
+		followerReadDelayNanos = 0
+	}
+
 	revisionQuery := fmt.Sprintf(
 		querySelectRevision,
 		colXID,
@@ -302,6 +308,7 @@ func newPostgresDatastore(
 		colTimestamp,
 		quantizationPeriodNanos,
 		colSnapshot,
+		followerReadDelayNanos,
 	)
 
 	validTransactionQuery := fmt.Sprintf(

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -35,9 +35,10 @@ const (
 	//   %[3] Name of timestamp column
 	//   %[4] Quantization period (in nanoseconds)
 	//   %[5] Name of snapshot column
+	//   %[6] Follower read delay (in nanoseconds)
 	querySelectRevision = `
 	WITH selected AS (SELECT (
-		(SELECT %[1]s FROM %[2]s WHERE %[3]s >= TO_TIMESTAMP(FLOOR(EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'utc') * 1000000000 / %[4]d) * %[4]d / 1000000000) AT TIME ZONE 'utc' ORDER BY %[3]s ASC LIMIT 1)
+		(SELECT %[1]s FROM %[2]s WHERE %[3]s >= TO_TIMESTAMP(FLOOR((EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'utc') * 1000000000 - %[6]d)/ %[4]d) * %[4]d / 1000000000) AT TIME ZONE 'utc' ORDER BY %[3]s ASC LIMIT 1)
 	) as xid)
 	SELECT selected.xid,
 	COALESCE((SELECT %[5]s FROM %[2]s WHERE %[1]s = selected.xid), (SELECT pg_current_snapshot())),


### PR DESCRIPTION
In CRDB and Spanner, follower read delay is used to artificially pick an older timestamp that should be synchronized to the follower nodes.

We have a similar situation in Postgres and MySQL with read replicas, where we'd like to pick a quantized revision that we think is likely to have been replicated, but prior to this PR, that flag was not used in those datastores.

To use this with postgres or mysql, set `--datastore-follower-read-delay-duration` to any non-default value (`4.8s`) (The postgres and mysql default is actually 0s even though the flag default is 4.8s)