### PR TITLE
Force indexes on Postgres and change subject sort order to match index

### DIFF
--- a/internal/datastore/postgres/reader.go
+++ b/internal/datastore/postgres/reader.go
@@ -157,6 +157,10 @@ func (r *pgReader) QueryRelationships(
 		return nil, err
 	}
 
+	builtOpts := options.NewQueryOptionsWithOptions(opts...)
+	indexingHint := schema.IndexingHintForQueryShape(r.schema, builtOpts.QueryShape)
+	qBuilder = qBuilder.WithIndexingHint(indexingHint)
+
 	return r.executor.ExecuteQuery(ctx, qBuilder, opts...)
 }
 
@@ -179,6 +183,9 @@ func (r *pgReader) ReverseQueryRelationships(
 			FilterToResourceType(queryOpts.ResRelation.Namespace).
 			FilterToRelation(queryOpts.ResRelation.Relation)
 	}
+
+	indexingHint := schema.IndexingHintForQueryShape(r.schema, queryOpts.QueryShapeForReverse)
+	qBuilder = qBuilder.WithIndexingHint(indexingHint)
 
 	return r.executor.ExecuteQuery(ctx,
 		qBuilder,

--- a/internal/datastore/postgres/schema/schema.go
+++ b/internal/datastore/postgres/schema/schema.go
@@ -56,5 +56,17 @@ func Schema(colOptimizationOpt common.ColumnOptimizationOption, expirationDisabl
 		common.WithColumnOptimization(colOptimizationOpt),
 		common.WithExpirationDisabled(expirationDisabled),
 		common.SetIndexes(pgIndexes),
+
+		// NOTE: this order differs from the default because the index
+		// used for sorting by subject (ix_relation_tuple_by_subject) is
+		// defined with the userset object ID first.
+		common.SetSortBySubjectColumnOrder([]string{
+			ColUsersetObjectID,
+			ColUsersetNamespace,
+			ColUsersetRelation,
+			ColNamespace,
+			ColRelation,
+			ColObjectID,
+		}),
 	)
 }


### PR DESCRIPTION
Requires `pg_hint_plan` to be installed for the index forcing to work