### PR TITLE
Parse schema from schemafile property

### DIFF
--- a/pkg/validationfile/loader_test.go
+++ b/pkg/validationfile/loader_test.go
@@ -2,6 +2,7 @@ package validationfile
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"testing"
 
@@ -12,15 +13,23 @@ import (
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
+
+type ExpectedError struct {
+	message string
+	source  string
+	line    uint64
+	column  uint64
+}
 
 func TestPopulateFromFiles(t *testing.T) {
 	tests := []struct {
 		name          string
 		filePaths     []string
 		want          []string
-		expectedError string
+		expectedError *ExpectedError
 	}{
 		{
 			name:      "no comment",
@@ -30,7 +39,17 @@ func TestPopulateFromFiles(t *testing.T) {
 				"example/project:pied_piper#reader@example/user:tarben",
 				"example/project:pied_piper#writer@example/user:freyja",
 			},
-			expectedError: "",
+			expectedError: nil,
+		},
+		{
+			name:      "using schemafile",
+			filePaths: []string{"testdata/loader_using_schemafile.yaml"},
+			want: []string{
+				"example/project:pied_piper#owner@example/user:milburga",
+				"example/project:pied_piper#reader@example/user:tarben",
+				"example/project:pied_piper#writer@example/user:freyja",
+			},
+			expectedError: nil,
 		},
 		{
 			name:      "with comment",
@@ -40,7 +59,7 @@ func TestPopulateFromFiles(t *testing.T) {
 				"example/project:pied_piper#reader@example/user:tarben",
 				"example/project:pied_piper#writer@example/user:freyja",
 			},
-			expectedError: "",
+			expectedError: nil,
 		},
 		{
 			name:      "multiple files",
@@ -53,7 +72,7 @@ func TestPopulateFromFiles(t *testing.T) {
 				"example/project:pied_piper#reader@example/user:tom",
 				"example/project:pied_piper#writer@example/user:sarah",
 			},
-			expectedError: "",
+			expectedError: nil,
 		},
 		{
 			name:      "multiple files",
@@ -66,19 +85,52 @@ func TestPopulateFromFiles(t *testing.T) {
 				"example/project:pied_piper#reader@example/user:tom",
 				"example/project:pied_piper#writer@example/user:sarah",
 			},
-			expectedError: "",
+			expectedError: nil,
 		},
 		{
 			name:          "missing schema",
 			filePaths:     []string{"testdata/just_rels.yaml"},
 			want:          nil,
-			expectedError: "object definition `example/project` not found",
+			expectedError: &ExpectedError{message: "object definition `example/project` not found"},
+		},
+		{
+			name:          "both schema and schemaFile",
+			filePaths:     []string{"testdata/schema_and_schemafile.yaml"},
+			want:          nil,
+			expectedError: &ExpectedError{message: "only one of schema or schemaFile can be specified"},
+		},
+		{
+			name:      "invalid schemaFile",
+			filePaths: []string{"testdata/loader_using_invalid_schemafile.yaml"},
+			want:      nil,
+			expectedError: &ExpectedError{
+				message: "error when parsing schema: Expected one of: [TokenTypeColon], found: TokenTypeIdentifier",
+				source:  "example",
+				line:    6,
+				column:  18,
+			},
+		},
+		{
+			name:      "non-local schemaFile",
+			filePaths: []string{"testdata/loader_using_non-local_schemafile.yaml"},
+			want:      nil,
+			expectedError: &ExpectedError{
+				message: "schema file \"../schemas/non_local_schemafile.zed\" is not local",
+			},
+		},
+		{
+			name:      "missing schemaFile",
+			filePaths: []string{"testdata/loader_using_missing_schemafile.yaml"},
+			want:      nil,
+			expectedError: &ExpectedError{
+				message: "error when opening schema file testdata/non_existant_schemafile.zed: open testdata/non_existant_schemafile.zed: no such file or directory",
+			},
 		},
 		{
 			name:          "legacy file",
 			filePaths:     []string{"testdata/legacy.yaml"},
 			want:          nil,
-			expectedError: "relationships must be specified in `relationships`",
+			expectedError: &ExpectedError{message: "relationships must be specified in `relationships`"},
 		},
 		{
 			name:      "basic caveats",
@@ -87,7 +139,7 @@ func TestPopulateFromFiles(t *testing.T) {
 				"resource:first#reader@user:sarah[some_caveat:{\"somecondition\":42}]",
 				"resource:first#reader@user:tom[some_caveat]",
 			},
-			expectedError: "",
+			expectedError: nil,
 		},
 		{
 			name:      "caveat order",
@@ -96,31 +148,31 @@ func TestPopulateFromFiles(t *testing.T) {
 				"resource:first#reader@user:sarah[some_caveat:{\"somecondition\":42}]",
 				"resource:first#reader@user:tom[some_caveat]",
 			},
-			expectedError: "",
+			expectedError: nil,
 		},
 		{
 			name:          "invalid caveat",
 			filePaths:     []string{"testdata/invalid_caveat.yaml"},
 			want:          nil,
-			expectedError: "could not lookup caveat `some_caveat` for relation `reader`: caveat with name `some_caveat` not found",
+			expectedError: &ExpectedError{message: "could not lookup caveat `some_caveat` for relation `reader`: caveat with name `some_caveat` not found"},
 		},
 		{
 			name:          "invalid caveated relationship",
 			filePaths:     []string{"testdata/invalid_caveated_rel.yaml"},
 			want:          nil,
-			expectedError: "subjects of type `user with some_caveat` are not allowed on relation `resource#reader`",
+			expectedError: &ExpectedError{message: "subjects of type `user with some_caveat` are not allowed on relation `resource#reader`"},
 		},
 		{
 			name:          "invalid caveated relationship syntax",
 			filePaths:     []string{"testdata/invalid_caveated_rel_syntax.yaml"},
 			want:          nil,
-			expectedError: "error parsing relationship",
+			expectedError: &ExpectedError{message: "error parsing relationship"},
 		},
 		{
 			name:          "repeated relationship",
 			filePaths:     []string{"testdata/repeated_relationship.yaml"},
 			want:          nil,
-			expectedError: "found repeated relationship `resource:first#reader@user:tom`",
+			expectedError: &ExpectedError{message: "found repeated relationship `resource:first#reader@user:tom`"},
 		},
 	}
 
@@ -132,7 +184,7 @@ func TestPopulateFromFiles(t *testing.T) {
 			require.NoError(err)
 
 			parsed, _, err := PopulateFromFiles(t.Context(), ds, caveattypes.Default.TypeSet, tt.filePaths)
-			if tt.expectedError == "" {
+			if tt.expectedError == nil {
 				require.NoError(err)
 
 				foundRelationships := make([]string, 0, len(parsed.Relationships))
@@ -145,7 +197,24 @@ func TestPopulateFromFiles(t *testing.T) {
 				require.Equal(tt.want, foundRelationships)
 			} else {
 				require.NotNil(err)
-				require.Contains(err.Error(), tt.expectedError)
+				if tt.expectedError.message != "" {
+					require.Contains(err.Error(), tt.expectedError.message)
+				}
+
+				var sourceError *spiceerrors.WithSourceError
+				if errors.As(err, &sourceError) {
+					if tt.expectedError.source != "" {
+						require.Equal(sourceError.SourceCodeString, tt.expectedError.source)
+					}
+
+					if tt.expectedError.line > 0 {
+						require.Equal(sourceError.LineNumber, tt.expectedError.line)
+					}
+
+					if tt.expectedError.column > 0 {
+						require.Equal(sourceError.ColumnPosition, tt.expectedError.column)
+					}
+				}
 			}
 		})
 	}

--- a/pkg/validationfile/schema_test.go
+++ b/pkg/validationfile/schema_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	yamlv3 "gopkg.in/yaml.v3"
 
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
-	"github.com/authzed/spicedb/pkg/validationfile/blocks"
+	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
+	"github.com/authzed/spicedb/pkg/schemadsl/input"
 )
 
 func TestParseSchema(t *testing.T) {
@@ -46,11 +46,11 @@ func TestParseSchema(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			schemaWithPosition := blocks.SchemaWithPosition{}
-			err := yamlv3.Unmarshal([]byte(tt.contents), &schemaWithPosition)
-			require.NoError(t, err)
-
-			compiled, err := CompileSchema(schemaWithPosition, caveattypes.Default.TypeSet)
+			inputSchema := compiler.InputSchema{
+				Source:       input.Source("schema"),
+				SchemaString: tt.contents,
+			}
+			compiled, err := CompileSchema(inputSchema, caveattypes.Default.TypeSet)
 			if tt.expectedError != "" {
 				require.NotNil(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
@@ -59,7 +59,6 @@ func TestParseSchema(t *testing.T) {
 				if tt.expectedDefCount > 0 {
 					require.NotNil(t, compiled)
 					require.Equal(t, tt.expectedDefCount, len(compiled.OrderedDefinitions))
-					require.Equal(t, tt.contents, schemaWithPosition.Schema)
 				}
 			}
 		})

--- a/pkg/validationfile/testdata/invalid_schemafile.zed
+++ b/pkg/validationfile/testdata/invalid_schemafile.zed
@@ -1,0 +1,11 @@
+definition example/user {}
+
+definition example/project {
+  relation reader: example/user
+  relation writer: example/user
+  relation owner example/user
+
+  permission read = reader + write
+  permission write = writer + admin
+  permission admin = owner
+}

--- a/pkg/validationfile/testdata/loader_using_invalid_schemafile.yaml
+++ b/pkg/validationfile/testdata/loader_using_invalid_schemafile.yaml
@@ -1,0 +1,12 @@
+---
+schemaFile: "./invalid_schemafile.zed"
+relationships: >-
+  example/project:pied_piper#owner@example/user:milburga
+
+  example/project:pied_piper#reader@example/user:tarben
+
+  example/project:pied_piper#writer@example/user:freyja
+assertions:
+  assertTrue: []
+  assertFalse: []
+validation: null

--- a/pkg/validationfile/testdata/loader_using_missing_schemafile.yaml
+++ b/pkg/validationfile/testdata/loader_using_missing_schemafile.yaml
@@ -1,0 +1,8 @@
+---
+schemaFile: "./non_existant_schemafile.zed"
+relationships: >-
+  example/project:pied_piper#owner@example/user:milburga
+assertions:
+  assertTrue: []
+  assertFalse: []
+validation: null

--- a/pkg/validationfile/testdata/loader_using_non-local_schemafile.yaml
+++ b/pkg/validationfile/testdata/loader_using_non-local_schemafile.yaml
@@ -1,0 +1,8 @@
+---
+schemaFile: "../../schemas/non_local_schemafile.zed"
+relationships: >-
+  example/project:pied_piper#owner@example/user:milburga
+assertions:
+  assertTrue: []
+  assertFalse: []
+validation: null

--- a/pkg/validationfile/testdata/loader_using_schemafile.yaml
+++ b/pkg/validationfile/testdata/loader_using_schemafile.yaml
@@ -1,0 +1,12 @@
+---
+schemaFile: "./separate_schemafile.zed"
+relationships: >-
+  example/project:pied_piper#owner@example/user:milburga
+
+  example/project:pied_piper#reader@example/user:tarben
+
+  example/project:pied_piper#writer@example/user:freyja
+assertions:
+  assertTrue: []
+  assertFalse: []
+validation: null

--- a/pkg/validationfile/testdata/schema_and_schemafile.yaml
+++ b/pkg/validationfile/testdata/schema_and_schemafile.yaml
@@ -1,0 +1,25 @@
+---
+schemaFile: "./separate_schemafile.zed"
+schema: >-
+  definition example/user {}
+
+
+  definition example/project {
+      relation reader: example/user
+      relation writer: example/user
+      relation owner: example/user
+
+      permission read = reader + write
+      permission write = writer + admin
+      permission admin = owner
+  }
+relationships: >-
+  example/project:pied_piper#owner@example/user:milburga
+
+  example/project:pied_piper#reader@example/user:tarben
+
+  example/project:pied_piper#writer@example/user:freyja
+assertions:
+  assertTrue: []
+  assertFalse: []
+validation: null

--- a/pkg/validationfile/testdata/separate_schemafile.zed
+++ b/pkg/validationfile/testdata/separate_schemafile.zed
@@ -1,0 +1,11 @@
+definition example/user {}
+
+definition example/project {
+  relation reader: example/user
+  relation writer: example/user
+  relation owner: example/user
+
+  permission read = reader + write
+  permission write = writer + admin
+  permission admin = owner
+}


### PR DESCRIPTION
Support for the `schemaFile` property in the validation file was added in [#2206](https://github.com/authzed/spicedb/pull/2206) but it was never fully integrated in to the bootstrap/import process.

This change adds support similar to the validator from the `zed` cli which was added in [zed#478](https://github.com/authzed/zed/pull/478).

If both `schema` and `schemaFile` are specified, an error is thrown. If only `schemaFile` is specified, the contents of the linked file are read and passed to the compilation function. If `schema` is specified or missing, this function behaves as it always has.