### PR TITLE
tests: re-enable concurrent spanner

### DIFF
--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -44,7 +44,7 @@ func TestSpannerDatastore(t *testing.T) {
 			return ds
 		})
 		return ds, nil
-	}), test.WithCategories(test.GCCategory, test.WatchCategory, test.StatsCategory, test.TransactionCategory), false)
+	}), test.WithCategories(test.GCCategory, test.WatchCategory, test.StatsCategory, test.TransactionCategory), true)
 
 	t.Run("TestFakeStats", createDatastoreTest(
 		b,


### PR DESCRIPTION
it appears to have been recently disabled
after the Spanner SDK was bumped

<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

<!--
Why do we need this PR? Any implementation details worth mentioning here?
-->

## Testing

<!--
How did you test this and how can reviewers test this?
-->

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->