### PR TITLE
chore: replace placeholder copyright in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Authzed, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

This PR updates the `LICENSE` file to replace the placeholder copyright line (`Copyright [yyyy] [name of copyright owner]`) with the actual copyright holder and year: `Copyright 2025 Authzed, Inc.`.

This change ensures the license reflects accurate ownership information and is compliant with Apache 2.0 formatting requirements.  

## Testing

No functional code changes were made, so no runtime testing is required.  

Verification steps:  

1. Open `LICENSE` in the repository root.  
2. Confirm that the copyright line now reads `Copyright 2025 Authzed, Inc.` instead of the placeholder.  

## References

- Apache 2.0 License guidelines: https://www.apache.org/licenses/LICENSE-2.0