### PR TITLE
Set pgx CancelRequestContextWatcherHandler.CancelRequestDelay to fixcancelation delay

### DIFF
--- a/internal/datastore/postgres/common/cancelation.go
+++ b/internal/datastore/postgres/common/cancelation.go
@@ -12,7 +12,7 @@ import (
 func CancelationContextHandler(pgConn *pgconn.PgConn) ctxwatch.Handler {
 	return &pgconn.CancelRequestContextWatcherHandler{
 		Conn:               pgConn,
-		CancelRequestDelay: 0 * time.Millisecond, // Cancel immediately.
-		DeadlineDelay:      1 * time.Second,      // If not acknowledged, close the connection after a second.
+		CancelRequestDelay: 50 * time.Millisecond, // Cancel immediately.
+		DeadlineDelay:      1 * time.Second,       // If not acknowledged, close the connection after a second.
 	}
 }


### PR DESCRIPTION
This fixes a 100ms `QueryRelationship` delay caused pgx when handling context cancelation