### PR TITLE
Fix default concurrency limit for bulk check API

### DIFF
--- a/internal/services/v1/bulkcheck.go
+++ b/internal/services/v1/bulkcheck.go
@@ -80,6 +80,10 @@ func (bc *bulkChecker) checkBulkPermissions(ctx context.Context, req *v1.CheckBu
 
 	bulkResponseMutex := sync.Mutex{}
 
+	spiceerrors.DebugAssert(func() bool {
+		return bc.maxConcurrency > 0
+	}, "max concurrency must be greater than 0 in bulk check")
+
 	tr := taskrunner.NewPreloadedTaskRunner(ctx, bc.maxConcurrency, len(groupedItems))
 
 	respMetadata := &dispatchv1.ResponseMeta{

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -118,6 +118,7 @@ func NewPermissionsServer(
 		MaxLookupResourcesLimit:         defaultIfZero(config.MaxLookupResourcesLimit, 1_000),
 		MaxBulkExportRelationshipsLimit: defaultIfZero(config.MaxBulkExportRelationshipsLimit, 100_000),
 		DispatchChunkSize:               defaultIfZero(config.DispatchChunkSize, 100),
+		MaxCheckBulkConcurrency:         defaultIfZero(config.MaxCheckBulkConcurrency, 50),
 		ExpiringRelationshipsEnabled:    true,
 	}
 


### PR DESCRIPTION
Before this change, the limit defaults to `0`, which sets it to serial, disallowing concurrent operations of the chunks within the bulk check