### PR TITLE
fix leader election retry interval for revision heartbeat

### DIFF
--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -751,7 +751,7 @@ func (pgd *pgDatastore) startRevisionHeartbeat(ctx context.Context) error {
 		}
 
 		jitter := time.Duration(float64(heartbeatDuration) * rand.Float64() * defaultMaxHeartbeatLeaderJitterPercent / 100) // nolint:gosec
-		time.Sleep(jitter)
+		time.Sleep(heartbeatDuration + jitter)
 	}
 
 	defer func() {

--- a/internal/graph/lookupresources2.go
+++ b/internal/graph/lookupresources2.go
@@ -115,7 +115,8 @@ func (crr *CursoredLookupResources2) afterSameType(
 	req ValidatedLookupResources2Request,
 	parentStream dispatch.LookupResources2Stream,
 ) error {
-	ctx, span := tracer.Start(ctx, "lookupViaReachability")
+	reachabilityForString := req.ResourceRelation.Namespace + "#" + req.ResourceRelation.Relation
+	ctx, span := tracer.Start(ctx, "reachability: "+reachabilityForString)
 	defer span.End()
 
 	dispatched := NewSyncONRSet()
@@ -145,9 +146,7 @@ func (crr *CursoredLookupResources2) afterSameType(
 			spiceerrors.DebugAssert(func() bool {
 				return err == nil
 			}, "Error in entrypoint.DebugString()")
-			ctx, span := tracer.Start(ctx, "entrypoint", trace.WithAttributes(
-				attribute.String("entrypoint", ds),
-			))
+			ctx, span := tracer.Start(ctx, "entrypoint: "+ds, trace.WithAttributes())
 			defer span.End()
 
 			switch entrypoint.EntrypointKind() {


### PR DESCRIPTION
each SpiceDB nodes attempts to acquire a postgres lock to become the leader in charge of publishing the
heartbeat revision.

Unfortunately I overlooked adding both the heartbeat and the jitter computed out of it, leading to
SpiceDB nodes trying to acquire locks
in very rapid succession.