### PR TITLE
fixes incorrect handling of definition deltas via Postgres Watch API

### DIFF
--- a/internal/datastore/common/changes.go
+++ b/internal/datastore/common/changes.go
@@ -187,8 +187,13 @@ func (ch *Changes[R, K]) AddDeletedNamespace(
 		return err
 	}
 
-	delete(record.definitionsChanged, nsPrefix+namespaceName)
+	// if a delete happens in the same transaction as a change, we assume it was a change in the first place
+	// because that's how namespace changes are implemented in the MVCC
+	if _, ok := record.definitionsChanged[nsPrefix+namespaceName]; ok {
+		return nil
+	}
 
+	delete(record.definitionsChanged, nsPrefix+namespaceName)
 	record.namespacesDeleted[namespaceName] = struct{}{}
 	return nil
 }
@@ -208,8 +213,13 @@ func (ch *Changes[R, K]) AddDeletedCaveat(
 		return err
 	}
 
-	delete(record.definitionsChanged, caveatPrefix+caveatName)
+	// if a delete happens in the same transaction as a change, we assume it was a change in the first place
+	// because that's how namespace changes are implemented in the MVCC
+	if _, ok := record.definitionsChanged[caveatPrefix+caveatName]; ok {
+		return nil
+	}
 
+	delete(record.definitionsChanged, caveatPrefix+caveatName)
 	record.caveatsDeleted[caveatName] = struct{}{}
 	return nil
 }


### PR DESCRIPTION
We observed malformed schema Watch API events in certain clusters, particularly always when using postgres as datastore. Typically the issue emerged as namespaces that did not exist. This impacted the experimental schema cache that is led by the Watch API, which could cause the cache to become corrupted and miss namespaces, which in turn causes the API to fail requests with "unknown namespace" errors.

common.Changes is a type used to track datastore changes as they are streamed as part of the queries used to implemented the Watch API, like relationship changes or namespace changes.

The tracker denotes namespace changes using two different states: changed and deleted.

Datastores like Postgres or MySQL implement their own MVCC to support snapshot consistency. This is done using row versioning and tombstone used to mark deleted entities. As a consequence, when reading the changes for a specific revision from the database, schema changes will always manifest as two rows: one denoting the deletion of the previous form of the namespace, and one creating it with the new form. Put differently: change = delete+create.

The problem is the operation was sensitive to the order in which those were created:
- deletion+creation led to a change
- but creation+deletion led to a deletion

When this happens in the same transaction, a creation+deletion cannot be interpreted as a deletion, because a deletion only involves 1 row instead of two.

The issue was non-deterministic because it depends on the order in which the two rows are returned. I had to modify the query with ORDER BY to reproduce the problem.

This did not impact other datastores like CRDB or Spanner because those do not do their own MVCC, and so a change is represented as a single change event, not a deletion and creation.