### PR TITLE
fix(memdb): check if closed

### DIFF
--- a/internal/datastore/memdb/revisions.go
+++ b/internal/datastore/memdb/revisions.go
@@ -2,7 +2,6 @@ package memdb
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/authzed/spicedb/internal/datastore/revisions"
@@ -42,8 +41,8 @@ func (mdb *memdbDatastore) newRevisionID() revisions.TimestampRevision {
 func (mdb *memdbDatastore) HeadRevision(_ context.Context) (datastore.Revision, error) {
 	mdb.RLock()
 	defer mdb.RUnlock()
-	if mdb.db == nil {
-		return nil, fmt.Errorf("datastore has been closed")
+	if err := mdb.checkNotClosed(); err != nil {
+		return nil, err
 	}
 
 	return mdb.headRevisionNoLock(), nil
@@ -65,8 +64,8 @@ func (mdb *memdbDatastore) headRevisionNoLock() revisions.TimestampRevision {
 func (mdb *memdbDatastore) OptimizedRevision(_ context.Context) (datastore.Revision, error) {
 	mdb.RLock()
 	defer mdb.RUnlock()
-	if mdb.db == nil {
-		return nil, fmt.Errorf("datastore has been closed")
+	if err := mdb.checkNotClosed(); err != nil {
+		return nil, err
 	}
 
 	now := nowRevision()
@@ -76,8 +75,8 @@ func (mdb *memdbDatastore) OptimizedRevision(_ context.Context) (datastore.Revis
 func (mdb *memdbDatastore) CheckRevision(_ context.Context, dr datastore.Revision) error {
 	mdb.RLock()
 	defer mdb.RUnlock()
-	if mdb.db == nil {
-		return fmt.Errorf("datastore has been closed")
+	if err := mdb.checkNotClosed(); err != nil {
+		return err
 	}
 
 	return mdb.checkRevisionLocalCallerMustLock(dr)

--- a/internal/datastore/memdb/watch.go
+++ b/internal/datastore/memdb/watch.go
@@ -103,6 +103,10 @@ func (mdb *memdbDatastore) loadChanges(_ context.Context, currentTxn int64, opti
 	mdb.RLock()
 	defer mdb.RUnlock()
 
+	if err := mdb.checkNotClosed(); err != nil {
+		return nil, 0, nil, err
+	}
+
 	loadNewTxn := mdb.db.Txn(false)
 	defer loadNewTxn.Abort()
 


### PR DESCRIPTION
When you call `memDb.Close()` and then call `memDb.Watch()`, you will see this panic:

```go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1052a7388]

goroutine 7204 [running]:
github.com/hashicorp/go-memdb.(*MemDB).getRoot(...)
	/Users/jschorr/go/pkg/mod/github.com/hashicorp/go-memdb@v1.3.4/memdb.go:65
github.com/hashicorp/go-memdb.(*MemDB).Txn(0x0, 0x0)
	/Users/jschorr/go/pkg/mod/github.com/hashicorp/go-memdb@v1.3.4/memdb.go:78 +0x88
github.com/authzed/spicedb/internal/datastore/memdb.(*memdbDatastore).loadChanges(0x14007d4ec80?, {0x107c1aac8?, 0x1400262bef0?}, 0x182bbed638122260, {0x7, 0x0, 0x0, 0x0, 0x0, 0xc21cfe22, ...})
	/Users/jschorr/go/pkg/mod/github.com/authzed/spicedb@v1.40.2-0.20250228130850-23e8eb31eb91/internal/datastore/memdb/watch.go:106 +0xe0
github.com/authzed/spicedb/internal/datastore/memdb.(*memdbDatastore).Watch.func2()
	/Users/jschorr/go/pkg/mod/github.com/authzed/spicedb@v1.40.2-0.20250228130850-23e8eb31eb91/internal/datastore/memdb/watch.go:69 +0x100
created by github.com/authzed/spicedb/internal/datastore/memdb.(*memdbDatastore).Watch in goroutine 7186
	/Users/jschorr/go/pkg/mod/github.com/authzed/spicedb@v1.40.2-0.20250228130850-23e8eb31eb91/internal/datastore/memdb/watch.go:59 +0x1d4
```