### PR TITLE
introduces depot runners

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,7 +15,7 @@ env:
   DOCKERHUB_PUBLIC_USER: "spicedbgithubactions"
 jobs:
   paths-filter:
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-small"
     outputs:
       codechange: "${{ steps.code-filter.outputs.codechange }}"
       protochange: "${{ steps.proto-filter.outputs.protochange }}"
@@ -45,7 +45,7 @@ jobs:
               - "go.mod"
   build:
     name: "Build Binary & Image"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -62,7 +62,7 @@ jobs:
 
   unit:
     name: "Unit"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -81,7 +81,7 @@ jobs:
 
   steelthread:
     name: "Steelthread"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -93,7 +93,7 @@ jobs:
 
   integration:
     name: "Integration Tests"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -109,7 +109,7 @@ jobs:
 
   datastoreinttest:
     name: "Datastore Integration Tests"
-    runs-on: "buildjet-8vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-8"
     needs: "paths-filter"
     strategy:
       fail-fast: false
@@ -135,7 +135,7 @@ jobs:
 
   datastoreconstest:
     name: "Datastore Consistency Tests"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     needs: "paths-filter"
     strategy:
       fail-fast: false
@@ -161,7 +161,7 @@ jobs:
 
   pgdatastoreinttest:
     name: "Datastore Integration Tests"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     needs: "paths-filter"
     strategy:
       fail-fast: false
@@ -188,7 +188,7 @@ jobs:
 
   pgdatastoreconstest:
     name: "Datastore Consistency Tests"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     needs: "paths-filter"
     strategy:
       fail-fast: false
@@ -215,7 +215,7 @@ jobs:
 
   crdbdatastoreinttest:
     name: "Datastore Integration Tests"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     needs: "paths-filter"
     strategy:
       fail-fast: false
@@ -242,7 +242,7 @@ jobs:
 
   crdbdatastoreconstest:
     name: "Datastore Consistency Tests"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     needs: "paths-filter"
     strategy:
       fail-fast: false
@@ -269,7 +269,7 @@ jobs:
 
   e2e:
     name: "E2E"
-    runs-on: "buildjet-8vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-8"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -279,30 +279,12 @@ jobs:
         with:
           go-version-file: "e2e/go.mod"
           cache-dependency-path: "e2e/go.sum"
-      - name: "Cache Binaries"
-        id: "cache-binaries"
-        uses: "buildjet/cache@v4"
-        with:
-          path: |
-            e2e/newenemy/cockroach
-            e2e/newenemy/chaosd
-            e2e/newenemy/watchmaker
-          # this key will need to be bumped when dependencies are changed
-          key: "cockroach-v22.1.5-chaosd-v1.1.1"
       - name: "Install cockroachdb and chaosd"
         if: "steps.cache-binaries.outputs.cache-hit != 'true'"
         working-directory: "e2e/newenemy"
         run: |
           curl https://binaries.cockroachdb.com/cockroach-v22.1.5.linux-amd64.tgz | tar -xz && mv cockroach-v22.1.5.linux-amd64/cockroach ./cockroach
           curl -fsSL https://mirrors.chaos-mesh.org/chaosd-v1.1.1-linux-amd64.tar.gz | tar -xz && mv chaosd-v1.1.1-linux-amd64/chaosd ./chaosd
-      - uses: "buildjet/cache@v4"
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: "${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}"
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: "Build SpiceDB"
         run: |
           go get -d ./...
@@ -320,7 +302,7 @@ jobs:
           path: "e2e/newenemy/*.log"
   analyzers-unit-tests:
     name: "Analyzers Unit Tests"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-small"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -334,19 +316,19 @@ jobs:
         run: "go run mage.go test:analyzers"
   development:
     name: "WASM Tests"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubuntu-22.04" # do not run Depot runners due to somehow triggering https://github.com/agnivade/wasmbrowsertest/issues/40
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
     steps:
       - uses: "actions/checkout@v4"
