### PR TITLE
Minimal decoupling of validation file parsing and schema compilation

### DIFF
--- a/pkg/validationfile/blocks/schema.go
+++ b/pkg/validationfile/blocks/schema.go
@@ -1,70 +1,28 @@
 package blocks
 
 import (
-	"errors"
-	"fmt"
-
 	yamlv3 "gopkg.in/yaml.v3"
 
-	"github.com/ccoveille/go-safecast"
-
-	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
-	"github.com/authzed/spicedb/pkg/schemadsl/input"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
-// ParsedSchema is the parsed schema in a validationfile.
-type ParsedSchema struct {
+// SchemaWithPosition is the schema string together with the
+// position of the schema within the validation file.
+type SchemaWithPosition struct {
 	// Schema is the schema found.
 	Schema string
 
 	// SourcePosition is the position of the schema in the file.
 	SourcePosition spiceerrors.SourcePosition
-
-	// CompiledSchema is the compiled schema.
-	CompiledSchema *compiler.CompiledSchema
 }
 
 // UnmarshalYAML is a custom unmarshaller.
-func (ps *ParsedSchema) UnmarshalYAML(node *yamlv3.Node) error {
+func (ps *SchemaWithPosition) UnmarshalYAML(node *yamlv3.Node) error {
 	err := node.Decode(&ps.Schema)
 	if err != nil {
 		return convertYamlError(err)
 	}
 
-	compiled, err := compiler.Compile(compiler.InputSchema{
-		Source:       input.Source("schema"),
-		SchemaString: ps.Schema,
-	}, compiler.AllowUnprefixedObjectType())
-	if err != nil {
-		var errWithContext compiler.WithContextError
-		if errors.As(err, &errWithContext) {
-			line, col, lerr := errWithContext.SourceRange.Start().LineAndColumn()
-			if lerr != nil {
-				return lerr
-			}
-
-			uintLine, err := safecast.ToUint64(line)
-			if err != nil {
-				return err
-			}
-			uintCol, err := safecast.ToUint64(col)
-			if err != nil {
-				return err
-			}
-
-			return spiceerrors.NewWithSourceError(
-				fmt.Errorf("error when parsing schema: %s", errWithContext.BaseMessage),
-				errWithContext.ErrorSourceCode,
-				uintLine+1, // source line is 0-indexed
-				uintCol+1,  // source col is 0-indexed
-			)
-		}
-
-		return fmt.Errorf("error when parsing schema: %w", err)
-	}
-
-	ps.CompiledSchema = compiled
 	ps.SourcePosition = spiceerrors.SourcePosition{LineNumber: node.Line, ColumnPosition: node.Column}
 	return nil
 }

--- a/pkg/validationfile/fileformat.go
+++ b/pkg/validationfile/fileformat.go
@@ -20,7 +20,7 @@ func DecodeValidationFile(contents []byte) (*ValidationFile, error) {
 // ValidationFile is a structural representation of the validation file format.
 type ValidationFile struct {
 	// Schema is the schema.
-	Schema blocks.ParsedSchema `yaml:"schema"`
+	Schema blocks.SchemaWithPosition `yaml:"schema"`
 
 	// Relationships are the relationships specified in the validation file.
 	Relationships blocks.ParsedRelationships `yaml:"relationships"`

--- a/pkg/validationfile/schema_test.go
+++ b/pkg/validationfile/schema_test.go
@@ -1,10 +1,14 @@
-package blocks
+package validationfile
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	yamlv3 "gopkg.in/yaml.v3"
+
+	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+
+	"github.com/authzed/spicedb/pkg/validationfile/blocks"
 )
 
 func TestParseSchema(t *testing.T) {
@@ -43,17 +47,20 @@ func TestParseSchema(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			ps := ParsedSchema{}
-			err := yamlv3.Unmarshal([]byte(tt.contents), &ps)
+			schemaWithPosition := blocks.SchemaWithPosition{}
+			err := yamlv3.Unmarshal([]byte(tt.contents), &schemaWithPosition)
+			require.NoError(t, err)
+
+			compiled, err := CompileSchema(schemaWithPosition, caveattypes.Default.TypeSet)
 			if tt.expectedError != "" {
 				require.NotNil(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
 			} else {
 				require.Nil(t, err)
 				if tt.expectedDefCount > 0 {
-					require.NotNil(t, ps.CompiledSchema)
-					require.Equal(t, tt.expectedDefCount, len(ps.CompiledSchema.OrderedDefinitions))
-					require.Equal(t, tt.contents, ps.Schema)
+					require.NotNil(t, compiled)
+					require.Equal(t, tt.expectedDefCount, len(compiled.OrderedDefinitions))
+					require.Equal(t, tt.contents, schemaWithPosition.Schema)
 				}
 			}
 		})


### PR DESCRIPTION
## Description
A subset of the work in #2268, this pulls out schema compilation from schema parsing so that we can pass in the caveat typesystem more easily.

## Changes
* Move schema compilation logic that was previously in parsing into its own function
* Remove CompiledSchema from yaml blocks used in parsing
* Amend callsites accordingly
## Testing
Review