### PR TITLE
make postgres a continuously checkpointing datastore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
 FROM golang:1.23.6-alpine3.20 AS health-probe-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
-RUN git clone https://github.com/authzed/grpc-health-probe.git
+RUN git clone https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout master
+RUN git checkout 86f0bc2dea67fda67e9a060689bc8bb7a19ebe44
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 FROM cgr.dev/chainguard/static:latest

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -4,9 +4,9 @@ ARG BASE=cgr.dev/chainguard/static:latest
 FROM golang:1.23.6-alpine3.20 AS health-probe-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
-RUN git clone https://github.com/authzed/grpc-health-probe.git
+RUN git clone https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout master
+RUN git checkout 86f0bc2dea67fda67e9a060689bc8bb7a19ebe44
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 FROM $BASE

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -721,7 +721,7 @@ func (pgd *pgDatastore) OfflineFeatures() (*datastore.Features, error) {
 				Status: datastore.FeatureUnsupported,
 			},
 			ContinuousCheckpointing: datastore.Feature{
-				Status: datastore.FeatureUnsupported,
+				Status: datastore.FeatureSupported,
 			},
 			WatchEmitsImmediately: datastore.Feature{
 				Status: datastore.FeatureUnsupported,

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -900,7 +900,7 @@ func OverlappingRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest)
 		{ // the two revisions are concurrent, and given they are past the quantization window (are way in the past, around unix epoch)
 			// the function should return a revision snapshot that captures both of them
 			"ConcurrentRevisions",
-			1 * time.Second,
+			5 * time.Second,
 			0,
 			[]postgresRevision{
 				{optionalTxID: newXid8(3), snapshot: pgSnapshot{xmin: 1, xmax: 4, xipList: []uint64{2}}, optionalNanosTimestamp: uint64((time.Second * 1) * time.Nanosecond)},

--- a/internal/datastore/postgres/snapshot.go
+++ b/internal/datastore/postgres/snapshot.go
@@ -144,6 +144,21 @@ const (
 	concurrent
 )
 
+func (cr comparisonResult) String() string {
+	switch cr {
+	case equal:
+		return "="
+	case lt:
+		return "<"
+	case gt:
+		return ">"
+	case concurrent:
+		return "~"
+	default:
+		return "?"
+	}
+}
+
 // compare will return whether we can definitely assert that one snapshot was
 // definitively created after, before, at the same time, or was executed
 // concurrent with another transaction. We assess this based on whether a
@@ -151,6 +166,9 @@ const (
 // of in-progress transactions. E.g. if one snapshot only sees txids 1 and 3 as
 // visible but another transaction sees 1-3 as visible, that transaction is
 // greater.
+// example:
+// 0:4:2   -> (1,3 visible)
+// 0:4:2,3 -> (1 visible)
 func (s pgSnapshot) compare(rhs pgSnapshot) comparisonResult {
 	rhsHasMoreInfo := rhs.anyTXVisible(s.xmax, s.xipList)
 	lhsHasMoreInfo := s.anyTXVisible(rhs.xmax, rhs.xipList)

--- a/internal/datastore/postgres/snapshot_test.go
+++ b/internal/datastore/postgres/snapshot_test.go
@@ -56,6 +56,7 @@ func TestMarkComplete(t *testing.T) {
 		{snap(3, 5, 3), 3, snap(5, 5)},
 		{snap(0, 0), 5, snap(0, 6, 0, 1, 2, 3, 4)},
 		{snap(5, 5), 4, snap(5, 5)},
+		{snap(3, 5, 4), 5, snap(4, 6, 4)},
 	}
 
 	for _, tc := range testCases {
@@ -64,6 +65,55 @@ func TestMarkComplete(t *testing.T) {
 			require := require.New(t)
 			completed := tc.snapshot.markComplete(tc.toMark)
 			require.Equal(tc.expected, completed, "%s != %s", tc.expected, completed)
+		})
+	}
+}
+
+func TestVisible(t *testing.T) {
+	testCases := []struct {
+		snapshot pgSnapshot
+		txID     uint64
+		visible  bool
+	}{
+		{snap(840, 842, 840), 841, true},
+		{snap(840, 842, 840), 840, false},
+		{snap(840, 842, 840), 842, false},
+		{snap(840, 842, 840), 839, true},
+	}
+
+	f := func(b bool) string {
+		if b {
+			return "visible"
+		}
+		return "not visible"
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(fmt.Sprintf("%d %s %s", tc.txID, f(tc.visible)+" in", tc.snapshot), func(t *testing.T) {
+			require := require.New(t)
+			result := tc.snapshot.txVisible(tc.txID)
+			require.Equal(tc.visible, result, "expected %s but got %s", f(tc.visible), f(result))
+		})
+	}
+}
+
+func TestCompare(t *testing.T) {
+	testCases := []struct {
+		snapshot    pgSnapshot
+		compareWith pgSnapshot
+		result      comparisonResult
+	}{
+		{snap(0, 4, 2), snap(0, 4, 2, 3), gt},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("%s %s %s", tc.snapshot, tc.result, tc.compareWith), func(t *testing.T) {
+			require := require.New(t)
+			result := tc.snapshot.compare(tc.compareWith)
+			require.Equal(tc.result, result, "expected %s got %s", tc.result, result)
 		})
 	}
 }

--- a/internal/datastore/postgres/snapshot_test.go
+++ b/internal/datastore/postgres/snapshot_test.go
@@ -106,6 +106,7 @@ func TestCompare(t *testing.T) {
 		result      comparisonResult
 	}{
 		{snap(0, 4, 2), snap(0, 4, 2, 3), gt},
+		{snap(1, 4, 2), snap(1, 4, 3), concurrent},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -197,6 +197,7 @@ func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories, 
 
 	if !except.Watch() && !except.WatchCheckpoints() {
 		t.Run("TestWatchCheckpoints", runner(tester, WatchCheckpointsTest))
+		t.Run("TestWatchContinuousCheckpoints", runner(tester, WatchContinuousCheckpointsTest))
 	}
 
 	t.Run("TestRelationshipCounters", runner(tester, RelationshipCountersTest))


### PR DESCRIPTION
## Context

Postgres datastore does not offer a continuous checkpointing Watch API because Postgres revisions are not time-based.
In the other databases, any timestamp represents a fully fledged revision, while in the Postgres datastore, a timestamp does not necessarily represent a transaction.

This is only relevant for consumers of the Watch API, and more particularly, consumers of the datastore Watch API, which exposes the concept of Watch Checkpoints. Consumers of the Postgres Watch API don't observe the passing of time, and this is important for any system that needs to report lag as a health metric.

## The Fix

This PR introduces a new way to report checkpoints in Postgres `Watch` by running an actual transaction. When no new application revisions are detected, a method will be invoked to create a new synthetic transaction, which is not written to the transactions table, it's just returned as the new checkpoint. Because we know there were no new revisions at the time of the evaluation of the query, we can return a new revision. This is not different from what `HeadRevision` does: it is the same, but the difference is that the transaction is assigned an ID.

The new logic leverages the `pg_current_xact_id()` function, which assigns a transaction ID to the current running transaction, even if not committed. We compute the transaction XID, the snapshot, and the timestamp, all within the same transaction that determines if there are new revisions to make sure there isn't a race. The operation will be run only if no new application revisions are determined.

The concern of this approach is the consumption of the XID8 space. XID8 is a 64-bit ID space, and thus, it would take 584.5 years to consume the space if we were able to generate 1 XID per nanosecond, which is totally unrealistic. The expectation is that the watch API poll interval happens at a maximum of 1 poll per second.

The other concern is that this makes `HeadRevision` move continuously, which impacts the selection of optimized revision, which keeps moving continuously and affects cache hit rates. This was also identified as an issue for SpiceDB deployments where other workloads run in the same Postgres instance, causing the `HeadRevision` to move continuously. The fix for this problem is described in detail in the next section. 

Finally, this change fixes a latent bug identified while reasoning about all the different pieces in place to support Postgres datastore watch API. In commit https://github.com/authzed/spicedb/commit/74dc7b26a8d1ec70266f7ac99edee10d11cb269f a change was introduced to address the lack of checkpoints when the Postgres datastore moved its `pg_current_snapshot()` outside of application changes (e.g. `VACUUM` operations, or other local databases in the same Postgres instance). The inconsistency identified is that `pg_current_snapshot()` will be emitted as a checkpoint, but it's entirely possible for a new transaction to come in and be evaluated at that transaction because `pg_current_snapshot()` returns _the snapshot at which
the query is evaluated_, and that does not consume it if not transaction ID was assigned (e.g. there was no commit involved). Consequently, it's possible to observe one checkpoint at revision T and then a change that comes after that at the same revision T, which violates the semantics of the checkpoint acting as a high watermark (the client must
not observe pop-in after the checkpoint).

This commit fixes it because the returned checkpoint is now part of an actual transaction, so no pop-in is possible. One phenomenon to remember is that a client might call Watch API with the revision out of a previous call to `HeadRevision`. If that revision was never committed, then the creation of the new revision will consume it. This is fine, but the code needs to ensure the checkpoint is not emitted via the `Watch` API because the API contract is only revisions above the provided argument revision will be emitted.

## Changes to `OptimizedRevision`

This PR also changes how Postgres-optimized revisions are done to be able to quantize revisions even when no application writes are happening and something else in the Postgres instance is causing the current snapshot to move (e.g., VACUUM or non-spicedb workloads).

The changes are put in place to address the impact of commit https://github.com/authzed/spicedb/commit/3f22176ac3b5fc53ae959975c205b8b36513a826, where we made PG watch API generate artificial new transaction IDs as a checkpoint heart-beat. The fix in this PR also mitigates the impact this has on the cache, which would cause cache thrashing because a new optimized revision is selected each time it is computed. It also fixes cache thrashing caused by sharing a Postgres database between multiple SpiceDB instances or sharing with unrelated workloads.