### PR TITLE
Add perfinsights middleware which writes the latency of API calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -162,6 +162,7 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/ashanbrown/forbidigo v1.6.0 // indirect
 	github.com/ashanbrown/makezero v1.2.0 // indirect
+	github.com/authzed/ctxkey v0.0.0-20250226155515-d49f99185584
 	github.com/aws/aws-sdk-go v1.44.256 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1447,6 +1447,8 @@ github.com/authzed/cel-go v0.20.2 h1:GlmLecGry7Z8HU0k+hmaHHUV05ZHrsFxduXHtIePvck
 github.com/authzed/cel-go v0.20.2/go.mod h1:pJHVFWbqUHV1J+klQoZubdKswlbxcsbojda3mye9kiU=
 github.com/authzed/consistent v0.1.0 h1:tlh1wvKoRbjRhMm2P+X5WQQyR54SRoS4MyjLOg17Mp8=
 github.com/authzed/consistent v0.1.0/go.mod h1:plwHlrN/EJUCwQ+Bca0MhM1KnisPs7HEkZI5giCXrcc=
+github.com/authzed/ctxkey v0.0.0-20250226155515-d49f99185584 h1:mP7EpcUL90EKcf/F+gYiU2pz3cGFEuKPHPfe7MntEXk=
+github.com/authzed/ctxkey v0.0.0-20250226155515-d49f99185584/go.mod h1:wnimjr5RPPouIhZQ3ztDBLMUKKuUroj3U9Jy0PxeaEE=
 github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b h1:wbh8IK+aMLTCey9sZasO7b6BWLAJnHHvb79fvWCXwxw=
 github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b/go.mod h1:s3qC7V7XIbiNWERv7Lfljy/Lx25/V1Qlexb0WJuA8uQ=
 github.com/aws/aws-sdk-go v1.44.256 h1:O8VH+bJqgLDguqkH/xQBFz5o/YheeZqgcOYIgsTVWY4=

--- a/internal/middleware/perfinsights/doc.go
+++ b/internal/middleware/perfinsights/doc.go
@@ -1,0 +1,7 @@
+// Package perfinsights defines middleware that reports the latency of API calls to Prometheus.
+//
+// Unlike the gRPC middleware, the perf insights middleware records API calls by "shape", versus
+// aggregating all calls simply by API kind. The shapes allow for more granular determination of
+// the latency of API calls, and can be used to determine if there are any specific
+// performance issues with specific API calls.
+package perfinsights

