### PR TITLE
support both old and new read replica flag prefixes

### DIFF
--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -46,6 +46,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.DisableStats = c.DisableStats
 		to.IncludeQueryParametersInTraces = c.IncludeQueryParametersInTraces
 		to.ReadReplicaConnPool = c.ReadReplicaConnPool
+		to.OldReadReplicaConnPool = c.OldReadReplicaConnPool
 		to.ReadReplicaURIs = c.ReadReplicaURIs
 		to.ReadReplicaCredentialsProviderName = c.ReadReplicaCredentialsProviderName
 		to.BootstrapFiles = c.BootstrapFiles
@@ -259,6 +260,13 @@ func WithIncludeQueryParametersInTraces(includeQueryParametersInTraces bool) Con
 func WithReadReplicaConnPool(readReplicaConnPool ConnPoolConfig) ConfigOption {
 	return func(c *Config) {
 		c.ReadReplicaConnPool = readReplicaConnPool
+	}
+}
+
+// WithOldReadReplicaConnPool returns an option that can set OldReadReplicaConnPool on a Config
+func WithOldReadReplicaConnPool(oldReadReplicaConnPool ConnPoolConfig) ConfigOption {
+	return func(c *Config) {
+		c.OldReadReplicaConnPool = oldReadReplicaConnPool
 	}
 }
 


### PR DESCRIPTION
This addresses a regression in supported flags in 1.42.0, so that read replica connection pool flags with both the old prefix (`datastore-read-replica-conn-pool`) and the new one (`datastore-read-replica-conn-pool-read`) are supported.

There is one edge case in this implementation: if a user explicitly sets a new flag, but sets it to the same value as the default, and also sets the old flag, then the old flag will take precedence (even though the new one is specified). I thought this was unlikely to be hit in practice and users should still see a deprecation warning if they do. We could avoid this issue, but it would require some more refactoring of flag handling so that after the flags are parsed we can lookup what has been actually set on the cli (vs the values in the config struct).

```sh
$ spicedb serve --datastore-read-replica-conn-pool-max-open=30 --grpc-preshared-key=abc
Flag --datastore-read-replica-conn-pool-max-open has been deprecated, please use the flags with the prefix "datastore-read-replica-conn-pool-read" instead of "datastore-read-replica-conn-pool"
<....>
DatastoreConfig.ReadReplicaConnPool.MaxOpenConns=30

$ spicedb serve --datastore-read-replica-conn-pool-read-max-open=30 --grpc-preshared-key=abc
<....>
DatastoreConfig.ReadReplicaConnPool.MaxOpenConns=30
```