### PR TITLE
Populate empty caveat_name and caveat_context in MySQL with default values

### DIFF
--- a/internal/datastore/mysql/readwrite.go
+++ b/internal/datastore/mysql/readwrite.go
@@ -56,13 +56,19 @@ type mysqlReadWriteTXN struct {
 type structpbWrapper map[string]any
 
 func (cc *structpbWrapper) Scan(val any) error {
+	if val == nil {
+		clear(*cc)
+		*cc = nil
+		return nil
+	}
+
 	v, ok := val.([]byte)
 	if !ok {
 		return fmt.Errorf("unsupported type: %T", v)
 	}
 
 	clear(*cc)
-	return json.Unmarshal(v, &cc)
+	return json.Unmarshal(v, cc)
 }
 
 func (cc *structpbWrapper) Value() (driver.Value, error) {

--- a/internal/datastore/mysql/readwrite_test.go
+++ b/internal/datastore/mysql/readwrite_test.go
@@ -1,0 +1,54 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructpbWrapperScan(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  structpbWrapper
+		val      any
+		expected structpbWrapper
+		wantErr  bool
+	}{
+		{
+			name:     "nil value",
+			initial:  structpbWrapper{"key": "value"},
+			val:      nil,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:     "valid JSON",
+			initial:  structpbWrapper{"old": "data"},
+			val:      []byte(`{"new":"data","count":42}`),
+			expected: structpbWrapper{"new": "data", "count": float64(42)},
+			wantErr:  false,
+		},
+		{
+			name:     "invalid type",
+			initial:  structpbWrapper{"key": "value"},
+			val:      "not a byte array",
+			expected: structpbWrapper{"key": "value"}, // Should remain unchanged
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			cc := tt.initial
+			err := cc.Scan(tt.val)
+
+			if tt.wantErr {
+				require.Error(err)
+			} else {
+				require.NoError(err)
+			}
+			require.Equal(tt.expected, cc)
+		})
+	}
+}


### PR DESCRIPTION
fixes #2500 

Introduce a new data migration for MySQL that updates rows with `NULL` values as `caveat_name` or `caveat_context` columns in `relation_tuple` table, replacing them with appropriate default values.