### PR TITLE
Sketching out a higher-level schema proto package

### DIFF
--- a/pkg/schema/schemalog/definition.go
+++ b/pkg/schema/schemalog/definition.go
@@ -1,0 +1,56 @@
+package schemalog
+
+import (
+	"iter"
+
+	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
+)
+
+type Definition struct {
+	schema      *Schema
+	Proto       *corev1.NamespaceDefinition
+	relations   map[string]*Relation
+	permissions map[string]*Permission
+}
+
+var _ Entity = &Definition{}
+
+// Name returns the full name of the Definition
+func (d *Definition) Name() string {
+	return d.Proto.GetName()
+}
+
+func (d *Definition) Relations() iter.Seq2[string, *Relation] {
+	return func(yield func(string, *Relation) bool) {
+		for k, v := range d.relations {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}
+
+func (d *Definition) Permissions() iter.Seq2[string, *Permission] {
+	return func(yield func(string, *Permission) bool) {
+		for k, v := range d.permissions {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}
+
+func (d *Definition) Edges() iter.Seq2[string, Edge] {
+	return func(yield func(string, Edge) bool) {
+		for k, v := range d.permissions {
+			if !yield(k, v) {
+				return
+			}
+		}
+		for k, v := range d.relations {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/schema/schemalog/edges.go
+++ b/pkg/schema/schemalog/edges.go
@@ -1,0 +1,39 @@
+package schemalog
+
+type Edge interface {
+	Entity
+	Rule
+	Definition() *Definition
+	Rules() []Rule
+}
+
+var _ Edge = &Relation{}
+var _ Edge = &Permission{}
+
+type Relation struct {
+	definition *Definition
+	name       string
+	body       []Rule
+}
+
+func (r *Relation) Name() string {
+	return r.name
+}
+
+func (r *Relation) Definition() *Definition {
+	return r.definition
+}
+
+type Permission struct {
+	definition *Definition
+	name       string
+	body       []Rule
+}
+
+func (p *Permission) Name() string {
+	return p.name
+}
+
+func (p *Permission) Definition() *Definition {
+	return p.definition
+}

--- a/pkg/schema/schemalog/rules.go
+++ b/pkg/schema/schemalog/rules.go
@@ -1,0 +1,29 @@
+package schemalog
+
+type Rule interface {
+	ResourceType() string
+	SubjectTypes() []string
+}
+
+type TypeRule struct {
+	Type string
+}
+
+type RelationRule struct {
+	Type     string
+	Relation string
+}
+
+type ExpansionRule struct {
+	EdgeName string
+}
+
+type ArrowRule struct {
+	Type     string
+	EdgeName string
+}
+
+type AllRule struct {
+	Type     string
+	EdgeName string
+}

--- a/pkg/schema/schemalog/schema.go
+++ b/pkg/schema/schemalog/schema.go
@@ -1,0 +1,17 @@
+package schemalog
+
+import corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
+
+type Schema struct {
+	definitions map[string]*Definition
+	edges       map[string]Edge
+	caveats     map[string]*Caveat
+}
+
+type Caveat struct {
+	Proto *corev1.CaveatDefinition
+}
+
+type Entity interface {
+	Name() string
+}


### PR DESCRIPTION
All the entities have a comparable proto portion -- but by lifting them into Go types with methods that understand these are all linked between each other, perhaps we can obviate some of the schema package