### PR TITLE
Add additional forced CRDB index in special case of no object IDs

### DIFF
--- a/internal/datastore/crdb/schema/indexes_test.go
+++ b/internal/datastore/crdb/schema/indexes_test.go
@@ -118,6 +118,82 @@ func TestIndexForFilter(t *testing.T) {
 			},
 			expected: "",
 		},
+		{
+			name: "filter by resource type, relation and subject type and relation",
+			filter: datastore.RelationshipsFilter{
+				OptionalResourceType:     "foo",
+				OptionalResourceRelation: "bar",
+				OptionalSubjectsSelectors: []datastore.SubjectsSelector{
+					{
+						OptionalSubjectType: "foo",
+						RelationFilter: datastore.SubjectRelationFilter{
+							NonEllipsisRelation: "baz",
+						},
+					},
+				},
+			},
+			expected: "ix_relation_tuple_by_subject_relation",
+		},
+		{
+			name: "filter by resource type, relation and subject type",
+			filter: datastore.RelationshipsFilter{
+				OptionalResourceType:     "foo",
+				OptionalResourceRelation: "bar",
+				OptionalSubjectsSelectors: []datastore.SubjectsSelector{
+					{
+						OptionalSubjectType: "foo",
+					},
+				},
+			},
+			expected: "pk_relation_tuple",
+		},
+		{
+			name: "filter by resource type, relation and subject relation",
+			filter: datastore.RelationshipsFilter{
+				OptionalResourceType:     "foo",
+				OptionalResourceRelation: "bar",
+				OptionalSubjectsSelectors: []datastore.SubjectsSelector{
+					{
+						RelationFilter: datastore.SubjectRelationFilter{
+							NonEllipsisRelation: "baz",
+						},
+					},
+				},
+			},
+			expected: "pk_relation_tuple",
+		},
+		{
+			name: "filter by resource relation and subject type and relation",
+			filter: datastore.RelationshipsFilter{
+				OptionalResourceRelation: "bar",
+				OptionalSubjectsSelectors: []datastore.SubjectsSelector{
+					{
+						OptionalSubjectType: "foo",
+						RelationFilter: datastore.SubjectRelationFilter{
+							NonEllipsisRelation: "baz",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "filter by resource type, relation and subject type and relation, include ellipsis",
+			filter: datastore.RelationshipsFilter{
+				OptionalResourceType:     "foo",
+				OptionalResourceRelation: "bar",
+				OptionalSubjectsSelectors: []datastore.SubjectsSelector{
+					{
+						OptionalSubjectType: "foo",
+						RelationFilter: datastore.SubjectRelationFilter{
+							IncludeEllipsisRelation: true,
+							NonEllipsisRelation:     "baz",
+						},
+					},
+				},
+			},
+			expected: "pk_relation_tuple",
+		},
 	}
 
 	schema := Schema(common.ColumnOptimizationOptionNone, false, false)


### PR DESCRIPTION
Before this change, the non-ID index would never be selected by read or delete relationships in CRDB. Now, it is used for the single, special case