--- a/internal/middleware/perfinsights/perfinsights.go
+++ b/internal/middleware/perfinsights/perfinsights.go
@@ -1,0 +1,213 @@
+package perfinsights
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/ccoveille/go-safecast"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+
+	"github.com/authzed/ctxkey"
+	"github.com/authzed/grpcutil"
+
+	"github.com/authzed/spicedb/pkg/spiceerrors"
+)
+
+type APIShapeLabel string
+
+const (
+	ResourceTypeLabel     APIShapeLabel = "resource_type"
+	ResourceRelationLabel APIShapeLabel = "resource_relation"
+	SubjectTypeLabel      APIShapeLabel = "subject_type"
+	SubjectRelationLabel  APIShapeLabel = "subject_relation"
+	NameLabel             APIShapeLabel = "name"
+	FilterLabel           APIShapeLabel = "filter"
+)
+
+var allLabels = []string{
+	string(ResourceTypeLabel),
+	string(ResourceRelationLabel),
+	string(SubjectTypeLabel),
+	string(SubjectRelationLabel),
+	string(NameLabel),
+	string(FilterLabel),
+}
+
+// APIShapeLabels is a map of APIShapeLabel to any value.
+type APIShapeLabels map[APIShapeLabel]any
+
+// NoLabels returns an empty APIShapeLabels map.
+func NoLabels() APIShapeLabels {
+	return APIShapeLabels{}
+}
+
+// APIShapeLatency is the metric that SpiceDB uses to keep track of the latency
+// of API calls, by shape. The "shape" of an API call is defined as the portions
+// of the API call that are not the specific object IDs, e.g. the resource type,
+// the relation, the subject type, etc.
+//
+// NOTE: This metric is a *native* histogram, which means that instead of predefined
+// the buckets, it uses a factor to determine the buckets. This is useful for latency-based
+// metrics, as the latency can vary widely and having a fixed set of buckets can lead to
+// imprecise results.
+//
+// To use make use of native histograms, a special flag must be set on Prometheus:
+// https://prometheus.io/docs/prometheus/latest/feature_flags/#native-histograms
+var APIShapeLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace:                   "spicedb",
+	Subsystem:                   "perf_insights",
+	Name:                        "api_shape_latency_seconds",
+	Help:                        "The latency of API calls, by shape",
+	Buckets:                     nil,
+	NativeHistogramBucketFactor: 1.1,
+}, append([]string{"api_kind"}, allLabels...))
+
+// ShapeBuilder is a function that returns a slice of strings representing the shape of the API call.
+// This is used to report the shape of the API call to Prometheus.
+type ShapeBuilder func() APIShapeLabels
+
+// ObserveShapeLatency observes the latency of the API call with the given shape.
+func ObserveShapeLatency(ctx context.Context, methodName string, shape APIShapeLabels, duration time.Duration) {
+	observeShapeLatency(ctx, APIShapeLatency, methodName, shape, duration)
+}
+
+func observeShapeLatency(ctx context.Context, metric *prometheus.HistogramVec, methodName string, shape APIShapeLabels, duration time.Duration) {
+	labels := buildLabels(methodName, shape)
+	if len(labels) == 0 {
+		log.Warn().Str("method", methodName).
+			Msg("ShapeBuilder returned an empty shape, skipping reporting")
+		return
+	}
+
+	o := metric.WithLabelValues(labels...)
+	if exemplarObserver, ok := o.(prometheus.ExemplarObserver); ok {
+		if spanCtx := trace.SpanContextFromContext(ctx); spanCtx.HasTraceID() {
+			traceID := prometheus.Labels{"traceID": spanCtx.TraceID().String()}
+			exemplarObserver.ObserveWithExemplar(duration.Seconds(), traceID)
+			return
+		}
+	}
+
+	o.Observe(duration.Seconds())
+}
+
+func buildLabels(methodName string, shape APIShapeLabels) []string {
+	labels := make([]string, len(allLabels)+1)
+	labels[0] = methodName
+
+	for index, label := range allLabels {
+		shapeValue, ok := shape[APIShapeLabel(label)]
+		if !ok {
+			continue
+		}
+
+		switch t := shapeValue.(type) {
+		case string:
+			labels[index+1] = t
+
+		case int:
+			labels[index+1] = strconv.Itoa(t)
+
+		case uint32:
+			intValue, err := safecast.ToInt(t)
+			if err != nil {
+				log.Warn().Str("method", methodName).
+					Str("key", label).
+					Str("type", fmt.Sprintf("%T", t)).
+					Msg("ShapeBuilder could not convert int, skipping reporting")
+				return nil
+			}
+			labels[index+1] = strconv.Itoa(intValue)
+
+		case int64:
+			intValue, err := safecast.ToInt(t)
+			if err != nil {
+				log.Warn().Str("method", methodName).
+					Str("key", label).
+					Str("type", fmt.Sprintf("%T", t)).
+					Msg("ShapeBuilder could not convert int, skipping reporting")
+				return nil
+			}
+			labels[index+1] = strconv.Itoa(intValue)
+
+		default:
+			spiceerrors.DebugAssert(func() bool { return false }, "unsupported type %T", t)
+			log.Warn().Str("method", methodName).
+				Str("key", label).
+				Str("type", fmt.Sprintf("%T", t)).
+				Msg("ShapeBuilder returned an unsupported type, skipping reporting")
+			return nil
+		}
+	}
+
+	return labels
+}
+
+type reporter struct {
+	isEnabled bool
+}
+
+func (r *reporter) ServerReporter(ctx context.Context, callMeta interceptors.CallMeta) (interceptors.Reporter, context.Context) {
+	if !r.isEnabled {
+		return &interceptors.NoopReporter{}, ctx
+	}
+
+	_, methodName := grpcutil.SplitMethodName(callMeta.FullMethod())
+	ctx = contextWithHandle(ctx)
+	return &serverReporter{ctx: ctx, methodName: methodName}, ctx
+}
+
+type serverReporter struct {
+	interceptors.NoopReporter
+	ctx        context.Context
+	methodName string
+}
+
+var ctxKey = ctxkey.NewBoxedWithDefault[ShapeBuilder](nil)
+
+func (r *serverReporter) PostCall(err error, duration time.Duration) {
+	// Do not report if the call resulted in an error.
+	if err != nil {
+		return
+	}
+
+	shapeClosure := ctxKey.Value(r.ctx)
+	spiceerrors.DebugAssertNotNil(shapeClosure, "ShapeBuilder should not be nil")
+
+	// If not testing and nil, simply skip.
+	if shapeClosure == nil {
+		log.Warn().Str("method", r.methodName).
+			Msg("ShapeBuilder is nil, skipping reporting")
+		return
+	}
+
+	ObserveShapeLatency(r.ctx, r.methodName, shapeClosure(), duration)
+}
+
+// UnaryServerInterceptor returns a gRPC server-side interceptor that provides reporting for Unary RPCs.
+func UnaryServerInterceptor(isEnabled bool) grpc.UnaryServerInterceptor {
+	return interceptors.UnaryServerInterceptor(&reporter{isEnabled: isEnabled})
+}
+
+// StreamServerInterceptor returns a gRPC server-side interceptor that provides reporting for Streaming RPCs.
+func StreamServerInterceptor(isEnabled bool) grpc.StreamServerInterceptor {
+	return interceptors.StreamServerInterceptor(&reporter{isEnabled: isEnabled})
+}
+
+// SetInContext sets the ShapeBuilder in the context.
+func SetInContext(ctx context.Context, builder ShapeBuilder) {
+	ctxKey.Set(ctx, builder)
+}
+
+// contextWithHandle returns a context with the ShapeBuilder set.
+// Should only be called by the server reporter or a test.
+func contextWithHandle(ctx context.Context) context.Context {
+	return ctxKey.SetBox(ctx)
+}

