### PR TITLE
Cursor concurrency improvements

### DIFF
--- a/internal/graph/lookupresources3.go
+++ b/internal/graph/lookupresources3.go
@@ -383,6 +383,10 @@ func (crr *CursoredLookupResources3) entrypointsIter(lctx lr3ctx) cter.Next[pram
 			return cter.YieldsError[result](err)
 		}
 
+		if len(entrypoints) == 0 {
+			return cter.UncursoredEmpty[result]()
+		}
+
 		// For each entrypoint, create an iterator that will yield results for that entrypoint via
 		// the entrypointIter method.
 		entrypointIterators := make([]cter.Next[pram], 0, len(entrypoints))


### PR DESCRIPTION
Implement improvements to the cursoring library used for LR3 to reduce goroutine creation

## Description

1. Iterator concurrency optimization - Added special handling to avoid creating goroutines when concurrency is set to 1
2. Cursored mapping iterator improvement - Modified the iterator to only spawn goroutines when necessary by utilizing TaskRunner
3. LR3 entrypoints optimization - Skip running entrypoints entirely when there aren't any to process

## Testing

`mage test:all`, including new unit tests
