### PR TITLE
add more default linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,27 +1,40 @@
 ---
 version: "2"
+run:
+  allow-parallel-runners: true
 linters:
   enable:
     - "bidichk"
     - "bodyclose"
+    - "errcheck"
     - "errname"
     - "errorlint"
+#    - "gocritic" TODO: fix issues
     - "goprintffuncname"
     - "gosec"
+#    - "govet" TODO: fix issues
     - "importas"
+    - "ineffassign"
     - "makezero"
     - "prealloc"
     - "predeclared"
     - "promlinter"
     - "revive"
     - "rowserrcheck"
+    - "spancheck"
     - "staticcheck"
+    - "tagalign"
+#    - "testifylint" TODO: fix issues
     - "tparallel"
     - "unconvert"
     - "usetesting"
     - "wastedassign"
     - "whitespace"
+    - "unused"
   settings:
+    staticcheck:
+      checks:
+        - "all"
     revive:
       rules:
         - name: "unused-parameter"

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -377,6 +377,7 @@ func (rwt *observableRWT) BulkLoad(ctx context.Context, iter datastore.BulkWrite
 	return rwt.delegate.BulkLoad(ctx, iter)
 }
 
+// nolint:spancheck
 func observe(ctx context.Context, name string, queryShape string, opts ...trace.SpanStartOption) (context.Context, func()) {
 	if queryShape == "" {
 		queryShape = "(none)"

--- a/internal/services/v0/sharestore.go
+++ b/internal/services/v0/sharestore.go
@@ -36,11 +36,11 @@ type SharedDataV1 struct {
 
 // SharedDataV2 represents the data stored in a shared playground file.
 type SharedDataV2 struct {
-	Version           string `json:"version" yaml:"-"`
-	Schema            string `json:"schema" yaml:"schema"`
+	Version           string `json:"version"            yaml:"-"`
+	Schema            string `json:"schema"             yaml:"schema"`
 	RelationshipsYaml string `json:"relationships_yaml" yaml:"relationships"`
-	ValidationYaml    string `json:"validation_yaml" yaml:"validation"`
-	AssertionsYaml    string `json:"assertions_yaml" yaml:"assertions"`
+	ValidationYaml    string `json:"validation_yaml"    yaml:"validation"`
+	AssertionsYaml    string `json:"assertions_yaml"    yaml:"assertions"`
 }
 
 // LookupStatus is an enum for the possible ShareStore lookup outcomes.

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -108,7 +108,7 @@ type Config struct {
 	RevisionQuantization        time.Duration `debugmap:"visible"`
 	MaxRevisionStalenessPercent float64       `debugmap:"visible"`
 	CredentialsProviderName     string        `debugmap:"visible"`
-	FilterMaximumIDCount        uint16        `debugmap:"hidden" default:"100"`
+	FilterMaximumIDCount        uint16        `debugmap:"hidden"    default:"100"`
 
 	// Options
 	ReadConnPool                   ConnPoolConfig `debugmap:"visible"`


### PR DESCRIPTION
Follow-up of https://github.com/authzed/spicedb/pull/2382#discussion_r2078341249, we went deep and found that we're missing a bunch of default linters.

<img width="403" alt="image" src="https://github.com/user-attachments/assets/39a1fe00-7633-4e30-8daa-491fb35a60a3" />

I also added a few other ones.