### PR TITLE
Switch to larger depot instances for datastore consistency tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -135,7 +135,7 @@ jobs:
 
   datastoreconstest:
     name: "Datastore Consistency Tests"
-    runs-on: "depot-ubuntu-24.04-4"
+    runs-on: "depot-ubuntu-24.04-8"
     needs: "paths-filter"
     strategy:
       fail-fast: false


### PR DESCRIPTION
Should reduce flakiness for the MySQL consistency test suite