### PR TITLE
fix(CI): CLA GitHub Action permissions

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -13,10 +13,10 @@ on:  # yamllint disable-line rule:truthy
     types:
       - "checks_requested"
 permissions:
-  actions: write
-  contents: read
-  pull-requests: write
-  statuses: write
+  actions: "write"
+  contents: "write"
+  pull-requests: "write"
+  statuses: "write"
 jobs:
   cla:
     name: "Check Signature"

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -13,7 +13,10 @@ on:  # yamllint disable-line rule:truthy
     types:
       - "checks_requested"
 permissions:
-  contents: "read"
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
 jobs:
   cla:
     name: "Check Signature"

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -14,7 +14,7 @@ on:  # yamllint disable-line rule:truthy
       - "checks_requested"
 permissions:
   actions: "write"
-  contents: "write"
+  contents: "read" # CLA signatures are stored in https://github.com/authzed/cla
   pull-requests: "write"
   statuses: "write"
 jobs:


### PR DESCRIPTION
The cla-assistant GitHub Action is currently failing with:
```
Error: Could not update the JSON file: Error occured when creating a pull request comment: Resource not accessible by integration
```
I suspect this was caused by a recent change to the workflow's
permissiosn in https://github.com/authzed/spicedb/pull/2353.

This should fix the issue, according to the workflow's
upstream's upstream
https://github.com/contributor-assistant/github-action?tab=readme-ov-file#configure-contributor-license-agreement-within-two-minutes.

Signed-off-by: squat <lserven@gmail.com>
