### PR TITLE
goreleaser-windows: fix deprecated option and update copyright year

### DIFF
--- a/.goreleaser.windows.yml
+++ b/.goreleaser.windows.yml
@@ -25,7 +25,7 @@ archives:
       - "completions/*"
     format_overrides:
       - goos: "windows"
-        format: "zip"
+        formats: ["zip"]
 
 chocolateys:
   - name: "spicedb"
@@ -35,7 +35,7 @@ chocolateys:
     project_url: "https://github.com/authzed/spicedb"
     url_template: "https://github.com/authzed/spicedb/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     icon_url: "https://authzed.com/favicon.svg"
-    copyright: "2024 AuthZed, Inc"
+    copyright: "2025 AuthZed, Inc"
     authors: "SpiceDB Contributors"
     license_url: "https://github.com/authzed/spicedb/blob/main/LICENSE"
     project_source_url: "https://github.com/authzed/spicedb"


### PR DESCRIPTION
Was looking for the config for chocolatey when found this, `format` is deprecated as per [deprecation notices](https://goreleaser.com/deprecations/#archivesformat_overridesformat), also updates copyright year, just a small nit here.