### PR TITLE
document packages

### DIFF
--- a/e2e/doc.go
+++ b/e2e/doc.go
@@ -1,0 +1,2 @@
+// Package e2e contains a series of tests, including tests that verify SpiceDB addresses the New Enemy problem.
+package e2e

--- a/e2e/spice/spicedb.go
+++ b/e2e/spice/spicedb.go
@@ -137,7 +137,7 @@ type Cluster []*Node
 
 // NewClusterFromCockroachCluster creates a spicedb instance for every
 // cockroach instance, with each spicedb configured to talk to the corresponding
-// cockraoch node.
+// cockroach node.
 func NewClusterFromCockroachCluster(c cockroach.Cluster, opts ...NodeOption) Cluster {
 	ss := make([]*Node, 0, len(c))
 

--- a/internal/auth/doc.go
+++ b/internal/auth/doc.go
@@ -1,0 +1,2 @@
+// Package auth contains helper methods for authentication.
+package auth

--- a/internal/caveats/builder.go
+++ b/internal/caveats/builder.go
@@ -36,8 +36,8 @@ func CaveatExprForTesting(name string) *core.CaveatExpression {
 	}
 }
 
-// CaveatExprForTesting returns a CaveatExpression referencing a caveat with the given name and
-// empty context.
+// MustCaveatExprForTestingWithContext returns a CaveatExpression referencing a caveat with the given name and
+// given context.
 func MustCaveatExprForTestingWithContext(name string, context map[string]any) *core.CaveatExpression {
 	contextStruct, err := structpb.NewStruct(context)
 	if err != nil {

--- a/internal/caveats/doc.go
+++ b/internal/caveats/doc.go
@@ -1,0 +1,2 @@
+// Package caveats contains code to evaluate a caveat with a given context.
+package caveats

--- a/internal/caveats/run.go
+++ b/internal/caveats/run.go
@@ -361,6 +361,7 @@ func (cr *CaveatRunner) runExpressionWithCaveats(
 }
 
 // ExpressionResult is the result of a caveat expression being run.
+// See also caveats.CaveatResult
 type ExpressionResult interface {
 	// Value is the resolved value for the expression. For partially applied expressions, this value will be false.
 	Value() bool

--- a/internal/datasets/basesubjectset.go
+++ b/internal/datasets/basesubjectset.go
@@ -379,7 +379,7 @@ func unionWildcardWithWildcard[T Subject[T]](existing *T, adding T, constructor 
 }
 
 // unionWildcardWithConcrete performs a union operation between a wildcard and a concrete subject
-// being added to the set, returning the updated wildcard (if applciable).
+// being added to the set, returning the updated wildcard (if applicable).
 func unionWildcardWithConcrete[T Subject[T]](existing *T, adding T, constructor constructor[T]) *T {
 	// If there is no existing wildcard, nothing more to do.
 	if existing == nil {

--- a/internal/datasets/doc.go
+++ b/internal/datasets/doc.go
@@ -1,0 +1,2 @@
+// Package datasets defines operations with sets of subjects.
+package datasets

--- a/internal/datasets/subjectset.go
+++ b/internal/datasets/subjectset.go
@@ -44,7 +44,7 @@ func (ss SubjectSet) UnionWithSet(other SubjectSet) error {
 	return ss.BaseSubjectSet.UnionWithSet(other.BaseSubjectSet)
 }
 
-// WithParentCaveatExpression returns a copy of the subject set with the parent caveat expression applied
+// WithParentCaveatExpression returns a copy of the subject set with the parent caveat expression applied
 // to all members of this set.
 func (ss SubjectSet) WithParentCaveatExpression(parentCaveatExpr *core.CaveatExpression) SubjectSet {
 	return SubjectSet{ss.BaseSubjectSet.WithParentCaveatExpression(parentCaveatExpr)}

--- a/internal/datastore/doc.go
+++ b/internal/datastore/doc.go
@@ -1,0 +1,2 @@
+// Package datastore contains datastore and revision implementations, proxies (decorators) for datastores, and code common to all datastores.
+package datastore

--- a/internal/developmentmembership/doc.go
+++ b/internal/developmentmembership/doc.go
@@ -1,0 +1,2 @@
+// Package developmentmembership defines operations with sets. To be used in tests only.
+package developmentmembership

--- a/internal/dispatch/combined/combined.go
+++ b/internal/dispatch/combined/combined.go
@@ -1,5 +1,3 @@
-// Package combined implements a dispatcher that combines caching,
-// redispatching and optional cluster dispatching.
 package combined
 
 import (

--- a/internal/dispatch/combined/doc.go
+++ b/internal/dispatch/combined/doc.go
@@ -1,0 +1,3 @@
+// Package combined implements a dispatcher that combines caching,
+// redispatching and optional cluster dispatching.
+package combined

--- a/internal/dispatch/doc.go
+++ b/internal/dispatch/doc.go
@@ -1,0 +1,2 @@
+// Package dispatch contains logic to dispatch requests locally or to other nodes.
+package dispatch

--- a/internal/dispatch/keys/hasher_ristretto.go
+++ b/internal/dispatch/keys/hasher_ristretto.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 )
 
-// dispatchCacheKeyHash computres a DispatchCheckKey for the given prefix and any hashable values.
+// dispatchCacheKeyHash computes a DispatchCheckKey for the given prefix and any hashable values.
 func dispatchCacheKeyHash(prefix cachePrefix, atRevision string, computeOption dispatchCacheKeyHashComputeOption, args ...hashableValue) DispatchCacheKey {
 	hasher := newDispatchCacheKeyHasher(prefix, computeOption)
 

--- a/internal/gateway/doc.go
+++ b/internal/gateway/doc.go
@@ -1,0 +1,3 @@
+// Package gateway implements an HTTP server that forwards JSON requests to
+// an upstream SpiceDB gRPC server.
+package gateway

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -1,5 +1,3 @@
-// Package gateway implements an HTTP server that forwards JSON requests to
-// an upstream SpiceDB gRPC server.
 package gateway
 
 import (

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1147,7 +1147,7 @@ func all[T any](
 	return checkResultsForMembership(membershipSet, responseMetadata)
 }
 
-// difference returns whether the first lazy check passes and none of the supsequent checks pass.
+// difference returns whether the first lazy check passes and none of the subsequent checks pass.
 func difference[T any](
 	ctx context.Context,
 	crc currentRequestContext,

--- a/internal/graph/doc.go
+++ b/internal/graph/doc.go
@@ -1,0 +1,2 @@
+// Package graph contains the code to traverse a relationship graph to solve requests like Checks, Expansions and Lookups.
+package graph

--- a/internal/lsp/doc.go
+++ b/internal/lsp/doc.go
@@ -1,0 +1,2 @@
+// Package lsp implements the Language Server Protocol for SpiceDB schema development.
+package lsp

--- a/internal/lsp/lsp.go
+++ b/internal/lsp/lsp.go
@@ -1,5 +1,3 @@
-// Package lsp implements the Language Server Protocol for SpiceDB schema
-// development.
 package lsp
 
 import (

--- a/internal/middleware/datastore/doc.go
+++ b/internal/middleware/datastore/doc.go
@@ -1,0 +1,2 @@
+// Package datastore defines middleware that injects the datastore into the context.
+package datastore

--- a/internal/middleware/dispatcher/doc.go
+++ b/internal/middleware/dispatcher/doc.go
@@ -1,0 +1,2 @@
+// Package dispatcher defines middleware that injects the dispatcher into the context.
+package dispatcher

--- a/internal/middleware/doc.go
+++ b/internal/middleware/doc.go
@@ -1,0 +1,2 @@
+// Package middleware defines various custom middlewares.
+package middleware

--- a/internal/middleware/handwrittenvalidation/doc.go
+++ b/internal/middleware/handwrittenvalidation/doc.go
@@ -1,0 +1,2 @@
+// Package handwrittenvalidation defines middleware that runs custom-made validations on incoming requests.
+package handwrittenvalidation

--- a/internal/middleware/pertoken/doc.go
+++ b/internal/middleware/pertoken/doc.go
@@ -1,0 +1,2 @@
+// Package pertoken defines middleware for testing purposes that injects a new in-memory datastore per incoming bearer token.
+package pertoken

--- a/internal/middleware/readonly/doc.go
+++ b/internal/middleware/readonly/doc.go
@@ -1,0 +1,2 @@
+// Package readonly defines middleware that injects a read-only proxy of the datastore into the context.
+package readonly

--- a/internal/middleware/servicespecific/doc.go
+++ b/internal/middleware/servicespecific/doc.go
@@ -1,0 +1,2 @@
+// Package servicespecific defines middleware that injects other middlewares.
+package servicespecific

--- a/internal/middleware/streamtimeout/doc.go
+++ b/internal/middleware/streamtimeout/doc.go
@@ -1,0 +1,2 @@
+// Package streamtimeout defines middleware that cancels the context after a timeout if no new data has been received.
+package streamtimeout

--- a/internal/middleware/usagemetrics/doc.go
+++ b/internal/middleware/usagemetrics/doc.go
@@ -1,0 +1,2 @@
+// Package usagemetrics defines middleware that adds usage data (e.g. dispatch counts) to the response.
+package usagemetrics

--- a/internal/middleware/usagemetrics/usagemetrics.go
+++ b/internal/middleware/usagemetrics/usagemetrics.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// DispatchedCountLabels are the labels that DispatchedCountHistogram will
-	// have have by default.
+	// have by default.
 	DispatchedCountLabels = []string{"method", "cached"}
 
 	// DispatchedCountHistogram is the metric that SpiceDB uses to keep track

--- a/internal/namespace/doc.go
+++ b/internal/namespace/doc.go
@@ -1,0 +1,2 @@
+// Package namespace provides functions for dealing with and validating types, relations and caveats.
+package namespace

--- a/internal/relationships/doc.go
+++ b/internal/relationships/doc.go
@@ -1,0 +1,2 @@
+// Package relationships contains helper methods to validate relationships that are going to be written.
+package relationships

--- a/internal/services/doc.go
+++ b/internal/services/doc.go
@@ -1,0 +1,2 @@
+// Package services contains all the gRPC controllers.
+package services

--- a/internal/taskrunner/doc.go
+++ b/internal/taskrunner/doc.go
@@ -1,0 +1,2 @@
+// Package taskrunner contains helper code run concurrent code.
+package taskrunner

--- a/internal/telemetry/doc.go
+++ b/internal/telemetry/doc.go
@@ -1,0 +1,6 @@
+// Package telemetry implements a client for reporting telemetry data used to
+// prioritize development of SpiceDB.
+//
+// For more information, see:
+// https://github.com/authzed/spicedb/blob/main/TELEMETRY.md
+package telemetry

--- a/internal/telemetry/reporter.go
+++ b/internal/telemetry/reporter.go
@@ -1,8 +1,3 @@
-// Package telemetry implements a client for reporting telemetry data used to
-// prioritize development of SpiceDB.
-//
-// For more information, see:
-// https://github.com/authzed/spicedb/blob/main/TELEMETRY.md
 package telemetry
 
 import (

--- a/internal/testfixtures/datastore.go
+++ b/internal/testfixtures/datastore.go
@@ -230,7 +230,7 @@ func createTestCaveat(require *require.Assertions) []*core.CaveatDefinition {
 }
 
 // DatastoreFromSchemaAndTestRelationships returns a validating datastore wrapping that specified,
-// loaded with the given scehma and relationships.
+// loaded with the given schema and relationships.
 func DatastoreFromSchemaAndTestRelationships(ds datastore.Datastore, schema string, relationships []tuple.Relationship, require *require.Assertions) (datastore.Datastore, datastore.Revision) {
 	ctx := context.Background()
 	validating := NewValidatingDatastore(ds)

--- a/internal/testfixtures/doc.go
+++ b/internal/testfixtures/doc.go
@@ -1,0 +1,2 @@
+// Package testfixtures contains code that helps to run tests against datastores.
+package testfixtures

--- a/internal/testserver/doc.go
+++ b/internal/testserver/doc.go
@@ -1,0 +1,2 @@
+// Package testserver defines a test server.
+package testserver

--- a/pkg/cache/doc.go
+++ b/pkg/cache/doc.go
@@ -1,0 +1,2 @@
+// Package cache defines interfaces and implementations of generic in-memory caches.
+package cache

--- a/pkg/caveats/doc.go
+++ b/pkg/caveats/doc.go
@@ -1,0 +1,2 @@
+// Package caveats contains code to compile caveats and to evaluate a caveat with a given context.
+package caveats

--- a/pkg/cmd/doc.go
+++ b/pkg/cmd/doc.go
@@ -1,0 +1,2 @@
+// Package cmd defines various public and internal commands.
+package cmd

--- a/pkg/composableschemadsl/dslshape/doc.go
+++ b/pkg/composableschemadsl/dslshape/doc.go
@@ -1,0 +1,2 @@
+// Package dslshape defines the types representing the structure of schema DSL.
+package dslshape

--- a/pkg/composableschemadsl/dslshape/dslshape.go
+++ b/pkg/composableschemadsl/dslshape/dslshape.go
@@ -1,6 +1,5 @@
 //go:generate go run golang.org/x/tools/cmd/stringer -type=NodeType -output zz_generated.nodetype_string.go
 
-// Package dslshape defines the types representing the structure of schema DSL.
 package dslshape
 
 // NodeType identifies the type of AST node.

--- a/pkg/cursor/doc.go
+++ b/pkg/cursor/doc.go
@@ -1,0 +1,2 @@
+// Package cursor implements encoding and decoding of cursors used in various APIs.
+package cursor

--- a/pkg/datastore/caveat.go
+++ b/pkg/datastore/caveat.go
@@ -27,7 +27,7 @@ type CaveatStorer interface {
 	CaveatReader
 
 	// WriteCaveats stores the provided caveats, and returns the assigned IDs
-	// Each element of the returning slice corresponds by possition to the input slice
+	// Each element of the returning slice corresponds by position to the input slice
 	WriteCaveats(context.Context, []*core.CaveatDefinition) error
 
 	// DeleteCaveats deletes the provided caveats by name

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -134,7 +134,7 @@ const (
 	// relationships both with and without caveats will be returned.
 	CaveatFilterOptionNone CaveatFilterOption = iota
 
-	// CaveatFilterOptionHasCaveat indicates that the caveat filter should only
+	// CaveatFilterOptionHasMatchingCaveat indicates that the caveat filter should only
 	// return relationships with the matching caveat.
 	CaveatFilterOptionHasMatchingCaveat
 

--- a/pkg/datastore/doc.go
+++ b/pkg/datastore/doc.go
@@ -1,0 +1,2 @@
+// Package datastore contains interfaces and code common to all datastores.
+package datastore

--- a/pkg/development/doc.go
+++ b/pkg/development/doc.go
@@ -1,0 +1,2 @@
+// Package development contains code that runs in the Playground.
+package development

--- a/pkg/diff/doc.go
+++ b/pkg/diff/doc.go
@@ -1,0 +1,2 @@
+// Package diff contains code for things that can be diffed (e.g. namespaces and caveats).
+package diff

--- a/pkg/genutil/doc.go
+++ b/pkg/genutil/doc.go
@@ -1,0 +1,2 @@
+// Package genutil contains helper functions to deal with generic data (e.g. maps and sets).
+package genutil

--- a/pkg/graph/doc.go
+++ b/pkg/graph/doc.go
@@ -1,0 +1,2 @@
+// Package graph contains helper code to traverse a schema.
+package graph

--- a/pkg/middleware/consistency/doc.go
+++ b/pkg/middleware/consistency/doc.go
@@ -1,0 +1,2 @@
+// Package consistency defines middleware to set, based on the request's consistency level, the right datastore revision to use.
+package consistency

--- a/pkg/middleware/datastore/doc.go
+++ b/pkg/middleware/datastore/doc.go
@@ -1,0 +1,2 @@
+// Package datastore defines middleware that injects the datastore into the context.
+package datastore

--- a/pkg/middleware/dispatcher/doc.go
+++ b/pkg/middleware/dispatcher/doc.go
@@ -1,0 +1,2 @@
+// Package dispatcher defines middleware that injects the dispatcher into the context.
+package dispatcher

--- a/pkg/middleware/logging/doc.go
+++ b/pkg/middleware/logging/doc.go
@@ -1,0 +1,2 @@
+// Package logging defines middleware to extract fields from requests and set them as fields in the logs.
+package logging

--- a/pkg/middleware/nodeid/doc.go
+++ b/pkg/middleware/nodeid/doc.go
@@ -1,0 +1,2 @@
+// Package nodeid defines middleware to update the context with the Id of the SpiceDB node running the request.
+package nodeid

--- a/pkg/middleware/requestid/doc.go
+++ b/pkg/middleware/requestid/doc.go
@@ -1,0 +1,2 @@
+// Package requestid defines middleware to set a request or response header with a request ID.
+package requestid

--- a/pkg/middleware/serverversion/doc.go
+++ b/pkg/middleware/serverversion/doc.go
@@ -1,0 +1,2 @@
+// Package serverversion defines middleware to return the version of the server.
+package serverversion

--- a/pkg/middleware/usagemetrics/doc.go
+++ b/pkg/middleware/usagemetrics/doc.go
@@ -1,0 +1,2 @@
+// Package usagemetrics defines middleware that adds usage data (e.g. dispatch counts) to the response.
+package usagemetrics

--- a/pkg/migrate/doc.go
+++ b/pkg/migrate/doc.go
@@ -1,0 +1,2 @@
+// Package migrate provides helper functions to execute datastore migrations.
+package migrate

--- a/pkg/namespace/doc.go
+++ b/pkg/namespace/doc.go
@@ -1,0 +1,2 @@
+// Package namespace contains helper functions to create namespaces in a schema.
+package namespace

--- a/pkg/namespace/metadata.go
+++ b/pkg/namespace/metadata.go
@@ -14,7 +14,7 @@ type WithSourcePosition interface {
 }
 
 // userDefinedMetadataTypeUrls are the type URLs of any user-defined metadata found
-//  in the namespace proto. If placed here, FilterUserDefinedMetadataInPlace will remove the
+// in the namespace proto. If placed here, FilterUserDefinedMetadataInPlace will remove the
 // metadata when called on the namespace.
 var userDefinedMetadataTypeUrls = map[string]struct{}{
 	"type.googleapis.com/impl.v1.DocComment": {},

--- a/pkg/releases/doc.go
+++ b/pkg/releases/doc.go
@@ -1,0 +1,2 @@
+// Package releases contains helper functions to determine the current and latest version of spiceDB.
+package releases

--- a/pkg/schema/compiled_schema_resolver.go
+++ b/pkg/schema/compiled_schema_resolver.go
@@ -8,7 +8,7 @@ import (
 )
 
 // FullSchemaResolver is a superset of a resolver that knows how to retrieve all definitions
-// from it's source by name (by having a complete list of names).
+// from its source by name (by having a complete list of names).
 type FullSchemaResolver interface {
 	Resolver
 	AllDefinitionNames() []string

--- a/pkg/schema/doc.go
+++ b/pkg/schema/doc.go
@@ -1,0 +1,2 @@
+// Package schema contains code that manipulates a schema and knows how to traverse it.
+package schema

--- a/pkg/schema/reachabilitygraph.go
+++ b/pkg/schema/reachabilitygraph.go
@@ -25,7 +25,7 @@ type DefinitionReachability struct {
 	hasOptimizedEntrypointCache sync.Map
 }
 
-// ReachabilityGraphFor returns a reachability graph for the given namespace.
+// Reachability returns a reachability graph for the given namespace.
 func (def *Definition) Reachability() *DefinitionReachability {
 	return &DefinitionReachability{def, sync.Map{}, sync.Map{}}
 }

--- a/pkg/schemadsl/compiler/doc.go
+++ b/pkg/schemadsl/compiler/doc.go
@@ -1,0 +1,2 @@
+// Package compiler knows how to build the Go representation of a SpiceDB schema text.
+package compiler

--- a/pkg/schemadsl/dslshape/doc.go
+++ b/pkg/schemadsl/dslshape/doc.go
@@ -1,0 +1,2 @@
+// Package dslshape defines the types representing the structure of schema DSL.
+package dslshape

--- a/pkg/schemadsl/dslshape/dslshape.go
+++ b/pkg/schemadsl/dslshape/dslshape.go
@@ -1,6 +1,5 @@
 //go:generate go run golang.org/x/tools/cmd/stringer -type=NodeType -output zz_generated.nodetype_string.go
 
-// Package dslshape defines the types representing the structure of schema DSL.
 package dslshape
 
 // NodeType identifies the type of AST node.

--- a/pkg/schemautil/doc.go
+++ b/pkg/schemautil/doc.go
@@ -1,0 +1,2 @@
+// Package schemautil contains helper functions to validate and apply changes to a schema.
+package schemautil

--- a/pkg/testutil/doc.go
+++ b/pkg/testutil/doc.go
@@ -1,0 +1,2 @@
+// Package testutil implements various utilities to reduce boilerplate in unit tests a la testify.
+package testutil

--- a/pkg/testutil/require.go
+++ b/pkg/testutil/require.go
@@ -1,5 +1,3 @@
-// Package testutil implements various utilities to reduce boilerplate in unit
-// tests a la testify.
 package testutil
 
 import (

--- a/pkg/tuple/core.go
+++ b/pkg/tuple/core.go
@@ -119,7 +119,7 @@ func CoreRR(namespace, relation string) *core.RelationReference {
 	}
 }
 
-// FromCoreRelationshipReference creates a RelationshipReference from a core.RelationshipReference.
+// FromCoreRelationReference creates a RelationReference from a core.RelationReference.
 func FromCoreRelationReference(rr *core.RelationReference) RelationReference {
 	spiceerrors.DebugAssert(func() bool {
 		return rr.Validate() == nil

--- a/pkg/tuple/doc.go
+++ b/pkg/tuple/doc.go
@@ -1,0 +1,2 @@
+// Package tuple provides ways to convert to and from proto structs to Go structs that can extend the core functionality.
+package tuple

--- a/pkg/tuple/strings.go
+++ b/pkg/tuple/strings.go
@@ -158,7 +158,7 @@ func StringCaveatContext(context *structpb.Struct) (string, error) {
 	return string(contextBytes), nil
 }
 
-// JoinObject joins the namespace and the objectId together into the standard
+// JoinObjectRef joins the namespace and the objectId together into the standard
 // format.
 //
 // This function assumes that the provided values have already been validated.

--- a/pkg/validationfile/doc.go
+++ b/pkg/validationfile/doc.go
@@ -1,0 +1,2 @@
+// Package validationfile contains code to manipulate files accepted by the `zed validate` CLI.
+package validationfile

--- a/pkg/x509util/doc.go
+++ b/pkg/x509util/doc.go
@@ -1,0 +1,2 @@
+// Package x509util contains helper functions to deal with certificates.
+package x509util

--- a/pkg/zedtoken/doc.go
+++ b/pkg/zedtoken/doc.go
@@ -1,0 +1,2 @@
+// Package zedtoken contains helper functions to handle zedtokens.
+package zedtoken

--- a/pkg/zedtoken/zedtoken.go
+++ b/pkg/zedtoken/zedtoken.go
@@ -1,4 +1,3 @@
-// Package zedtoken converts decimal.Decimal to zedtoken and vice versa
 package zedtoken
 
 import (


### PR DESCRIPTION
I glazed over the code to see what is implemented and to get a feeling of the overall organization. (And I fixed some typos along the way)

What stood out to me is that there are lot of **folders with the same name within `internal` and within `pkg`**. The line of what goes where seems blurry. E.g.:
- `graph` (only 2 files in `pkg`?)
- `caveats`. And, surprisingly, different `Evaluation Results` structs exist in both folders
- `namespace` / `schema` 

I believe that this could be simplified by merging folders, but this could break existing consumers of `pkg` if we move to `internal`. Who are the code consumers of `pkg` today? Do we provide guarantees on its stability?

**Other things I noticed:**
- I think it'd be good to document in https://authzed.com/docs/spicedb/ what request and response headers are available.
- the code used by the Playground appeared to be spread across a couple of folders


I'd be happy to submit follow-up PRs for all these things 😄 
