### PR TITLE
Decouple validation file schema compilation from yaml parsing

### DIFF
--- a/internal/datastore/proxy/schemacaching/types.go
+++ b/internal/datastore/proxy/schemacaching/types.go
@@ -1,6 +1,6 @@
 package schemacaching
 
-import "github.com/authzed/spicedb/pkg/schemadsl/compiler"
+import "github.com/authzed/spicedb/pkg/commonschemadsl"
 
 // *DefinitionSizeVTMultiplier are the mulitipliers to be used for
 // estimating the in-memory cost of a SchemaDefinition based on its
@@ -16,6 +16,6 @@ const (
 )
 
 type schemaDefinition interface {
-	compiler.SchemaDefinition
+	commonschemadsl.SchemaDefinition
 	SizeVT() int
 }

--- a/internal/graph/computed/computecheck_test.go
+++ b/internal/graph/computed/computecheck_test.go
@@ -941,11 +941,11 @@ func writeCaveatedTuples(ctx context.Context, _ *testing.T, ds datastore.Datasto
 	}
 
 	return ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-		if err := rwt.WriteNamespaces(ctx, compiled.ObjectDefinitions...); err != nil {
+		if err := rwt.WriteNamespaces(ctx, compiled.GetObjectDefinitions()...); err != nil {
 			return err
 		}
 
-		if err := rwt.WriteCaveats(ctx, compiled.CaveatDefinitions); err != nil {
+		if err := rwt.WriteCaveats(ctx, compiled.GetCaveatDefinitions()); err != nil {
 			return err
 		}
 

--- a/pkg/commonschemadsl/types.go
+++ b/pkg/commonschemadsl/types.go
@@ -1,0 +1,26 @@
+package commonschemadsl
+
+import (
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// SchemaDefinition represents an object or caveat definition in a schema.
+type SchemaDefinition interface {
+	proto.Message
+
+	GetName() string
+}
+
+// CompiledSchema is the result of compiling a schema when there are no errors.
+type CompiledSchema interface {
+	// GetObjectDefinitions holds the object definitions in the schema.
+	GetObjectDefinitions() []*core.NamespaceDefinition
+
+	// GetCaveatDefinitions holds the caveat definitions in the schema.
+	GetCaveatDefinitions() []*core.CaveatDefinition
+
+	// GetOrderedDefinitions holds the object and caveat definitions in the schema, in the
+	// order in which they were found.
+	GetOrderedDefinitions() []SchemaDefinition
+}

--- a/pkg/composableschemadsl/compiler/compiler.go
+++ b/pkg/composableschemadsl/compiler/compiler.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	"google.golang.org/protobuf/proto"
 	"k8s.io/utils/strings/slices"
 
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+	"github.com/authzed/spicedb/pkg/commonschemadsl"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/dslshape"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/input"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/parser"
@@ -24,13 +24,6 @@ type InputSchema struct {
 	SchemaString string
 }
 
-// SchemaDefinition represents an object or caveat definition in a schema.
-type SchemaDefinition interface {
-	proto.Message
-
-	GetName() string
-}
-
 // CompiledSchema is the result of compiling a schema when there are no errors.
 type CompiledSchema struct {
 	// ObjectDefinitions holds the object definitions in the schema.
@@ -41,10 +34,22 @@ type CompiledSchema struct {
 
 	// OrderedDefinitions holds the object and caveat definitions in the schema, in the
 	// order in which they were found.
-	OrderedDefinitions []SchemaDefinition
+	OrderedDefinitions []commonschemadsl.SchemaDefinition
 
 	rootNode *dslNode
 	mapper   input.PositionMapper
+}
+
+func (cs *CompiledSchema) GetObjectDefinitions() []*core.NamespaceDefinition {
+	return cs.ObjectDefinitions
+}
+
+func (cs *CompiledSchema) GetCaveatDefinitions() []*core.CaveatDefinition {
+	return cs.CaveatDefinitions
+}
+
+func (cs *CompiledSchema) GetOrderedDefinitions() []commonschemadsl.SchemaDefinition {
+	return cs.OrderedDefinitions
 }
 
 // SourcePositionToRunePosition converts a source position to a rune position.

--- a/pkg/composableschemadsl/compiler/compiler_test.go
+++ b/pkg/composableschemadsl/compiler/compiler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/authzed/spicedb/pkg/caveats"
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+	"github.com/authzed/spicedb/pkg/commonschemadsl"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/input"
 	"github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -28,7 +29,7 @@ func TestCompile(t *testing.T) {
 		objectPrefix  ObjectPrefixOption
 		input         string
 		expectedError string
-		expectedProto []SchemaDefinition
+		expectedProto []commonschemadsl.SchemaDefinition
 	}
 
 	tests := []compileTest{
@@ -37,14 +38,14 @@ func TestCompile(t *testing.T) {
 			withTenantPrefix,
 			"",
 			"",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"parse error",
 			withTenantPrefix,
 			"foo",
 			"parse error in `parse error`, line 1, column 1: Unexpected token at root level: TokenTypeIdentifier",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"nested parse error",
@@ -53,14 +54,14 @@ func TestCompile(t *testing.T) {
 				relation something: rela | relb + relc
 			}`,
 			"parse error in `nested parse error`, line 2, column 37: Expected end of statement or definition, found: TokenTypePlus",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"allows bypassing prefix requirement",
 			AllowUnprefixedObjectType(),
 			`definition def {}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("def"),
 			},
 		},
@@ -69,7 +70,7 @@ func TestCompile(t *testing.T) {
 			withTenantPrefix,
 			`definition def {}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/def"),
 			},
 		},
@@ -80,7 +81,7 @@ func TestCompile(t *testing.T) {
 				relation foo: bar;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foo", nil,
 						namespace.AllowedRelation("sometenant/bar", "..."),
@@ -99,7 +100,7 @@ func TestCompile(t *testing.T) {
 				...view_partial
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("user", nil,
 						namespace.AllowedRelation("sometenant/user", "..."),
@@ -127,7 +128,7 @@ func TestCompile(t *testing.T) {
 			}
 			`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/user"),
 				namespace.Namespace("sometenant/organization"),
 				namespace.Namespace("sometenant/resource",
@@ -161,7 +162,7 @@ func TestCompile(t *testing.T) {
 				relation user: user;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("user", nil,
 						namespace.AllowedRelation("sometenant/user", "..."),
@@ -186,7 +187,7 @@ func TestCompile(t *testing.T) {
 			}
 			`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("user", nil,
 						namespace.AllowedRelation("sometenant/user", "..."),
@@ -211,7 +212,7 @@ func TestCompile(t *testing.T) {
 			}
 			`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("user", nil,
 						namespace.AllowedRelation("sometenant/user", "..."),
@@ -236,7 +237,7 @@ func TestCompile(t *testing.T) {
 			}
 			`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("user", nil,
 						namespace.AllowedRelation("sometenant/user", "..."),
@@ -266,7 +267,7 @@ func TestCompile(t *testing.T) {
 			}
 			`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("user", nil,
 						namespace.AllowedRelation("sometenant/user", "..."),
@@ -294,7 +295,7 @@ func TestCompile(t *testing.T) {
 			}
 			`,
 			"could not resolve partials",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"definition reference to nonexistent partial",
@@ -305,7 +306,7 @@ func TestCompile(t *testing.T) {
 			}
 			`,
 			"could not find partial reference",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"definition with same name as partial",
@@ -319,7 +320,7 @@ func TestCompile(t *testing.T) {
 			}
 			`,
 			"found definition with same name as existing partial",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"caveat with same name as partial",
@@ -335,7 +336,7 @@ func TestCompile(t *testing.T) {
 			}
 			`,
 			"found caveat with same name as existing partial",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"definition reference to another definition errors",
@@ -348,7 +349,7 @@ func TestCompile(t *testing.T) {
 			}
 			`,
 			"could not find partial reference",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"explicit relation",
@@ -357,7 +358,7 @@ func TestCompile(t *testing.T) {
 				relation foos: bars#mehs;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos", nil,
 						namespace.AllowedRelation("sometenant/bars", "mehs"),
@@ -372,7 +373,7 @@ func TestCompile(t *testing.T) {
 				relation foos: bars:*
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos", nil,
 						namespace.AllowedPublicNamespace("sometenant/bars"),
@@ -387,7 +388,7 @@ func TestCompile(t *testing.T) {
 				relation foos: anothertenant/bars#mehs;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos", nil,
 						namespace.AllowedRelation("anothertenant/bars", "mehs"),
@@ -403,7 +404,7 @@ func TestCompile(t *testing.T) {
 				relation hello: there | world;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos", nil,
 						namespace.AllowedRelation("sometenant/bars", "mehs"),
@@ -424,7 +425,7 @@ func TestCompile(t *testing.T) {
 				relation viewer: user with somecaveat
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.MustCaveatDefinition(caveats.MustEnvForVariablesWithDefaultTypeSet(
 					map[string]caveattypes.VariableType{
 						"someparam": caveattypes.Default.IntType,
@@ -445,7 +446,7 @@ func TestCompile(t *testing.T) {
 				relation viewer: user with somecaveat | user
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("viewer", nil,
 						namespace.AllowedRelationWithCaveat("sometenant/user", "...",
@@ -462,7 +463,7 @@ func TestCompile(t *testing.T) {
 				relation viewer: user with somecaveat | user | team#member with anothercaveat
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("viewer", nil,
 						namespace.AllowedRelationWithCaveat("sometenant/user", "...",
@@ -481,7 +482,7 @@ func TestCompile(t *testing.T) {
 				permission foos = bars;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -498,7 +499,7 @@ func TestCompile(t *testing.T) {
 				permission foos = bars + bazs;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -516,7 +517,7 @@ func TestCompile(t *testing.T) {
 				permission foos = bars & bazs;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Intersection(
@@ -534,7 +535,7 @@ func TestCompile(t *testing.T) {
 				permission foos = bars - bazs;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Exclusion(
@@ -552,7 +553,7 @@ func TestCompile(t *testing.T) {
 				permission foos = bars + bazs + mehs;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -571,7 +572,7 @@ func TestCompile(t *testing.T) {
 				permission foos = bars + bazs - mehs;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/complex",
 					namespace.MustRelation("foos",
 						namespace.Exclusion(
@@ -594,7 +595,7 @@ func TestCompile(t *testing.T) {
 				permission foos = bars + (bazs - mehs);
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/complex",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -617,7 +618,7 @@ func TestCompile(t *testing.T) {
 				permission foos = bars->bazs
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/arrowed",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -636,7 +637,7 @@ func TestCompile(t *testing.T) {
 				permission foos = somerel->brel->crel
 			}`,
 			"parse error in `multiarrow permission`, line 3, column 23: Nested arrows not yet supported",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 
 		/*
@@ -648,7 +649,7 @@ func TestCompile(t *testing.T) {
 					permission foo = somerel->brel->crel
 				}`,
 				"",
-				[]SchemaDefinition{
+				[]commonschemadsl.SchemaDefinition{
 					namespace.Namespace("sometenant/arrowed",
 						namespace.MustRelation("foo",
 							namespace.Union(
@@ -667,7 +668,7 @@ func TestCompile(t *testing.T) {
 				permission foos = ((arel->brel) + nil) - drel
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/expressioned",
 					namespace.MustRelation("foos",
 						namespace.Exclusion(
@@ -693,7 +694,7 @@ func TestCompile(t *testing.T) {
 				permission fourth = bars->bazs
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/multiple",
 					namespace.MustRelation("first",
 						namespace.Union(
@@ -728,7 +729,7 @@ func TestCompile(t *testing.T) {
 				permission foos = aaaa + nil + bbbb;
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -745,14 +746,14 @@ func TestCompile(t *testing.T) {
 			nilPrefix,
 			`definition foos {}`,
 			"parse error in `no implicit tenant with unspecified tenant`, line 1, column 1: found reference `foos` without prefix",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"no implicit tenant with specified tenant",
 			nilPrefix,
 			`definition some_tenant/foos {}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("some_tenant/foos"),
 			},
 		},
@@ -763,14 +764,14 @@ func TestCompile(t *testing.T) {
 				relation somerel: bars
 			}`,
 			"parse error in `no implicit tenant with unspecified tenant on type ref`, line 2, column 23: found reference `bars` without prefix",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"invalid definition name",
 			nilPrefix,
 			`definition someTenant/fo {}`,
 			"parse error in `invalid definition name`, line 1, column 1: error in object definition someTenant/fo: invalid NamespaceDefinition.Name: value does not match regex pattern \"^([a-z][a-z0-9_]{1,62}[a-z0-9]/)*[a-z][a-z0-9_]{1,62}[a-z0-9]$\"",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"invalid relation name",
@@ -779,7 +780,7 @@ func TestCompile(t *testing.T) {
 				relation ab: some_tenant/foos
 			}`,
 			"parse error in `invalid relation name`, line 2, column 5: error in relation ab: invalid Relation.Name: value does not match regex pattern \"^[a-z][a-z0-9_]{1,62}[a-z0-9]$\"",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"no implicit tenant with specified tenant on type ref",
@@ -788,7 +789,7 @@ func TestCompile(t *testing.T) {
 				relation somerel: some_tenant/bars
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("some_tenant/foos",
 					namespace.MustRelation(
 						"somerel",
@@ -816,7 +817,7 @@ func TestCompile(t *testing.T) {
 				permission first = bars + bazs
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.WithComment("sometenant/user", `/**
 * user is a user
 */`),
@@ -840,7 +841,7 @@ func TestCompile(t *testing.T) {
 			`definition foo {}
 			definition foo {}`,
 			"parse error in `duplicate definition`, line 2, column 4: found name reused between multiple definitions and/or caveats: sometenant/foo",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"duplicate definitions across objects and caveats",
@@ -850,7 +851,7 @@ func TestCompile(t *testing.T) {
 			}
 			definition foo {}`,
 			"parse error in `duplicate definitions across objects and caveats`, line 4, column 4: found name reused between multiple definitions and/or caveats: sometenant/foo",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"caveat missing parameters",
@@ -859,7 +860,7 @@ func TestCompile(t *testing.T) {
 				someParam == 42
 			}`,
 			"parse error in `caveat missing parameters`, line 1, column 12: Unexpected token at root level: TokenTypeRightParen",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"caveat missing expression",
@@ -867,7 +868,7 @@ func TestCompile(t *testing.T) {
 			`caveat foo(someParam int) {
 			}`,
 			"Unexpected token at root level: TokenTypeRightBrace",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"caveat invalid parameter type",
@@ -876,7 +877,7 @@ func TestCompile(t *testing.T) {
 				someParam == 42
 			}`,
 			"parse error in `caveat invalid parameter type`, line 1, column 12: invalid type for caveat parameter `someParam` on caveat `foo`: unknown type `foobar`",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"caveat invalid parameter type",
@@ -885,7 +886,7 @@ func TestCompile(t *testing.T) {
 				someParam == 42
 			}`,
 			"unknown type `foobar`",
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"caveat missing parameter",
@@ -894,7 +895,7 @@ func TestCompile(t *testing.T) {
 				anotherParam == 42
 			}`,
 			`ERROR: sometenant/foo:2:5: undeclared reference to 'anotherParam'`,
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"caveat missing parameter on a different line",
@@ -904,7 +905,7 @@ func TestCompile(t *testing.T) {
 					anotherParam
 			}`,
 			`ERROR: sometenant/foo:3:6: undeclared reference to 'anotherParam'`,
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"caveat invalid expression type",
@@ -913,7 +914,7 @@ func TestCompile(t *testing.T) {
 				someParam
 			}`,
 			`caveat expression must result in a boolean value`,
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"caveat invalid expression",
@@ -922,7 +923,7 @@ func TestCompile(t *testing.T) {
 				someParam:{}
 			}`,
 			`ERROR: sometenant/foo:2:14: Syntax error: mismatched input ':'`,
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"caveat valid",
@@ -931,7 +932,7 @@ func TestCompile(t *testing.T) {
 				someParam == 42
 			}`,
 			``,
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.MustCaveatDefinition(caveats.MustEnvForVariablesWithDefaultTypeSet(
 					map[string]caveattypes.VariableType{
 						"someParam": caveattypes.Default.IntType,
@@ -947,7 +948,7 @@ func TestCompile(t *testing.T) {
 				someParam > 56 && anotherParam == "hi there" && 42 in thirdParam
 			}`,
 			``,
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.MustCaveatDefinition(caveats.MustEnvForVariablesWithDefaultTypeSet(
 					map[string]caveattypes.VariableType{
 						"someParam":    caveattypes.Default.IntType,
@@ -966,7 +967,7 @@ func TestCompile(t *testing.T) {
 				!user_ip.in_cidr('1.2.3.0')
 			}`,
 			``,
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.MustCaveatDefinition(caveats.MustEnvForVariablesWithDefaultTypeSet(
 					map[string]caveattypes.VariableType{
 						"user_ip": caveattypes.Default.IPAddressType,
@@ -982,7 +983,7 @@ func TestCompile(t *testing.T) {
 				someMap.isSubtreeOf(anotherMap)
 			}`,
 			``,
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.MustCaveatDefinition(caveats.MustEnvForVariablesWithDefaultTypeSet(
 					map[string]caveattypes.VariableType{
 						"someMap":    caveattypes.Default.MustMapType(caveattypes.Default.AnyType),
@@ -999,7 +1000,7 @@ func TestCompile(t *testing.T) {
 				permission foos = first + second + third + fourth
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -1019,7 +1020,7 @@ func TestCompile(t *testing.T) {
 				permission foos = first + second + (foo - bar) + fourth
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -1044,7 +1045,7 @@ func TestCompile(t *testing.T) {
 				permission foos = first & second & third & fourth
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Intersection(
@@ -1064,7 +1065,7 @@ func TestCompile(t *testing.T) {
 				permission foos = first - second - third - fourth
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Exclusion(
@@ -1092,7 +1093,7 @@ func TestCompile(t *testing.T) {
 				permission foos = (first + second) + (third + fourth)
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("someothertenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -1112,7 +1113,7 @@ func TestCompile(t *testing.T) {
 				permission foos = (first + second) + (third + fourth)
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/some_team/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -1132,7 +1133,7 @@ func TestCompile(t *testing.T) {
 				permission foos = (first + second) + (third + fourth)
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -1152,7 +1153,7 @@ func TestCompile(t *testing.T) {
 				permission foos = (first + second) + (middle & thing) + (third + fourth)
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -1178,7 +1179,7 @@ func TestCompile(t *testing.T) {
 				permission foos = first + second + (fourth & (sixth - seventh) & fifth) + third
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foos",
 						namespace.Union(
@@ -1209,7 +1210,7 @@ func TestCompile(t *testing.T) {
 				permission foo = bar.any(baz)
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foo",
 						namespace.Union(
@@ -1226,7 +1227,7 @@ func TestCompile(t *testing.T) {
 				permission foo = bar.all(baz)
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("foo",
 						namespace.Union(
@@ -1245,7 +1246,7 @@ func TestCompile(t *testing.T) {
 				relation viewer: user with expiration
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("viewer", nil,
 						namespace.AllowedRelationWithExpiration("sometenant/user", "..."),
@@ -1264,7 +1265,7 @@ func TestCompile(t *testing.T) {
 				relation viewer: user with expiration
 			}`,
 			`found duplicate use flag`,
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"expiration use without use expiration",
@@ -1274,7 +1275,7 @@ func TestCompile(t *testing.T) {
 				relation viewer: user with expiration
 			}`,
 			`expiration flag is not enabled`,
-			[]SchemaDefinition{},
+			[]commonschemadsl.SchemaDefinition{},
 		},
 		{
 			"relation with expiration trait and caveat",
@@ -1285,7 +1286,7 @@ func TestCompile(t *testing.T) {
 				relation viewer: user with somecaveat and expiration
 			}`,
 			"",
-			[]SchemaDefinition{
+			[]commonschemadsl.SchemaDefinition{
 				namespace.Namespace("sometenant/simple",
 					namespace.MustRelation("viewer", nil,
 						namespace.AllowedRelationWithCaveatAndExpiration("sometenant/user", "...", namespace.AllowedCaveat("sometenant/somecaveat")),

--- a/pkg/composableschemadsl/compiler/translator.go
+++ b/pkg/composableschemadsl/compiler/translator.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/authzed/spicedb/pkg/caveats"
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+	"github.com/authzed/spicedb/pkg/commonschemadsl"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/dslshape"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/input"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
@@ -59,7 +60,7 @@ func (tctx *translationContext) prefixedPath(definitionName string) (string, err
 const Ellipsis = "..."
 
 func translate(tctx *translationContext, root *dslNode) (*CompiledSchema, error) {
-	orderedDefinitions := make([]SchemaDefinition, 0, len(root.GetChildren()))
+	orderedDefinitions := make([]commonschemadsl.SchemaDefinition, 0, len(root.GetChildren()))
 	var objectDefinitions []*core.NamespaceDefinition
 	var caveatDefinitions []*core.CaveatDefinition
 

--- a/pkg/composableschemadsl/generator/generator.go
+++ b/pkg/composableschemadsl/generator/generator.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/authzed/spicedb/pkg/caveats"
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
-	"github.com/authzed/spicedb/pkg/composableschemadsl/compiler"
+	"github.com/authzed/spicedb/pkg/commonschemadsl"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	"github.com/authzed/spicedb/pkg/graph"
 	"github.com/authzed/spicedb/pkg/namespace"
@@ -25,11 +25,11 @@ const Ellipsis = "..."
 const MaxSingleLineCommentLength = 70 // 80 - the comment parts and some padding
 
 // GenerateSchema generates a DSL view of the given schema.
-func GenerateSchema(definitions []compiler.SchemaDefinition) (string, bool, error) {
+func GenerateSchema(definitions []commonschemadsl.SchemaDefinition) (string, bool, error) {
 	return GenerateSchemaWithCaveatTypeSet(definitions, caveattypes.Default.TypeSet)
 }
 
-func GenerateSchemaWithCaveatTypeSet(definitions []compiler.SchemaDefinition, caveatTypeSet *caveattypes.TypeSet) (string, bool, error) {
+func GenerateSchemaWithCaveatTypeSet(definitions []commonschemadsl.SchemaDefinition, caveatTypeSet *caveattypes.TypeSet) (string, bool, error) {
 	generated := make([]string, 0, len(definitions))
 	flags := mapz.NewSet[string]()
 

--- a/pkg/development/resolver.go
+++ b/pkg/development/resolver.go
@@ -70,7 +70,7 @@ type Resolver struct {
 
 // NewResolver creates a new resolver for the given schema.
 func NewResolver(compiledSchema *compiler.CompiledSchema) (*Resolver, error) {
-	resolver := schema.ResolverForCompiledSchema(*compiledSchema)
+	resolver := schema.ResolverForCompiledSchema(compiledSchema)
 	ts := schema.NewTypeSystem(resolver)
 	return &Resolver{schema: compiledSchema, typeSystem: ts}, nil
 }

--- a/pkg/development/schema.go
+++ b/pkg/development/schema.go
@@ -2,10 +2,13 @@ package development
 
 import (
 	"errors"
+	"github.com/authzed/spicedb/pkg/commonschemadsl"
 
 	"github.com/ccoveille/go-safecast"
 
 	log "github.com/authzed/spicedb/internal/logging"
+	composablecompiler "github.com/authzed/spicedb/pkg/composableschemadsl/compiler"
+	composableinput "github.com/authzed/spicedb/pkg/composableschemadsl/input"
 	devinterface "github.com/authzed/spicedb/pkg/proto/developer/v1"
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
@@ -14,41 +17,60 @@ import (
 // CompileSchema compiles a schema into its caveat and namespace definition(s), returning a developer
 // error if the schema could not be compiled. The non-developer error is returned only if an
 // internal errors occurred.
-func CompileSchema(schema string) (*compiler.CompiledSchema, *devinterface.DeveloperError, error) {
-	compiled, err := compiler.Compile(compiler.InputSchema{
+func CompileSchema(schema string) (commonschemadsl.CompiledSchema, *devinterface.DeveloperError, error) {
+	compiled, compilationErr := compiler.Compile(compiler.InputSchema{
 		Source:       input.Source("schema"),
 		SchemaString: schema,
 	}, compiler.AllowUnprefixedObjectType())
 
-	var contextError compiler.WithContextError
-	if errors.As(err, &contextError) {
-		line, col, lerr := contextError.SourceRange.Start().LineAndColumn()
-		if lerr != nil {
-			return nil, nil, lerr
-		}
-
-		// NOTE: zeroes are fine here on failure.
-		uintLine, err := safecast.ToUint32(line)
-		if err != nil {
-			log.Err(err).Msg("could not cast lineNumber to uint32")
-		}
-		uintColumn, err := safecast.ToUint32(col)
-		if err != nil {
-			log.Err(err).Msg("could not cast columnPosition to uint32")
-		}
-		return nil, &devinterface.DeveloperError{
-			Message: contextError.BaseMessage,
-			Kind:    devinterface.DeveloperError_SCHEMA_ISSUE,
-			Source:  devinterface.DeveloperError_SCHEMA,
-			Line:    uintLine + 1,   // 0-indexed in parser.
-			Column:  uintColumn + 1, // 0-indexed in parser.
-			Context: contextError.ErrorSourceCode,
-		}, nil
-	}
-
-	if err != nil {
-		return nil, nil, err
+	if compilationErr != nil {
+		devError, err := handleCompilationErrors(compilationErr)
+		return nil, devError, err
 	}
 
 	return compiled, nil, nil
+}
+
+// CompileComposableSchema Same as CompileSchema, but for composable schemas. Uses a different compiler.
+func CompileComposableSchema(schema string) (*composablecompiler.CompiledSchema, *devinterface.DeveloperError, error) {
+	compiled, compilationErr := composablecompiler.Compile(composablecompiler.InputSchema{
+		Source:       composableinput.Source("schema"),
+		SchemaString: schema,
+	}, composablecompiler.AllowUnprefixedObjectType())
+
+	if compilationErr != nil {
+		devError, err := handleCompilationErrors(compilationErr)
+		return nil, devError, err
+	}
+
+	return compiled, nil, nil
+}
+
+// Attempts to turn a compilation error into a DeveloperError that can be displayed
+// to the user
+func handleCompilationErrors(compilationErr error) (*devinterface.DeveloperError, error) {
+	var contextError compiler.WithContextError
+	if errors.As(compilationErr, &contextError) {
+		line, col, lerr := contextError.SourceRange.Start().LineAndColumn()
+		if lerr != nil {
+			return nil, lerr
+		}
+
+		// NOTE: zeroes are fine here on failure.
+		_, err := safecast.ToUint32(line)
+		if err != nil {
+			log.Err(err).Msg("could not cast lineNumber to uint32")
+		}
+		_, err := safecast.ToUint32(col)
+		if err != nil {
+			log.Err(err).Msg("could not cast columnPosition to uint32")
+		}
+		return &devinterface.DeveloperError{
+			Message: contextError.BaseCompilerError.BaseMessage,
+			Kind:    devinterface.DeveloperError_SCHEMA_ISSUE,
+			Source:  devinterface.DeveloperError_SCHEMA,
+			Context: contextError.ErrorSourceCode,
+		}, nil
+	}
+	return nil, compilationErr
 }

--- a/pkg/development/warnings.go
+++ b/pkg/development/warnings.go
@@ -61,10 +61,10 @@ func warningForPosition(warningName string, message string, sourceCode string, s
 // GetWarnings returns a list of warnings for the given developer context.
 func GetWarnings(ctx context.Context, devCtx *DevContext) ([]*devinterface.DeveloperWarning, error) {
 	warnings := []*devinterface.DeveloperWarning{}
-	res := schema.ResolverForCompiledSchema(*devCtx.CompiledSchema)
+	res := schema.ResolverForCompiledSchema(devCtx.CompiledSchema)
 	ts := schema.NewTypeSystem(res)
 
-	for _, def := range devCtx.CompiledSchema.ObjectDefinitions {
+ 	for _, def := range devCtx.CompiledSchema.GetObjectDefinitions() {
 		found, err := addDefinitionWarnings(ctx, def, ts)
 		if err != nil {
 			return nil, err

--- a/pkg/diff/namespace/diffexpr_test.go
+++ b/pkg/diff/namespace/diffexpr_test.go
@@ -173,5 +173,5 @@ func parseUsersetRewrite(s string) (*core.UsersetRewrite, error) {
 		return nil, err
 	}
 
-	return compiled.ObjectDefinitions[0].Relation[0].UsersetRewrite, nil
+	return compiled.GetObjectDefinitions()[0].Relation[0].UsersetRewrite, nil
 }

--- a/pkg/schema/arrows_test.go
+++ b/pkg/schema/arrows_test.go
@@ -85,11 +85,11 @@ func TestLookupTuplesetArrows(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			res := ResolverForCompiledSchema(*schema)
+			res := ResolverForCompiledSchema(schema)
 			arrowSet, err := buildArrowSet(context.Background(), res)
 			require.NoError(t, err)
 
-			for _, resource := range schema.ObjectDefinitions {
+			for _, resource := range schema.GetObjectDefinitions() {
 				for _, relation := range resource.Relation {
 					arrows := arrowSet.LookupTuplesetArrows(resource.Name, relation.Name)
 					require.NotNil(t, arrows)
@@ -177,7 +177,7 @@ func TestAllReachableRelations(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			res := ResolverForCompiledSchema(*schema)
+			res := ResolverForCompiledSchema(schema)
 			arrows, err := buildArrowSet(context.Background(), res)
 			require.NoError(t, err)
 

--- a/pkg/schema/compiled_schema_resolver.go
+++ b/pkg/schema/compiled_schema_resolver.go
@@ -3,8 +3,8 @@ package schema
 import (
 	"context"
 
+	"github.com/authzed/spicedb/pkg/commonschemadsl"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 )
 
 // FullSchemaResolver is a superset of a resolver that knows how to retrieve all definitions
@@ -17,11 +17,11 @@ type FullSchemaResolver interface {
 // CompiledSchemaResolver is a resolver for a fully compiled schema. It implements FullSchemaResolver,
 // as it has the full context of the schema.
 type CompiledSchemaResolver struct {
-	schema compiler.CompiledSchema
+	schema commonschemadsl.CompiledSchema
 }
 
 // ResolverForCompiledSchema builds a resolver from a compiled schema.
-func ResolverForCompiledSchema(schema compiler.CompiledSchema) *CompiledSchemaResolver {
+func ResolverForCompiledSchema(schema commonschemadsl.CompiledSchema) *CompiledSchemaResolver {
 	return &CompiledSchemaResolver{
 		schema: schema,
 	}
@@ -31,7 +31,7 @@ var _ FullSchemaResolver = &CompiledSchemaResolver{}
 
 // LookupDefinition lookups up a namespace, also returning whether it was pre-validated.
 func (c CompiledSchemaResolver) LookupDefinition(ctx context.Context, name string) (*core.NamespaceDefinition, bool, error) {
-	for _, o := range c.schema.ObjectDefinitions {
+	for _, o := range c.schema.GetObjectDefinitions() {
 		if o.GetName() == name {
 			return o, false, nil
 		}
@@ -41,7 +41,7 @@ func (c CompiledSchemaResolver) LookupDefinition(ctx context.Context, name strin
 
 // LookupCaveat lookups up a caveat.
 func (c CompiledSchemaResolver) LookupCaveat(ctx context.Context, name string) (*Caveat, error) {
-	for _, v := range c.schema.CaveatDefinitions {
+	for _, v := range c.schema.GetCaveatDefinitions() {
 		if v.GetName() == name {
 			return v, nil
 		}
@@ -52,8 +52,8 @@ func (c CompiledSchemaResolver) LookupCaveat(ctx context.Context, name string) (
 // AllDefinitionNames returns a list of all the names of defined namespaces for this resolved schema.
 // Every definition is a valid parameter for LookupDefinition
 func (c CompiledSchemaResolver) AllDefinitionNames() []string {
-	out := make([]string, len(c.schema.ObjectDefinitions))
-	for i, o := range c.schema.ObjectDefinitions {
+	out := make([]string, len(c.schema.GetObjectDefinitions()))
+	for i, o := range c.schema.GetObjectDefinitions() {
 		out[i] = o.GetName()
 	}
 	return out

--- a/pkg/schema/definition_test.go
+++ b/pkg/schema/definition_test.go
@@ -960,11 +960,11 @@ func TestTypeSystemAccessors(t *testing.T) {
 
 			reader := ds.SnapshotReader(lastRevision)
 			resolver := ResolverForDatastoreReader(reader).WithPredefinedElements(PredefinedElements{
-				Definitions: compiled.ObjectDefinitions,
-				Caveats:     compiled.CaveatDefinitions,
+				Definitions: compiled.GetObjectDefinitions(),
+				Caveats:     compiled.GetCaveatDefinitions(),
 			})
 			ts := NewTypeSystem(resolver)
-			for _, nsDef := range compiled.ObjectDefinitions {
+			for _, nsDef := range compiled.GetObjectDefinitions() {
 				vts, err := ts.GetValidatedDefinition(ctx, nsDef.GetName())
 				require.NoError(err)
 

--- a/pkg/schema/full_reachability_test.go
+++ b/pkg/schema/full_reachability_test.go
@@ -299,11 +299,11 @@ func TestRelationsReferencing(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			res := ResolverForCompiledSchema(*schema)
+			res := ResolverForCompiledSchema(schema)
 			graph, err := BuildGraph(context.Background(), res)
 			require.NoError(t, err)
 
-			for _, resource := range schema.ObjectDefinitions {
+			for _, resource := range schema.GetObjectDefinitions() {
 				for _, relation := range resource.Relation {
 					references := graph.RelationsReferencing(resource.Name, relation.Name)
 					rel := resource.Name + "#" + relation.Name
@@ -355,7 +355,7 @@ func BenchmarkRelationsReferencing(b *testing.B) {
 	}, compiler.AllowUnprefixedObjectType())
 	require.NoError(b, err)
 
-	res := ResolverForCompiledSchema(*schema)
+	res := ResolverForCompiledSchema(schema)
 	graph, err := BuildGraph(context.Background(), res)
 	require.NoError(b, err)
 

--- a/pkg/schema/reachabilitygraph_test.go
+++ b/pkg/schema/reachabilitygraph_test.go
@@ -220,7 +220,7 @@ func TestRelationsEncounteredForSubject(t *testing.T) {
 
 			// Write the schema.
 			_, err = ds.ReadWriteTx(context.Background(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
-				for _, nsDef := range compiled.ObjectDefinitions {
+				for _, nsDef := range compiled.GetObjectDefinitions() {
 					if err := tx.WriteNamespaces(ctx, nsDef); err != nil {
 						return err
 					}
@@ -240,7 +240,7 @@ func TestRelationsEncounteredForSubject(t *testing.T) {
 
 			rg := vts.Reachability()
 
-			relations, err := rg.RelationsEncounteredForSubject(ctx, compiled.ObjectDefinitions, &core.RelationReference{
+			relations, err := rg.RelationsEncounteredForSubject(ctx, compiled.GetObjectDefinitions(), &core.RelationReference{
 				Namespace: tc.subjectType,
 				Relation:  tc.relation,
 			})
@@ -589,7 +589,7 @@ func TestRelationsEncounteredForResource(t *testing.T) {
 
 			// Write the schema.
 			_, err = ds.ReadWriteTx(context.Background(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
-				for _, nsDef := range compiled.ObjectDefinitions {
+				for _, nsDef := range compiled.GetObjectDefinitions() {
 					if err := tx.WriteNamespaces(ctx, nsDef); err != nil {
 						return err
 					}
@@ -1204,10 +1204,10 @@ func TestReachabilityGraph(t *testing.T) {
 			reader := ds.SnapshotReader(lastRevision)
 
 			var rdef *ValidatedDefinition
-			for _, nsDef := range compiled.ObjectDefinitions {
+			for _, nsDef := range compiled.GetObjectDefinitions() {
 				resolver := ResolverForDatastoreReader(reader).WithPredefinedElements(PredefinedElements{
-					Definitions: compiled.ObjectDefinitions,
-					Caveats:     compiled.CaveatDefinitions,
+					Definitions: compiled.GetObjectDefinitions(),
+					Caveats:     compiled.GetCaveatDefinitions(),
 				})
 				ts := NewTypeSystem(resolver)
 

--- a/pkg/schemadsl/compiler/development.go
+++ b/pkg/schemadsl/compiler/development.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"github.com/authzed/spicedb/pkg/schemadsl/dslshape"
+	"github.com/authzed/spicedb/pkg/commonschemadsl"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
 )
 
@@ -54,7 +55,7 @@ func (nc *NodeChain) String() string {
 }
 
 // PositionToAstNodeChain returns the AST node, and its parents (if any), found at the given position in the source, if any.
-func PositionToAstNodeChain(schema *CompiledSchema, source input.Source, position input.Position) (*NodeChain, error) {
+func PositionToAstNodeChain(schema commonschemadsl.CompiledSchema, source input.Source, position input.Position) (*NodeChain, error) {
 	rootSource, err := schema.rootNode.GetString(dslshape.NodePredicateSource)
 	if err != nil {
 		return nil, err

--- a/pkg/schemadsl/compiler/translator.go
+++ b/pkg/schemadsl/compiler/translator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/authzed/spicedb/pkg/caveats"
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+	"github.com/authzed/spicedb/pkg/commonschemadsl"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	"github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -48,14 +49,14 @@ func (tctx *translationContext) prefixedPath(definitionName string) (string, err
 const Ellipsis = "..."
 
 func translate(tctx *translationContext, root *dslNode) (*CompiledSchema, error) {
-	orderedDefinitions := make([]SchemaDefinition, 0, len(root.GetChildren()))
+	orderedDefinitions := make([]commonschemadsl.SchemaDefinition, 0, len(root.GetChildren()))
 	var objectDefinitions []*core.NamespaceDefinition
 	var caveatDefinitions []*core.CaveatDefinition
 
 	names := mapz.NewSet[string]()
 
 	for _, definitionNode := range root.GetChildren() {
-		var definition SchemaDefinition
+		var definition commonschemadsl.SchemaDefinition
 
 		switch definitionNode.GetType() {
 		case dslshape.NodeTypeUseFlag:

--- a/pkg/schemadsl/generator/generator.go
+++ b/pkg/schemadsl/generator/generator.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/authzed/spicedb/pkg/caveats"
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+	"github.com/authzed/spicedb/pkg/commonschemadsl"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	"github.com/authzed/spicedb/pkg/graph"
 	"github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
@@ -24,12 +24,12 @@ const Ellipsis = "..."
 // MaxSingleLineCommentLength sets the maximum length for a comment to made single line.
 const MaxSingleLineCommentLength = 70 // 80 - the comment parts and some padding
 
-func GenerateSchema(definitions []compiler.SchemaDefinition) (string, bool, error) {
+func GenerateSchema(definitions []commonschemadsl.SchemaDefinition) (string, bool, error) {
 	return GenerateSchemaWithCaveatTypeSet(definitions, caveattypes.Default.TypeSet)
 }
 
 // GenerateSchemaWithCaveatTypeSet generates a DSL view of the given schema.
-func GenerateSchemaWithCaveatTypeSet(definitions []compiler.SchemaDefinition, caveatTypeSet *caveattypes.TypeSet) (string, bool, error) {
+func GenerateSchemaWithCaveatTypeSet(definitions []commonschemadsl.SchemaDefinition, caveatTypeSet *caveattypes.TypeSet) (string, bool, error) {
 	generated := make([]string, 0, len(definitions))
 	flags := mapz.NewSet[string]()
 

--- a/pkg/schemadsl/generator/generator_test.go
+++ b/pkg/schemadsl/generator/generator_test.go
@@ -407,7 +407,7 @@ definition document {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(err)
 
-			source, _, err := GenerateSchema(compiled.OrderedDefinitions)
+			source, _, err := GenerateSchema(compiled.GetOrderedDefinitions())
 			require.NoError(err)
 			require.Equal(test.expected, source)
 		})

--- a/pkg/schemautil/schemautil.go
+++ b/pkg/schemautil/schemautil.go
@@ -7,18 +7,18 @@ import (
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
+	"github.com/authzed/spicedb/pkg/commonschemadsl"
 )
 
 // ValidateSchemaChanges validates the schema found in the compiled schema and returns a
 // ValidatedSchemaChanges, if fully validated.
-func ValidateSchemaChanges(ctx context.Context, compiled *compiler.CompiledSchema, isAdditiveOnly bool) (*shared.ValidatedSchemaChanges, error) {
+func ValidateSchemaChanges(ctx context.Context, compiled commonschemadsl.CompiledSchema, isAdditiveOnly bool) (*shared.ValidatedSchemaChanges, error) {
 	return ValidateSchemaChangesWithCaveatTypeSet(ctx, compiled, caveattypes.Default.TypeSet, isAdditiveOnly)
 }
 
 func ValidateSchemaChangesWithCaveatTypeSet(
 	ctx context.Context,
-	compiled *compiler.CompiledSchema,
+	compiled commonschemadsl.CompiledSchema,
 	caveatTypeSet *caveattypes.TypeSet,
 	isAdditiveOnly bool,
 ) (*shared.ValidatedSchemaChanges, error) {

--- a/pkg/validationfile/schema_test.go
+++ b/pkg/validationfile/schema_test.go
@@ -58,7 +58,7 @@ func TestParseSchema(t *testing.T) {
 				require.Nil(t, err)
 				if tt.expectedDefCount > 0 {
 					require.NotNil(t, compiled)
-					require.Equal(t, tt.expectedDefCount, len(compiled.OrderedDefinitions))
+					require.Equal(t, tt.expectedDefCount, len(compiled.GetOrderedDefinitions()))
 					require.Equal(t, tt.contents, schemaWithPosition.Schema)
 				}
 			}


### PR DESCRIPTION
## Description
Part of making it possible to run `zed validate` on files that use composable schema syntax. In order to have different compilation behaviors in different cases, we need to not run the compilation as a part of yaml parsing. This implements that.

## Changes
Will annotate.

## Testing
Review. See that things are green.