### PR TITLE
Reattach child contexts to the parent for streaming dispatch

### DIFF
--- a/internal/dispatch/remote/cluster.go
+++ b/internal/dispatch/remote/cluster.go
@@ -423,7 +423,7 @@ func dispatchStreamingRequest[Q requestMessage, R responseMessage](
 		log.Debug().Str("dispatcher", name).Msg("running secondary dispatcher")
 		defer wg.Done()
 
-		clientCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cr.dispatchOverallTimeout)
+		clientCtx, cancel := context.WithTimeout(ctx, cr.dispatchOverallTimeout)
 		defer cancel()
 
 		var startTime time.Time


### PR DESCRIPTION
Ensure child streaming dispatches are canceled when the parent context is canceled, as this will be necessary for hedging