### PR TITLE
tighten github workflow scopes

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -10,6 +10,8 @@ on: # yamllint disable-line rule:truthy
   merge_group:
     types:
       - "checks_requested"
+permissions:
+  contents: "read"
 env:
   DOCKERHUB_PUBLIC_ACCESS_TOKEN: "dckr_pat_8AEETZWxu8f7FvJUk9NrpyX_ZEQ"
   DOCKERHUB_PUBLIC_USER: "spicedbgithubactions"

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -12,6 +12,8 @@ on:  # yamllint disable-line rule:truthy
   merge_group:
     types:
       - "checks_requested"
+permissions:
+  contents: "read"
 jobs:
   cla:
     name: "Check Signature"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -5,6 +5,8 @@ on:  # yamllint disable-line rule:truthy
   merge_group:
     types:
       - "checks_requested"
+permissions:
+  contents: "read"
 jobs:
   triage:
     runs-on: "depot-ubuntu-24.04-small"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,8 @@ on:  # yamllint disable-line rule:truthy
   merge_group:
     types:
       - "checks_requested"
+permissions:
+  contents: "read"
 jobs:
   go-license-check:
     name: "License Check"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,11 +5,13 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - "main"
 permissions:
-  contents: "write"
-  packages: "write"
+  contents: "read"
 jobs:
   goreleaser:
     runs-on: "depot-ubuntu-24.04-4"
+    permissions:
+      contents: "write"
+      packages: "write" # publish to GHCR
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -5,11 +5,13 @@ on:  # yamllint disable-line rule:truthy
     tags:
       - "*"
 permissions:
-  contents: "write"
-  packages: "write"
+  contents: "read"
 jobs:
   release-windows:
     runs-on: "windows-latest"
+    permissions:
+      contents: "write"
+      packages: "write" # publish to GHCR
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,11 +6,13 @@ on:  # yamllint disable-line rule:truthy
       - "*"
   workflow_dispatch:
 permissions:
-  contents: "write"
-  packages: "write"
+  contents: "read"
 jobs:
   goreleaser:
     runs-on: "depot-ubuntu-24.04-4"
+    permissions:
+      contents: "write"
+      packages: "write" # publish to GHCR
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -10,6 +10,8 @@ on:  # yamllint disable-line rule:truthy
   merge_group:
     types:
       - "checks_requested"
+permissions:
+  contents: "read"
 env:
   DOCKERHUB_PUBLIC_ACCESS_TOKEN: "dckr_pat_8AEETZWxu8f7FvJUk9NrpyX_ZEQ"
   DOCKERHUB_PUBLIC_USER: "spicedbgithubactions"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -4,11 +4,13 @@ on:  # yamllint disable-line rule:truthy
   release:
     types: ["created"]
 permissions:
-  contents: "write"
+  contents: "read"
 jobs:
   build:
     name: "Build WASM"
     runs-on: "depot-ubuntu-24.04-small"
+    permissions:
+      contents: "write"
     steps:
       - uses: "actions/checkout@v4"
         with:


### PR DESCRIPTION
Followed instructions in https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions.

The goal is to improve the OpenSSF score:

![Screenshot 2025-04-23 at 10 56 43 AM](https://github.com/user-attachments/assets/07a90cfd-7c19-4605-9cc3-14f59773b127)
