### PR TITLE
Update the datastore interface to return the number of deleted relationships

### DIFF
--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -350,7 +350,7 @@ func (rwt *observableRWT) DeleteNamespaces(ctx context.Context, nsNames ...strin
 	return rwt.delegate.DeleteNamespaces(ctx, nsNames...)
 }
 
-func (rwt *observableRWT) DeleteRelationships(ctx context.Context, filter *v1.RelationshipFilter, options ...options.DeleteOptionsOption) (bool, error) {
+func (rwt *observableRWT) DeleteRelationships(ctx context.Context, filter *v1.RelationshipFilter, options ...options.DeleteOptionsOption) (uint64, bool, error) {
 	ctx, closer := observe(ctx, "DeleteRelationships", trace.WithAttributes(
 		filterToAttributes(filter)...,
 	))

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -269,9 +269,9 @@ func (dm *MockReadWriteTransaction) WriteRelationships(_ context.Context, mutati
 	return args.Error(0)
 }
 
-func (dm *MockReadWriteTransaction) DeleteRelationships(_ context.Context, filter *v1.RelationshipFilter, options ...options.DeleteOptionsOption) (bool, error) {
+func (dm *MockReadWriteTransaction) DeleteRelationships(_ context.Context, filter *v1.RelationshipFilter, options ...options.DeleteOptionsOption) (uint64, bool, error) {
 	args := dm.Called(filter)
-	return false, args.Error(0)
+	return 0, false, args.Error(0)
 }
 
 func (dm *MockReadWriteTransaction) WriteNamespaces(_ context.Context, newConfigs ...*core.NamespaceDefinition) error {

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -476,7 +476,7 @@ func (ps *permissionServer) DeleteRelationships(ctx context.Context, req *v1.Del
 		// Delete with the specified limit.
 		if req.OptionalLimit > 0 {
 			deleteLimit := uint64(req.OptionalLimit)
-			reachedLimit, err := rwt.DeleteRelationships(ctx, req.RelationshipFilter, options.WithDeleteLimit(&deleteLimit))
+			_, reachedLimit, err := rwt.DeleteRelationships(ctx, req.RelationshipFilter, options.WithDeleteLimit(&deleteLimit))
 			if err != nil {
 				return err
 			}
@@ -489,7 +489,7 @@ func (ps *permissionServer) DeleteRelationships(ctx context.Context, req *v1.Del
 		}
 
 		// Otherwise, kick off an unlimited deletion.
-		_, err = rwt.DeleteRelationships(ctx, req.RelationshipFilter)
+		_, _, err = rwt.DeleteRelationships(ctx, req.RelationshipFilter)
 		return err
 	}, options.WithMetadata(req.OptionalTransactionMetadata))
 	if err != nil {

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -225,9 +225,9 @@ func (vrwt validatingReadWriteTransaction) WriteRelationships(ctx context.Contex
 	return vrwt.delegate.WriteRelationships(ctx, mutations)
 }
 
-func (vrwt validatingReadWriteTransaction) DeleteRelationships(ctx context.Context, filter *v1.RelationshipFilter, options ...options.DeleteOptionsOption) (bool, error) {
+func (vrwt validatingReadWriteTransaction) DeleteRelationships(ctx context.Context, filter *v1.RelationshipFilter, options ...options.DeleteOptionsOption) (uint64, bool, error) {
 	if err := filter.Validate(); err != nil {
-		return false, err
+		return 0, false, err
 	}
 
 	return vrwt.delegate.DeleteRelationships(ctx, filter, options...)

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -504,11 +504,12 @@ type ReadWriteTransaction interface {
 	WriteRelationships(ctx context.Context, mutations []tuple.RelationshipUpdate) error
 
 	// DeleteRelationships deletes relationships that match the provided filter, with
-	// the optional limit. If a limit is provided and reached, the method will return
-	// true as the first return value. Otherwise, the boolean can be ignored.
+	// the optional limit. Returns the number of deleted relationships. If a limit
+	// is provided and reached, the method will return true as the second return value.
+	// Otherwise, the boolean can be ignored.
 	DeleteRelationships(ctx context.Context, filter *v1.RelationshipFilter,
 		options ...options.DeleteOptionsOption,
-	) (bool, error)
+	) (uint64, bool, error)
 
 	// WriteNamespaces takes proto namespace definitions and persists them.
 	WriteNamespaces(ctx context.Context, newConfigs ...*core.NamespaceDefinition) error

--- a/pkg/datastore/test/watch.go
+++ b/pkg/datastore/test/watch.go
@@ -111,7 +111,7 @@ func WatchTest(t *testing.T, tester DatastoreTester) {
 			testUpdates = append(testUpdates, batch, []tuple.RelationshipUpdate{deleteUpdate})
 
 			_, err = ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-				_, err := rwt.DeleteRelationships(ctx, &v1.RelationshipFilter{
+				_, _, err := rwt.DeleteRelationships(ctx, &v1.RelationshipFilter{
 					ResourceType:     testResourceNamespace,
 					OptionalRelation: testReaderRelation,
 					OptionalSubjectFilter: &v1.SubjectFilter{

--- a/pkg/datastore/util.go
+++ b/pkg/datastore/util.go
@@ -28,7 +28,7 @@ func DeleteAllData(ctx context.Context, ds Datastore) error {
 		// Delete all relationships.
 		namespaceNames := make([]string, 0, len(nsDefs))
 		for _, nsDef := range nsDefs {
-			_, err = rwt.DeleteRelationships(ctx, &v1.RelationshipFilter{
+			_, _, err = rwt.DeleteRelationships(ctx, &v1.RelationshipFilter{
 				ResourceType: nsDef.Definition.Name,
 			})
 			if err != nil {


### PR DESCRIPTION
This will be added to the API in a followup