### PR TITLE
Fix handling of no columns in Spanner

### DIFF
--- a/internal/datastore/common/sql.go
+++ b/internal/datastore/common/sql.go
@@ -865,7 +865,7 @@ func ColumnsToSelect[CN any, CC any, EC any](
 	}
 
 	if len(colsToSelect) == 0 {
-		var unused int
+		var unused int64
 		colsToSelect = append(colsToSelect, &unused)
 	}
 

--- a/internal/datastore/mysql/indexes.go
+++ b/internal/datastore/mysql/indexes.go
@@ -19,6 +19,10 @@ var IndexUniqueLivingRelationships = common.IndexDefinition{
 var IndexUniqueRelationships = common.IndexDefinition{
 	Name:       `uq_relation_tuple_namespace`,
 	ColumnsSQL: `UNIQUE (namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, created_transaction, deleted_transaction)`,
+	Shapes: []queryshape.Shape{
+		queryshape.CheckPermissionSelectDirectSubjects,
+		queryshape.CheckPermissionSelectIndirectSubjects,
+	},
 }
 
 // IndexRelationshipBySubject is the index on the relationship table for

--- a/internal/datastore/postgres/schema/indexes.go
+++ b/internal/datastore/postgres/schema/indexes.go
@@ -81,13 +81,10 @@ var IndexSortedRelationTupleTransaction = common.IndexDefinition{
 }
 
 // IndexRelationTupleTransactionTimestamp adds an index to relation_tuple_transaction table
-// to support garbage collection.
-// DEPRECATED: Superceded by IndexSortedRelationTupleTransaction and should be removed in
-// the future.
+// to support optimized revision lookup.
 var IndexRelationTupleTransactionTimestamp = common.IndexDefinition{
-	Name:         `ix_relation_tuple_transaction_by_timestamp`,
-	ColumnsSQL:   `relation_tuple_transaction(timestamp)`,
-	IsDeprecated: true,
+	Name:       `ix_relation_tuple_transaction_by_timestamp`,
+	ColumnsSQL: `relation_tuple_transaction(timestamp)`,
 }
 
 // IndexGCDeadRelationships is an index for the GC process to quickly find dead relationships

--- a/internal/services/steelthreadtesting/steelthread_test.go
+++ b/internal/services/steelthreadtesting/steelthread_test.go
@@ -56,6 +56,7 @@ func TestNonMemdbSteelThreads(t *testing.T) {
 						dsconfig.WithGCWindow(time.Duration(90_000_000_000_000)),
 						dsconfig.WithRevisionQuantization(10),
 						dsconfig.WithMaxRetries(50),
+						dsconfig.WithExperimentalColumnOptimization(true),
 						dsconfig.WithRequestHedgingEnabled(false)))
 
 					ds = proxy.WrapWithIndexCheckingDatastoreProxyIfApplicable(ds)

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -165,7 +165,7 @@ func datastoreTest(ctx context.Context, datastore string, env map[string]string,
 	mergedTags := append([]string{"ci", "docker"}, tags...)
 	tagString := strings.Join(mergedTags, ",")
 	mg.Deps(checkDocker)
-	return goDirTestWithEnv(ctx, ".", fmt.Sprintf("./internal/datastore/%s/...", datastore), env, "-tags", tagString, "-timeout", "10m")
+	return goDirTestWithEnv(ctx, ".", fmt.Sprintf("./internal/datastore/%s/...", datastore), env, "-tags", tagString, "-timeout", "15m")
 }
 
 type Testcons mg.Namespace


### PR DESCRIPTION
Also enables the feature flag for steelthread tests, which means adjusting one of the indexes for MySQL and Postgres