### PR TITLE
revert pgx context cancellation

### DIFF
--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
 
+	datastoreinternal "github.com/authzed/spicedb/internal/datastore"
 	"github.com/authzed/spicedb/internal/datastore/common"
 	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
 	"github.com/authzed/spicedb/internal/datastore/postgres/migrations"
@@ -108,7 +109,7 @@ func NewPostgresDatastore(
 		return nil, err
 	}
 
-	return ds, nil
+	return datastoreinternal.NewSeparatingContextDatastoreProxy(ds), nil
 }
 
 // NewReadOnlyPostgresDatastore initializes a SpiceDB datastore that uses a PostgreSQL
@@ -125,7 +126,7 @@ func NewReadOnlyPostgresDatastore(
 		return nil, err
 	}
 
-	return ds, nil
+	return datastoreinternal.NewSeparatingContextDatastoreProxy(ds), nil
 }
 
 func newPostgresDatastore(
@@ -145,9 +146,6 @@ func newPostgresDatastore(
 	if err != nil {
 		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, pgURL)
 	}
-
-	// Install the cancelation handler for contexts.
-	parsedConfig.ConnConfig.BuildContextWatcherHandler = pgxcommon.CancelationContextHandler
 
 	// Setup the default custom plan setting, if applicable.
 	// Setup the default query execution mode setting, if applicable.


### PR DESCRIPTION
reverts https://github.com/authzed/spicedb/pull/2294

We've observed unreliable behavior from pgx cancellation:
- connections were returned to the pool before the cancelation error was returned. This led to subsequent API requests fail with `SQLSTATE 57014`
- Context cancellation can cause the system enter an unrecoverable feedback loop were the connection pool is being starved because of deadlines.