### PR TITLE
Add development containers support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.238.1/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version (use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon): ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT="jammy"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+# Install additional OS packages, if needed.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install protobuf-compiler

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+    "build": {
+      "dockerfile": "Dockerfile",
+      // Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
+      // Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
+      "args": {
+        "VARIANT": "ubuntu-22.04"
+      }
+    },
+    "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+    "postCreateCommand": "bash .devcontainer/post-create-command.sh",
+    "features": {
+      "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+      "ghcr.io/devcontainers/features/git-lfs:1": {},
+      "ghcr.io/devcontainers/features/github-cli:1": {},
+      "ghcr.io/devcontainers/features/go:1": {},
+      "ghcr.io/katallaxie/devcontainer-features/buf-cli:1": {},
+      "ghcr.io/guiyomh/features/mage:0": {}
+    },
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "authzed.spicedb-vscode",
+          "golang.go",
+          "ms-azuretools.vscode-docker"
+        ]
+      }
+    }
+  }

--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# This script is executed after the creation of a new project.
+
+# Install goreleaser pro
+echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+sudo apt update
+sudo apt install goreleaser-pro

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
   <a href="https://www.bestpractices.dev/en/projects/6348" target="_blank"><img alt="cii badge" src="https://img.shields.io/cii/percentage/6348?style=flat-square&label=cii%20best%20practices&color=F8D44B"></a>
   &nbsp;
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/authzed/spicedb" target="_blank"><img alt="ssf badge" src="https://api.securityscorecards.dev/projects/github.com/authzed/spicedb/badge"></a>
-  &nbsp;
 </p>
 
 <p align="center">
@@ -34,6 +33,12 @@
     <a href="https://twitter.com/authzed"><img alt="twitter badge" src="https://img.shields.io/badge/twitter-@authzed-1d9bf0.svg?style=flat-square"></a>
     &nbsp;
     <a href="https://www.linkedin.com/company/authzed/"><img alt="linkedin badge" src="https://img.shields.io/badge/linkedin-+authzed-2D65BC.svg?style=flat-square"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=396856161" target="_blank"><img alt="launch codespaces badge" src="https://img.shields.io/badge/launch-Codespaces-blue?style=flat-square"></a>
+  &nbsp;
+  <a href="https://gitpod.io/#https://github.com/authzed/spicedb" target="_blank"><img alt="launch gitpod badge" src="https://img.shields.io/badge/Gitpod-ready--to--code-blue?style=flat-square"></a>
 </p>
 
 ## What is SpiceDB?


### PR DESCRIPTION
## Describe your changes

The changes here add support for development containers to make it easy to spin-up a development environment.

* Adding support for [development container](https://containers.dev/)
* Adding badges to launch the container in [Codespaces](https://github.com/features/codespaces) or [http://gitpod.io](https://gitpod.io)
* Runs in local devcontainer environments

To test this works with most of the tools the `go run cmd/spicedb/main.go` was run to run the server locally and `mage -l`.