### PR TITLE
ci: unpin github actions related to go

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: "actions/setup-go@v6.2.0"
+      - uses: "authzed/actions/setup-go@main"
         with:
           go-version-file: "./go.mod"
           cache-dependency-path: "./go.sum"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -22,7 +22,7 @@ jobs:
       codechange: "${{ steps.code-filter.outputs.codechange }}"
       protochange: "${{ steps.proto-filter.outputs.protochange }}"
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
       - uses: "dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36" # v3.0.2
         id: "code-filter"
         with:
@@ -52,8 +52,8 @@ jobs:
     if: |
       needs.paths-filter.outputs.codechange == 'true'
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
       - uses: "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9" # v3.7.0
         with:
           username: "${{ env.DOCKERHUB_PUBLIC_USER }}"
@@ -71,8 +71,8 @@ jobs:
     if: |
       needs.paths-filter.outputs.codechange == 'true'
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
       - name: "Unit tests with coverage"
         run: "go run mage.go test:unitCover"
       - name: "Coverage"
@@ -89,8 +89,8 @@ jobs:
     if: |
       needs.paths-filter.outputs.codechange == 'true'
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
       - name: "Steelthread tests"
         run: "go run mage.go test:steelthread"
 
@@ -101,8 +101,8 @@ jobs:
     if: |
       needs.paths-filter.outputs.codechange == 'true'
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
       - uses: "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9" # v3.7.0
         with:
           username: "${{ env.DOCKERHUB_PUBLIC_USER }}"
@@ -125,10 +125,10 @@ jobs:
       matrix:
         datastore: ["mysql", "spanner"]
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9" # v3.7.0
@@ -159,10 +159,10 @@ jobs:
       matrix:
         datastore: ["mysql", "spanner"]
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9" # v3.7.0
@@ -194,10 +194,10 @@ jobs:
         datastore: ["postgres", "pgbouncer"]
         pgversion: ["13.8", "14", "15", "16", "17"]
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9" # v3.7.0
@@ -229,10 +229,10 @@ jobs:
         datastore: ["postgres"]
         pgversion: ["13.8", "14", "15", "16", "17"]
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9" # v3.7.0
@@ -264,10 +264,10 @@ jobs:
         datastore: ["crdb"]
         crdbversion: ["25.2.0", "25.3.0"]
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9" # v3.7.0
@@ -299,10 +299,10 @@ jobs:
         datastore: ["crdb"]
         crdbversion: ["25.2.0", "25.3.0"]
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
         if: |
           needs.paths-filter.outputs.codechange == 'true'
       - uses: "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9" # v3.7.0
@@ -337,8 +337,8 @@ jobs:
     if: |
       needs.paths-filter.outputs.codechange == 'true'
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
         with:
           go-version-file: "e2e/go.mod"
           cache-dependency-path: "e2e/go.sum"
@@ -358,8 +358,8 @@ jobs:
     if: |
       needs.paths-filter.outputs.codechange == 'true'
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
         with:
           go-version-file: "tools/analyzers/go.mod"
           cache-dependency-path: "tools/analyzers/go.sum"
@@ -372,8 +372,8 @@ jobs:
     if: |
       needs.paths-filter.outputs.codechange == 'true'
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
       - name: "Disable AppArmor"
         if:
           "runner.os == 'Linux'"
@@ -398,8 +398,8 @@ jobs:
     if: |
       needs.paths-filter.outputs.protochange == 'true'
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
       - name: "Generate Protos"
         run: "go run mage.go gen:proto"
       - uses: "chainguard-dev/actions/nodiff@18e5e3427cf9d6bcfbefe60dca48e40292f000c5" # main
@@ -428,11 +428,11 @@ jobs:
       github.event_name == 'pull_request' &&
       github.base_ref == 'main'
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         with:
           fetch-depth: 0
 
-      - uses: "actions/setup-go@a5f9b05d2d216f63e13859e0d847461041025775" # v5.4.0
+      - uses: "authzed/actions/setup-go@main"
         with:
           go-version-file: "./go.mod"
           cache-dependency-path: "./go.sum"

--- a/.github/workflows/keep-a-changelog.yaml
+++ b/.github/workflows/keep-a-changelog.yaml
@@ -23,13 +23,14 @@ jobs:
       - uses: "dangoslen/changelog-enforcer@ea6a56764870c323a4563f450c0a50c5f2d72cd6"
         with:
           skipLabels: "Skip-Changelog,dependencies,tests"
