### PR TITLE
Fix flaky test for telemetry reporting

### DIFF
--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -62,6 +62,8 @@ func TestServerGracefulTermination(t *testing.T) {
 
 func TestOTelReporting(t *testing.T) {
 	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+	spanrecorder, restoreOtel := setupSpanRecorder()
+	defer restoreOtel()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -102,9 +104,6 @@ func TestOTelReporting(t *testing.T) {
 	go func() {
 		require.NoError(t, srv.Run(ctx))
 	}()
-
-	spanrecorder, restoreOtel := setupSpanRecorder()
-	defer restoreOtel()
 
 	// test unary OTel middleware
 	_, err = schemaSrv.WriteSchema(ctx, &v1.WriteSchemaRequest{


### PR DESCRIPTION
When the CPU is busy doing something else, the test `TestOTelReporting` fails:

```
davide@gentoo-hp ~/workspace/github/authzed/spicedb $ go test -count=5000 ./pkg/cmd/server -run TestOTelReporting
--- FAIL: TestOTelReporting (0.00s)
    server_test.go:124: 
                Error Trace:    /home/davide/workspace/github/authzed/spicedb/pkg/cmd/server/server_test.go:146
                                                        /home/davide/workspace/github/authzed/spicedb/pkg/cmd/server/server_test.go:124
                Error:          Should be true
                Test:           TestOTelReporting
                Messages:       missing trace for Streaming gRPC call
--- FAIL: TestOTelReporting (0.00s)
    server_test.go:132: 
                Error Trace:    /home/davide/workspace/github/authzed/spicedb/pkg/cmd/server/server_test.go:146
                                                        /home/davide/workspace/github/authzed/spicedb/pkg/cmd/server/server_test.go:132
                Error:          Should be true
                Test:           TestOTelReporting
                Messages:       missing trace for Streaming gRPC call
FAIL
FAIL    github.com/authzed/spicedb/pkg/cmd/server       15.889s
FAIL
```

By moving the initialization of the span recorder before any other object creation, we can avoid a race condition.