### PR TITLE
fix custom analyzers skipping all files

### DIFF
--- a/magefiles/lint.go
+++ b/magefiles/lint.go
@@ -87,7 +87,7 @@ func (Lint) Analyzers() error {
 		"-exprstatementcheck",
 		"-exprstatementcheck.disallowed-expr-statement-types=*github.com/rs/zerolog.Event:MarshalZerologObject:missing Send or Msg on zerolog log Event",
 		"-paniccheck",
-		"-paniccheck.skip-files=_test,zz_",
+		"-paniccheck.skip-files=_test,zz_,migrations/index.go",
 		"-zerologmarshalcheck",
 		"-zerologmarshalcheck.skip-files=_test,zz_",
 		"-protomarshalcheck",

--- a/tools/analyzers/lendowncastcheck/lendowncastcheck.go
+++ b/tools/analyzers/lendowncastcheck/lendowncastcheck.go
@@ -48,7 +48,7 @@ func Analyzer() *analysis.Analyzer {
 			// Check for a skipped file.
 			skipFilePatterns := make([]string, 0)
 			if len(*skipFiles) > 0 {
-				skipFilePatterns = lo.Map(strings.Split(*skipPkg, ","), func(skipped string, _ int) string { return strings.TrimSpace(skipped) })
+				skipFilePatterns = lo.Map(strings.Split(*skipFiles, ","), func(skipped string, _ int) string { return strings.TrimSpace(skipped) })
 			}
 			for _, pattern := range skipFilePatterns {
 				_, err := regexp.Compile(pattern)

--- a/tools/analyzers/mutexcheck/mutexcheck.go
+++ b/tools/analyzers/mutexcheck/mutexcheck.go
@@ -39,7 +39,7 @@ func Analyzer() *analysis.Analyzer {
 			// Check for a skipped file.
 			skipFilePatterns := make([]string, 0)
 			if len(*skipFiles) > 0 {
-				skipFilePatterns = lo.Map(strings.Split(*skipPkg, ","), func(skipped string, _ int) string { return strings.TrimSpace(skipped) })
+				skipFilePatterns = lo.Map(strings.Split(*skipFiles, ","), func(skipped string, _ int) string { return strings.TrimSpace(skipped) })
 			}
 			for _, pattern := range skipFilePatterns {
 				_, err := regexp.Compile(pattern)

--- a/tools/analyzers/paniccheck/paniccheck.go
+++ b/tools/analyzers/paniccheck/paniccheck.go
@@ -35,7 +35,7 @@ func Analyzer() *analysis.Analyzer {
 			// Check for a skipped file.
 			skipFilePatterns := make([]string, 0)
 			if len(*skipFiles) > 0 {
-				skipFilePatterns = lo.Map(strings.Split(*skipPkg, ","), func(skipped string, _ int) string { return strings.TrimSpace(skipped) })
+				skipFilePatterns = lo.Map(strings.Split(*skipFiles, ","), func(skipped string, _ int) string { return strings.TrimSpace(skipped) })
 			}
 			for _, pattern := range skipFilePatterns {
 				_, err := regexp.Compile(pattern)

--- a/tools/analyzers/zerologmarshalcheck/zerologmarshalcheck.go
+++ b/tools/analyzers/zerologmarshalcheck/zerologmarshalcheck.go
@@ -39,7 +39,7 @@ func Analyzer() *analysis.Analyzer {
 			// Check for a skipped file.
 			skipFilePatterns := make([]string, 0)
 			if len(*skipFiles) > 0 {
-				skipFilePatterns = lo.Map(strings.Split(*skipPkg, ","), func(skipped string, _ int) string { return strings.TrimSpace(skipped) })
+				skipFilePatterns = lo.Map(strings.Split(*skipFiles, ","), func(skipped string, _ int) string { return strings.TrimSpace(skipped) })
 			}
 			for _, pattern := range skipFilePatterns {
 				_, err := regexp.Compile(pattern)


### PR DESCRIPTION
I was wondering why `-mutexcheck.skip-files` was skipping _everything_. Now I know.