### PR TITLE
introduces a flag to relax postgres isolation level

### DIFF
--- a/internal/datastore/postgres/options.go
+++ b/internal/datastore/postgres/options.go
@@ -35,6 +35,7 @@ type postgresOptions struct {
 	columnOptimizationOption       common.ColumnOptimizationOption
 	includeQueryParametersInTraces bool
 	revisionHeartbeatEnabled       bool
+	relaxedIsolationLevel          bool
 
 	migrationPhase    string
 	allowedMigrations []string
@@ -79,8 +80,9 @@ const (
 	defaultExpirationDisabled                = false
 	defaultWatchDisabled                     = false
 	// no follower delay by default, it should only be set if using read replicas
-	defaultFollowerReadDelay = 0
-	defaultRevisionHeartbeat = true
+	defaultFollowerReadDelay     = 0
+	defaultRevisionHeartbeat     = true
+	defaultRelaxedIsolationLevel = false
 )
 
 // Option provides the facility to configure how clients within the
@@ -109,6 +111,7 @@ func generateConfig(options []Option) (postgresOptions, error) {
 		watchDisabled:                  defaultWatchDisabled,
 		followerReadDelay:              defaultFollowerReadDelay,
 		revisionHeartbeatEnabled:       defaultRevisionHeartbeat,
+		relaxedIsolationLevel:          defaultRelaxedIsolationLevel,
 	}
 
 	for _, option := range options {
@@ -435,4 +438,11 @@ func WithRevisionHeartbeat(isEnabled bool) Option {
 // WithWatchDisabled disables the watch functionality.
 func WithWatchDisabled(isDisabled bool) Option {
 	return func(po *postgresOptions) { po.watchDisabled = isDisabled }
+}
+
+// WithRelaxedIsolationLevel relaxes the required Serializable isolation level to run SpiceDB on Postgres.
+// Please note this will defeat the new enemy problem and SpiceDB won't be able to provide strong consistency
+// guarantees.
+func WithRelaxedIsolationLevel(isEnabled bool) Option {
+	return func(po *postgresOptions) { po.relaxedIsolationLevel = isEnabled }
 }

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -65,6 +65,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.ConnectRate = c.ConnectRate
 		to.GCInterval = c.GCInterval
 		to.GCMaxOperationTime = c.GCMaxOperationTime
+		to.RelaxedIsolationLevel = c.RelaxedIsolationLevel
 		to.SpannerCredentialsFile = c.SpannerCredentialsFile
 		to.SpannerCredentialsJSON = c.SpannerCredentialsJSON
 		to.SpannerEmulatorHost = c.SpannerEmulatorHost
@@ -122,6 +123,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["ConnectRate"] = helpers.DebugValue(c.ConnectRate, false)
 	debugMap["GCInterval"] = helpers.DebugValue(c.GCInterval, false)
 	debugMap["GCMaxOperationTime"] = helpers.DebugValue(c.GCMaxOperationTime, false)
+	debugMap["RelaxedIsolationLevel"] = helpers.DebugValue(c.RelaxedIsolationLevel, false)
 	debugMap["SpannerCredentialsFile"] = helpers.DebugValue(c.SpannerCredentialsFile, false)
 	debugMap["SpannerCredentialsJSON"] = helpers.SensitiveDebugValue(c.SpannerCredentialsJSON)
 	debugMap["SpannerEmulatorHost"] = helpers.DebugValue(c.SpannerEmulatorHost, false)
@@ -415,6 +417,13 @@ func WithGCInterval(gCInterval time.Duration) ConfigOption {
 func WithGCMaxOperationTime(gCMaxOperationTime time.Duration) ConfigOption {
 	return func(c *Config) {
 		c.GCMaxOperationTime = gCMaxOperationTime
+	}
+}
+
+// WithRelaxedIsolationLevel returns an option that can set RelaxedIsolationLevel on a Config
+func WithRelaxedIsolationLevel(relaxedIsolationLevel bool) ConfigOption {
+	return func(c *Config) {
+		c.RelaxedIsolationLevel = relaxedIsolationLevel
 	}
 }
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -430,8 +430,15 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		return nil, fmt.Errorf("error building streaming middlewares: %w", err)
 	}
 
+	// NOTE: Preconditions are disabled if the isolation level is relaxed, as we cannot
+	// ensure the transactional guarantees of preconditions in that case.
+	maxPreconditionCount := c.MaximumPreconditionCount
+	if c.DatastoreConfig.RelaxedIsolationLevel {
+		maxPreconditionCount = 0
+	}
+
 	permSysConfig := v1svc.PermissionsServerConfig{
-		MaxPreconditionsCount:           c.MaximumPreconditionCount,
+		MaxPreconditionsCount:           maxPreconditionCount,
 		MaxUpdatesPerWrite:              c.MaximumUpdatesPerWrite,
 		MaximumAPIDepth:                 c.DispatchMaxDepth,
 		MaxCaveatContextSize:            c.MaxCaveatContextSize,


### PR DESCRIPTION
⚠️ This completely defeats SpiceDB consistency guarantees but may be advisable for scenarios where consistency can be compromised, and the Postgres instance is exhibiting a lot of write contention