### PR TITLE
make pg datastore continuously checkpoint using a revision heartbeat

### DIFF
--- a/internal/datastore/postgres/locks.go
+++ b/internal/datastore/postgres/locks.go
@@ -11,6 +11,9 @@ type lockID uint32
 const (
 	// gcRunLock is the lock ID for the garbage collection run.
 	gcRunLock lockID = 1
+
+	// revisionHeartbeatLock is the lock ID for the leader that will generate the heartbeat revisions.
+	revisionHeartbeatLock lockID = 2
 )
 
 func (pgd *pgDatastore) tryAcquireLock(ctx context.Context, lockID lockID) (bool, error) {

--- a/internal/datastore/postgres/options.go
+++ b/internal/datastore/postgres/options.go
@@ -33,6 +33,7 @@ type postgresOptions struct {
 	expirationDisabled             bool
 	columnOptimizationOption       common.ColumnOptimizationOption
 	includeQueryParametersInTraces bool
+	revisionHeartbeatEnabled       bool
 
 	migrationPhase    string
 	allowedMigrations []string
@@ -77,6 +78,7 @@ const (
 	defaultExpirationDisabled                = false
 	// no follower delay by default, it should only be set if using read replicas
 	defaultFollowerReadDelay = 0
+	defaultRevisionHeartbeat = false
 )
 
 // Option provides the facility to configure how clients within the
@@ -103,6 +105,7 @@ func generateConfig(options []Option) (postgresOptions, error) {
 		includeQueryParametersInTraces: defaultIncludeQueryParametersInTraces,
 		expirationDisabled:             defaultExpirationDisabled,
 		followerReadDelay:              defaultFollowerReadDelay,
+		revisionHeartbeatEnabled:       defaultRevisionHeartbeat,
 	}
 
 	for _, option := range options {
@@ -419,4 +422,9 @@ func WithColumnOptimization(isEnabled bool) Option {
 // WithExpirationDisabled disables support for relationship expiration.
 func WithExpirationDisabled(isDisabled bool) Option {
 	return func(po *postgresOptions) { po.expirationDisabled = isDisabled }
+}
+
+// WithRevisionHeartbeat enables the revision heartbeat.
+func WithRevisionHeartbeat(isEnabled bool) Option {
+	return func(po *postgresOptions) { po.revisionHeartbeatEnabled = isEnabled }
 }

--- a/internal/datastore/postgres/snapshot.go
+++ b/internal/datastore/postgres/snapshot.go
@@ -144,6 +144,21 @@ const (
 	concurrent
 )
 
+func (cr comparisonResult) String() string {
+	switch cr {
+	case equal:
+		return "="
+	case lt:
+		return "<"
+	case gt:
+		return ">"
+	case concurrent:
+		return "~"
+	default:
+		return "?"
+	}
+}
+
 // compare will return whether we can definitely assert that one snapshot was
 // definitively created after, before, at the same time, or was executed
 // concurrent with another transaction. We assess this based on whether a
@@ -151,6 +166,9 @@ const (
 // of in-progress transactions. E.g. if one snapshot only sees txids 1 and 3 as
 // visible but another transaction sees 1-3 as visible, that transaction is
 // greater.
+// example:
+// 0:4:2   -> (1,3 visible)
+// 0:4:2,3 -> (1 visible)
 func (s pgSnapshot) compare(rhs pgSnapshot) comparisonResult {
 	rhsHasMoreInfo := rhs.anyTXVisible(s.xmax, s.xipList)
 	lhsHasMoreInfo := s.anyTXVisible(rhs.xmax, rhs.xipList)

--- a/internal/datastore/postgres/snapshot_test.go
+++ b/internal/datastore/postgres/snapshot_test.go
@@ -56,6 +56,7 @@ func TestMarkComplete(t *testing.T) {
 		{snap(3, 5, 3), 3, snap(5, 5)},
 		{snap(0, 0), 5, snap(0, 6, 0, 1, 2, 3, 4)},
 		{snap(5, 5), 4, snap(5, 5)},
+		{snap(3, 5, 4), 5, snap(4, 6, 4)},
 	}
 
 	for _, tc := range testCases {
@@ -64,6 +65,55 @@ func TestMarkComplete(t *testing.T) {
 			require := require.New(t)
 			completed := tc.snapshot.markComplete(tc.toMark)
 			require.Equal(tc.expected, completed, "%s != %s", tc.expected, completed)
+		})
+	}
+}
+
+func TestVisible(t *testing.T) {
+	testCases := []struct {
+		snapshot pgSnapshot
+		txID     uint64
+		visible  bool
+	}{
+		{snap(840, 842, 840), 841, true},
+		{snap(840, 842, 840), 840, false},
+		{snap(840, 842, 840), 842, false},
+		{snap(840, 842, 840), 839, true},
+	}
+
+	f := func(b bool) string {
+		if b {
+			return "visible"
+		}
+		return "not visible"
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(fmt.Sprintf("%d %s %s", tc.txID, f(tc.visible)+" in", tc.snapshot), func(t *testing.T) {
+			require := require.New(t)
+			result := tc.snapshot.txVisible(tc.txID)
+			require.Equal(tc.visible, result, "expected %s but got %s", f(tc.visible), f(result))
+		})
+	}
+}
+
+func TestCompare(t *testing.T) {
+	testCases := []struct {
+		snapshot    pgSnapshot
+		compareWith pgSnapshot
+		result      comparisonResult
+	}{
+		{snap(0, 4, 2), snap(0, 4, 2, 3), gt},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("%s %s %s", tc.snapshot, tc.result, tc.compareWith), func(t *testing.T) {
+			require := require.New(t)
+			result := tc.snapshot.compare(tc.compareWith)
+			require.Equal(tc.result, result, "expected %s got %s", tc.result, result)
 		})
 	}
 }

--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -125,7 +125,7 @@ func (pgd *pgDatastore) Watch(
 		currentTxn := afterRevision
 		requestedCheckpoints := options.Content&datastore.WatchCheckpoints == datastore.WatchCheckpoints
 		for {
-			newTxns, optionalHeadRevision, err := pgd.getNewRevisions(ctx, currentTxn, requestedCheckpoints)
+			newTxns, err := pgd.getNewRevisions(ctx, currentTxn)
 			if err != nil {
 				if errors.Is(ctx.Err(), context.Canceled) {
 					errs <- datastore.NewWatchCanceledErr()
@@ -187,31 +187,6 @@ func (pgd *pgDatastore) Watch(
 					}
 				}
 			} else {
-				// PG head revision could move outside of changes (e.g. VACUUM ANALYZE), and we still need to
-				// send a checkpoint to the client, as could have determined also via Head that changes exist and
-				// called Watch API
-				//
-				// we need to compute the head revision in the same transaction where we determine any new spicedb,
-				// transactions, otherwise there could be a race that means we issue a checkpoint before we issue
-				// the corresponding changes.
-				if requestedCheckpoints {
-					if optionalHeadRevision == nil {
-						errs <- spiceerrors.MustBugf("expected to have an optional head revision")
-						return
-					}
-
-					if optionalHeadRevision.GreaterThan(currentTxn) {
-						if !sendChange(datastore.RevisionChanges{
-							Revision:     *optionalHeadRevision,
-							IsCheckpoint: true,
-						}) {
-							return
-						}
-
-						currentTxn = *optionalHeadRevision
-					}
-				}
-
 				select {
 				case <-time.NewTimer(watchSleep).C:
 					break
@@ -226,18 +201,9 @@ func (pgd *pgDatastore) Watch(
 	return updates, errs
 }
 
-func (pgd *pgDatastore) getNewRevisions(ctx context.Context, afterTX postgresRevision, returnHeadRevision bool) ([]postgresRevision, *postgresRevision, error) {
+func (pgd *pgDatastore) getNewRevisions(ctx context.Context, afterTX postgresRevision) ([]postgresRevision, error) {
 	var ids []postgresRevision
-	var optionalHeadRevision *postgresRevision
-	var err error
 	if err := pgx.BeginTxFunc(ctx, pgd.readPool, pgx.TxOptions{IsoLevel: pgx.RepeatableRead}, func(tx pgx.Tx) error {
-		if returnHeadRevision {
-			optionalHeadRevision, err = pgd.getHeadRevision(ctx, tx)
-			if err != nil {
-				return fmt.Errorf("unable to get head revision: %w", err)
-			}
-		}
-
 		rows, err := tx.Query(ctx, newRevisionsQuery, afterTX.snapshot)
 		if err != nil {
 			return fmt.Errorf("unable to load new revisions: %w", err)
@@ -270,10 +236,10 @@ func (pgd *pgDatastore) getNewRevisions(ctx context.Context, afterTX postgresRev
 		}
 		return nil
 	}); err != nil {
-		return nil, optionalHeadRevision, fmt.Errorf("transaction error: %w", err)
+		return nil, fmt.Errorf("transaction error: %w", err)
 	}
 
-	return ids, optionalHeadRevision, nil
+	return ids, nil
 }
 
 func (pgd *pgDatastore) loadChanges(ctx context.Context, revisions []postgresRevision, options datastore.WatchOptions) ([]datastore.RevisionChanges, error) {

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -174,6 +174,7 @@ type Config struct {
 	// Expermimental
 	ExperimentalColumnOptimization           bool `debugmap:"visible"`
 	EnableExperimentalRelationshipExpiration bool `debugmap:"visible"`
+	EnableExperimentalRevisionHeartbeat      bool `debugmap:"visible"`
 }
 
 //go:generate go run github.com/ecordell/optgen -sensitive-field-name-matches uri,secure -output zz_generated.relintegritykey.options.go . RelIntegrityKey
@@ -627,6 +628,7 @@ func newPostgresPrimaryDatastore(ctx context.Context, opts Config) (datastore.Da
 		postgres.WatchBufferWriteTimeout(opts.WatchBufferWriteTimeout),
 		postgres.MigrationPhase(opts.MigrationPhase),
 		postgres.AllowedMigrations(opts.AllowedMigrations),
+		postgres.WithRevisionHeartbeat(opts.EnableExperimentalRevisionHeartbeat),
 	}
 
 	commonOptions, err := commonPostgresDatastoreOptions(opts)

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -81,6 +81,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.AllowedMigrations = c.AllowedMigrations
 		to.ExperimentalColumnOptimization = c.ExperimentalColumnOptimization
 		to.EnableExperimentalRelationshipExpiration = c.EnableExperimentalRelationshipExpiration
+		to.EnableExperimentalRevisionHeartbeat = c.EnableExperimentalRevisionHeartbeat
 	}
 }
 
@@ -136,6 +137,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["AllowedMigrations"] = helpers.DebugValue(c.AllowedMigrations, false)
 	debugMap["ExperimentalColumnOptimization"] = helpers.DebugValue(c.ExperimentalColumnOptimization, false)
 	debugMap["EnableExperimentalRelationshipExpiration"] = helpers.DebugValue(c.EnableExperimentalRelationshipExpiration, false)
+	debugMap["EnableExperimentalRevisionHeartbeat"] = helpers.DebugValue(c.EnableExperimentalRevisionHeartbeat, false)
 	return debugMap
 }
 
@@ -544,5 +546,12 @@ func WithExperimentalColumnOptimization(experimentalColumnOptimization bool) Con
 func WithEnableExperimentalRelationshipExpiration(enableExperimentalRelationshipExpiration bool) ConfigOption {
 	return func(c *Config) {
 		c.EnableExperimentalRelationshipExpiration = enableExperimentalRelationshipExpiration
+	}
+}
+
+// WithEnableExperimentalRevisionHeartbeat returns an option that can set EnableExperimentalRevisionHeartbeat on a Config
+func WithEnableExperimentalRevisionHeartbeat(enableExperimentalRevisionHeartbeat bool) ConfigOption {
+	return func(c *Config) {
+		c.EnableExperimentalRevisionHeartbeat = enableExperimentalRevisionHeartbeat
 	}
 }

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -169,6 +169,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 			Msg("The old implementation of LookupResources is no longer available, and a `false` value is no longer valid. Please remove this flag.")
 	}
 
+	experimentalFlags.BoolVar(&config.EnableExperimentalRevisionHeartbeat, "enable-experimental-revision-heartbeat", false, "enables experimental support for postgres revision heartbeat, used to create a synthetic revision on a given interval (postgres only)")
 	experimentalFlags.BoolVar(&config.EnableExperimentalRelationshipExpiration, "enable-experimental-relationship-expiration", false, "enables experimental support for first-class relationship expiration")
 	experimentalFlags.BoolVar(&config.EnableExperimentalWatchableSchemaCache, "enable-experimental-watchable-schema-cache", false, "enables the experimental schema cache which makes use of the Watch API for automatic updates")
 	// TODO: these two could reasonably be put in either the Dispatch group or the Experimental group. Is there a preference?

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -121,6 +121,7 @@ type Config struct {
 	MaxBulkExportRelationshipsLimit          uint32        `debugmap:"visible"`
 	EnableExperimentalLookupResources        bool          `debugmap:"visible"`
 	EnableExperimentalRelationshipExpiration bool          `debugmap:"visible"`
+	EnableExperimentalRevisionHeartbeat      bool          `debugmap:"visible"`
 
 	// Additional Services
 	MetricsAPI util.HTTPServerConfig `debugmap:"visible"`
@@ -228,6 +229,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 			// are at most the number of elements returned from a datastore query
 			datastorecfg.WithFilterMaximumIDCount(c.DispatchChunkSize),
 			datastorecfg.WithEnableExperimentalRelationshipExpiration(c.EnableExperimentalRelationshipExpiration),
+			datastorecfg.WithEnableExperimentalRevisionHeartbeat(c.EnableExperimentalRevisionHeartbeat),
 		)
 		if err != nil {
 			return nil, spiceerrors.NewTerminationErrorBuilder(fmt.Errorf("failed to create datastore: %w", err)).

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -89,6 +89,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.MaxBulkExportRelationshipsLimit = c.MaxBulkExportRelationshipsLimit
 		to.EnableExperimentalLookupResources = c.EnableExperimentalLookupResources
 		to.EnableExperimentalRelationshipExpiration = c.EnableExperimentalRelationshipExpiration
+		to.EnableExperimentalRevisionHeartbeat = c.EnableExperimentalRevisionHeartbeat
 		to.MetricsAPI = c.MetricsAPI
 		to.UnaryMiddlewareModification = c.UnaryMiddlewareModification
 		to.StreamingMiddlewareModification = c.StreamingMiddlewareModification
@@ -158,6 +159,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["MaxBulkExportRelationshipsLimit"] = helpers.DebugValue(c.MaxBulkExportRelationshipsLimit, false)
 	debugMap["EnableExperimentalLookupResources"] = helpers.DebugValue(c.EnableExperimentalLookupResources, false)
 	debugMap["EnableExperimentalRelationshipExpiration"] = helpers.DebugValue(c.EnableExperimentalRelationshipExpiration, false)
+	debugMap["EnableExperimentalRevisionHeartbeat"] = helpers.DebugValue(c.EnableExperimentalRevisionHeartbeat, false)
 	debugMap["MetricsAPI"] = helpers.DebugValue(c.MetricsAPI, false)
 	debugMap["SilentlyDisableTelemetry"] = helpers.DebugValue(c.SilentlyDisableTelemetry, false)
 	debugMap["TelemetryCAOverridePath"] = helpers.DebugValue(c.TelemetryCAOverridePath, false)
@@ -567,6 +569,13 @@ func WithEnableExperimentalLookupResources(enableExperimentalLookupResources boo
 func WithEnableExperimentalRelationshipExpiration(enableExperimentalRelationshipExpiration bool) ConfigOption {
 	return func(c *Config) {
 		c.EnableExperimentalRelationshipExpiration = enableExperimentalRelationshipExpiration
+	}
+}
+
+// WithEnableExperimentalRevisionHeartbeat returns an option that can set EnableExperimentalRevisionHeartbeat on a Config
+func WithEnableExperimentalRevisionHeartbeat(enableExperimentalRevisionHeartbeat bool) ConfigOption {
+	return func(c *Config) {
+		c.EnableExperimentalRevisionHeartbeat = enableExperimentalRevisionHeartbeat
 	}
 }
 


### PR DESCRIPTION
alternative implementation to https://github.com/authzed/spicedb/pull/2247

## Context

Postgres datastore does not offer a continuous checkpointing Watch API because Postgres revisions are not time-based.
In the other databases, any timestamp represents a fully fledged revision, while in the Postgres datastore, a timestamp does not necessarily represent a transaction.

This is only relevant for consumers of the Watch API, and more particularly, consumers of the datastore Watch API, which exposes the concept of Watch Checkpoints. Consumers of the Postgres Watch API don't observe the passing of time, and this is important for any system that needs to report lag as a health metric.

## The solution

Introduces a leader-elected worker that will insert an artificial transaction into the transactions table so long there isn't any other revision already in the same quantization window.

This fixes three problems

## Problem 1: Cache Thrashing with Out-Of-Band changes

When out-of-band writes happen in the same cluster, it will make the `OptimizedRevision` continuously move, and this will impact revision quantization and thus caching, essentially turning into `fully_consistent` behavior. This can happen in SpiceDB clusters that share Postgres instances with another SpiceDB cluster or unrelated workloads.

## Problem 2: Watch API Continuous Checkpointing

If no changes are happening in the cluster, Watch API does not emit any changes or checkpoints, which makes it difficult for clients to know what the reported lag is, but also makes it difficult to reestablish a dropped Watch API connection because the client would be holding onto a very old revision potentially outside of the GC window.

## Problem 3: Bug on Watch API with out-of-band changes

This change fixes a latent bug identified while reasoning about all the different pieces in place to support Postgres datastore watch API. 

In commit https://github.com/authzed/spicedb/commit/74dc7b26a8d1ec70266f7ac99edee10d11cb269f a change was introduced to address the lack of checkpoints when the Postgres datastore moved its `pg_current_snapshot()` outside of application changes (e.g. `VACUUM` operations, or other local databases in the same Postgres instance). The inconsistency identified is that `pg_current_snapshot()` will be emitted as a checkpoint, but a new transaction can come in and be evaluated at that transaction because `pg_current_snapshot()` returns _the snapshot at which the query is evaluated_, and that does not consume it if not transaction ID was assigned (e.g. there was no commit involved). Consequently, it's possible to observe one checkpoint at revision T and then a change that comes after that at the same revision T, which violates the semantics of the checkpoint acting as a high watermark (the client must
not observe pop-in after the checkpoint).

The issue is now solved because it uses the data fed from the table using a synthetic revision.