### PR TITLE
postgres datastore: do not warn on context cancelation

### DIFF
--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -653,7 +653,9 @@ func (pgd *pgDatastore) Close() error {
 
 	if pgd.workerGroup != nil {
 		err := pgd.workerGroup.Wait()
-		log.Warn().Err(err).Msg("completed shutdown of postgres datastore")
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Warn().Err(err).Msg("completed shutdown of postgres datastore")
+		}
 	}
 
 	pgd.readPool.Close()
@@ -780,7 +782,7 @@ func (pgd *pgDatastore) startRevisionHeartbeat(ctx context.Context) error {
 	}
 
 	defer func() {
-		if err := pgd.releaseLock(ctx, conn, revisionHeartbeatLock); err != nil {
+		if err := pgd.releaseLock(ctx, conn, revisionHeartbeatLock); err != nil && !errors.Is(err, context.Canceled) {
 			log.Warn().Err(err).Msg("failed to release revision heartbeat lock")
 		}
 	}()


### PR DESCRIPTION
these warns are emitted on termination because the context was canceled and add unnecessary noise. The change makes it so we only log if the error is not context cancelation.