### PR TITLE
fix: in Watch server, respect config flag StreamingAPITimeout

### DIFF
--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -1,8 +1,6 @@
 package services
 
 import (
-	"time"
-
 	"google.golang.org/grpc"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
@@ -55,7 +53,7 @@ func RegisterGrpcServices(
 	schemaServiceOption SchemaServiceOption,
 	watchServiceOption WatchServiceOption,
 	permSysConfig v1svc.PermissionsServerConfig,
-	watchHeartbeatDuration time.Duration,
+	watchServiceConfig v1svc.WatchServerConfig,
 ) {
 	healthManager.RegisterReportedService(OverallServerHealthCheckKey)
 
@@ -64,7 +62,7 @@ func RegisterGrpcServices(
 	healthManager.RegisterReportedService(v1.PermissionsService_ServiceDesc.ServiceName)
 
 	if watchServiceOption == WatchServiceEnabled {
-		v1.RegisterWatchServiceServer(srv, v1svc.NewWatchServer(watchHeartbeatDuration))
+		v1.RegisterWatchServiceServer(srv, v1svc.NewWatchServer(watchServiceConfig))
 		healthManager.RegisterReportedService(v1.WatchService_ServiceDesc.ServiceName)
 	}
 

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -103,7 +103,7 @@ func RegisterServeFlags(cmd *cobra.Command, config *server.Config) error {
 	apiFlags.Uint16Var(&config.MaximumUpdatesPerWrite, "write-relationships-max-updates-per-call", 1000, "maximum number of updates allowed for WriteRelationships calls")
 	apiFlags.IntVar(&config.MaxCaveatContextSize, "max-caveat-context-size", 4096, "maximum allowed size of request caveat context in bytes. A value of zero or less means no limit")
 	apiFlags.IntVar(&config.MaxRelationshipContextSize, "max-relationship-context-size", 25000, "maximum allowed size of the context to be stored in a relationship")
-	apiFlags.DurationVar(&config.StreamingAPITimeout, "streaming-api-response-delay-timeout", 30*time.Second, "maximum duration time elapsed between messages sent by the server-side to the client (responses) before the stream times out")
+	apiFlags.DurationVar(&config.StreamingAPITimeout, "streaming-api-response-delay-timeout", 30*time.Second, "maximum time until the server will return an error to a caller of a streaming API because no data has been sent")
 	apiFlags.DurationVar(&config.WatchHeartbeat, "watch-api-heartbeat", 1*time.Second, "heartbeat time on the watch in the API. 0 means to default to the datastore's minimum.")
 	apiFlags.Uint32Var(&config.MaxReadRelationshipsLimit, "max-read-relationships-limit", 1000, "maximum number of relationships that can be read in a single request")
 	apiFlags.Uint32Var(&config.MaxDeleteRelationshipsLimit, "max-delete-relationships-limit", 1000, "maximum number of relationships that can be deleted in a single request")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -459,6 +459,11 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 		PerformanceInsightMetricsEnabled: c.EnablePerformanceInsightMetrics,
 	}
 
+	watchServiceConfig := v1svc.WatchServerConfig{
+		HeartbeatDuration:   c.WatchHeartbeat,
+		StreamingAPITimeout: c.StreamingAPITimeout,
+	}
+
 	healthManager := health.NewHealthManager(dispatcher, ds)
 	grpcServer, err := c.GRPCServer.Complete(zerolog.InfoLevel,
 		func(server *grpc.Server) {
@@ -469,7 +474,7 @@ func (c *Config) Complete(ctx context.Context) (RunnableServer, error) {
 				v1SchemaServiceOption,
 				watchServiceOption,
 				permSysConfig,
-				c.WatchHeartbeat,
+				watchServiceConfig,
 			)
 		},
 	)

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -89,7 +89,9 @@ func (c *Config) Complete() (RunnableTestServer, error) {
 				ExpiringRelationshipsEnabled:    true,
 				CaveatTypeSet:                   cts,
 			},
-			1*time.Second,
+			v1svc.WatchServerConfig{
+				HeartbeatDuration: 1 * time.Second,
+			},
 		)
 	}
 


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

I tested `zed watch` on a server that had no changes going in, and noticed that setting flag `STREAMING_API_RESPONSE_DELAY_TIMEOUT=(averybignumber)` had no effect whatsoever.

An option to this PR would be to clarify in the docs that this flag doesn't affect the Watch API 🤷‍♀️ 

## Testing

**Before:**


```shell
docker run --rm -p 50051:50051 authzed/spicedb:latest serve --grpc-preshared-key=random --streaming-api-response-delay-timeout=1s

zed ctx set local localhost:50051 random
zed watch --insecure

// no errors received
```


**Now:**

```shell
docker build . -t spicedblocal
docker run --rm -p 50051:50051 spicedblocal serve --grpc-preshared-key=random --streaming-api-response-delay-timeout=1s

zed ctx set local localhost:50051 random
zed watch --insecure

//  ERR terminated with errors error="rpc error: code = Canceled desc = watch canceled by user: watch was canceled by the caller"
```

and the server logs this:


```
{"level":"warn","time":"2025-07-28T20:24:58Z","message":"operation took longer than allowed 1s to complete"}
{"level":"info","protocol":"grpc","grpc.component":"server","grpc.service":"authzed.api.v1.WatchService","grpc.method":"Watch","grpc.method_type":"server_stream","requestID":"d23tp6a18gnc73f98fb0","peer.address":"130.211.126.102:53587","grpc.start_time":"2025-07-28T20:24:57Z","grpc.code":"Canceled","grpc.error":"rpc error: code = Canceled desc = watch canceled by user: watch was canceled by the caller","grpc.time_ms":1006,"time":"2025-07-28T20:24:58Z","message":"finished call"}
```

