### PR TITLE
move default GOMEMLIMIT to 90% of available memory

### DIFF
--- a/pkg/cmd/server/defaults.go
+++ b/pkg/cmd/server/defaults.go
@@ -76,10 +76,9 @@ func DefaultPreRunE(programName string) cobrautil.CobraRunFunc {
 		).RunE(),
 		// NOTE: These need to be declared after the logger to access
 		// the logging context.
-		// NOTE: The default memlimit is 0.9. Our assumption is that SpiceDB
-		// will be the only thing consuming memory in its context, and if
-		// this needs to be configurable we can do that as a future step.
-		cobraproclimits.SetMemLimitRunE(memlimit.WithRatio(1.0)),
+		// NOTE: We've observed OOMKill when setting to 1.0 under heavy-load,
+		// and zero under the same load and 0.9
+		cobraproclimits.SetMemLimitRunE(memlimit.WithRatio(0.9)),
 		cobraproclimits.SetProcLimitRunE(),
 		cobraotel.New("spicedb",
 			cobraotel.WithLogger(zerologr.New(&logging.Logger)),


### PR DESCRIPTION
We've observed setting GOMEMLIMIT to 100% of available memory can lead to SpiceDB getting OOMKilled under saturation scenarios. When moved to 90%, the system was able to keep up, although still saturated.

This changes the automemlimit default to 90%. Users can still override this using the GOMEMLIMIT env var.