-      - uses: "authzed/actions/setup-go@main"
+      - uses: "authzed/actions/setup-go@94cd886a616b37dbfd47dbf15ef83b4925ae1b16"
       - name: "WASM tests"
         run: "go run mage.go test:wasm"
 
   protobuf:
     name: "Generate Protobufs"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-small"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.protochange == 'true'

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   cla:
     name: "Check Signature"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-small"
     steps:
       - uses: "authzed/actions/cla-check@main"
         with:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       - "checks_requested"
 jobs:
   triage:
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-small"
     steps:
       - uses: "actions/labeler@v5"
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   go-license-check:
     name: "License Check"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-small"
     steps:
       - uses: "actions/checkout@v4"
       - uses: "authzed/actions/setup-go@main"
@@ -24,7 +24,7 @@ jobs:
 
   go-lint:
     name: "Lint Go"
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04"
     steps:
       - uses: "actions/checkout@v4"
       - uses: "authzed/actions/setup-go@main"
@@ -37,7 +37,7 @@ jobs:
 
   extra-lint:
     name: "Lint YAML & Markdown"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-small"
     steps:
       - uses: "actions/checkout@v4"
       - uses: "authzed/actions/setup-go@main"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,7 +9,7 @@ permissions:
   packages: "write"
 jobs:
   goreleaser:
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
   packages: "write"
 jobs:
   goreleaser:
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-4"
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -17,7 +17,7 @@ jobs:
   codeql:
     name: "CodeQL Analyze"
     if: "${{ github.event_name == 'pull_request' }}"  # workaround to https://github.com/github/codeql-action/issues/1537
-    runs-on: "buildjet-8vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-8"
     timeout-minutes: "${{ (matrix.language == 'swift' && 120) || 360 }}"
     permissions:
       # required for all workflows
@@ -39,7 +39,7 @@ jobs:
 
   trivy:
     name: "Analyze Code and Docker Image with Trivvy"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-small"
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     name: "Build WASM"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "depot-ubuntu-24.04-small"
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -5,7 +5,7 @@ go 1.23.4
 toolchain go1.24.0
 
 require (
-	github.com/agnivade/wasmbrowsertest v0.10.0
+	github.com/agnivade/wasmbrowsertest v0.11.0
 	github.com/authzed/ctxkey v0.0.0-20250127172433-d71cd97e3833
 	github.com/bufbuild/buf v1.35.1
 	github.com/ecordell/optgen v0.0.9

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -52,8 +52,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
-github.com/agnivade/wasmbrowsertest v0.10.0 h1:kAJoj/1NraZiCOP5S8FC/8iU/3hwZyc6l9kxXjvPJiI=
-github.com/agnivade/wasmbrowsertest v0.10.0/go.mod h1:fL1DzIi4hpO6WPZaA93RJx84/eyVP7Z5fXV0kWyktz4=
+github.com/agnivade/wasmbrowsertest v0.11.0 h1:Feg5lmJzfC3j9nMgOxRZdYqzYtt93MvcFG29KeRt2VI=
+github.com/agnivade/wasmbrowsertest v0.11.0/go.mod h1:kgT4RR8m3auEg0UdL0uOj/0hCjRt5yQQNb4kjUY5GgU=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/authzed/ctxkey v0.0.0-20250127172433-d71cd97e3833 h1:rby2719UdmcOltB30ALyPY4Lozz9nkYSpjqnBiHXBQI=


### PR DESCRIPTION
We are migrating to use Depot runners to get no concurrency limits, and more reliable builds.

The WASM build was left in a stock GitHub Actions runner because the WASM tests were failing with `total length of command line and environment variables exceeds limit` on the depot ubuntu 22.X runners (see https://github.com/authzed/spicedb/actions/runs/14218670450/job/39841176114?pr=2297), which is described in https://github.com/agnivade/wasmbrowsertest/issues/40. It also had issues with Ubuntu 24.x runners related to the AppArmor issue that prevents Chrome from starting up.