### PR TITLE
OS-222: Require definitions and partials to have distinct names

### DIFF
--- a/pkg/composableschemadsl/compiler/compiler.go
+++ b/pkg/composableschemadsl/compiler/compiler.go
@@ -139,7 +139,7 @@ func Compile(schema InputSchema, prefix ObjectPrefixOption, opts ...Option) (*Co
 		skipValidate:       cfg.skipValidation,
 		allowedFlags:       cfg.allowedFlags,
 		existingNames:      mapz.NewSet[string](),
-		compiledPartials:   &initialCompiledPartials,
+		compiledPartials:   initialCompiledPartials,
 		unresolvedPartials: mapz.NewMultiMap[string, *dslNode](),
 	}, root)
 	if err != nil {

--- a/pkg/composableschemadsl/compiler/compiler.go
+++ b/pkg/composableschemadsl/compiler/compiler.go
@@ -130,6 +130,8 @@ func Compile(schema InputSchema, prefix ObjectPrefixOption, opts ...Option) (*Co
 		return nil, err
 	}
 
+	initialCompiledPartials := make(map[string][]*core.Relation)
+
 	compiled, err := translate(&translationContext{
 		objectTypePrefix:   cfg.objectTypePrefix,
 		mapper:             mapper,
@@ -137,7 +139,7 @@ func Compile(schema InputSchema, prefix ObjectPrefixOption, opts ...Option) (*Co
 		skipValidate:       cfg.skipValidation,
 		allowedFlags:       cfg.allowedFlags,
 		existingNames:      mapz.NewSet[string](),
-		compiledPartials:   make(map[string][]*core.Relation),
+		compiledPartials:   &initialCompiledPartials,
 		unresolvedPartials: mapz.NewMultiMap[string, *dslNode](),
 	}, root)
 	if err != nil {

--- a/pkg/composableschemadsl/compiler/compiler_test.go
+++ b/pkg/composableschemadsl/compiler/compiler_test.go
@@ -50,7 +50,7 @@ func TestCompile(t *testing.T) {
 			"nested parse error",
 			withTenantPrefix,
 			`definition foo {
-				relation something: rela | relb + relc	
+				relation something: rela | relb + relc
 			}`,
 			"parse error in `nested parse error`, line 2, column 37: Expected end of statement or definition, found: TokenTypePlus",
 			[]SchemaDefinition{},
@@ -955,7 +955,7 @@ func TestCompile(t *testing.T) {
 						"thirdParam":   caveattypes.MustListType(caveattypes.IntType),
 					},
 				), "sometenant/foo",
-					`someParam == 42 && someParam != 43 && someParam < 12 && someParam > 56 
+					`someParam == 42 && someParam != 43 && someParam < 12 && someParam > 56
 					&& anotherParam == "hi there" && 42 in thirdParam`),
 			},
 		},
@@ -1240,7 +1240,7 @@ func TestCompile(t *testing.T) {
 			"relation with expiration trait",
 			withTenantPrefix,
 			`use expiration
-			
+
 			definition simple {
 				relation viewer: user with expiration
 			}`,
@@ -1280,7 +1280,7 @@ func TestCompile(t *testing.T) {
 			"relation with expiration trait and caveat",
 			withTenantPrefix,
 			`use expiration
-			
+
 			definition simple {
 				relation viewer: user with somecaveat and expiration
 			}`,

--- a/pkg/composableschemadsl/compiler/compiler_test.go
+++ b/pkg/composableschemadsl/compiler/compiler_test.go
@@ -308,6 +308,36 @@ func TestCompile(t *testing.T) {
 			[]SchemaDefinition{},
 		},
 		{
+			"definition with same name as partial",
+			withTenantPrefix,
+			`
+			partial simple {
+				relation user: user
+			}
+			definition simple {
+				...simple
+			}
+			`,
+			"found definition with same name as existing partial",
+			[]SchemaDefinition{},
+		},
+		{
+			"caveat with same name as partial",
+			withTenantPrefix,
+			`
+			caveat some_caveat(someparam int) { someparam == 42}
+
+			partial some_caveat {
+				relation user: user
+			}
+			definition simple {
+				...some_caveat
+			}
+			`,
+			"found caveat with same name as existing partial",
+			[]SchemaDefinition{},
+		},
+		{
 			"definition reference to another definition errors",
 			withTenantPrefix,
 			`


### PR DESCRIPTION
## Description
Currently, it's possible to give a definition and a partial the same name, which is fine but potentially misleading/confusing. This makes it so that if a definition or a caveat has the same name as an existing partial, there's an error.

Note that it also brings the notion of prefixes into partials. I'm not entirely sure if that makes sense, because a prefix will never be a part of a realized schema, but I don't think it should be a problem.

## Changes
* Make the `compiledPartials` map a reference instead of a value so that it can be read post-modification
* Add new tests for collision
* Add prefixes to the names of partials so that they match the names of caveats/definitions
* Add checks for collision

## Testing
Review. See that tests go green