--- a/internal/middleware/perfinsights/perfinsights_test.go
+++ b/internal/middleware/perfinsights/perfinsights_test.go
@@ -1,0 +1,119 @@
+package perfinsights
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildLabels(t *testing.T) {
+	tcs := []struct {
+		name           string
+		shape          APIShapeLabels
+		expectedLabels []string
+	}{
+		{
+			name:           "empty shape",
+			shape:          APIShapeLabels{},
+			expectedLabels: []string{"testMethod", "", "", "", "", "", ""},
+		},
+		{
+			name: "full shape",
+			shape: APIShapeLabels{
+				ResourceTypeLabel:     "resource_type",
+				ResourceRelationLabel: "resource_relation",
+				SubjectTypeLabel:      "subject_type",
+				SubjectRelationLabel:  "subject_relation",
+				NameLabel:             "name",
+				FilterLabel:           "filter",
+			},
+			expectedLabels: []string{"testMethod", "resource_type", "resource_relation", "subject_type", "subject_relation", "name", "filter"},
+		},
+		{
+			name: "full shape with integers",
+			shape: APIShapeLabels{
+				ResourceTypeLabel:     "resource_type",
+				ResourceRelationLabel: "resource_relation",
+				SubjectTypeLabel:      "subject_type",
+				SubjectRelationLabel:  int64(40),
+				NameLabel:             uint32(41),
+				FilterLabel:           42,
+			},
+			expectedLabels: []string{"testMethod", "resource_type", "resource_relation", "subject_type", "40", "41", "42"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			labels := buildLabels("testMethod", tc.shape)
+			require.Equal(t, tc.expectedLabels, labels)
+		})
+	}
+}
+
+func TestObserveShapeLatency(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	metric := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                   "spicedb",
+		Subsystem:                   "perf_insights",
+		Name:                        "api_shape_latency_seconds",
+		Help:                        "The latency of API calls, by shape",
+		Buckets:                     nil,
+		NativeHistogramBucketFactor: 1.1,
+	}, append([]string{"api_kind"}, allLabels...))
+	require.NoError(t, reg.Register(metric))
+
+	// Report some data.
+	observeShapeLatency(context.Background(), metric, "testMethod", APIShapeLabels{
+		ResourceTypeLabel:     "resource_type",
+		ResourceRelationLabel: "resource_relation",
+		SubjectTypeLabel:      42,
+	}, 100*time.Millisecond)
+
+	// Ensure it was added to the metric.
+	metrics, err := reg.Gather()
+	require.NoError(t, err)
+	require.NotEmpty(t, metrics)
+
+	for _, metric := range metrics {
+		if !strings.HasSuffix(metric.GetName(), "api_shape_latency_seconds") {
+			continue
+		}
+
+		require.Equal(t, io_prometheus_client.MetricType_HISTOGRAM, metric.GetType())
+
+		require.Equal(t, uint64(1), metric.GetMetric()[0].Histogram.GetSampleCount())
+		require.Equal(t, float64(0.1), metric.GetMetric()[0].Histogram.GetSampleSum())
+		require.Equal(t, "testMethod", metric.GetMetric()[0].Label[0].GetValue())
+
+		for _, label := range metric.GetMetric()[0].Label {
+			if label.GetName() == "api_kind" {
+				require.Equal(t, "testMethod", label.GetValue())
+				continue
+			}
+
+			if label.GetName() == "resource_type" {
+				require.Equal(t, "resource_type", label.GetValue())
+				continue
+			}
+
+			if label.GetName() == "resource_relation" {
+				require.Equal(t, "resource_relation", label.GetValue())
+				continue
+			}
+
+			if label.GetName() == "subject_type" {
+				require.Equal(t, "42", label.GetValue())
+				continue
+			}
+
+			require.Empty(t, label.GetValue())
+		}
+	}
+}

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -69,7 +69,13 @@ func RegisterGrpcServices(
 	}
 
 	if schemaServiceOption == V1SchemaServiceEnabled || schemaServiceOption == V1SchemaServiceAdditiveOnly {
-		v1.RegisterSchemaServiceServer(srv, v1svc.NewSchemaServer(permSysConfig.CaveatTypeSet, schemaServiceOption == V1SchemaServiceAdditiveOnly, permSysConfig.ExpiringRelationshipsEnabled))
+		schemaConfig := v1svc.SchemaServerConfig{
+			CaveatTypeSet:                    permSysConfig.CaveatTypeSet,
+			AdditiveOnly:                     schemaServiceOption == V1SchemaServiceAdditiveOnly,
+			ExpiringRelsEnabled:              permSysConfig.ExpiringRelationshipsEnabled,
+			PerformanceInsightMetricsEnabled: permSysConfig.PerformanceInsightMetricsEnabled,
+		}
+		v1.RegisterSchemaServiceServer(srv, v1svc.NewSchemaServer(schemaConfig))
 		healthManager.RegisterReportedService(v1.SchemaService_ServiceDesc.ServiceName)
 	}
 

