### PR TITLE
trim binary by removing dep to github.com/google/go-github/v43

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ linters:
   enable:
     - "bidichk"
     - "bodyclose"
+    - "depguard"
     - "errcheck"
     - "errname"
     - "errorlint"
@@ -32,6 +33,12 @@ linters:
     - "whitespace"
     - "unused"
   settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "k8s.io/utils/strings/slices$"
+              desc: "use github.com/samber/lo"
     staticcheck:
       checks:
         - "all"

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.5.12
 	github.com/benbjohnson/clock v1.3.5
 	github.com/bits-and-blooms/bloom/v3 v3.7.0
+	github.com/caio/go-tdigest/v4 v4.0.1
 	github.com/ccoveille/go-safecast v1.6.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cespare/xxhash/v2 v2.3.0
@@ -48,8 +49,8 @@ require (
 	github.com/go-sql-driver/mysql v1.9.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v1.0.0
+	github.com/golangci/golangci-lint/v2 v2.1.6
 	github.com/google/go-cmp v0.7.0
-	github.com/google/go-github/v43 v43.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.15.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
@@ -117,14 +118,6 @@ require (
 	resenje.org/singleflight v0.4.3
 	sigs.k8s.io/controller-runtime v0.21.0
 )
-
-require (
-	github.com/caio/go-tdigest/v4 v4.0.1
-	github.com/golangci/golangci-lint/v2 v2.1.6
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
-)
-
-require sigs.k8s.io/randfill v1.0.0 // indirect
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
@@ -251,7 +244,6 @@ require (
 	github.com/golangci/revgrep v0.8.0 // indirect
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
@@ -424,9 +416,11 @@ require (
 	k8s.io/client-go v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	mvdan.cc/gofumpt v0.8.0 // indirect
 	mvdan.cc/unparam v0.0.0-20250301125049-0df0534333a4 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1860,12 +1860,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v43 v43.0.0 h1:y+GL7LIsAIF2NZlJ46ZoC/D1W1ivZasT0lnWHMYPZ+U=
-github.com/google/go-github/v43 v43.0.0/go.mod h1:ZkTvvmCXBvsfPpTHXnH/d2hP9Y0cTbvN9kr5xqyXOIc=
 github.com/google/go-pkcs11 v0.2.0/go.mod h1:6eQoGcuNJpa7jnd5pMGdkSaQpNDYvPlXWMcjXXThLlY=
 github.com/google/go-pkcs11 v0.2.1-0.20230907215043-c6f79328ddf9/go.mod h1:6eQoGcuNJpa7jnd5pMGdkSaQpNDYvPlXWMcjXXThLlY=
-github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
-github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -9,10 +9,22 @@ import (
 
 type Build mg.Namespace
 
+// Binary builds the binary
+func (Build) Binary() error {
+	return sh.RunWithV(
+		map[string]string{},
+		"go", "build",
+		"-o", "./dist",
+		"./cmd/spicedb/main.go",
+	)
+}
+
 // Wasm Build the wasm bundle
 func (Build) Wasm() error {
 	return sh.RunWithV(map[string]string{"GOOS": "js", "GOARCH": "wasm"},
-		"go", "build", "-o", "dist/development.wasm", "./pkg/development/wasm/...")
+		// -s: Omit the symbol table.
+		// -w: Omit the DWARF debugging information.
+		"go", "build", "-ldflags=-s -w", "-o", "dist/development.wasm", "./pkg/development/wasm/...")
 }
 
 // Testimage Build the spicedb image for tests

--- a/pkg/composableschemadsl/compiler/compiler.go
+++ b/pkg/composableschemadsl/compiler/compiler.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/samber/lo"
 	"google.golang.org/protobuf/proto"
-	"k8s.io/utils/strings/slices"
 
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/dslshape"
@@ -90,7 +90,7 @@ const expirationFlag = "expiration"
 
 func DisallowExpirationFlag() Option {
 	return func(cfg *config) {
-		cfg.allowedFlags = slices.Filter([]string{}, cfg.allowedFlags, func(s string) bool {
+		cfg.allowedFlags = lo.Filter(cfg.allowedFlags, func(s string, _ int) bool {
 			return s != expirationFlag
 		})
 	}

--- a/pkg/schemadsl/compiler/compiler.go
+++ b/pkg/schemadsl/compiler/compiler.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/samber/lo"
 	"google.golang.org/protobuf/proto"
-	"k8s.io/utils/strings/slices"
 
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -80,7 +80,7 @@ const expirationFlag = "expiration"
 
 func DisallowExpirationFlag() Option {
 	return func(cfg *config) {
-		cfg.allowedFlags = slices.Filter([]string{}, cfg.allowedFlags, func(s string) bool {
+		cfg.allowedFlags = lo.Filter(cfg.allowedFlags, func(s string, _ int) bool {
 			return s != expirationFlag
 		})
 	}


### PR DESCRIPTION
## Description

```
 goweight ./cmd/spicedb/main.go                    
execute: go build -C /Users/miparnisari/Documents/GitHub/spicedb -o goweight-bin-target -work -a ./cmd/spicedb/main.go
    Size Module
   27 MB k8s.io/api/core/v1
   26 MB github.com/authzed/authzed-go/proto/authzed/api/v1
   26 MB github.com/jackc/pgx/v5/pgtype
   20 MB github.com/authzed/spicedb/pkg/cmd/server
   15 MB github.com/google/go-github/v43/github
   14 MB runtime
   13 MB cloud.google.com/go/spanner
   13 MB github.com/envoyproxy/go-control-plane/envoy/config/core/v3
   10 MB net/http
  9.7 MB github.com/authzed/cel-go/parser/gen
  9.2 MB k8s.io/client-go/kubernetes/typed/core/v1
  9.1 MB github.com/envoyproxy/go-control-plane/envoy/config/route/v3
  8.6 MB github.com/antlr4-go/antlr/v4
  8.0 MB k8s.io/client-go/applyconfigurations/core/v1
  7.9 MB github.com/authzed/spicedb/pkg/proto/core/v1

```

I wish I could remove more, but this will do for now. k8s looks like an obvious candidate to remove, and i don't know why the `authzed-go` dependency needs so much space.

## Testing

Verify that the tests pass.

