### PR TITLE
[schema] fix automatic validation if the source is pre-validated

### DIFF
--- a/pkg/schema/definition_test.go
+++ b/pkg/schema/definition_test.go
@@ -440,12 +440,15 @@ func TestDefinition(t *testing.T) {
 
 			ts := NewTypeSystem(resolver)
 
-			_, terr := ts.GetValidatedDefinition(ctx, tc.toCheck.GetName())
+			def, gerr := ts.GetDefinition(ctx, tc.toCheck.GetName())
+			require.NoError(gerr)
+
+			_, verr := def.Validate(ctx)
 			if tc.expectedError == "" {
-				require.NoError(terr)
+				require.NoError(verr)
 			} else {
-				require.Error(terr)
-				require.Equal(tc.expectedError, terr.Error())
+				require.Error(verr)
+				require.Equal(tc.expectedError, verr.Error())
 			}
 		})
 	}

--- a/pkg/schema/typesystem.go
+++ b/pkg/schema/typesystem.go
@@ -16,33 +16,41 @@ type (
 // TypeSystem is a cache and view into an entire combined schema of type definitions and caveats.
 // It also provides accessors to build reachability graphs for the underlying types.
 type TypeSystem struct {
-	definitions        map[string]*Definition
-	resolver           Resolver
-	wildcardCheckCache map[string]*WildcardTypeReference
+	validatedDefinitions map[string]*ValidatedDefinition
+	resolver             Resolver
+	wildcardCheckCache   map[string]*WildcardTypeReference
 }
 
 // NewTypeSystem builds a TypeSystem object from a resolver, which can look up the definitions.
 func NewTypeSystem(resolver Resolver) *TypeSystem {
 	return &TypeSystem{
-		definitions:        make(map[string]*Definition),
-		resolver:           resolver,
-		wildcardCheckCache: nil,
+		validatedDefinitions: make(map[string]*ValidatedDefinition),
+		resolver:             resolver,
+		wildcardCheckCache:   nil,
 	}
 }
 
 // GetDefinition looks up and returns a definition struct.
 func (ts *TypeSystem) GetDefinition(ctx context.Context, definition string) (*Definition, error) {
-	if v, ok := ts.definitions[definition]; ok {
-		return v, nil
+	v, _, err := ts.getDefinition(ctx, definition)
+	return v, err
+}
+
+// getDefinition is an internal helper for GetDefinition and GetValidatedDefinition
+func (ts *TypeSystem) getDefinition(ctx context.Context, definition string) (*Definition, bool, error) {
+	if v, ok := ts.validatedDefinitions[definition]; ok {
+		return v.Definition, true, nil
 	}
-	ns, _, err := ts.resolver.LookupDefinition(ctx, definition)
+	ns, prevalidated, err := ts.resolver.LookupDefinition(ctx, definition)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	d, err := NewDefinition(ts, ns)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	ts.definitions[definition] = d
-	return d, nil
+	if prevalidated {
+		ts.validatedDefinitions[definition] = &ValidatedDefinition{Definition: d}
+	}
+	return d, prevalidated, nil
 }

--- a/pkg/schema/typesystem_test.go
+++ b/pkg/schema/typesystem_test.go
@@ -1,0 +1,52 @@
+package schema
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/authzed/spicedb/pkg/caveats"
+	ns "github.com/authzed/spicedb/pkg/namespace"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeSystemConcurrency(t *testing.T) {
+	emptyEnv := caveats.NewEnvironment()
+	setup := &PredefinedElements{
+		Definitions: []*core.NamespaceDefinition{
+			ns.Namespace(
+				"document",
+				ns.MustRelation("viewer", nil,
+					ns.AllowedRelationWithExpiration("user", "..."),
+					ns.AllowedRelationWithCaveat("user", "...", ns.AllowedCaveat("definedcaveat")),
+				),
+			),
+			ns.Namespace("user"),
+			ns.Namespace("team",
+				ns.MustRelation("member", nil),
+			),
+		},
+		Caveats: []*core.CaveatDefinition{
+			ns.MustCaveatDefinition(emptyEnv, "definedcaveat", "1 == 2"),
+		},
+	}
+
+	var wg sync.WaitGroup
+	ctx := context.Background()
+	ts := NewTypeSystem(ResolverForPredefinedDefinitions(*setup))
+	require := require.New(t)
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			for range 20 {
+				for _, n := range []string{"document", "user", "team"} {
+					_, err := ts.GetValidatedDefinition(ctx, n)
+					require.NoError(err)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/schema/typesystem_test.go
+++ b/pkg/schema/typesystem_test.go
@@ -5,10 +5,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/authzed/spicedb/pkg/caveats"
 	ns "github.com/authzed/spicedb/pkg/namespace"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTypeSystemConcurrency(t *testing.T) {

--- a/pkg/schema/typesystem_validation.go
+++ b/pkg/schema/typesystem_validation.go
@@ -14,11 +14,19 @@ import (
 
 // GetValidatedDefinition runs validation on the type system for the definition to ensure it is consistent.
 func (ts *TypeSystem) GetValidatedDefinition(ctx context.Context, definition string) (*ValidatedDefinition, error) {
-	def, err := ts.GetDefinition(ctx, definition)
+	def, validated, err := ts.getDefinition(ctx, definition)
 	if err != nil {
 		return nil, err
 	}
-	return def.Validate(ctx)
+	if validated {
+		return &ValidatedDefinition{Definition: def}, nil
+	}
+	vdef, err := def.Validate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ts.validatedDefinitions[definition] = vdef
+	return vdef, nil
 }
 
 func (def *Definition) Validate(ctx context.Context) (*ValidatedDefinition, error) {
@@ -27,7 +35,7 @@ func (def *Definition) Validate(ctx context.Context) (*ValidatedDefinition, erro
 
 		// Validate the usersets's.
 		usersetRewrite := relation.GetUsersetRewrite()
-		rerr, err := graph.WalkRewrite(usersetRewrite, func(childOneof *core.SetOperation_Child) (interface{}, error) {
+		rerr, err := graph.WalkRewrite(usersetRewrite, func(childOneof *core.SetOperation_Child) (any, error) {
 			switch child := childOneof.ChildType.(type) {
 			case *core.SetOperation_Child_ComputedUserset:
 				relationName := child.ComputedUserset.GetRelation()

--- a/pkg/schema/typesystem_validation.go
+++ b/pkg/schema/typesystem_validation.go
@@ -25,7 +25,11 @@ func (ts *TypeSystem) GetValidatedDefinition(ctx context.Context, definition str
 	if err != nil {
 		return nil, err
 	}
-	ts.validatedDefinitions[definition] = vdef
+	ts.Lock()
+	defer ts.Unlock()
+	if _, ok := ts.validatedDefinitions[definition]; !ok {
+		ts.validatedDefinitions[definition] = vdef
+	}
 	return vdef, nil
 }
 


### PR DESCRIPTION
Cache only definitions that are validated. If it's coming from a datastore, it's pre-validated; if it's local it may not be. This allows us to skip validating if we've already done the work.