--- a/internal/services/v1/relationships_unit_test.go
+++ b/internal/services/v1/relationships_unit_test.go
@@ -1,0 +1,118 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+
+	"github.com/authzed/spicedb/internal/middleware/perfinsights"
+)
+
+func TestLabelsForFilter(t *testing.T) {
+	tcs := []struct {
+		name     string
+		filter   *v1.RelationshipFilter
+		expected perfinsights.APIShapeLabels
+	}{
+		{
+			name:     "no filter",
+			filter:   nil,
+			expected: perfinsights.NoLabels(),
+		},
+		{
+			name:   "empty filter",
+			filter: &v1.RelationshipFilter{},
+			expected: perfinsights.APIShapeLabels{
+				perfinsights.ResourceTypeLabel:     "",
+				perfinsights.ResourceRelationLabel: "",
+			},
+		},
+		{
+			name: "resource type and relation",
+			filter: &v1.RelationshipFilter{
+				ResourceType:     "foo",
+				OptionalRelation: "bar",
+			},
+			expected: perfinsights.APIShapeLabels{
+				perfinsights.ResourceTypeLabel:     "foo",
+				perfinsights.ResourceRelationLabel: "bar",
+			},
+		},
+		{
+			name: "resource type only",
+			filter: &v1.RelationshipFilter{
+				ResourceType: "foo",
+			},
+			expected: perfinsights.APIShapeLabels{
+				perfinsights.ResourceTypeLabel:     "foo",
+				perfinsights.ResourceRelationLabel: "",
+			},
+		},
+		{
+			name: "relation only",
+			filter: &v1.RelationshipFilter{
+				OptionalRelation: "bar",
+			},
+			expected: perfinsights.APIShapeLabels{
+				perfinsights.ResourceTypeLabel:     "",
+				perfinsights.ResourceRelationLabel: "bar",
+			},
+		},
+		{
+			name: "subject type and relation",
+			filter: &v1.RelationshipFilter{
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					SubjectType: "foo",
+					OptionalRelation: &v1.SubjectFilter_RelationFilter{
+						Relation: "bar",
+					},
+				},
+			},
+			expected: perfinsights.APIShapeLabels{
+				perfinsights.ResourceTypeLabel:     "",
+				perfinsights.ResourceRelationLabel: "",
+				perfinsights.SubjectTypeLabel:      "foo",
+				perfinsights.SubjectRelationLabel:  "bar",
+			},
+		},
+		{
+			name: "subject type only",
+			filter: &v1.RelationshipFilter{
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					SubjectType: "foo",
+				},
+			},
+			expected: perfinsights.APIShapeLabels{
+				perfinsights.ResourceTypeLabel:     "",
+				perfinsights.ResourceRelationLabel: "",
+				perfinsights.SubjectTypeLabel:      "foo",
+			},
+		},
+		{
+			name: "subject type and empty relation",
+			filter: &v1.RelationshipFilter{
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					SubjectType: "foo",
+					OptionalRelation: &v1.SubjectFilter_RelationFilter{
+						Relation: "",
+					},
+				},
+			},
+			expected: perfinsights.APIShapeLabels{
+				perfinsights.ResourceTypeLabel:     "",
+				perfinsights.ResourceRelationLabel: "",
+				perfinsights.SubjectTypeLabel:      "foo",
+				perfinsights.SubjectRelationLabel:  "",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			labels := labelsForFilter(tc.filter)
+			require.Equal(t, tc.expected, labels)
+		})
+	}
+}

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -196,6 +196,7 @@ func TestClusterWithDispatchAndCacheConfig(t testing.TB, size uint, ds datastore
 			server.WithDispatchMaxDepth(50),
 			server.WithMaximumPreconditionCount(1000),
 			server.WithMaximumUpdatesPerWrite(1000),
+			server.WithEnableExperimentalRelationshipExpiration(true),
 			server.WithGRPCServer(util.GRPCServerConfig{
 				Network: util.BufferedNetwork,
 				Enabled: true,

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -113,6 +113,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	apiFlags.Uint32Var(&config.MaxLookupResourcesLimit, "max-lookup-resources-limit", 1000, "maximum number of resources that can be looked up in a single request")
 	apiFlags.Uint32Var(&config.MaxBulkExportRelationshipsLimit, "max-bulk-export-relationships-limit", 10_000, "maximum number of relationships that can be exported in a single request")
 	apiFlags.BoolVar(&config.EnableRevisionHeartbeat, "enable-revision-heartbeat", true, "enables support for revision heartbeat, used to create a synthetic revision on an interval defined by the quantization window (postgres only)")
+	apiFlags.BoolVar(&config.EnablePerformanceInsightMetrics, "enable-performance-insight-metrics", false, "enables performance insight metrics, which are used to track the latency of API calls by shape")
 
 	datastoreFlags := nfs.FlagSet(BoldBlue("Datastore"))
 	// Flags for the datastore

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -124,6 +124,7 @@ type Config struct {
 	EnableExperimentalLookupResources        bool          `debugmap:"visible"`
 	EnableExperimentalRelationshipExpiration bool          `debugmap:"visible"`
 	EnableRevisionHeartbeat                  bool          `debugmap:"visible"`
+	EnablePerformanceInsightMetrics          bool          `debugmap:"visible"`
 
 	// Additional Services
 	MetricsAPI util.HTTPServerConfig `debugmap:"visible"`
@@ -439,20 +440,21 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 	}
 
 	permSysConfig := v1svc.PermissionsServerConfig{
-		MaxPreconditionsCount:           maxPreconditionCount,
-		MaxUpdatesPerWrite:              c.MaximumUpdatesPerWrite,
-		MaximumAPIDepth:                 c.DispatchMaxDepth,
-		MaxCaveatContextSize:            c.MaxCaveatContextSize,
-		MaxRelationshipContextSize:      c.MaxRelationshipContextSize,
-		MaxDatastoreReadPageSize:        c.MaxDatastoreReadPageSize,
-		StreamingAPITimeout:             c.StreamingAPITimeout,
-		MaxReadRelationshipsLimit:       c.MaxReadRelationshipsLimit,
-		MaxDeleteRelationshipsLimit:     c.MaxDeleteRelationshipsLimit,
-		MaxLookupResourcesLimit:         c.MaxLookupResourcesLimit,
-		MaxBulkExportRelationshipsLimit: c.MaxBulkExportRelationshipsLimit,
-		DispatchChunkSize:               c.DispatchChunkSize,
-		ExpiringRelationshipsEnabled:    c.EnableExperimentalRelationshipExpiration,
-		CaveatTypeSet:                   c.DatastoreConfig.CaveatTypeSet,
+		MaxPreconditionsCount:            maxPreconditionCount,
+		MaxUpdatesPerWrite:               c.MaximumUpdatesPerWrite,
+		MaximumAPIDepth:                  c.DispatchMaxDepth,
+		MaxCaveatContextSize:             c.MaxCaveatContextSize,
+		MaxRelationshipContextSize:       c.MaxRelationshipContextSize,
+		MaxDatastoreReadPageSize:         c.MaxDatastoreReadPageSize,
+		StreamingAPITimeout:              c.StreamingAPITimeout,
+		MaxReadRelationshipsLimit:        c.MaxReadRelationshipsLimit,
+		MaxDeleteRelationshipsLimit:      c.MaxDeleteRelationshipsLimit,
+		MaxLookupResourcesLimit:          c.MaxLookupResourcesLimit,
+		MaxBulkExportRelationshipsLimit:  c.MaxBulkExportRelationshipsLimit,
+		DispatchChunkSize:                c.DispatchChunkSize,
+		ExpiringRelationshipsEnabled:     c.EnableExperimentalRelationshipExpiration,
+		CaveatTypeSet:                    c.DatastoreConfig.CaveatTypeSet,
+		PerformanceInsightMetricsEnabled: c.EnablePerformanceInsightMetrics,
 	}
 
 	healthManager := health.NewHealthManager(dispatcher, ds)

--- a/pkg/cmd/server/zz_generated.options.go
+++ b/pkg/cmd/server/zz_generated.options.go
@@ -91,6 +91,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.EnableExperimentalLookupResources = c.EnableExperimentalLookupResources
 		to.EnableExperimentalRelationshipExpiration = c.EnableExperimentalRelationshipExpiration
 		to.EnableRevisionHeartbeat = c.EnableRevisionHeartbeat
+		to.EnablePerformanceInsightMetrics = c.EnablePerformanceInsightMetrics
 		to.MetricsAPI = c.MetricsAPI
 		to.UnaryMiddlewareModification = c.UnaryMiddlewareModification
 		to.StreamingMiddlewareModification = c.StreamingMiddlewareModification
@@ -161,6 +162,7 @@ func (c Config) DebugMap() map[string]any {
 	debugMap["EnableExperimentalLookupResources"] = helpers.DebugValue(c.EnableExperimentalLookupResources, false)
 	debugMap["EnableExperimentalRelationshipExpiration"] = helpers.DebugValue(c.EnableExperimentalRelationshipExpiration, false)
 	debugMap["EnableRevisionHeartbeat"] = helpers.DebugValue(c.EnableRevisionHeartbeat, false)
+	debugMap["EnablePerformanceInsightMetrics"] = helpers.DebugValue(c.EnablePerformanceInsightMetrics, false)
 	debugMap["MetricsAPI"] = helpers.DebugValue(c.MetricsAPI, false)
 	debugMap["SilentlyDisableTelemetry"] = helpers.DebugValue(c.SilentlyDisableTelemetry, false)
 	debugMap["TelemetryCAOverridePath"] = helpers.DebugValue(c.TelemetryCAOverridePath, false)
@@ -584,6 +586,13 @@ func WithEnableExperimentalRelationshipExpiration(enableExperimentalRelationship
 func WithEnableRevisionHeartbeat(enableRevisionHeartbeat bool) ConfigOption {
 	return func(c *Config) {
 		c.EnableRevisionHeartbeat = enableRevisionHeartbeat
+	}
+}
+
+// WithEnablePerformanceInsightMetrics returns an option that can set EnablePerformanceInsightMetrics on a Config
+func WithEnablePerformanceInsightMetrics(enablePerformanceInsightMetrics bool) ConfigOption {
+	return func(c *Config) {
+		c.EnablePerformanceInsightMetrics = enablePerformanceInsightMetrics
 	}
 }
 

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -168,14 +168,20 @@ func (dc *DevContext) RunV1InMemoryService() (*grpc.ClientConn, func(), error) {
 		),
 	)
 	ps := v1svc.NewPermissionsServer(dc.Dispatcher, v1svc.PermissionsServerConfig{
-		MaxUpdatesPerWrite:           50,
-		MaxPreconditionsCount:        50,
-		MaximumAPIDepth:              50,
-		MaxCaveatContextSize:         0,
-		ExpiringRelationshipsEnabled: true,
-		CaveatTypeSet:                caveattypes.Default.TypeSet,
+		MaxUpdatesPerWrite:               50,
+		MaxPreconditionsCount:            50,
+		MaximumAPIDepth:                  50,
+		MaxCaveatContextSize:             0,
+		ExpiringRelationshipsEnabled:     true,
+		CaveatTypeSet:                    caveattypes.Default.TypeSet,
+		PerformanceInsightMetricsEnabled: false,
 	})
-	ss := v1svc.NewSchemaServer(caveattypes.Default.TypeSet, false, true)
+	ss := v1svc.NewSchemaServer(v1svc.SchemaServerConfig{
+		CaveatTypeSet:                    caveattypes.Default.TypeSet,
+		AdditiveOnly:                     false,
+		ExpiringRelsEnabled:              true,
+		PerformanceInsightMetricsEnabled: false,
+	})
 
 	v1.RegisterPermissionsServiceServer(s, ps)
 	v1.RegisterSchemaServiceServer(s, ss)


### PR DESCRIPTION
to a new native histogram bucket

Should help users determine top-line API latency