### PR TITLE
fix panic when running mage test:all

### DIFF
--- a/internal/testserver/datastore/crdb.go
+++ b/internal/testserver/datastore/crdb.go
@@ -55,7 +55,9 @@ func RunCRDBForTesting(t testing.TB, bridgeNetworkName string, crdbVersion strin
 		creds:    "root:fake",
 	}
 	t.Cleanup(func() {
-		require.NoError(t, builder.conn.Close(context.Background()))
+		if builder.conn != nil {
+			require.NoError(t, builder.conn.Close(context.Background()))
+		}
 		require.NoError(t, pool.Purge(resource))
 	})
 


### PR DESCRIPTION
```
--- FAIL: TestConsistencyPerDatastore (56.88s)
    --- FAIL: TestConsistencyPerDatastore/cockroachdb (56.88s)
        --- FAIL: TestConsistencyPerDatastore/cockroachdb/intersectionarrow.yaml (56.87s)
            crdb.go:71: 
                        Error Trace:    /Users/miparnisari/Documents/GitHub/spicedb/internal/testserver/datastore/crdb.go:71
                                                                /Users/miparnisari/Documents/GitHub/spicedb/internal/testserver/datastore/datastore.go:70
                                                                /Users/miparnisari/Documents/GitHub/spicedb/internal/testserver/datastore/datastore.go:54
                                                                /Users/miparnisari/Documents/GitHub/spicedb/internal/services/integrationtesting/consistency_datastore_test.go:54
                        Error:          Received unexpected error:
                                        failed to connect to `user=root database=defaultdb`:
                                                [::1]:55008 (localhost): dial error: dial tcp [::1]:55008: connect: connection refused
                                                127.0.0.1:55008 (localhost): dial error: dial tcp 127.0.0.1:55008: connect: connection refused
                        Test:           TestConsistencyPerDatastore/cockroachdb/intersectionarrow.yaml
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1035b5840]

goroutine 106 [running]:
testing.tRunner.func1.2({0x1051d9e00, 0x107603a80})
        /Users/miparnisari/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
        /Users/miparnisari/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/testing/testing.go:1737 +0x334
panic({0x1051d9e00?, 0x107603a80?})
        /Users/miparnisari/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/runtime/panic.go:792 +0x124
github.com/jackc/pgx/v5.(*Conn).IsClosed(...)
        /Users/miparnisari/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.4/conn.go:420
github.com/jackc/pgx/v5.(*Conn).Close(0x66?, {0x1058532e8?, 0x1076ca900?})
        /Users/miparnisari/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.4/conn.go:299 +0x20
github.com/authzed/spicedb/internal/testserver/datastore.RunCRDBForTesting.func2()
        /Users/miparnisari/Documents/GitHub/spicedb/internal/testserver/datastore/crdb.go:58 +0x54
testing.(*common).Cleanup.func1()
        /Users/miparnisari/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/testing/testing.go:1211 +0xf4
testing.(*common).runCleanup(0x14000003dc0, 0x14000102fc0?)
        /Users/miparnisari/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/testing/testing.go:1445 +0xe4
testing.tRunner.func2()
        /Users/miparnisari/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/testing/testing.go:1786 +0x2c
runtime.Goexit()
        /Users/miparnisari/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/runtime/panic.go:636 +0x60
testing.(*common).FailNow(0x14000003dc0)
        /Users/miparnisari/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/testing/testing.go:1041 +0x48
github.com/stretchr/testify/require.NoError({0x105830eb0, 0x14000003dc0}, {0x105814c80, 0x14000137758}, {0x0, 0x0, 0x0})
        /Users/miparnisari/go/pkg/mod/github.com/stretchr/testify@v1.10.0/require/require.go:1357 +0xcc
github.com/authzed/spicedb/internal/testserver/datastore.RunCRDBForTesting({0x10587a000, 0x14000003dc0}, {0x0, 0x0}, {0x1048fb91a, 0x6})
        /Users/miparnisari/Documents/GitHub/spicedb/internal/testserver/datastore/crdb.go:71 +0x508
github.com/authzed/spicedb/internal/testserver/datastore.RunDatastoreEngineWithBridge({0x10587a000, 0x14000003dc0}, {0x104905f6c, 0xb}, {0x0, 0x0})

```