+          missingUpdateErrorMessage: "If your PR has a change that users might care about, please add an entry to CHANGELOG.md, run 'npx keep-a-changelog', and commit the changes. Otherwise, add the Skip-Changelog label to your PR."
       - uses: "actions/checkout@v6"
       - uses: "actions/setup-node@v6"
       - run: "npx keep-a-changelog@2.8.0"
       - run: |
           files=$(git status --porcelain)
           if [[ -n ${files}  ]]; then
-            >&2 echo "If your PR has a change that users might care about, please edit CHANGELOG.md and then run \`npx keep-a-changelog\`. Otherwise, add the Skip-Changelog label to your PR."
+            >&2 echo "Please run \`npx keep-a-changelog\` and commit the changes."
             >&2 echo ""
             >&2 echo "${files}"
             >&2 echo ""

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,8 +17,8 @@ jobs:
     name: "License Check"
     runs-on: "depot-ubuntu-24.04-small"
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
       - name: "Check Licenses"
         uses: "authzed/actions/go-license-check@11667c9b2e8b3649ad2af4d788e57d18f8e8eaf1" # main
         with:
@@ -27,8 +27,8 @@ jobs:
     name: "Ensure Docs are up to date"
     runs-on: "depot-ubuntu-24.04-4"
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
       - name: "Generate docs"
         run: "go run mage.go gen:docs"
       - uses: "chainguard-dev/actions/nodiff@18e5e3427cf9d6bcfbefe60dca48e40292f000c5" # main
@@ -39,8 +39,8 @@ jobs:
     name: "Lint Everything"
     runs-on: "depot-ubuntu-24.04-4"
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
       - name: "Lint Everything"
         run: "go run mage.go lint:all"
       - uses: "chainguard-dev/actions/nodiff@18e5e3427cf9d6bcfbefe60dca48e40292f000c5" # main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,10 +13,10 @@ jobs:
       contents: "write"
       packages: "write" # publish to GHCR
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         with:
           fetch-depth: 0
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
       - name: "Install snapcraft"
         run: |
           sudo snap install snapcraft --channel=8.x/stable --classic

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -13,10 +13,10 @@ jobs:
       contents: "write"
       packages: "write" # publish to GHCR
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         with:
           fetch-depth: 0
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
       - uses: "nowsprinting/check-version-format-action@bb1181a02ee5d9ae4feead2842236183c85152c6" # v4.0.7
         id: "version"
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,10 +14,10 @@ jobs:
       contents: "write"
       packages: "write" # publish to GHCR
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         with:
           fetch-depth: 0
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
       - uses: "nowsprinting/check-version-format-action@bb1181a02ee5d9ae4feead2842236183c85152c6" # v4.0.7
         id: "version"
         with:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -35,15 +35,15 @@ jobs:
         language: ["go"]
 
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "actions/checkout@v6"
+      - uses: "authzed/actions/setup-go@main"
       - uses: "authzed/actions/codeql@11667c9b2e8b3649ad2af4d788e57d18f8e8eaf1" # main"
 
   trivy:
     name: "Analyze Code and Docker Image with Trivvy"
     runs-on: "depot-ubuntu-24.04"
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         with:
           # Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set fetch-depth: 0
           # to fetch all history for all branches and tags. Refer here to learn which commit $GITHUB_SHA
@@ -52,7 +52,7 @@ jobs:
           # this is used so goreleaser generates the right version out of the tags, which we need so that
           # trivy does not flag an old SpiceDB version
           fetch-depth: 0
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
       - uses: "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9" # v3.7.0
         with:
           username: "${{ env.DOCKERHUB_PUBLIC_USER }}"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -12,10 +12,10 @@ jobs:
     permissions:
       contents: "write"
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8" # v4.2.2
+      - uses: "actions/checkout@v6"
         with:
           ref: "${{ env.GITHUB_SHA }}"
-      - uses: "authzed/actions/setup-go@6cde6aeb82fab36d8383c2f55bed8128955af34d" # main
+      - uses: "authzed/actions/setup-go@main"
       - name: "Build WASM"
         run: "go run mage.go build:wasm"
       - uses: "shogo82148/actions-upload-release-asset@8f6863c6c894ba46f9e676ef5cccec4752723c1e" # v1.9.2


### PR DESCRIPTION
this is so that when Go has a new vulnerability we don't have to update everywhere.