### PR TITLE
fix regression in #2353 - add PR write permissions to labeler action

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   triage:
     runs-on: "depot-ubuntu-24.04-small"
+    permissions:
+      pull-requests: "write"
     steps:
       - uses: "actions/labeler@v5"
         with:


### PR DESCRIPTION
Failure seen in https://github.com/authzed/spicedb/actions/runs/14628462199/job/41045593653?pr=2354

```
Run actions/labeler@v5
The configuration file (path: .github/labeler.yml) was not found locally, fetching via the api
Warning: The action requires write permission to add labels to pull requests. For more information please refer to the action documentation: https://github.com/actions/labeler#permissions
Error: Resource not accessible by integration
```

Docs: https://github.com/actions/labeler#create-workflow