### PR TITLE
Have revision errors only log at debug level

### DIFF
--- a/internal/datastore/postgres/common/pgx.go
+++ b/internal/datastore/postgres/common/pgx.go
@@ -73,9 +73,10 @@ func ConfigurePGXLogger(connConfig *pgx.ConnConfig) {
 			truncateLargeSQL(data)
 
 			// log cancellation and serialization errors at debug level
+			// log revision not available errors at debug level
 			if errArg, ok := data["err"]; ok {
 				err, ok := errArg.(error)
-				if ok && (common.IsCancellationError(err) || IsSerializationError(err)) {
+				if ok && (common.IsCancellationError(err) || IsSerializationError(err) || IsReplicationLagError(err)) {
 					logger.Log(ctx, tracelog.LogLevelDebug, msg, data)
 					return
 				}

--- a/internal/datastore/postgres/strictreader_test.go
+++ b/internal/datastore/postgres/strictreader_test.go
@@ -45,7 +45,7 @@ func TestStrictReaderDetectsLagErrors(t *testing.T) {
 		},
 		{
 			name: "missing revision on replica - invalid argument",
-			in:   &pgconn.PgError{Code: pgInvalidArgument, Message: "is in the future"},
+			in:   &pgconn.PgError{Code: "22023", Message: "is in the future"},
 			want: common.RevisionUnavailableError{},
 		},
 		{


### PR DESCRIPTION
These errors are "expected" when read replicas are enabled, and they are cluttering the logs at "error" level