### PR TITLE
do not count closed conns due to cancellation toward health check

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -53,12 +53,12 @@ jobs:
       needs.paths-filter.outputs.codechange == 'true'
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
         with:
           username: "${{ env.DOCKERHUB_PUBLIC_USER }}"
           password: "${{ env.DOCKERHUB_PUBLIC_ACCESS_TOKEN }}"
-      - uses: "authzed/actions/go-build@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/go-build@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - name: "Image tests"
         run: "go run mage.go test:image"
 
@@ -70,7 +70,7 @@ jobs:
       needs.paths-filter.outputs.codechange == 'true'
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - name: "Unit tests with coverage"
         run: "go run mage.go test:unitCover"
       - name: "Coverage"
@@ -88,7 +88,7 @@ jobs:
       needs.paths-filter.outputs.codechange == 'true'
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - name: "Steelthread tests"
         run: "go run mage.go test:steelthread"
 
@@ -100,7 +100,7 @@ jobs:
       needs.paths-filter.outputs.codechange == 'true'
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
         with:
           username: "${{ env.DOCKERHUB_PUBLIC_USER }}"
@@ -126,7 +126,7 @@ jobs:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
@@ -160,7 +160,7 @@ jobs:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
@@ -195,7 +195,7 @@ jobs:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
@@ -230,7 +230,7 @@ jobs:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
@@ -265,7 +265,7 @@ jobs:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
@@ -300,7 +300,7 @@ jobs:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
@@ -330,7 +330,7 @@ jobs:
       needs.paths-filter.outputs.codechange == 'true'
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         with:
           go-version-file: "e2e/go.mod"
           cache-dependency-path: "e2e/go.sum"
@@ -363,7 +363,7 @@ jobs:
       needs.paths-filter.outputs.codechange == 'true'
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         with:
           go-version-file: "tools/analyzers/go.mod"
           cache-dependency-path: "tools/analyzers/go.sum"
@@ -377,7 +377,7 @@ jobs:
       needs.paths-filter.outputs.codechange == 'true'
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - name: "WASM tests"
         run: "go run mage.go test:wasm"
 
@@ -389,7 +389,7 @@ jobs:
       needs.paths-filter.outputs.protochange == 'true'
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - name: "Generate Protos"
         run: "go run mage.go gen:proto"
       - uses: "chainguard-dev/actions/nodiff@ce51233d303aed2394a9976e7f5642fd2158f693" # main

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -22,7 +22,7 @@ jobs:
     name: "Check Signature"
     runs-on: "depot-ubuntu-24.04-small"
     steps:
