### PR TITLE
Handle both kinds of cancelation errors in test, part 2

### DIFF
--- a/internal/dispatch/remote/cluster_test.go
+++ b/internal/dispatch/remote/cluster_test.go
@@ -212,7 +212,7 @@ func TestDispatchTimeout(t *testing.T) {
 			}, stream)
 			if tc.sleepTime > tc.timeout {
 				require.Error(t, err)
-				require.ErrorContains(t, err, "context deadline exceeded")
+				require.True(t, strings.Contains(err.Error(), "context deadline exceeded") || strings.Contains(err.Error(), "CANCEL"))
 			} else {
 				require.NoError(t, err)
 				require.NotEmpty(t, stream.Results())


### PR DESCRIPTION
Companion of https://github.com/authzed/spicedb/pull/2390, we just missed one other place.