### PR TITLE
Remove subject check for deleted definitions in schema

### DIFF
--- a/internal/datastore/crdb/schema/indexes.go
+++ b/internal/datastore/crdb/schema/indexes.go
@@ -25,7 +25,6 @@ var IndexRelationshipBySubject = common.IndexDefinition{
 	ColumnsSQL: `relation_tuple (userset_object_id, userset_namespace, userset_relation, namespace, relation)`,
 	Shapes: []queryshape.Shape{
 		queryshape.MatchingResourcesForSubject,
-		queryshape.FindSubjectOfType,
 	},
 }
 
@@ -77,9 +76,6 @@ func IndexingHintForQueryShape(schema common.SchemaInformation, qs queryshape.Sh
 
 	case queryshape.FindResourceOfType:
 		return forcedIndex{IndexPrimaryKey}
-
-	case queryshape.FindSubjectOfType:
-		return forcedIndex{IndexRelationshipBySubject}
 
 	default:
 		return nil

--- a/internal/datastore/postgres/schema/indexes.go
+++ b/internal/datastore/postgres/schema/indexes.go
@@ -113,9 +113,6 @@ func IndexingHintForQueryShape(schema common.SchemaInformation, qs queryshape.Sh
 	case queryshape.MatchingResourcesForSubject:
 		return forcedIndex{schema.RelationshipTableName, IndexRelationshipBySubject}
 
-	case queryshape.FindSubjectOfType:
-		return forcedIndex{schema.RelationshipTableName, IndexRelationshipBySubject}
-
 	default:
 		return nil
 	}

--- a/internal/datastore/proxy/indexcheck/queryshapevalidators.go
+++ b/internal/datastore/proxy/indexcheck/queryshapevalidators.go
@@ -175,21 +175,6 @@ func validateReverseQueryShape(queryShape queryshape.Shape, subjectFilter datast
 
 		return nil
 
-	case queryshape.FindSubjectOfType:
-		if subjectFilter.SubjectType == "" {
-			return fmt.Errorf("subject type required for FindSubjectOfType")
-		}
-
-		if len(subjectFilter.OptionalSubjectIds) != 0 {
-			return fmt.Errorf("no optional subject ids allowed for FindSubjectOfType")
-		}
-
-		if queryOpts.ResRelation != nil {
-			return fmt.Errorf("no resource relation allowed for FindSubjectOfType")
-		}
-
-		return nil
-
 	case queryshape.Varying:
 		// Nothing to validate.
 		return nil

--- a/internal/datastore/spanner/indexes.go
+++ b/internal/datastore/spanner/indexes.go
@@ -23,9 +23,6 @@ func IndexingHintForQueryShape(schema common.SchemaInformation, qs queryshape.Sh
 	case queryshape.MatchingResourcesForSubject:
 		return forcedIndex{IndexRelationshipBySubject}
 
-	case queryshape.FindSubjectOfType:
-		return forcedIndex{IndexRelationshipBySubject}
-
 	default:
 		return NoIndexingHint
 	}

--- a/pkg/datastore/queryshape/queryshape.go
+++ b/pkg/datastore/queryshape/queryshape.go
@@ -67,15 +67,6 @@ const (
 	// ✅ resource_type, *️⃣ resource_id, *️⃣ resource_relation, *️⃣ subject_type, *️⃣ subject_id, *️⃣ subject_relation, *️⃣ caveat, *️⃣ expiration
 	FindResourceOfType = "find-resource-of-type"
 
-	// FindSubjectOfType indicates that the query is selecting a subject of
-	// a given type.
-	//
-	// The query shape selects a subject of a given type, which is specified by
-	// providing the subject type. The other fields are never specified.
-	//
-	// *️⃣ resource_type, *️⃣ resource_id, *️⃣ resource_relation, ✅ subject_type, *️⃣ subject_id, *️⃣ subject_relation, *️⃣ caveat, *️⃣ expiration
-	FindSubjectOfType = "find-subject-of-type"
-
 	// FindResourceOfTypeAndRelation indicates that the query is selecting a single
 	// resource of a given type and relation.
 	//

--- a/pkg/datastore/test/pagination.go
+++ b/pkg/datastore/test/pagination.go
@@ -367,7 +367,7 @@ func ReverseQueryCursorTest(t *testing.T, tester DatastoreTester) {
 					options.WithSortForReverse(sortBy),
 					options.WithLimitForReverse(&limit),
 					options.WithAfterForReverse(cursor),
-					options.WithQueryShapeForReverse(queryshape.FindSubjectOfType),
+					options.WithQueryShapeForReverse(queryshape.Varying),
 				)
 				require.NoError(t, err)
 

--- a/pkg/datastore/test/relationships.go
+++ b/pkg/datastore/test/relationships.go
@@ -179,7 +179,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 			// Check for larger reverse queries.
 			iter, err = dsReader.ReverseQueryRelationships(ctx, datastore.SubjectsFilter{
 				SubjectType: testUserNamespace,
-			}, options.WithQueryShapeForReverse(queryshape.FindSubjectOfType))
+			}, options.WithQueryShapeForReverse(queryshape.Varying))
 			require.NoError(err)
 			tRequire.VerifyIteratorResults(iter, testRels...)
 
@@ -188,7 +188,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 				limit, _ := safecast.ToUint64(len(testRels) - 1)
 				iter, err := dsReader.ReverseQueryRelationships(ctx, datastore.SubjectsFilter{
 					SubjectType: testUserNamespace,
-				}, options.WithLimitForReverse(&limit), options.WithQueryShapeForReverse(queryshape.FindSubjectOfType))
+				}, options.WithLimitForReverse(&limit), options.WithQueryShapeForReverse(queryshape.Varying))
 				require.NoError(err)
 
 				tRequire.VerifyIteratorCount(iter, len(testRels)-1)


### PR DESCRIPTION
This is a relic of a time before schema had full type checking. Now that subject types removed from relations are checked, there is no way to construct relationships with dangling references to a subject type while a relation type doesn't exist, so the relation subject type check is sufficient