### PR TITLE
remove deprecated tenv linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,10 +37,10 @@ linters:
     - 'rowserrcheck'
     - 'staticcheck'
     - 'stylecheck'
-    - 'tenv'
     - 'typecheck'
     - 'unconvert'
     - 'unused'
+    - 'usetesting'
     - 'wastedassign'
     - 'whitespace'
 issues:

--- a/internal/services/integrationtesting/cert_test.go
+++ b/internal/services/integrationtesting/cert_test.go
@@ -46,8 +46,7 @@ func TestCertRotation(t *testing.T) {
 		waitFactor = 2
 	)
 
-	certDir, err := os.MkdirTemp("", "test-certs-")
-	require.NoError(t, err)
+	certDir := t.TempDir()
 
 	ca := &x509.Certificate{
 		NotBefore:             time.Now(),

--- a/pkg/cmd/datastore/datastore_test.go
+++ b/pkg/cmd/datastore/datastore_test.go
@@ -35,7 +35,7 @@ func TestLoadDatastoreFromFileContents(t *testing.T) {
 }
 
 func TestLoadDatastoreFromFile(t *testing.T) {
-	file, err := os.CreateTemp("", "")
+	file, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 	_, err = file.Write([]byte("schema: definition user{}"))
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestLoadDatastoreFromFile(t *testing.T) {
 }
 
 func TestLoadDatastoreFromFileAndContents(t *testing.T) {
-	file, err := os.CreateTemp("", "")
+	file, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 	_, err = file.Write([]byte("schema: definition repository{}"))
 	require.NoError(t, err)

--- a/pkg/cmd/termination/termination_test.go
+++ b/pkg/cmd/termination/termination_test.go
@@ -17,7 +17,7 @@ func TestPublishError(t *testing.T) {
 	cmd := cobra.Command{}
 	RegisterFlags(cmd.Flags())
 
-	f, err := os.CreateTemp("", "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 	filePath := f.Name()
 	cmd.Flag(terminationLogFlagName).Value = newStringValue(filePath, &filePath)


### PR DESCRIPTION
Addresses this:

```
[17:04:58] ~/Documents/GitHub/spicedb (main) $ mage lint:golangcilint
running golangci-lint
WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature in another linter. Replaced by usetesting. 
```