### PR TITLE
Allow for setting of the same metadata on a CRDB watch transaction

### DIFF
--- a/internal/datastore/common/changes.go
+++ b/internal/datastore/common/changes.go
@@ -145,7 +145,9 @@ func (ch *Changes[R, K]) SetRevisionMetadata(ctx context.Context, rev R, metadat
 	}
 
 	if len(record.metadata) > 0 {
-		return spiceerrors.MustBugf("metadata already set for revision")
+		if !maps.Equal(record.metadata, metadata) {
+			return spiceerrors.MustBugf("different metadata already set for revision %v: %v vs %v", rev, record.metadata, metadata)
+		}
 	}
 
 	maps.Copy(record.metadata, metadata)


### PR DESCRIPTION
CRDB can return the same watch event multiple times, so we need to allow for re-setting the *same* metadata

Fixes #2439