### PR TITLE
postgres: optimize CheckRevision query

### DIFF
--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -73,18 +73,31 @@ const (
 	//   %[4] Inverse of GC window (in seconds)
 	//   %[5] Name of the snapshot column
 	queryValidTransaction = `
-	WITH minvalid AS (
-		SELECT %[1]s, %[5]s
-        FROM %[2]s
-        WHERE 
-            %[3]s >= NOW() - INTERVAL '%[4]f seconds'
-          OR
-             %[3]s = (SELECT MAX(%[3]s) FROM %[2]s)
-        ORDER BY %[3]s ASC
-        LIMIT 1
-	)
-	SELECT minvalid.%[1]s, minvalid.%[5]s, pg_current_snapshot() FROM minvalid;`
-
+	WITH
+	  earliest AS (
+		SELECT %[1]s, %[5]s, %[3]s
+		FROM %[2]s
+		WHERE %[3]s >= NOW() - INTERVAL '%[4]f seconds'
+		ORDER BY %[3]s ASC
+		LIMIT 1
+	  ),
+	  newest AS (
+		SELECT %[1]s, %[5]s, %[3]s
+		FROM %[2]s
+		ORDER BY %[3]s DESC
+		LIMIT 1
+	  )
+	SELECT
+	  %[1]s,
+	  %[5]s,
+	  pg_current_snapshot()
+	FROM (
+	  SELECT * FROM earliest
+	  UNION ALL
+	  SELECT * FROM newest
+	) AS candidates
+	ORDER BY %[3]s ASC
+	LIMIT 1;`
 	queryCurrentSnapshot = `SELECT pg_current_snapshot();`
 
 	queryCurrentTransactionID = `SELECT pg_current_xact_id()::text::integer;`


### PR DESCRIPTION
the condition in postgres' CheckRevision datastore could lead to slow queries for very large
transactions table. This was caused by the
`timestamp = (SELECT MAX(timestamp) FROM relation_tuple_transaction)` portion of the query, which led to filtering rows which could have been discarded in the first place by the other expression.

This query was contributed by one of our customers.