### PR TITLE
fixes breakage of Proposal A6: Retry policies

### DIFF
--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -267,7 +267,8 @@ func TestRetryPolicy(t *testing.T) {
 	permSrv := v1.NewPermissionsServiceClient(conn)
 	var trailer metadata.MD
 	ctxWithRequestID := requestmeta.WithRequestID(ctx, "foobar")
-	_, err = permSrv.WriteRelationships(ctxWithRequestID, &v1.WriteRelationshipsRequest{
+	ctxWithServerVersion := metadata.AppendToOutgoingContext(ctxWithRequestID, string(requestmeta.RequestServerVersion), "t")
+	_, err = permSrv.WriteRelationships(ctxWithServerVersion, &v1.WriteRelationshipsRequest{
 		Updates: []*v1.RelationshipUpdate{
 			tuple.MustUpdateToV1RelationshipUpdate(tuple.Touch(tuple.MustParse("resource:resource#reader@user:user#..."))),
 		},

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -13,14 +13,19 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 
+	"github.com/authzed/authzed-go/pkg/requestmeta"
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/grpcutil"
 
 	"github.com/authzed/spicedb/internal/datastore/dsfortesting"
 	"github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/cmd/datastore"
 	"github.com/authzed/spicedb/pkg/cmd/util"
 	"github.com/authzed/spicedb/pkg/testutil"
+	"github.com/authzed/spicedb/pkg/tuple"
 )
 
 func TestServerGracefulTermination(t *testing.T) {
@@ -158,6 +163,122 @@ func setupSpanRecorder() (*tracetest.SpanRecorder, func()) {
 	return spanrecorder, func() {
 		otel.SetTracerProvider(defaultProvider)
 	}
+}
+
+type countingInterceptor struct {
+	val int
+}
+
+func (m *countingInterceptor) unaryIntercept(ctx context.Context, req any, _ *grpc.UnaryServerInfo, h grpc.UnaryHandler) (resp any, err error) {
+	m.val++
+	return h(ctx, req)
+}
+
+// TestRetryPolicy tests that the retry policy specified in the grpc.WithDefaultServiceConfig is respected.
+// It does this by installing a unary interceptor that counts the number of calls, and then returning a
+// FAILED_PRECONDITION error from the WriteRelationships call.
+// This test is in place to make sure we don't regress this again by messing with grpc in our middlewares.
+func TestRetryPolicy(t *testing.T) {
+	defer goleak.VerifyNone(t, append(testutil.GoLeakIgnores(), goleak.IgnoreCurrent())...)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	ds, err := datastore.NewDatastore(ctx,
+		datastore.DefaultDatastoreConfig().ToOption(),
+		datastore.WithRequestHedgingEnabled(false),
+	)
+	if err != nil {
+		log.Fatalf("unable to start memdb datastore: %s", err)
+	}
+
+	var interceptor countingInterceptor
+	configOpts := []ConfigOption{
+		WithGRPCServer(util.GRPCServerConfig{
+			Network: util.BufferedNetwork,
+			Enabled: true,
+		}),
+		WithGRPCAuthFunc(func(ctx context.Context) (context.Context, error) {
+			return ctx, nil
+		}),
+		WithHTTPGateway(util.HTTPServerConfig{HTTPEnabled: false}),
+		WithMetricsAPI(util.HTTPServerConfig{HTTPEnabled: false}),
+		WithDispatchCacheConfig(CacheConfig{Enabled: false, Metrics: false}),
+		WithNamespaceCacheConfig(CacheConfig{Enabled: false, Metrics: false}),
+		WithClusterDispatchCacheConfig(CacheConfig{Enabled: false, Metrics: false}),
+		WithDatastore(ds),
+		SetUnaryMiddlewareModification([]MiddlewareModification[grpc.UnaryServerInterceptor]{
+			{
+				Operation:                OperationAppend,
+				DependencyMiddlewareName: DefaultMiddlewareRequestID,
+				Middlewares: []ReferenceableMiddleware[grpc.UnaryServerInterceptor]{
+					NewUnaryMiddleware().
+						WithName("foobar").
+						WithInterceptor(interceptor.unaryIntercept).
+						EnsureAlreadyExecuted(DefaultMiddlewareRequestID). // make sure requestID is executed because before we fixed it, it broke retry policies
+						Done(),
+				},
+			},
+		}),
+	}
+
+	srv, err := NewConfigWithOptionsAndDefaults(configOpts...).Complete(ctx)
+	require.NoError(t, err)
+
+	conn, err := srv.GRPCDialContext(ctx,
+		grpc.WithDefaultServiceConfig(`{
+                  "methodConfig": [
+                    {
+                      "name": [
+                        {
+                          "service": "authzed.api.v1.PermissionsService",
+                          "method": "WriteRelationships"
+                        }
+                      ],
+                      "retryPolicy": {
+                        "maxAttempts": 5,
+                        "initialBackoff": "0.01s",
+                        "maxBackoff": "0.1s",
+                        "backoffMultiplier": 2,
+                        "retryableStatusCodes": [
+                          "FAILED_PRECONDITION"
+                        ]
+                      }
+                    }
+                  ]
+                }`))
+	require.NoError(t, err)
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	schemaSrv := v1.NewSchemaServiceClient(conn)
+
+	go func() {
+		require.NoError(t, srv.Run(ctx))
+	}()
+
+	_, err = schemaSrv.WriteSchema(ctx, &v1.WriteSchemaRequest{
+		Schema: `definition user {}`,
+	})
+	require.NoError(t, err)
+
+	interceptor.val = 0
+	permSrv := v1.NewPermissionsServiceClient(conn)
+	var trailer metadata.MD
+	ctxWithRequestID := requestmeta.WithRequestID(ctx, "foobar")
+	_, err = permSrv.WriteRelationships(ctxWithRequestID, &v1.WriteRelationshipsRequest{
+		Updates: []*v1.RelationshipUpdate{
+			tuple.MustUpdateToV1RelationshipUpdate(tuple.Touch(tuple.MustParse("resource:resource#reader@user:user#..."))),
+		},
+	}, grpc.Trailer(&trailer))
+	grpcutil.RequireStatus(t, codes.FailedPrecondition, err)
+
+	// validate that requestID was used, as it used to break retry policies before
+	require.Equal(t, 5, interceptor.val)
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.NotEmpty(t, requestIDs)
+	require.Contains(t, requestIDs, "foobar")
 }
 
 func TestServerGracefulTerminationOnError(t *testing.T) {

--- a/pkg/middleware/requestid/requestid_test.go
+++ b/pkg/middleware/requestid/requestid_test.go
@@ -1,0 +1,374 @@
+package requestid
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/authzed/authzed-go/pkg/requestmeta"
+)
+
+// testServer implements the test service for middleware testing
+type testServer struct {
+	testpb.UnimplementedTestServiceServer
+}
+
+func (t *testServer) PingEmpty(ctx context.Context, req *testpb.PingEmptyRequest) (*testpb.PingEmptyResponse, error) {
+	return &testpb.PingEmptyResponse{}, nil
+}
+
+func (t *testServer) Ping(ctx context.Context, req *testpb.PingRequest) (*testpb.PingResponse, error) {
+	// Check if this is an error test request
+	if req.GetValue() == "ERROR" { // Use value as error trigger
+		return nil, status.Errorf(codes.Internal, "test error")
+	}
+	return &testpb.PingResponse{Counter: 1}, nil
+}
+
+func (t *testServer) PingList(_ *testpb.PingListRequest, server testpb.TestService_PingListServer) error {
+	// Send a few responses to test server streaming
+	for i := 0; i < 3; i++ {
+		if err := server.Send(&testpb.PingListResponse{Value: "ping"}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *testServer) PingStream(server testpb.TestService_PingStreamServer) error {
+	// Handle bidirectional streaming - echo back what we receive
+	for {
+		req, err := server.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if err := server.Send(&testpb.PingStreamResponse{Value: req.Value}); err != nil {
+			return err
+		}
+	}
+}
+
+// requestIDMiddlewareTestSuite is a test suite for the requestid middleware
+type requestIDMiddlewareTestSuite struct {
+	*testpb.InterceptorTestSuite
+}
+
+func TestRequestIDMiddleware(t *testing.T) {
+	s := &requestIDMiddlewareTestSuite{
+		InterceptorTestSuite: &testpb.InterceptorTestSuite{
+			TestService: &testServer{},
+			ServerOpts: []grpc.ServerOption{
+				grpc.ChainUnaryInterceptor(
+					UnaryServerInterceptor(GenerateIfMissing(true)),
+				),
+				grpc.ChainStreamInterceptor(
+					StreamServerInterceptor(GenerateIfMissing(true)),
+				),
+			},
+			ClientOpts: []grpc.DialOption{
+				grpc.WithChainUnaryInterceptor(
+					UnaryClientInterceptor(GenerateIfMissing(true)),
+				),
+				grpc.WithChainStreamInterceptor(
+					StreamClientInterceptor(GenerateIfMissing(true)),
+				),
+			},
+		},
+	}
+	suite.Run(t, s)
+}
+
+func (s *requestIDMiddlewareTestSuite) TestUnaryInterceptor_GeneratesAndReturnsRequestID() {
+	// Test unary RPC - should generate request ID and return it in response trailers
+	var trailer metadata.MD
+	_, err := s.Client.PingEmpty(s.SimpleCtx(), &testpb.PingEmptyRequest{}, grpc.Trailer(&trailer))
+	require.NoError(s.T(), err)
+
+	// Check that response metadata contains request ID
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.NotEmpty(s.T(), requestIDs, "Request ID should be present in response trailers")
+	require.Len(s.T(), requestIDs, 1, "Should have exactly one request ID")
+	require.NotEmpty(s.T(), requestIDs[0], "Request ID should not be empty")
+}
+
+func (s *requestIDMiddlewareTestSuite) TestUnaryInterceptor_PreservesExistingRequestID() {
+	// Test unary RPC with existing request ID in incoming metadata
+	existingRequestID := "test-request-123"
+
+	ctx := requestmeta.WithRequestID(s.SimpleCtx(), existingRequestID)
+
+	var trailer metadata.MD
+	_, err := s.Client.PingEmpty(ctx, &testpb.PingEmptyRequest{}, grpc.Trailer(&trailer))
+	require.NoError(s.T(), err)
+
+	// Check that response metadata contains the same request ID
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.NotEmpty(s.T(), requestIDs)
+	require.Equal(s.T(), existingRequestID, requestIDs[0], "Should preserve existing request ID")
+}
+
+func (s *requestIDMiddlewareTestSuite) TestServerStreamingInterceptor_ReturnsRequestID() {
+	// Test server streaming RPC - should return request ID in response trailers
+	stream, err := s.Client.PingList(s.SimpleCtx(), &testpb.PingListRequest{})
+	require.NoError(s.T(), err)
+
+	// Receive all messages to complete the stream
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(s.T(), err)
+	}
+
+	// Get trailers after stream completion
+	trailer := stream.Trailer()
+
+	// Check that response metadata contains request ID
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.NotEmpty(s.T(), requestIDs, "Request ID should be present in response trailers")
+	require.NotEmpty(s.T(), requestIDs[0], "Request ID should not be empty")
+}
+
+func (s *requestIDMiddlewareTestSuite) TestServerStreamingInterceptor_PreservesExistingRequestID() {
+	// Test server streaming RPC with existing request ID
+	existingRequestID := "test-stream-456"
+	ctx := requestmeta.WithRequestID(s.SimpleCtx(), existingRequestID)
+
+	stream, err := s.Client.PingList(ctx, &testpb.PingListRequest{})
+	require.NoError(s.T(), err)
+
+	// Complete the stream
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(s.T(), err)
+	}
+
+	// Get trailers after stream completion
+	trailer := stream.Trailer()
+
+	// Check that response metadata contains the same request ID
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.NotEmpty(s.T(), requestIDs)
+	require.Equal(s.T(), existingRequestID, requestIDs[0], "Should preserve existing request ID")
+}
+
+func (s *requestIDMiddlewareTestSuite) TestBidirectionalStreamingInterceptor_ReturnsRequestID() {
+	// Test bidirectional streaming RPC - should return request ID in response trailers
+	stream, err := s.Client.PingStream(s.SimpleCtx())
+	require.NoError(s.T(), err)
+
+	// Send a message first
+	err = stream.Send(&testpb.PingStreamRequest{Value: "test"})
+	require.NoError(s.T(), err)
+
+	// Receive the echoed message
+	resp, err := stream.Recv()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), "test", resp.Value)
+
+	// Close the stream
+	err = stream.CloseSend()
+	require.NoError(s.T(), err)
+
+	// need to call receive on bidirectional after close, otherwise you get no trailer frame
+	_, err = stream.Recv()
+	require.ErrorIs(s.T(), err, io.EOF)
+
+	// Get trailers after stream completion
+	trailer := stream.Trailer()
+
+	// Check that response metadata contains request ID
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.NotEmpty(s.T(), requestIDs, "Request ID should be present in response trailers")
+	require.NotEmpty(s.T(), requestIDs[0], "Request ID should not be empty")
+}
+
+func (s *requestIDMiddlewareTestSuite) TestBidirectionalStreamingInterceptor_PreservesExistingRequestID() {
+	// Test bidirectional streaming RPC with existing request ID
+	existingRequestID := "test-bidi-789"
+	ctx := requestmeta.WithRequestID(s.SimpleCtx(), existingRequestID)
+
+	stream, err := s.Client.PingStream(ctx)
+	require.NoError(s.T(), err)
+
+	// Send a message first
+	err = stream.Send(&testpb.PingStreamRequest{Value: "test"})
+	require.NoError(s.T(), err)
+
+	// Complete the stream
+	_, err = stream.Recv()
+	require.NoError(s.T(), err)
+
+	err = stream.CloseSend()
+	require.NoError(s.T(), err)
+
+	// need to call receive on bidirectional after close, otherwise you get no trailer frame
+	_, err = stream.Recv()
+	require.ErrorIs(s.T(), err, io.EOF)
+
+	// Get trailers after stream completion
+	trailer := stream.Trailer()
+
+	// Check that response metadata contains the same request ID
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.NotEmpty(s.T(), requestIDs)
+	require.Equal(s.T(), existingRequestID, requestIDs[0], "Should preserve existing request ID")
+}
+
+func (s *requestIDMiddlewareTestSuite) TestUnaryInterceptor_ReturnsRequestIDOnError() {
+	// Test unary RPC that returns an error - should still return request ID in response trailers
+	var trailer metadata.MD
+	_, err := s.Client.Ping(s.SimpleCtx(), &testpb.PingRequest{Value: "ERROR"}, grpc.Trailer(&trailer))
+	require.Error(s.T(), err, "Should return error for Value='ERROR'")
+
+	// Check that response metadata contains request ID even when there's an error
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.NotEmpty(s.T(), requestIDs, "Request ID should be present in response trailers even on error")
+	require.NotEmpty(s.T(), requestIDs[0], "Request ID should not be empty even on error")
+}
+
+// Test suite for middleware without generation enabled
+type requestIDNoGenerateMiddlewareTestSuite struct {
+	*testpb.InterceptorTestSuite
+}
+
+func TestRequestIDMiddlewareNoGenerate(t *testing.T) {
+	s := &requestIDNoGenerateMiddlewareTestSuite{
+		InterceptorTestSuite: &testpb.InterceptorTestSuite{
+			TestService: &testServer{},
+			ServerOpts: []grpc.ServerOption{
+				grpc.ChainUnaryInterceptor(
+					UnaryServerInterceptor(), // No generation enabled
+				),
+				grpc.ChainStreamInterceptor(
+					StreamServerInterceptor(),
+				),
+			},
+			ClientOpts: []grpc.DialOption{},
+		},
+	}
+	suite.Run(t, s)
+}
+
+func (s *requestIDNoGenerateMiddlewareTestSuite) TestUnaryInterceptor_NoRequestIDWithoutGeneration() {
+	// Test unary RPC without generation - should not add request ID if none provided
+	var trailer metadata.MD
+	_, err := s.Client.PingEmpty(s.SimpleCtx(), &testpb.PingEmptyRequest{}, grpc.Trailer(&trailer))
+	require.NoError(s.T(), err)
+
+	// Check that response metadata does not contain request ID
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.Empty(s.T(), requestIDs, "Request ID should not be present when generation is disabled")
+}
+
+func (s *requestIDNoGenerateMiddlewareTestSuite) TestUnaryInterceptor_PreservesProvidedRequestID() {
+	// Test unary RPC with provided request ID - should still preserve it even without generation
+	existingRequestID := "provided-request-id"
+	ctx := requestmeta.WithRequestID(s.SimpleCtx(), existingRequestID)
+
+	var trailer metadata.MD
+	_, err := s.Client.PingEmpty(ctx, &testpb.PingEmptyRequest{}, grpc.Trailer(&trailer))
+	require.NoError(s.T(), err)
+
+	// Check that response metadata contains the provided request ID
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.NotEmpty(s.T(), requestIDs)
+	require.Equal(s.T(), existingRequestID, requestIDs[0], "Should preserve provided request ID")
+}
+
+// Test suite for custom ID generator
+type requestIDCustomGeneratorTestSuite struct {
+	*testpb.InterceptorTestSuite
+	customIDPrefix string
+}
+
+func TestRequestIDMiddlewareCustomGenerator(t *testing.T) {
+	customIDPrefix := "custom-"
+	customGenerator := func() string {
+		return customIDPrefix + GenerateRequestID()
+	}
+
+	customGeneratorOption := func(h *handleRequestID) {
+		h.requestIDGenerator = customGenerator
+	}
+
+	s := &requestIDCustomGeneratorTestSuite{
+		InterceptorTestSuite: &testpb.InterceptorTestSuite{
+			TestService: &testServer{},
+			ServerOpts: []grpc.ServerOption{
+				grpc.ChainUnaryInterceptor(
+					UnaryServerInterceptor(
+						GenerateIfMissing(true),
+						customGeneratorOption,
+					),
+				),
+			},
+			ClientOpts: []grpc.DialOption{},
+		},
+		customIDPrefix: customIDPrefix,
+	}
+	suite.Run(t, s)
+}
+
+func (s *requestIDCustomGeneratorTestSuite) TestCustomGenerator() {
+	var trailer metadata.MD
+	_, err := s.Client.PingEmpty(s.SimpleCtx(), &testpb.PingEmptyRequest{}, grpc.Trailer(&trailer))
+	require.NoError(s.T(), err)
+
+	requestIDs := trailer.Get("io.spicedb.respmeta.requestid")
+	require.NotEmpty(s.T(), requestIDs)
+	require.Contains(s.T(), requestIDs[0], s.customIDPrefix, "Custom generator should be used")
+}
+
+// Test suite for timeout handling
+type requestIDTimeoutTestSuite struct {
+	*testpb.InterceptorTestSuite
+}
+
+func TestRequestIDMiddlewareTimeout(t *testing.T) {
+	s := &requestIDTimeoutTestSuite{
+		InterceptorTestSuite: &testpb.InterceptorTestSuite{
+			TestService: &testServer{},
+			ServerOpts: []grpc.ServerOption{
+				grpc.ChainUnaryInterceptor(
+					UnaryServerInterceptor(GenerateIfMissing(true)),
+				),
+			},
+			ClientOpts: []grpc.DialOption{},
+		},
+	}
+	suite.Run(t, s)
+}
+
+func (s *requestIDTimeoutTestSuite) TestContextTimeout() {
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithTimeout(s.SimpleCtx(), time.Nanosecond)
+	defer cancel()
+
+	// Wait for context to be cancelled
+	time.Sleep(time.Millisecond)
+
+	var trailer metadata.MD
+	_, err := s.Client.PingEmpty(ctx, &testpb.PingEmptyRequest{}, grpc.Trailer(&trailer))
+
+	// The RPC should fail due to context cancellation, but middleware should handle it gracefully
+	require.Error(s.T(), err)
+}

--- a/pkg/middleware/serverversion/serverversion.go
+++ b/pkg/middleware/serverversion/serverversion.go
@@ -34,8 +34,8 @@ func (r *HandleServerVersion) ServerReporter(ctx context.Context, _ interceptors
 					return interceptors.NoopReporter{}, ctx
 				}
 
-				err = responsemeta.SetResponseHeaderMetadata(ctx, map[responsemeta.ResponseMetadataHeaderKey]string{
-					responsemeta.ServerVersion: version,
+				err = responsemeta.SetResponseTrailerMetadata(ctx, map[responsemeta.ResponseMetadataTrailerKey]string{
+					responsemeta.ResponseMetadataTrailerKey(responsemeta.ServerVersion): version,
 				})
 				// if context is cancelled, the stream will be closed, and gRPC will return ErrIllegalHeaderWrite
 				// this prevents logging unnecessary error messages


### PR DESCRIPTION
See https://github.com/grpc/proposal/blob/master/A6-client-retries.md#when-retries-are-valid

As I attempted to implement an example client using retry policies, I found that they didn't work.
This was due to the fact SpiceDB's response violated the expectations from that spec, notably:

> In certain cases it is not valid to retry an RPC. These cases occur when the RPC has been committed, and thus it does not make sense to perform the retry.
> The reasoning behind the first scenario is that the Response-Headers include initial metadata
from the server. The metadata (or its absence) it is transmitted to the client application. This may fundamentally change the state of the client, so we cannot safely retry if a failure occurs later in the RPC’s life.

The RequestID middleware was sending the `requestID` as a metadata header, which causes the stream to send a frame just to send the headers before sending the actual response. This, in turn, causes the stream to become committed, which, according to the A6 spec, disables retry policies.

The TL;DR is: use trailers for metadata unless there is an explicit reason to use metadata headers; otherwise, retry policies will become disabled.

This also fixes the version middleware, which was subject to the same problem.

⚠️ This is a breaking change because it moves two values from header to trailer. I'm aware `zed` makes use of this.