### PR TITLE
Remove codecov from ALL zz files, which include migrations, which are…

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,5 +1,5 @@
 ignore:
-  - "**/zz_generated*.go"
+  - "**/zz_*.go"
   - "**/*.pb.go"
   - "**/*.pb.validate.go"
 coverage:


### PR DESCRIPTION
… tested by the datastore driver tests