### PR TITLE
default cockroachdb connection jitter to 30m

### DIFF
--- a/internal/datastore/crdb/options_test.go
+++ b/internal/datastore/crdb/options_test.go
@@ -1,0 +1,67 @@
+package crdb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfiguration(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  []Option
+		validate func(t *testing.T, config crdbOptions)
+	}{
+		{
+			name:    "default jitter configuration",
+			options: []Option{},
+			validate: func(t *testing.T, config crdbOptions) {
+				require.NotNil(t, config.readPoolOpts.ConnMaxLifetimeJitter)
+				require.Equal(t, 30*time.Minute, *config.readPoolOpts.ConnMaxLifetimeJitter)
+
+				require.NotNil(t, config.writePoolOpts.ConnMaxLifetimeJitter)
+				require.Equal(t, 30*time.Minute, *config.writePoolOpts.ConnMaxLifetimeJitter)
+			},
+		},
+		{
+			name: "explicit jitter values preserved",
+			options: []Option{
+				ReadConnMaxLifetimeJitter(10 * time.Minute),
+				WriteConnMaxLifetimeJitter(15 * time.Minute),
+			},
+			validate: func(t *testing.T, config crdbOptions) {
+				// Should preserve explicitly set values
+				require.NotNil(t, config.readPoolOpts.ConnMaxLifetimeJitter)
+				require.Equal(t, 10*time.Minute, *config.readPoolOpts.ConnMaxLifetimeJitter)
+
+				require.NotNil(t, config.writePoolOpts.ConnMaxLifetimeJitter)
+				require.Equal(t, 15*time.Minute, *config.writePoolOpts.ConnMaxLifetimeJitter)
+			},
+		},
+		{
+			name: "zeros values applies defaults",
+			options: []Option{
+				// This simulates what happens when pkg/cmd/datastore passes zero values
+				// from ConnPoolConfig.MaxLifetimeJitter (which defaults to 0)
+				ReadConnMaxLifetimeJitter(time.Duration(0)),
+				WriteConnMaxLifetimeJitter(time.Duration(0)),
+			},
+			validate: func(t *testing.T, config crdbOptions) {
+				require.NotNil(t, config.readPoolOpts.ConnMaxLifetimeJitter)
+				require.Equal(t, 30*time.Minute, *config.readPoolOpts.ConnMaxLifetimeJitter)
+
+				require.NotNil(t, config.writePoolOpts.ConnMaxLifetimeJitter)
+				require.Equal(t, 30*time.Minute, *config.writePoolOpts.ConnMaxLifetimeJitter)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := generateConfig(tt.options)
+			require.NoError(t, err)
+			tt.validate(t, config)
+		})
+	}
+}

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -85,7 +85,7 @@ func RegisterConnPoolFlagsWithPrefix(flagSet *pflag.FlagSet, prefix string, defa
 	flagSet.IntVar(&opts.MaxOpenConns, flagName("max-open"), defaults.MaxOpenConns, "number of concurrent connections open in a remote datastore's connection pool")
 	flagSet.IntVar(&opts.MinOpenConns, flagName("min-open"), defaults.MinOpenConns, "number of minimum concurrent connections open in a remote datastore's connection pool")
 	flagSet.DurationVar(&opts.MaxLifetime, flagName("max-lifetime"), defaults.MaxLifetime, "maximum amount of time a connection can live in a remote datastore's connection pool")
-	flagSet.DurationVar(&opts.MaxLifetimeJitter, flagName("max-lifetime-jitter"), defaults.MaxLifetimeJitter, "waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection (default: 20% of max lifetime)")
+	flagSet.DurationVar(&opts.MaxLifetimeJitter, flagName("max-lifetime-jitter"), defaults.MaxLifetimeJitter, "waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection (default: 20% of max lifetime, 30m for CockroachDB)")
 	flagSet.DurationVar(&opts.MaxIdleTime, flagName("max-idletime"), defaults.MaxIdleTime, "maximum amount of time a connection can idle in a remote datastore's connection pool")
 	flagSet.DurationVar(&opts.HealthCheckInterval, flagName("healthcheck-interval"), defaults.HealthCheckInterval, "amount of time between connection health checks in a remote datastore's connection pool")
 }


### PR DESCRIPTION
In cockroach, the custom connection pooler allows us to have larger pools with longer lifetimes. With large pools, it's better to spread out the connection lifecycle with more jitter, so that there's not a stampede of connections closing / re-opening on regular intervals.