### PR TITLE
feat: make build notification links clickable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,8 +63,10 @@ jobs:
                   type: "mrkdwn"
                   text: |
                     *Goreleaser Job* finished with status: ${{ job.status }}
-                    *Repository:* ${{ github.repository }}
-                    *Commit:* ${{ github.sha }}
-                    *Author:* ${{ github.actor }}
+                    *Source ring:* ${{ inputs.source }}
+                    *Repository:* <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>
+                    *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>
+                    *Job Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Job Run>
+                    *Actor:* ${{ github.actor }}
                     *Ref:* ${{ github.ref }}
                     *Workflow:* ${{ github.workflow }}


### PR DESCRIPTION
this pr updates our slack notifications to include clickable links for the repository, commit, and job run for easier interactions.