### PR TITLE
Postgres: configure migration driver to support PgBouncer

### DIFF
--- a/internal/datastore/postgres/common/pgx.go
+++ b/internal/datastore/postgres/common/pgx.go
@@ -299,3 +299,22 @@ func SleepOnErr(ctx context.Context, err error, retries uint8) {
 	case <-ctx.Done():
 	}
 }
+
+// ConfigureDefaultQueryExecMode parses a Postgres URI and determines if a default_query_exec_mode
+// has been specified. If not, it defaults to "exec".
+// SpiceDB queries have high variability of arguments and rarely benefit from using prepared statements.
+// The default and recommended query exec mode is 'exec', which has shown the best performance under various
+// synthetic workloads. See more in https://spicedb.dev/d/query-exec-mode.
+//
+// The docs for the different execution modes offered by pgx may be found
+// here: https://pkg.go.dev/github.com/jackc/pgx/v5#QueryExecMode
+func ConfigureDefaultQueryExecMode(config *pgx.ConnConfig) {
+	if !strings.Contains(config.ConnString(), "default_query_exec_mode") {
+		// the execution mode was not overridden by the user
+		config.DefaultQueryExecMode = pgx.QueryExecModeExec
+	}
+
+	log.Info().
+		Str("details-url", "https://spicedb.dev/d/query-exec-mode").
+		Msg("found default_query_exec_mode in DB URI; leaving as-is")
+}

--- a/internal/datastore/postgres/migrations/driver.go
+++ b/internal/datastore/postgres/migrations/driver.go
@@ -38,6 +38,7 @@ func NewAlembicPostgresDriver(ctx context.Context, url string, credentialsProvid
 	}
 	pgxcommon.ConfigurePGXLogger(connConfig)
 	pgxcommon.ConfigureOTELTracer(connConfig, includeQueryParametersInTraces)
+	pgxcommon.ConfigureDefaultQueryExecMode(connConfig)
 
 	if credentialsProvider != nil {
 		log.Ctx(ctx).Debug().Str("name", credentialsProvider.Name()).Msg("using credentials provider")

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -8,7 +8,6 @@ import (
 	"math/rand/v2"
 	"os"
 	"strconv"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -142,14 +141,14 @@ func newPostgresDatastore(
 	}
 
 	// Parse the DB URI into configuration.
-	parsedConfig, err := pgxpool.ParseConfig(pgURL)
+	pgConfig, err := pgxpool.ParseConfig(pgURL)
 	if err != nil {
 		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, pgURL)
 	}
 
 	// Setup the default custom plan setting, if applicable.
 	// Setup the default query execution mode setting, if applicable.
-	pgConfig := DefaultQueryExecMode(parsedConfig)
+	pgxcommon.ConfigureDefaultQueryExecMode(pgConfig.ConnConfig)
 
 	// Setup the credentials provider
 	var credentialsProvider datastore.CredentialsProvider
@@ -818,27 +817,6 @@ func buildLivingObjectFilterForRevision(revision postgresRevision) queryFilterer
 
 func currentlyLivingObjects(original sq.SelectBuilder) sq.SelectBuilder {
 	return original.Where(sq.Eq{schema.ColDeletedXid: liveDeletedTxnID})
-}
-
-// DefaultQueryExecMode parses a Postgres URI and determines if a default_query_exec_mode
-// has been specified. If not, it defaults to "exec".
-// SpiceDB queries have high variability of arguments and rarely benefit from using prepared statements.
-// The default and recommended query exec mode is 'exec', which has shown the best performance under various
-// synthetic workloads. See more in https://spicedb.dev/d/query-exec-mode.
-//
-// The docs for the different execution modes offered by pgx may be found
-// here: https://pkg.go.dev/github.com/jackc/pgx/v5#QueryExecMode
-func DefaultQueryExecMode(poolConfig *pgxpool.Config) *pgxpool.Config {
-	if !strings.Contains(poolConfig.ConnString(), "default_query_exec_mode") {
-		// the execution mode was not overridden by the user
-		poolConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
-		return poolConfig
-	}
-
-	log.Info().
-		Str("details-url", "https://spicedb.dev/d/query-exec-mode").
-		Msg("found default_query_exec_mode in DB URI; leaving as-is")
-	return poolConfig
 }
 
 var _ datastore.Datastore = &pgDatastore{}

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/authzed/spicedb/internal/datastore/postgres/common"
 	"github.com/authzed/spicedb/internal/datastore/postgres/version"
 	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
 
@@ -85,14 +86,14 @@ func TestDefaultQueryExecMode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, parsedConfig.ConnConfig.DefaultQueryExecMode, pgx.QueryExecModeCacheStatement)
 
-	pgConfig := DefaultQueryExecMode(parsedConfig)
-	require.Equal(t, pgConfig.ConnConfig.DefaultQueryExecMode, pgx.QueryExecModeExec)
+	common.ConfigureDefaultQueryExecMode(parsedConfig.ConnConfig)
+	require.Equal(t, parsedConfig.ConnConfig.DefaultQueryExecMode, pgx.QueryExecModeExec)
 }
 
 func TestDefaultQueryExecModeOverridden(t *testing.T) {
 	parsedConfig, err := pgxpool.ParseConfig("postgres://username:password@localhost:5432/dbname?default_query_exec_mode=cache_statement")
 	require.NoError(t, err)
 
-	pgConfig := DefaultQueryExecMode(parsedConfig)
-	require.Equal(t, pgConfig.ConnConfig.DefaultQueryExecMode, pgx.QueryExecModeCacheStatement)
+	common.ConfigureDefaultQueryExecMode(parsedConfig.ConnConfig)
+	require.Equal(t, parsedConfig.ConnConfig.DefaultQueryExecMode, pgx.QueryExecModeCacheStatement)
 }


### PR DESCRIPTION
In https://github.com/authzed/spicedb/pull/1994/commits/dcc797274edc59eb57222eefc0227442bb7abee2 we adjusted the postgres datastore handling of connections to use `exec` mode by default. This fixes the compatibility issues SpiceDB had with PgBouncer.

However, that fix overlooked the fact that we had to do the same in the migrations driver, which has its own logic for creating the connections. We discovered this after [a user report](https://github.com/orgs/authzed/discussions/2461) indicating the failures emerged during migrations, but not during regular operation.

This would manifest as errors like:
```
unable to load alembic revision: FATAL: prepared statement name is already in use (SQLSTATE 08P01)
```

## Workaround

For those reading, a potential (untested) workaround would be to set the DSN to:
```
postgres://username:password@localhost:5432/dbname?default_query_exec_mode=exec
```