### PR TITLE
update cockroachdb and chaosd used in e2e tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -338,8 +338,8 @@ jobs:
         if: "steps.cache-binaries.outputs.cache-hit != 'true'"
         working-directory: "e2e/newenemy"
         run: |
-          curl https://binaries.cockroachdb.com/cockroach-v22.1.5.linux-amd64.tgz | tar -xz && mv cockroach-v22.1.5.linux-amd64/cockroach ./cockroach
-          curl -fsSL https://mirrors.chaos-mesh.org/chaosd-v1.1.1-linux-amd64.tar.gz | tar -xz && mv chaosd-v1.1.1-linux-amd64/chaosd ./chaosd
+          curl https://binaries.cockroachdb.com/cockroach-v23.1.30.linux-amd64.tgz | tar -xz && mv cockroach-v23.1.30.linux-amd64/cockroach ./cockroach
+          curl -fsSL https://mirrors.chaos-mesh.org/chaosd-v1.4.0-linux-amd64.tar.gz | tar -xz && mv chaosd-v1.4.0-linux-amd64/chaosd ./chaosd
       - name: "Build SpiceDB"
         run: |
           go get -d ./...

--- a/e2e/cockroach/cockroach.go
+++ b/e2e/cockroach/cockroach.go
@@ -151,15 +151,12 @@ func (cs Cluster) Stop(out io.Writer) error {
 }
 
 // Init runs the cockroach init command against the cluster
-func (cs Cluster) Init(ctx context.Context, out, errOut io.Writer) {
+func (cs Cluster) Init(ctx context.Context, out, errOut io.Writer) error {
 	// this retries until it succeeds, it won't return unless it does
-	if err := e2e.Run(ctx, out, errOut, "./cockroach",
+	return e2e.Run(ctx, out, errOut, "./cockroach",
 		"init",
 		"--insecure",
-		"--host="+cs[0].Addr,
-	); err != nil {
-		panic(err)
-	}
+		"--host="+cs[0].Addr)
 }
 
 // SQL runs the set of SQL commands against the cluster

--- a/e2e/newenemy/newenemy_test.go
+++ b/e2e/newenemy/newenemy_test.go
@@ -105,7 +105,7 @@ func initializeTestCRDBCluster(ctx context.Context, t testing.TB) cockroach.Clus
 
 	t.Log("initializing crdb...")
 
-	crdbCluster.Init(ctx, tlog, tlog)
+	require.NoError(crdbCluster.Init(ctx, tlog, tlog))
 	require.NoError(crdbCluster.SQL(ctx, tlog, tlog,
 		"SET CLUSTER SETTING kv.range.backpressure_range_size_multiplier=0;",
 	))
@@ -648,9 +648,11 @@ func leaderFromRangeRow(row pgx.Row) int {
 		leaseHoldeLocality sql.NullString
 		replicas           []pgtype.Int8
 		replicaLocalities  []pgtype.Text
+		votingReplicas     []pgtype.Int8
+		nonVotingReplicas  []pgtype.Int8
 	)
 
-	if err := row.Scan(&startKey, &endKey, &rangeID, &leaseHolder, &leaseHoldeLocality, &replicas, &replicaLocalities); err != nil {
+	if err := row.Scan(&startKey, &endKey, &rangeID, &leaseHolder, &leaseHoldeLocality, &replicas, &replicaLocalities, &votingReplicas, &nonVotingReplicas); err != nil {
 		log.Fatal(fmt.Errorf("failed to load leader id: %w", err))
 	}
 

--- a/internal/datastore/crdb/version/version.go
+++ b/internal/datastore/crdb/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 // MinimumSupportedCockroachDBVersion is the minimum version of CockroachDB supported for this driver.
+// If you update this, please also update the E2E step in the Github workflow.
 //
 // NOTE: must match a tag on DockerHub for the `cockroachdb/cockroach` image, without the `v` prefix.
 const MinimumSupportedCockroachDBVersion = "23.1.30"


### PR DESCRIPTION
I noticed a flake in https://github.com/authzed/spicedb/actions/runs/14630677169/job/41052252409?pr=2356. I don't know the root cause of the flake, but the versions used are old, so why not update? 😄 