### PR TITLE
Switch experimental column optimizations to be enabled by default

### DIFF
--- a/internal/datastore/crdb/options.go
+++ b/internal/datastore/crdb/options.go
@@ -60,7 +60,7 @@ const (
 	defaultConnectRate                    = 100 * time.Millisecond
 	defaultFilterMaximumIDCount           = 100
 	defaultWithIntegrity                  = false
-	defaultColumnOptimizationOption       = common.ColumnOptimizationOptionNone
+	defaultColumnOptimizationOption       = common.ColumnOptimizationOptionStaticValues
 	defaultIncludeQueryParametersInTraces = false
 	defaultExpirationDisabled             = false
 	defaultWatchDisabled                  = false

--- a/internal/datastore/mysql/options.go
+++ b/internal/datastore/mysql/options.go
@@ -26,7 +26,7 @@ const (
 	defaultGCEnabled                         = true
 	defaultCredentialsProviderName           = ""
 	defaultFilterMaximumIDCount              = 100
-	defaultColumnOptimizationOption          = common.ColumnOptimizationOptionNone
+	defaultColumnOptimizationOption          = common.ColumnOptimizationOptionStaticValues
 	defaultExpirationDisabled                = false
 	defaultWatchDisabled                     = false
 	// no follower delay by default, it should only be set if using read replicas

--- a/internal/datastore/postgres/options.go
+++ b/internal/datastore/postgres/options.go
@@ -75,7 +75,7 @@ const (
 	defaultCredentialsProviderName           = ""
 	defaultReadStrictMode                    = false
 	defaultFilterMaximumIDCount              = 100
-	defaultColumnOptimizationOption          = common.ColumnOptimizationOptionNone
+	defaultColumnOptimizationOption          = common.ColumnOptimizationOptionStaticValues
 	defaultIncludeQueryParametersInTraces    = false
 	defaultExpirationDisabled                = false
 	defaultWatchDisabled                     = false

--- a/internal/datastore/spanner/options.go
+++ b/internal/datastore/spanner/options.go
@@ -81,7 +81,7 @@ const (
 	defaultDisableStats                = false
 	maxRevisionQuantization            = 24 * time.Hour
 	defaultFilterMaximumIDCount        = 100
-	defaultColumnOptimizationOption    = common.ColumnOptimizationOptionNone
+	defaultColumnOptimizationOption    = common.ColumnOptimizationOptionStaticValues
 	defaultExpirationDisabled          = false
 	defaultWatchDisabled               = false
 )

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -308,7 +308,7 @@ func RegisterDatastoreFlagsWithPrefix(flagSet *pflag.FlagSet, prefix string, opt
 		return fmt.Errorf("failed to mark flag as hidden: %w", err)
 	}
 
-	flagSet.BoolVar(&opts.ExperimentalColumnOptimization, flagName("datastore-experimental-column-optimization"), false, "enable experimental column optimization")
+	flagSet.BoolVar(&opts.ExperimentalColumnOptimization, flagName("datastore-experimental-column-optimization"), true, "enable experimental column optimization")
 
 	return nil
 }
@@ -359,7 +359,7 @@ func DefaultDatastoreConfig() *Config {
 		RelationshipIntegrityCurrentKey:          RelIntegrityKey{},
 		RelationshipIntegrityExpiredKeys:         []string{},
 		AllowedMigrations:                        []string{},
-		ExperimentalColumnOptimization:           false,
+		ExperimentalColumnOptimization:           true,
 		IncludeQueryParametersInTraces:           false,
 		EnableExperimentalRelationshipExpiration: false,
 	}


### PR DESCRIPTION
When enabled, the columns with static values and/or those not needed (caveats, expiration) are elided from the SQL queries entirely