### PR TITLE
Change PG and CRDB datastore drivers to use PGX cancelation

### DIFF
--- a/internal/datastore/common/gc_test.go
+++ b/internal/datastore/common/gc_test.go
@@ -19,9 +19,10 @@ import (
 // Fake garbage collector that returns a new incremented revision each time
 // TxIDBefore is called.
 type fakeGC struct {
-	lock         sync.RWMutex
-	deleter      gcDeleter // GUARDED_BY(lock)
+	lock sync.RWMutex
+
 	metrics      gcMetrics // GUARDED_BY(lock)
+	deleter      gcDeleter // GUARDED_BY(lock)
 	lastRevision uint64    // GUARDED_BY(lock)
 	wasLocked    bool      // GUARDED_BY(lock)
 	wasUnlocked  bool      // GUARDED_BY(lock)
@@ -29,15 +30,58 @@ type fakeGC struct {
 
 type gcMetrics struct {
 	deleteBeforeTxCount    int
-	markedCompleteCount    int
-	resetGCCompletedCount  int
 	deleteExpiredRelsCount int
 }
 
-func newFakeGC(deleter gcDeleter) fakeGC {
-	return fakeGC{
-		lastRevision: 0,
-		deleter:      deleter,
+type fakeGCStore struct {
+	lock sync.RWMutex
+
+	markedCompleteCount   int // GUARDED_BY(lock)
+	resetGCCompletedCount int // GUARDED_BY(lock)
+
+	fakeGC *fakeGC
+}
+
+func (f *fakeGCStore) BuildGarbageCollector(ctx context.Context) (GarbageCollector, error) {
+	return f.fakeGC, nil
+}
+
+func (f *fakeGCStore) ReadyState(context.Context) (datastore.ReadyState, error) {
+	return datastore.ReadyState{
+		IsReady: true,
+	}, nil
+}
+
+func (f *fakeGCStore) HasGCRun() bool {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	return f.markedCompleteCount > 0
+}
+
+func (f *fakeGCStore) MarkGCCompleted() {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	f.markedCompleteCount++
+}
+
+func (f *fakeGCStore) ResetGCCompleted() {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	f.resetGCCompletedCount++
+}
+
+func newFakeGCStore(deleter gcDeleter) *fakeGCStore {
+	return &fakeGCStore{
+		sync.RWMutex{},
+		0,
+		0,
+		&fakeGC{
+			lastRevision: 0,
+			deleter:      deleter,
+		},
 	}
 }
 
@@ -55,13 +99,6 @@ func (gc *fakeGC) UnlockAfterGCRun() error {
 
 	gc.wasUnlocked = true
 	return nil
-}
-
-func (*fakeGC) ReadyState(_ context.Context) (datastore.ReadyState, error) {
-	return datastore.ReadyState{
-		Message: "Ready",
-		IsReady: true,
-	}, nil
 }
 
 func (*fakeGC) Now(_ context.Context) (time.Time, error) {
@@ -99,33 +136,16 @@ func (gc *fakeGC) DeleteExpiredRels(_ context.Context) (int64, error) {
 	return gc.deleter.DeleteExpiredRels()
 }
 
-func (gc *fakeGC) HasGCRun() bool {
-	gc.lock.Lock()
-	defer gc.lock.Unlock()
-
-	return gc.metrics.markedCompleteCount > 0
-}
-
-func (gc *fakeGC) MarkGCCompleted() {
-	gc.lock.Lock()
-	defer gc.lock.Unlock()
-
-	gc.metrics.markedCompleteCount++
-}
-
-func (gc *fakeGC) ResetGCCompleted() {
-	gc.lock.Lock()
-	defer gc.lock.Unlock()
-
-	gc.metrics.resetGCCompletedCount++
-}
-
 func (gc *fakeGC) GetMetrics() gcMetrics {
 	gc.lock.Lock()
 	defer gc.lock.Unlock()
 
 	return gc.metrics
 }
+
+func (gc *fakeGC) Close() {}
+
+var _ GarbageCollector = &fakeGC{}
 
 // Allows specifying different deletion behaviors for tests
 type gcDeleter interface {
@@ -169,8 +189,8 @@ func TestGCFailureBackoff(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		gc := newFakeGC(alwaysErrorDeleter{})
-		require.Error(t, startGarbageCollectorWithMaxElapsedTime(ctx, &gc, 100*time.Millisecond, 1*time.Second, 1*time.Nanosecond, 1*time.Minute, localCounter))
+		gc := newFakeGCStore(alwaysErrorDeleter{})
+		require.Error(t, startGarbageCollectorWithMaxElapsedTime(ctx, gc, 100*time.Millisecond, 1*time.Second, 1*time.Nanosecond, 1*time.Minute, localCounter))
 	}()
 	time.Sleep(200 * time.Millisecond)
 	cancel()
@@ -191,8 +211,8 @@ func TestGCFailureBackoff(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		gc := newFakeGC(alwaysErrorDeleter{})
-		require.Error(t, startGarbageCollectorWithMaxElapsedTime(ctx, &gc, 100*time.Millisecond, 0, 1*time.Second, 1*time.Minute, localCounter))
+		gc := newFakeGCStore(alwaysErrorDeleter{})
+		require.Error(t, startGarbageCollectorWithMaxElapsedTime(ctx, gc, 100*time.Millisecond, 0, 1*time.Second, 1*time.Minute, localCounter))
 	}()
 	time.Sleep(200 * time.Millisecond)
 	cancel()
@@ -211,7 +231,7 @@ func TestGCFailureBackoff(t *testing.T) {
 // error. The garbage collector should not continue to use the exponential
 // backoff interval that is activated on error.
 func TestGCFailureBackoffReset(t *testing.T) {
-	gc := newFakeGC(revisionErrorDeleter{
+	gc := newFakeGCStore(revisionErrorDeleter{
 		// Error on revisions 1 - 5, giving the exponential
 		// backoff enough time to fail the test if the interval
 		// is not reset properly.
@@ -226,7 +246,7 @@ func TestGCFailureBackoffReset(t *testing.T) {
 		window := 10 * time.Second
 		timeout := 1 * time.Minute
 
-		require.Error(t, StartGarbageCollector(ctx, &gc, interval, window, timeout))
+		require.Error(t, StartGarbageCollector(ctx, gc, interval, window, timeout))
 	}()
 
 	time.Sleep(500 * time.Millisecond)
@@ -235,11 +255,14 @@ func TestGCFailureBackoffReset(t *testing.T) {
 	// The next interval should have been reset after recovering from the error.
 	// If it is not reset, the last exponential backoff interval will not give
 	// the GC enough time to run.
-	require.Greater(t, gc.GetMetrics().markedCompleteCount, 20, "Next interval was not reset with backoff")
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+
+	require.Greater(t, gc.markedCompleteCount, 20, "Next interval was not reset with backoff")
 }
 
 func TestGCUnlockOnTimeout(t *testing.T) {
-	gc := newFakeGC(alwaysErrorDeleter{})
+	gc := newFakeGCStore(alwaysErrorDeleter{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -249,15 +272,15 @@ func TestGCUnlockOnTimeout(t *testing.T) {
 		window := 10 * time.Second
 		timeout := 1 * time.Millisecond
 
-		require.Error(t, StartGarbageCollector(ctx, &gc, interval, window, timeout))
+		require.Error(t, StartGarbageCollector(ctx, gc, interval, window, timeout))
 	}()
 
 	time.Sleep(30 * time.Millisecond)
 	require.False(t, gc.HasGCRun(), "GC should not have run")
 
-	gc.lock.Lock()
-	defer gc.lock.Unlock()
+	gc.fakeGC.lock.Lock()
+	defer gc.fakeGC.lock.Unlock()
 
-	require.True(t, gc.wasLocked, "GC should have been locked")
-	require.True(t, gc.wasUnlocked, "GC should have been unlocked")
+	require.True(t, gc.fakeGC.wasLocked, "GC should have been locked")
+	require.True(t, gc.fakeGC.wasUnlocked, "GC should have been unlocked")
 }

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -252,7 +252,11 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	// Run GC at the transaction and ensure no relationships are removed.
 	mds := ds.(*Datastore)
 
-	removed, err := mds.DeleteBeforeTx(ctx, writtenAt)
+	mgg, err := mds.BuildGarbageCollector(ctx)
+	req.NoError(err)
+	defer mgg.Close()
+
+	removed, err := mgg.DeleteBeforeTx(ctx, writtenAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Zero(removed.Namespaces)
@@ -272,7 +276,7 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	req.NoError(err)
 
 	// Run GC to remove the old namespace
-	removed, err = mds.DeleteBeforeTx(ctx, writtenAt)
+	removed, err = mgg.DeleteBeforeTx(ctx, writtenAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Equal(int64(1), removed.Transactions)
@@ -284,14 +288,14 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	req.NoError(err)
 
 	// Run GC at the transaction and ensure no relationships are removed, but 1 transaction (the previous write namespace) is.
-	removed, err = mds.DeleteBeforeTx(ctx, relWrittenAt)
+	removed, err = mgg.DeleteBeforeTx(ctx, relWrittenAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Equal(int64(1), removed.Transactions)
 	req.Zero(removed.Namespaces)
 
 	// Run GC again and ensure there are no changes.
-	removed, err = mds.DeleteBeforeTx(ctx, relWrittenAt)
+	removed, err = mgg.DeleteBeforeTx(ctx, relWrittenAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Zero(removed.Transactions)
@@ -307,14 +311,14 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	req.NoError(err)
 
 	// Run GC at the transaction and ensure the (older copy of the) relationship is removed, as well as 1 transaction (the write).
-	removed, err = mds.DeleteBeforeTx(ctx, relOverwrittenAt)
+	removed, err = mgg.DeleteBeforeTx(ctx, relOverwrittenAt)
 	req.NoError(err)
 	req.Equal(int64(1), removed.Relationships)
 	req.Equal(int64(1), removed.Transactions)
 	req.Zero(removed.Namespaces)
 
 	// Run GC again and ensure there are no changes.
-	removed, err = mds.DeleteBeforeTx(ctx, relOverwrittenAt)
+	removed, err = mgg.DeleteBeforeTx(ctx, relOverwrittenAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Zero(removed.Transactions)
@@ -331,14 +335,14 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	tRequire.NoRelationshipExists(ctx, crel, relDeletedAt)
 
 	// Run GC at the transaction and ensure the relationship is removed, as well as 1 transaction (the overwrite).
-	removed, err = mds.DeleteBeforeTx(ctx, relDeletedAt)
+	removed, err = mgg.DeleteBeforeTx(ctx, relDeletedAt)
 	req.NoError(err)
 	req.Equal(int64(1), removed.Relationships)
 	req.Equal(int64(1), removed.Transactions)
 	req.Zero(removed.Namespaces)
 
 	// Run GC again and ensure there are no changes.
-	removed, err = mds.DeleteBeforeTx(ctx, relDeletedAt)
+	removed, err = mgg.DeleteBeforeTx(ctx, relDeletedAt)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.Zero(removed.Transactions)
@@ -359,7 +363,7 @@ func GarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 
 	// Run GC at the transaction and ensure the older copies of the relationships are removed,
 	// as well as the 2 older write transactions and the older delete transaction.
-	removed, err = mds.DeleteBeforeTx(ctx, relLastWriteAt)
+	removed, err = mgg.DeleteBeforeTx(ctx, relLastWriteAt)
 	req.NoError(err)
 	req.Equal(int64(2), removed.Relationships)
 	req.Equal(int64(3), removed.Transactions)
@@ -392,6 +396,10 @@ func GarbageCollectionByTimeTest(t *testing.T, ds datastore.Datastore) {
 
 	mds := ds.(*Datastore)
 
+	mgg, err := mds.BuildGarbageCollector(ctx)
+	req.NoError(err)
+	defer mgg.Close()
+
 	// Sleep 1ms to ensure GC will delete the previous transaction.
 	time.Sleep(1 * time.Millisecond)
 
@@ -402,13 +410,13 @@ func GarbageCollectionByTimeTest(t *testing.T, ds datastore.Datastore) {
 	req.NoError(err)
 
 	// Run GC and ensure only transactions were removed.
-	afterWrite, err := mds.Now(ctx)
+	afterWrite, err := mgg.Now(ctx)
 	req.NoError(err)
 
-	afterWriteTx, err := mds.TxIDBefore(ctx, afterWrite)
+	afterWriteTx, err := mgg.TxIDBefore(ctx, afterWrite)
 	req.NoError(err)
 
-	removed, err := mds.DeleteBeforeTx(ctx, afterWriteTx)
+	removed, err := mgg.DeleteBeforeTx(ctx, afterWriteTx)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.NotZero(removed.Transactions)
@@ -426,13 +434,13 @@ func GarbageCollectionByTimeTest(t *testing.T, ds datastore.Datastore) {
 	req.NoError(err)
 
 	// Run GC and ensure the relationship is removed.
-	afterDelete, err := mds.Now(ctx)
+	afterDelete, err := mgg.Now(ctx)
 	req.NoError(err)
 
-	afterDeleteTx, err := mds.TxIDBefore(ctx, afterDelete)
+	afterDeleteTx, err := mgg.TxIDBefore(ctx, afterDelete)
 	req.NoError(err)
 
-	removed, err = mds.DeleteBeforeTx(ctx, afterDeleteTx)
+	removed, err = mgg.DeleteBeforeTx(ctx, afterDeleteTx)
 	req.NoError(err)
 	req.Equal(int64(1), removed.Relationships)
 	req.Equal(int64(1), removed.Transactions)
@@ -450,15 +458,19 @@ func EmptyGarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	req.NoError(err)
 	req.True(r.IsReady)
 
-	gc := ds.(common.GarbageCollector)
+	gc := ds.(common.GarbageCollectableDatastore)
 
-	now, err := gc.Now(ctx)
+	mgg, err := gc.BuildGarbageCollector(ctx)
+	req.NoError(err)
+	defer mgg.Close()
+
+	now, err := mgg.Now(ctx)
 	req.NoError(err)
 
-	watermark, err := gc.TxIDBefore(ctx, now.Add(-1*time.Minute))
+	watermark, err := mgg.TxIDBefore(ctx, now.Add(-1*time.Minute))
 	req.NoError(err)
 
-	collected, err := gc.DeleteBeforeTx(ctx, watermark)
+	collected, err := mgg.DeleteBeforeTx(ctx, watermark)
 	req.NoError(err)
 
 	req.Equal(int64(0), collected.Relationships)
@@ -487,15 +499,19 @@ func NoRelationshipsGarbageCollectionTest(t *testing.T, ds datastore.Datastore) 
 	})
 	req.NoError(err)
 
-	gc := ds.(common.GarbageCollector)
+	gc := ds.(common.GarbageCollectableDatastore)
 
-	now, err := gc.Now(ctx)
+	mgg, err := gc.BuildGarbageCollector(ctx)
+	req.NoError(err)
+	defer mgg.Close()
+
+	now, err := mgg.Now(ctx)
 	req.NoError(err)
 
-	watermark, err := gc.TxIDBefore(ctx, now.Add(-1*time.Minute))
+	watermark, err := mgg.TxIDBefore(ctx, now.Add(-1*time.Minute))
 	req.NoError(err)
 
-	collected, err := gc.DeleteBeforeTx(ctx, watermark)
+	collected, err := mgg.DeleteBeforeTx(ctx, watermark)
 	req.NoError(err)
 
 	req.Equal(int64(0), collected.Relationships)
@@ -526,6 +542,10 @@ func ChunkedGarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 
 	mds := ds.(*Datastore)
 
+	mgg, err := mds.BuildGarbageCollector(ctx)
+	req.NoError(err)
+	defer mgg.Close()
+
 	// Prepare relationships to write.
 	var rels []tuple.Relationship
 	for i := 0; i < chunkRelationshipCount; i++ {
@@ -544,13 +564,13 @@ func ChunkedGarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	}
 
 	// Run GC and ensure only transactions were removed.
-	afterWrite, err := mds.Now(ctx)
+	afterWrite, err := mgg.Now(ctx)
 	req.NoError(err)
 
-	afterWriteTx, err := mds.TxIDBefore(ctx, afterWrite)
+	afterWriteTx, err := mgg.TxIDBefore(ctx, afterWrite)
 	req.NoError(err)
 
-	removed, err := mds.DeleteBeforeTx(ctx, afterWriteTx)
+	removed, err := mgg.DeleteBeforeTx(ctx, afterWriteTx)
 	req.NoError(err)
 	req.Zero(removed.Relationships)
 	req.NotZero(removed.Transactions)
@@ -572,13 +592,13 @@ func ChunkedGarbageCollectionTest(t *testing.T, ds datastore.Datastore) {
 	time.Sleep(1 * time.Millisecond)
 
 	// Run GC and ensure all the stale relationships are removed.
-	afterDelete, err := mds.Now(ctx)
+	afterDelete, err := mgg.Now(ctx)
 	req.NoError(err)
 
-	afterDeleteTx, err := mds.TxIDBefore(ctx, afterDelete)
+	afterDeleteTx, err := mgg.TxIDBefore(ctx, afterDelete)
 	req.NoError(err)
 
-	removed, err = mds.DeleteBeforeTx(ctx, afterDeleteTx)
+	removed, err = mgg.DeleteBeforeTx(ctx, afterDeleteTx)
 	req.NoError(err)
 	req.Equal(int64(chunkRelationshipCount), removed.Relationships)
 	req.Equal(int64(1), removed.Transactions)
@@ -664,7 +684,11 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 			})
 			mds := ds.(*Datastore)
 
-			dbNow, err := mds.Now(ctx)
+			mgg, err := mds.BuildGarbageCollector(ctx)
+			require.NoError(err)
+			defer mgg.Close()
+
+			dbNow, err := mgg.Now(ctx)
 			require.NoError(err)
 
 			tx, err := mds.db.BeginTx(ctx, nil)
@@ -721,7 +745,11 @@ func TransactionTimestampsTest(t *testing.T, ds datastore.Datastore) {
 	req.True(r.IsReady)
 
 	// Get timestamp in UTC as reference
-	startTimeUTC, err := ds.(*Datastore).Now(ctx)
+	mgg, err := ds.(*Datastore).BuildGarbageCollector(ctx)
+	req.NoError(err)
+	defer mgg.Close()
+
+	startTimeUTC, err := mgg.Now(ctx)
 	req.NoError(err)
 
 	// Transaction timestamp should not be stored in system time zone

--- a/internal/datastore/postgres/common/cancelation.go
+++ b/internal/datastore/postgres/common/cancelation.go
@@ -1,0 +1,18 @@
+package common
+
+import (
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgconn/ctxwatch"
+)
+
+// CancelationContextHandler returns a context watcher handler for canceling requests
+// when a context is canceled, rather than closing connections.
+func CancelationContextHandler(pgConn *pgconn.PgConn) ctxwatch.Handler {
+	return &pgconn.CancelRequestContextWatcherHandler{
+		Conn:               pgConn,
+		CancelRequestDelay: 0 * time.Millisecond, // Cancel immediately.
+		DeadlineDelay:      1 * time.Second,      // If not acknowledged, close the connection after a second.
+	}
+}

--- a/internal/datastore/postgres/common/interceptor.go
+++ b/internal/datastore/postgres/common/interceptor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Querier holds common methods for connections and pools, equivalent to
@@ -21,6 +22,7 @@ type ConnPooler interface {
 	Begin(ctx context.Context) (pgx.Tx, error)
 	BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error)
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
+	Acquire(ctx context.Context) (c *pgxpool.Conn, err error)
 	Close()
 }
 
@@ -178,6 +180,10 @@ func (i InterceptorPooler) BeginTx(ctx context.Context, txOptions pgx.TxOptions)
 
 func (i InterceptorPooler) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
 	return i.delegate.CopyFrom(ctx, tableName, columnNames, rowSrc)
+}
+
+func (i InterceptorPooler) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
+	return i.delegate.Acquire(ctx)
 }
 
 func (i InterceptorPooler) Close() {

--- a/internal/datastore/postgres/locks.go
+++ b/internal/datastore/postgres/locks.go
@@ -2,8 +2,7 @@ package postgres
 
 import (
 	"context"
-
-	log "github.com/authzed/spicedb/internal/logging"
+	"fmt"
 )
 
 type lockID uint32
@@ -48,8 +47,7 @@ func (pgd *pgDatastore) releaseLock(ctx context.Context, lockID lockID) error {
 	}
 
 	if !lockReleased {
-		log.Warn().Uint32("lock_id", uint32(lockID)).Msg("held lock not released; this likely indicates a bug")
-		return nil
+		return fmt.Errorf("failed to release lock %d", lockID)
 	}
 
 	return nil

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
 
-	datastoreinternal "github.com/authzed/spicedb/internal/datastore"
 	"github.com/authzed/spicedb/internal/datastore/common"
 	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
 	"github.com/authzed/spicedb/internal/datastore/postgres/migrations"
@@ -109,7 +108,7 @@ func NewPostgresDatastore(
 		return nil, err
 	}
 
-	return datastoreinternal.NewSeparatingContextDatastoreProxy(ds), nil
+	return ds, nil
 }
 
 // NewReadOnlyPostgresDatastore initializes a SpiceDB datastore that uses a PostgreSQL
@@ -126,7 +125,7 @@ func NewReadOnlyPostgresDatastore(
 		return nil, err
 	}
 
-	return datastoreinternal.NewSeparatingContextDatastoreProxy(ds), nil
+	return ds, nil
 }
 
 func newPostgresDatastore(
@@ -134,7 +133,7 @@ func newPostgresDatastore(
 	pgURL string,
 	replicaIndex int,
 	options ...Option,
-) (datastore.Datastore, error) {
+) (datastore.StrictReadDatastore, error) {
 	isPrimary := replicaIndex == primaryInstanceID
 	config, err := generateConfig(options)
 	if err != nil {
@@ -146,6 +145,9 @@ func newPostgresDatastore(
 	if err != nil {
 		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, pgURL)
 	}
+
+	// Install the cancelation handler for contexts.
+	parsedConfig.ConnConfig.BuildContextWatcherHandler = pgxcommon.CancelationContextHandler
 
 	// Setup the default custom plan setting, if applicable.
 	// Setup the default query execution mode setting, if applicable.

--- a/pkg/cmd/datastore.go
+++ b/pkg/cmd/datastore.go
@@ -71,8 +71,8 @@ func NewGCDatastoreCommand(programName string, cfg *datastore.Config) *cobra.Com
 				return fmt.Errorf("failed to create datastore: %w", err)
 			}
 
-			gc := dspkg.UnwrapAs[common.GarbageCollector](ds)
-			if gc == nil {
+			gcds := dspkg.UnwrapAs[common.GarbageCollectableDatastore](ds)
+			if gcds == nil {
 				return fmt.Errorf("datastore of type %T does not support garbage collection", ds)
 			}
 
@@ -80,10 +80,12 @@ func NewGCDatastoreCommand(programName string, cfg *datastore.Config) *cobra.Com
 				Float64("gc_window_seconds", cfg.GCWindow.Seconds()).
 				Float64("gc_max_operation_time_seconds", cfg.GCMaxOperationTime.Seconds()).
 				Msg("Running garbage collection...")
-			err = common.RunGarbageCollection(gc, cfg.GCWindow, cfg.GCMaxOperationTime)
+
+			err = common.RunGarbageCollection(gcds, cfg.GCWindow, cfg.GCMaxOperationTime)
 			if err != nil {
 				return err
 			}
+
 			log.Ctx(ctx).Info().Msg("Garbage collection completed")
 			return nil
 		}),

--- a/pkg/datastore/test/revisions.go
+++ b/pkg/datastore/test/revisions.go
@@ -121,7 +121,7 @@ func GCProcessRunTest(t *testing.T, tester DatastoreTester) {
 	})
 	require.NoError(err)
 
-	gcable, ok := ds.(common.GarbageCollector)
+	gcable, ok := ds.(common.GarbageCollectableDatastore)
 	if !ok {
 		return
 	}
@@ -174,7 +174,7 @@ func RevisionGCTest(t *testing.T, tester DatastoreTester) {
 	// Sleep to ensure we're past the GC window.
 	time.Sleep(gcWindow)
 
-	gcable, ok := ds.(common.GarbageCollector)
+	gcable, ok := ds.(common.GarbageCollectableDatastore)
 	if ok {
 		// Run garbage collection.
 		gcable.ResetGCCompleted()


### PR DESCRIPTION
This should (in most cases) allow the connection to be reused when the parent context is canceled, instead of our current behavior of severing the context and allowing the query to finish processing. Severing was initially done because the default behavior in PGX is to *close* the connection, which added overhead on other requests