### PR TITLE
fix: handling of multiple metadata for a single revision in Watch

### DIFF
--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -216,7 +216,7 @@ func (mdb *memdbDatastore) ReadWriteTx(
 		tracked := common.NewChanges(revisions.TimestampIDKeyFunc, datastore.WatchRelationships|datastore.WatchSchema, 0)
 		if tx != nil {
 			if config.Metadata != nil && len(config.Metadata.GetFields()) > 0 {
-				if err := tracked.SetRevisionMetadata(ctx, newRevision, config.Metadata.AsMap()); err != nil {
+				if err := tracked.AddRevisionMetadata(ctx, newRevision, config.Metadata.AsMap()); err != nil {
 					return datastore.NoRevision, err
 				}
 			}

--- a/internal/datastore/mysql/watch.go
+++ b/internal/datastore/mysql/watch.go
@@ -176,7 +176,7 @@ func (mds *Datastore) loadChanges(
 		}
 
 		if len(metadata) > 0 {
-			if err := stagedChanges.SetRevisionMetadata(ctx, revisions.NewForTransactionID(txnID), metadata); err != nil {
+			if err := stagedChanges.AddRevisionMetadata(ctx, revisions.NewForTransactionID(txnID), metadata); err != nil {
 				return nil, 0, err
 			}
 		}

--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -262,7 +262,7 @@ func (pgd *pgDatastore) loadChanges(ctx context.Context, revisions []postgresRev
 		txidToRevision[rev.optionalTxID.Uint64] = rev
 
 		if len(rev.optionalMetadata) > 0 {
-			if err := tracked.SetRevisionMetadata(ctx, rev, rev.optionalMetadata); err != nil {
+			if err := tracked.AddRevisionMetadata(ctx, rev, rev.optionalMetadata); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/datastore/spanner/watch.go
+++ b/internal/datastore/spanner/watch.go
@@ -182,7 +182,7 @@ func (sd *spannerDatastore) watch(
 
 	addMetadataForTransactionTag := func(ctx context.Context, tracked *common.Changes[revisions.TimestampRevision, int64], revision revisions.TimestampRevision, transactionTag string) error {
 		if metadata, ok := metadataForTransactionTag[transactionTag]; ok {
-			return tracked.SetRevisionMetadata(ctx, revision, metadata)
+			return tracked.AddRevisionMetadata(ctx, revision, metadata)
 		}
 
 		// Otherwise, load the metadata from the transactions metadata table.
@@ -192,7 +192,7 @@ func (sd *spannerDatastore) watch(
 		}
 
 		metadataForTransactionTag[transactionTag] = transactionMetadata
-		return tracked.SetRevisionMetadata(ctx, revision, transactionMetadata)
+		return tracked.AddRevisionMetadata(ctx, revision, transactionMetadata)
 	}
 
 	err = reader.Read(ctx, func(result *changestreams.ReadResult) error {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -42,7 +42,7 @@ func EngineOptions() string {
 // hand side of a tuple.
 const Ellipsis = "..."
 
-// RevisionChanges represents the changes in a single transaction.
+// RevisionChanges represents the changes in a single revision.
 type RevisionChanges struct {
 	Revision Revision
 
@@ -63,8 +63,8 @@ type RevisionChanges struct {
 	// have occurred before this point.
 	IsCheckpoint bool
 
-	// Metadata is the metadata associated with the revision, if any.
-	Metadata *structpb.Struct
+	// Metadatas is the list of metadata associated with the revision, if any.
+	Metadatas []*structpb.Struct
 }
 
 func (rc RevisionChanges) DebugString() string {

--- a/pkg/datastore/test/watch.go
+++ b/pkg/datastore/test/watch.go
@@ -212,7 +212,12 @@ func VerifyUpdatesWithMetadata(
 			require.True(missingExpected.IsEmpty(), "expected changes missing: %s", missingExpected)
 			require.True(unexpected.IsEmpty(), "unexpected changes: %s", unexpected)
 
-			require.Equal(expected.metadata, change.Metadata.AsMap(), "metadata mismatch")
+			if len(expected.metadata) == 0 {
+				require.Empty(change.Metadatas, "expected no metadata, but found some: %v", change.Metadatas)
+			} else {
+				require.NotNil(change.Metadatas, "expected metadata, but found none")
+				require.Len(change.Metadatas, 1, "expected single metadata entry, but found: %v", change.Metadatas)
+			}
 
 			time.Sleep(1 * time.Millisecond)
 		case <-changeWait.C:
@@ -879,8 +884,8 @@ func WatchEmissionStrategyTest(t *testing.T, tester DatastoreTester) {
 				continue // we expect each change to come in individual change event
 			}
 
-			if change.Metadata != nil {
-				require.Contains(change.Metadata.AsMap(), "foo")
+			if len(change.Metadatas) == 1 {
+				require.Contains(change.Metadatas[0].AsMap(), "foo")
 				metadataEmitted = true
 				changeCount++
 				require.True(targetRev.Equal(change.Revision))


### PR DESCRIPTION
Fixes #2439 by returning all sets of metadata found in that scenario