-      - uses: "authzed/actions/cla-check@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/cla-check@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           cla_assistant_token: "${{ secrets.CLA_ASSISTANT_ACCESS_TOKEN }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,9 +18,9 @@ jobs:
     runs-on: "depot-ubuntu-24.04-small"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - name: "Check Licenses"
-        uses: "authzed/actions/go-license-check@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+        uses: "authzed/actions/go-license-check@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         with:
           ignore: "buf.build"  # Has no license information
 
@@ -29,7 +29,7 @@ jobs:
     runs-on: "depot-ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - name: "Lint Go"
         run: "go run mage.go lint:go"
       - uses: "chainguard-dev/actions/nodiff@ce51233d303aed2394a9976e7f5642fd2158f693" # main
@@ -42,7 +42,7 @@ jobs:
     runs-on: "depot-ubuntu-24.04-small"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - name: "Lint Everything Else"
         run: "go run mage.go lint:extra"
       - uses: "chainguard-dev/actions/nodiff@ce51233d303aed2394a9976e7f5642fd2158f693" # main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,13 +16,13 @@ jobs:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         with:
           fetch-depth: 0
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - name: "Install snapcraft"
         run: |
           sudo snap install snapcraft --channel=8.x/stable --classic
           mkdir -p $HOME/.cache/snapcraft/download
           mkdir -p $HOME/.cache/snapcraft/stage-packages
-      - uses: "authzed/actions/docker-login@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/docker-login@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         with:
           quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"
           github_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -16,12 +16,12 @@ jobs:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         with:
           fetch-depth: 0
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - uses: "nowsprinting/check-version-format-action@c7180d5aa53d69af70c364c047482fc71e133f55" # v4.0.6
         id: "version"
         with:
           prefix: "v"
-      - uses: "authzed/actions/docker-login@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/docker-login@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         with:
           quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"
           github_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         with:
           fetch-depth: 0
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - uses: "nowsprinting/check-version-format-action@c7180d5aa53d69af70c364c047482fc71e133f55" # v4.0.6
         id: "version"
         with:
@@ -31,7 +31,7 @@ jobs:
           sudo snap install snapcraft --channel=8.x/stable --classic
           mkdir -p $HOME/.cache/snapcraft/download
           mkdir -p $HOME/.cache/snapcraft/stage-packages
-      - uses: "authzed/actions/docker-login@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/docker-login@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
         with:
           quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"
           github_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -36,8 +36,8 @@ jobs:
 
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
-      - uses: "authzed/actions/codeql@9013d08e1002d122cc87f21d9ed43063555642d0" # main"
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
+      - uses: "authzed/actions/codeql@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main"
 
   trivy:
     name: "Analyze Code and Docker Image with Trivvy"
@@ -52,7 +52,7 @@ jobs:
           # this is used so goreleaser generates the right version out of the tags, which we need so that
           # trivy does not flag an old SpiceDB version
           fetch-depth: 0
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
         with:
           username: "${{ env.DOCKERHUB_PUBLIC_USER }}"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         with:
           ref: "${{ env.GITHUB_SHA }}"
-      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "authzed/actions/setup-go@391defc4658e3e4ac6e53ba66da5b90a3b3f80e2" # main
       - name: "Build WASM"
         run: "go run mage.go build:wasm"
       - uses: "shogo82148/actions-upload-release-asset@d22998fda4c1407f60d1ab48cd6fe67f360f34de" # v1.8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.24.3-alpine3.20@sha256:9f98e9893fbc798c710f3432baa1e0ac6127799127c3101d2c263c3a954f0abe AS spicedb-builder
+FROM golang:1.24.4-alpine3.21@sha256:17656bcdf9097d55d0028bef53f5a2789e9e49cda4eb31cd6f437f8a29f0754d AS spicedb-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 go build -v ./cmd/...
 
-FROM golang:1.24.3-alpine3.20@sha256:9f98e9893fbc798c710f3432baa1e0ac6127799127c3101d2c263c3a954f0abe AS health-probe-builder
+FROM golang:1.24.4-alpine3.21@sha256:17656bcdf9097d55d0028bef53f5a2789e9e49cda4eb31cd6f437f8a29f0754d AS health-probe-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 RUN git clone https://github.com/authzed/grpc-health-probe.git

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,5 @@
 # vim: syntax=dockerfile
-FROM golang:1.24.3-alpine3.20@sha256:9f98e9893fbc798c710f3432baa1e0ac6127799127c3101d2c263c3a954f0abe AS health-probe-builder
+FROM golang:1.24.4-alpine3.21@sha256:17656bcdf9097d55d0028bef53f5a2789e9e49cda4eb31cd6f437f8a29f0754d AS health-probe-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git
 RUN git clone https://github.com/authzed/grpc-health-probe.git

--- a/internal/datastore/crdb/pool/pool_test.go
+++ b/internal/datastore/crdb/pool/pool_test.go
@@ -1,0 +1,83 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+type fakePgxPool struct {
+	Pool
+}
+
+func (m *fakePgxPool) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
+	return &pgxpool.Conn{}, nil
+}
+
+func TestWithRetries(t *testing.T) {
+	originalClosedFunc := isConnClosed
+	t.Cleanup(func() {
+		isConnClosed = originalClosedFunc
+	})
+
+	isConnClosed = func(conn *pgxpool.Conn) bool {
+		return true
+	}
+
+	originalGetConnFunc := getConn
+	t.Cleanup(func() {
+		getConn = originalGetConnFunc
+	})
+
+	conn1 := &pgx.Conn{}
+	getConn = func(conn *pgxpool.Conn) *pgx.Conn {
+		return conn1
+	}
+
+	tracker := &NodeHealthTracker{
+		healthyNodes:  make(map[uint32]struct{}),
+		nodesEverSeen: make(map[uint32]*rate.Limiter),
+		newLimiter: func() *rate.Limiter {
+			return rate.NewLimiter(rate.Every(1*time.Minute), 0)
+		},
+	}
+	tracker.SetNodeHealth(1, true)
+	rp := RetryPool{
+		pool:          &fakePgxPool{},
+		healthTracker: tracker,
+		nodeForConn:   map[*pgx.Conn]uint32{conn1: 1},
+		gc:            make(map[*pgx.Conn]struct{}),
+	}
+
+	// Test that a closed connection caused by context cancellation does not count towards health check
+	err := rp.withRetries(context.Background(), func(conn *pgxpool.Conn) error {
+		return context.Canceled
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, tracker.IsHealthy(1))
+
+	// Test that a closed connection due to a non-context error reports to the health check.
+	// Given the limiter is set to 0, it should mark the node unhealthy immediately
+	foobarErr := errors.New("foobar")
+	err = rp.withRetries(context.Background(), func(conn *pgxpool.Conn) error {
+		return foobarErr
+	})
+	require.Equal(t, err, &MaxRetryError{LastErr: foobarErr})
+	require.False(t, tracker.IsHealthy(1))
+
+	// Test that a resettable error with open connection reports to the health check
+	tracker.SetNodeHealth(1, true)
+	rp.nodeForConn[conn1] = 1
+	resettableErr := ResettableError{Err: foobarErr}
+	err = rp.withRetries(context.Background(), func(conn *pgxpool.Conn) error {
+		return &resettableErr
+	})
+	require.Equal(t, err, &MaxRetryError{LastErr: &resettableErr})
+	require.False(t, tracker.IsHealthy(1))
+}

--- a/internal/datastore/crdb/pool/pool_test.go
+++ b/internal/datastore/crdb/pool/pool_test.go
@@ -14,9 +14,11 @@ import (
 
 type fakePgxPool struct {
 	Pool
+	acquired int
 }
 
-func (m *fakePgxPool) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
+func (m *fakePgxPool) Acquire(_ context.Context) (*pgxpool.Conn, error) {
+	m.acquired++
 	return &pgxpool.Conn{}, nil
 }
 
@@ -47,9 +49,10 @@ func TestWithRetries(t *testing.T) {
 			return rate.NewLimiter(rate.Every(1*time.Minute), 0)
 		},
 	}
+	fakePool := &fakePgxPool{}
 	tracker.SetNodeHealth(1, true)
 	rp := RetryPool{
-		pool:          &fakePgxPool{},
+		pool:          fakePool,
 		healthTracker: tracker,
 		nodeForConn:   map[*pgx.Conn]uint32{conn1: 1},
 		gc:            make(map[*pgx.Conn]struct{}),
@@ -61,17 +64,21 @@ func TestWithRetries(t *testing.T) {
 	})
 	require.ErrorIs(t, err, context.Canceled)
 	require.True(t, tracker.IsHealthy(1))
+	require.Equal(t, 1, fakePool.acquired)
 
 	// Test that a closed connection due to a non-context error reports to the health check.
 	// Given the limiter is set to 0, it should mark the node unhealthy immediately
+	fakePool.acquired = 0
 	foobarErr := errors.New("foobar")
 	err = rp.withRetries(context.Background(), func(conn *pgxpool.Conn) error {
 		return foobarErr
 	})
 	require.Equal(t, err, &MaxRetryError{LastErr: foobarErr})
 	require.False(t, tracker.IsHealthy(1))
+	require.Equal(t, 1, fakePool.acquired) // It does not try to acquire from a new node because it's not retrying
 
 	// Test that a resettable error with open connection reports to the health check
+	fakePool.acquired = 0
 	tracker.SetNodeHealth(1, true)
 	rp.nodeForConn[conn1] = 1
 	resettableErr := ResettableError{Err: foobarErr}
@@ -80,4 +87,17 @@ func TestWithRetries(t *testing.T) {
 	})
 	require.Equal(t, err, &MaxRetryError{LastErr: &resettableErr})
 	require.False(t, tracker.IsHealthy(1))
+	require.Equal(t, 1, fakePool.acquired) // It does not try to acquire from a new node because it's not retrying
+
+	// Test retries
+	fakePool.acquired = 0
+	tracker.SetNodeHealth(1, true)
+	rp.nodeForConn[conn1] = 1
+	rp.maxRetries = 1
+	err = rp.withRetries(context.Background(), func(conn *pgxpool.Conn) error {
+		return &resettableErr
+	})
+	require.Equal(t, err, &MaxRetryError{MaxRetries: 1, LastErr: &resettableErr})
+	require.False(t, tracker.IsHealthy(1))
+	require.Equal(t, 2, fakePool.acquired) // attempts to acquire a new connection after the first failure
 }


### PR DESCRIPTION
We noticed that when clients called APIs that propagate cancellation errors like `WriteRelationships`, a tight deadline could cause the write connection pool to get starved. This is because the `RetryPool` considers an error to count toward the health check when it has caused a connection to be closed.

This commit modifies the code to ensure that this is ignored when the connection is closed as part of context cancellation. This should prevent marking as unhealthy a node that is observing connections being closed, which is caused by the client's cancellation or deadlines. The idea is to prevent the client from inducing this condition.