### PR TITLE
perf: have the Changes functions return an iter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed MySQL metrics prefixed with `go_sql_stats_connections_*` in favor of those prefixed with `go_sql_*` (https://github.com/authzed/spicedb/pull/2980)
 - Removed support for Spanner flag value `--datastore-spanner-metrics=deprecated-prometheus`; please use values `otel` or `native` (https://github.com/authzed/spicedb/pull/2980)
 - Reduced binary size (https://github.com/authzed/spicedb/pull/3005)
+- Reduce memory consumption of Watch API (https://github.com/authzed/spicedb/pull/2578)
 
 ### Fixed
 - On a Postgres setup with read replicas, some requests may silently swallow errors of sort "revision not found in replica" (https://github.com/authzed/spicedb/pull/2979)

--- a/internal/datastore/common/changes.go
+++ b/internal/datastore/common/changes.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"iter"
 	"maps"
 	"slices"
 	"sort"
@@ -290,73 +291,80 @@ func (ch *Changes[R, K]) AddChangedDefinition(
 
 // AsRevisionChanges returns the list of changes processed so far as a datastore watch
 // compatible, ordered, changelist.
-func (ch *Changes[R, K]) AsRevisionChanges(lessThanFunc func(lhs K, rhs K) bool) ([]datastore.RevisionChanges, error) {
+func (ch *Changes[R, K]) AsRevisionChanges(lessThanFunc func(lhs, rhs K) bool) iter.Seq2[datastore.RevisionChanges, error] {
 	return ch.revisionChanges(lessThanFunc, *new(R), false)
 }
 
 // FilterAndRemoveRevisionChanges filters a list of changes processed up to the bound revision from the changes list, removing them
 // and returning the filtered changes.
-func (ch *Changes[R, K]) FilterAndRemoveRevisionChanges(lessThanFunc func(lhs, rhs K) bool, boundRev R) ([]datastore.RevisionChanges, error) {
-	changes, err := ch.revisionChanges(lessThanFunc, boundRev, true)
-	if err != nil {
-		return nil, err
-	}
+func (ch *Changes[R, K]) FilterAndRemoveRevisionChanges(lessThanFunc func(lhs, rhs K) bool, boundRev R) iter.Seq2[datastore.RevisionChanges, error] {
+	return func(yield func(datastore.RevisionChanges, error) bool) {
+		for change, err := range ch.revisionChanges(lessThanFunc, boundRev, true) {
+			if !yield(change, err) {
+				break
+			}
+		}
 
-	ch.removeAllChangesBefore(boundRev)
-	return changes, nil
+		ch.removeAllChangesBefore(boundRev)
+	}
 }
 
-func (ch *Changes[R, K]) revisionChanges(lessThanFunc func(lhs K, rhs K) bool, boundRev R, withBound bool) ([]datastore.RevisionChanges, error) {
-	if ch.IsEmpty() {
-		return nil, nil
-	}
-
-	ch.recordsMutex.RLock()
-	revisionsWithChanges := make([]K, 0, len(ch.records))
-	for rk, cr := range ch.records {
-		if !withBound || boundRev.GreaterThan(cr.rev) {
-			revisionsWithChanges = append(revisionsWithChanges, rk)
+func (ch *Changes[R, K]) revisionChanges(lessThanFunc func(lhs, rhs K) bool, boundRev R, withBound bool) iter.Seq2[datastore.RevisionChanges, error] {
+	return func(yield func(datastore.RevisionChanges, error) bool) {
+		if ch.IsEmpty() {
+			return
 		}
-	}
-	ch.recordsMutex.RUnlock()
 
-	if len(revisionsWithChanges) == 0 {
-		return nil, nil
-	}
-
-	sort.Slice(revisionsWithChanges, func(i int, j int) bool {
-		return lessThanFunc(revisionsWithChanges[i], revisionsWithChanges[j])
-	})
-
-	changes := make([]datastore.RevisionChanges, len(revisionsWithChanges))
-
-	ch.recordsMutex.RLock()
-	defer ch.recordsMutex.RUnlock()
-
-	for i, k := range revisionsWithChanges {
-		revisionChangeRecord := ch.records[k]
-		changes[i].Revision = revisionChangeRecord.rev
-		for _, rel := range revisionChangeRecord.relTouches {
-			changes[i].RelationshipChanges = append(changes[i].RelationshipChanges, tuple.Touch(rel))
+		ch.recordsMutex.RLock()
+		revisionsWithChanges := make([]K, 0, len(ch.records))
+		for rk, cr := range ch.records {
+			if !withBound || boundRev.GreaterThan(cr.rev) {
+				revisionsWithChanges = append(revisionsWithChanges, rk)
+			}
 		}
-		for _, rel := range revisionChangeRecord.relDeletes {
-			changes[i].RelationshipChanges = append(changes[i].RelationshipChanges, tuple.Delete(rel))
-		}
-		changes[i].ChangedDefinitions = slices.Collect(maps.Values(revisionChangeRecord.definitionsChanged))
-		changes[i].DeletedNamespaces = slices.Collect(maps.Keys(revisionChangeRecord.namespacesDeleted))
-		changes[i].DeletedCaveats = slices.Collect(maps.Keys(revisionChangeRecord.caveatsDeleted))
+		ch.recordsMutex.RUnlock()
 
-		if len(revisionChangeRecord.metadatas) > 0 {
-			metadatas := make([]*structpb.Struct, 0, len(revisionChangeRecord.metadatas))
-			for _, metadata := range revisionChangeRecord.metadatas {
-				metadatas = append(metadatas, metadata.MustStruct())
+		if len(revisionsWithChanges) == 0 {
+			return
+		}
+
+		sort.Slice(revisionsWithChanges, func(i int, j int) bool {
+			return lessThanFunc(revisionsWithChanges[i], revisionsWithChanges[j])
+		})
+
+		ch.recordsMutex.RLock()
+		defer ch.recordsMutex.RUnlock()
+
+		for _, k := range revisionsWithChanges {
+			revisionChangeRecord := ch.records[k]
+			change := datastore.RevisionChanges{
+				Revision: revisionChangeRecord.rev,
 			}
 
-			changes[i].Metadatas = metadatas
+			for _, rel := range revisionChangeRecord.relTouches {
+				change.RelationshipChanges = append(change.RelationshipChanges, tuple.Touch(rel))
+			}
+			for _, rel := range revisionChangeRecord.relDeletes {
+				change.RelationshipChanges = append(change.RelationshipChanges, tuple.Delete(rel))
+			}
+			change.ChangedDefinitions = slices.Collect(maps.Values(revisionChangeRecord.definitionsChanged))
+			change.DeletedNamespaces = slices.Collect(maps.Keys(revisionChangeRecord.namespacesDeleted))
+			change.DeletedCaveats = slices.Collect(maps.Keys(revisionChangeRecord.caveatsDeleted))
+
+			if len(revisionChangeRecord.metadatas) > 0 {
+				metadatas := make([]*structpb.Struct, 0, len(revisionChangeRecord.metadatas))
+				for _, metadata := range revisionChangeRecord.metadatas {
+					metadatas = append(metadatas, metadata.MustStruct())
+				}
+
+				change.Metadatas = metadatas
+			}
+
+			if !yield(change, nil) {
+				break
+			}
 		}
 	}
-
-	return changes, nil
 }
 
 func (ch *Changes[R, K]) removeAllChangesBefore(boundRev R) {

--- a/internal/datastore/common/changes_test.go
+++ b/internal/datastore/common/changes_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"iter"
 	"math"
 	"slices"
 	"sort"
@@ -336,7 +337,7 @@ func TestChanges(t *testing.T) {
 				}
 			}
 
-			actual, err := ch.AsRevisionChanges(revisions.TransactionIDKeyLessThanFunc)
+			actual, err := collectChanges(ch.AsRevisionChanges(revisions.TransactionIDKeyLessThanFunc))
 			require.NoError(err)
 
 			require.Equal(
@@ -372,7 +373,7 @@ func TestChanges(t *testing.T) {
 				}
 			}
 
-			actual, err := ch.AsRevisionChanges(revisions.TransactionIDKeyLessThanFunc)
+			actual, err := collectChanges(ch.AsRevisionChanges(revisions.TransactionIDKeyLessThanFunc))
 			require.NoError(err)
 
 			require.Equal(
@@ -401,7 +402,7 @@ func TestAddMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ch.IsEmpty())
 
-	results, err := ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2)
+	results, err := collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2))
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.True(t, ch.IsEmpty())
@@ -441,7 +442,7 @@ func TestAddRevisionMetadataComprehensive(t *testing.T) {
 		err = ch.AddRevisionMetadata(ctx, rev1, map[string]any{"operation": "create", "user_id": "123"})
 		require.NoError(t, err)
 
-		results, err := ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2)
+		results, err := collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2))
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		require.Len(t, results[0].Metadatas, 1)
@@ -464,7 +465,7 @@ func TestAddRevisionMetadataComprehensive(t *testing.T) {
 		err = ch.AddRevisionMetadata(ctx, rev1, metadata3)
 		require.NoError(t, err)
 
-		results, err := ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2)
+		results, err := collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2))
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		require.Len(t, results[0].Metadatas, 3)
@@ -504,7 +505,7 @@ func TestAddRevisionMetadataComprehensive(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		results, err := ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2)
+		results, err := collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2))
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		require.Len(t, results[0].Metadatas, 1)
@@ -525,7 +526,7 @@ func TestAddRevisionMetadataComprehensive(t *testing.T) {
 		err = ch.AddRevisionMetadata(ctx, rev2, metadata2)
 		require.NoError(t, err)
 
-		results, err := ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev3)
+		results, err := collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev3))
 		require.NoError(t, err)
 		require.Len(t, results, 2)
 
@@ -548,7 +549,7 @@ func TestAddRevisionMetadataComprehensive(t *testing.T) {
 		err = ch.AddRevisionMetadata(ctx, rev1, metadata2)
 		require.NoError(t, err)
 
-		results, err := ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2)
+		results, err := collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2))
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		require.Len(t, results[0].Metadatas, 2)
@@ -577,7 +578,7 @@ func TestAddRevisionMetadataComprehensive(t *testing.T) {
 		err = ch.AddRevisionMetadata(ctx, rev1, metadata5)
 		require.NoError(t, err)
 
-		results, err := ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2)
+		results, err := collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2))
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		require.Len(t, results[0].Metadatas, 4)
@@ -602,7 +603,7 @@ func TestAddRevisionMetadataComprehensive(t *testing.T) {
 		err = ch.AddRevisionMetadata(ctx, rev1, metadata1)
 		require.NoError(t, err)
 
-		results, err := ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2)
+		results, err := collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev2))
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		require.Len(t, results[0].Metadatas, 3)
@@ -640,7 +641,7 @@ func TestFilterAndRemoveRevisionChanges(t *testing.T) {
 
 	require.False(t, ch.IsEmpty())
 
-	results, err := ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev3)
+	results, err := collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, rev3))
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 	require.False(t, ch.IsEmpty())
@@ -660,9 +661,9 @@ func TestFilterAndRemoveRevisionChanges(t *testing.T) {
 		},
 	}, results)
 
-	remaining, err := ch.AsRevisionChanges(revisions.TransactionIDKeyLessThanFunc)
-	require.Len(t, remaining, 1)
+	remaining, err := collectChanges(ch.AsRevisionChanges(revisions.TransactionIDKeyLessThanFunc))
 	require.NoError(t, err)
+	require.Len(t, remaining, 1)
 
 	require.Equal(t, []datastore.RevisionChanges{
 		{
@@ -673,12 +674,12 @@ func TestFilterAndRemoveRevisionChanges(t *testing.T) {
 		},
 	}, remaining)
 
-	results, err = ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, revOneMillion)
+	results, err = collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, revOneMillion))
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.True(t, ch.IsEmpty())
 
-	results, err = ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, revOneMillionOne)
+	results, err = collectChanges(ch.FilterAndRemoveRevisionChanges(revisions.TransactionIDKeyLessThanFunc, revOneMillionOne))
 	require.NoError(t, err)
 	require.Empty(t, results)
 	require.True(t, ch.IsEmpty())
@@ -702,7 +703,7 @@ func TestHLCOrdering(t *testing.T) {
 	err = ch.AddRelationshipChange(ctx, rev0, tuple.MustParse("document:foo#viewer@user:tom"), tuple.UpdateOperationTouch)
 	require.NoError(t, err)
 
-	remaining, err := ch.AsRevisionChanges(revisions.HLCKeyLessThanFunc)
+	remaining, err := collectChanges(ch.AsRevisionChanges(revisions.HLCKeyLessThanFunc))
 	require.NoError(t, err)
 	require.Len(t, remaining, 2)
 
@@ -746,7 +747,7 @@ func TestHLCSameRevision(t *testing.T) {
 	err = ch.AddRelationshipChange(ctx, rev0again, tuple.MustParse("document:foo#viewer@user:sarah"), tuple.UpdateOperationTouch)
 	require.NoError(t, err)
 
-	remaining, err := ch.AsRevisionChanges(revisions.HLCKeyLessThanFunc)
+	remaining, err := collectChanges(ch.AsRevisionChanges(revisions.HLCKeyLessThanFunc))
 	require.NoError(t, err)
 	require.Len(t, remaining, 1)
 
@@ -1003,7 +1004,7 @@ func TestThreadSafe(t *testing.T) {
 			return ch.AddRevisionMetadata(t.Context(), revisions.NewForTransactionID(1), map[string]any{"foo": i})
 		})
 		wg.Go(func() error {
-			_, err := ch.AsRevisionChanges(revisions.TransactionIDKeyLessThanFunc)
+			_, err := collectChanges(ch.AsRevisionChanges(revisions.TransactionIDKeyLessThanFunc))
 			return err
 		})
 		wg.Go(func() error {
@@ -1014,4 +1015,15 @@ func TestThreadSafe(t *testing.T) {
 
 	err := wg.Wait()
 	require.NoError(t, err)
+}
+
+func collectChanges(changes iter.Seq2[datastore.RevisionChanges, error]) ([]datastore.RevisionChanges, error) {
+	out := make([]datastore.RevisionChanges, 0, 10)
+	for change, err := range changes {
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, change)
+	}
+	return out, nil
 }

--- a/internal/datastore/crdb/watch.go
+++ b/internal/datastore/crdb/watch.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"strconv"
 	"strings"
 	"time"
@@ -225,7 +226,7 @@ func (cds *crdbDatastore) watch(
 
 // changeTracker takes care of accumulating changes received from CockroachDB until a checkpoint is emitted
 type changeTracker[R datastore.Revision, K comparable] interface {
-	FilterAndRemoveRevisionChanges(lessThanFunc func(lhs, rhs K) bool, boundRev R) ([]datastore.RevisionChanges, error)
+	FilterAndRemoveRevisionChanges(lessThanFunc func(lhs, rhs K) bool, boundRev R) iter.Seq2[datastore.RevisionChanges, error]
 	AddRelationshipChange(ctx context.Context, rev R, rel tuple.Relationship, op tuple.UpdateOperation) error
 	AddChangedDefinition(ctx context.Context, rev R, def datastore.SchemaDefinition) error
 	AddDeletedNamespace(ctx context.Context, rev R, namespaceName string) error
@@ -244,9 +245,10 @@ type streamingChangeProvider struct {
 	sendError  sendErrorFunc
 }
 
-func (s streamingChangeProvider) FilterAndRemoveRevisionChanges(_ func(lhs revisions.HLCRevision, rhs revisions.HLCRevision) bool, _ revisions.HLCRevision) ([]datastore.RevisionChanges, error) {
-	// we do not accumulate in this implementation, but stream right away
-	return nil, nil
+func (s streamingChangeProvider) FilterAndRemoveRevisionChanges(_ func(lhs revisions.HLCRevision, rhs revisions.HLCRevision) bool, _ revisions.HLCRevision) iter.Seq2[datastore.RevisionChanges, error] {
+	return func(yield func(datastore.RevisionChanges, error) bool) {
+		// Nothing to do here, as changes are sent immediately.
+	}
 }
 
 func (s streamingChangeProvider) AddRelationshipChange(ctx context.Context, rev revisions.HLCRevision, rel tuple.Relationship, op tuple.UpdateOperation) error {
@@ -376,13 +378,13 @@ func (cds *crdbDatastore) processChanges(ctx context.Context, changes pgx.Rows, 
 				return
 			}
 
-			filtered, err := tracked.FilterAndRemoveRevisionChanges(revisions.HLCKeyLessThanFunc, rev)
-			if err != nil {
-				sendError(err)
-				return
-			}
+			filtered := tracked.FilterAndRemoveRevisionChanges(revisions.HLCKeyLessThanFunc, rev)
+			for revChange, err := range filtered {
+				if err != nil {
+					sendError(err)
+					return
+				}
 
-			for _, revChange := range filtered {
 				// TODO(jschorr): Change this to a new event type if/when we decide to report these
 				// row GCs.
 

--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -293,24 +293,26 @@ func (mdb *memdbDatastore) ReadWriteTx(
 				}
 			}
 
-			var rc datastore.RevisionChanges
-			changes, err := tracked.AsRevisionChanges(revisions.TimestampIDKeyLessThanFunc)
-			if err != nil {
-				return datastore.NoRevision, err
-			}
+			changes := tracked.AsRevisionChanges(revisions.TimestampIDKeyLessThanFunc)
+			isFirstChange := true
+			for rc, err := range changes {
+				if err != nil {
+					return datastore.NoRevision, err
+				}
 
-			if len(changes) > 1 {
-				return datastore.NoRevision, spiceerrors.MustBugf("unexpected MemDB transaction with multiple revision changes")
-			} else if len(changes) == 1 {
-				rc = changes[0]
-			}
+				if !isFirstChange {
+					return datastore.NoRevision, spiceerrors.MustBugf("unexpected MemDB transaction with multiple revision changes")
+				}
 
-			change := &changelog{
-				revisionNanos: newRevision.TimestampNanoSec(),
-				changes:       rc,
-			}
-			if err := tx.Insert(tableChangelog, change); err != nil {
-				return datastore.NoRevision, fmt.Errorf("error writing changelog: %w", err)
+				change := &changelog{
+					revisionNanos: newRevision.TimestampNanoSec(),
+					changes:       rc,
+				}
+				if err := tx.Insert(tableChangelog, change); err != nil {
+					return datastore.NoRevision, fmt.Errorf("error writing changelog: %w", err)
+				}
+
+				isFirstChange = false
 			}
 
 			tx.Commit()

--- a/internal/datastore/mysql/watch.go
+++ b/internal/datastore/mysql/watch.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"errors"
+	"iter"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -86,9 +87,7 @@ func (mds *mysqlDatastore) Watch(ctx context.Context, afterRevisionRaw datastore
 
 		currentTxn := afterRevision.TransactionID()
 		for {
-			var stagedUpdates []datastore.RevisionChanges
-			var err error
-			stagedUpdates, currentTxn, err = mds.loadChanges(ctx, currentTxn, options)
+			stagedUpdates, ctxn, err := mds.loadChanges(ctx, currentTxn, options)
 			if err != nil {
 				if errors.Is(ctx.Err(), context.Canceled) {
 					errs <- datastore.NewWatchCanceledErr()
@@ -97,16 +96,24 @@ func (mds *mysqlDatastore) Watch(ctx context.Context, afterRevisionRaw datastore
 				}
 				return
 			}
+			currentTxn = ctxn
 
 			// Write the staged updates to the channel
-			for _, changeToWrite := range stagedUpdates {
+			changeCount := 0
+			for changeToWrite, err := range stagedUpdates {
+				if err != nil {
+					errs <- err
+					return
+				}
+
 				if !sendChange(changeToWrite) {
 					return
 				}
+				changeCount++
 			}
 
 			// If there were no changes, sleep a bit
-			if len(stagedUpdates) == 0 {
+			if changeCount == 0 {
 				sleep := time.NewTimer(watchSleep)
 
 				select {
@@ -127,14 +134,14 @@ func (mds *mysqlDatastore) loadChanges(
 	ctx context.Context,
 	afterRevision uint64,
 	options datastore.WatchOptions,
-) (changes []datastore.RevisionChanges, newRevision uint64, err error) {
-	newRevision, err = mds.loadRevision(ctx)
+) (iter.Seq2[datastore.RevisionChanges, error], uint64, error) {
+	newRevision, err := mds.loadRevision(ctx)
 	if err != nil {
-		return changes, newRevision, err
+		return nil, 0, err
 	}
 
 	if newRevision == afterRevision {
-		return changes, newRevision, err
+		return func(yield func(datastore.RevisionChanges, error) bool) {}, newRevision, nil
 	}
 
 	watchBufferSize := options.MaximumBufferedChangesByteSize
@@ -152,7 +159,7 @@ func (mds *mysqlDatastore) loadChanges(
 		},
 	}).ToSql()
 	if err != nil {
-		return changes, newRevision, err
+		return nil, 0, err
 	}
 
 	rows, err := mds.db.QueryContext(ctx, sql, args...)
@@ -165,7 +172,7 @@ func (mds *mysqlDatastore) loadChanges(
 		case common.IsResettableError(err):
 			err = datastore.NewWatchTemporaryErr(err)
 		}
-		return changes, newRevision, err
+		return nil, 0, err
 	}
 	defer common.LogOnError(ctx, rows.Close)
 
@@ -188,7 +195,7 @@ func (mds *mysqlDatastore) loadChanges(
 	}
 	rows.Close()
 	if rows.Err() != nil {
-		return changes, newRevision, err
+		return nil, 0, err
 	}
 
 	// Load the changes relationships for the revision range.
@@ -203,7 +210,7 @@ func (mds *mysqlDatastore) loadChanges(
 		},
 	}).ToSql()
 	if err != nil {
-		return changes, newRevision, err
+		return nil, 0, err
 	}
 
 	rows, err = mds.db.QueryContext(ctx, sql, args...)
@@ -211,7 +218,7 @@ func (mds *mysqlDatastore) loadChanges(
 		if errors.Is(err, context.Canceled) {
 			err = datastore.NewWatchCanceledErr()
 		}
-		return changes, newRevision, err
+		return nil, 0, err
 	}
 	defer common.LogOnError(ctx, rows.Close)
 
@@ -241,7 +248,7 @@ func (mds *mysqlDatastore) loadChanges(
 			&deletedTxn,
 		)
 		if err != nil {
-			return changes, newRevision, err
+			return nil, 0, err
 		}
 
 		relationship := tuple.Relationship{
@@ -262,25 +269,24 @@ func (mds *mysqlDatastore) loadChanges(
 
 		relationship.OptionalCaveat, err = common.ContextualizedCaveatFrom(caveatName, caveatContext)
 		if err != nil {
-			return changes, newRevision, err
+			return nil, 0, err
 		}
 
 		if createdTxn > afterRevision && createdTxn <= newRevision {
 			if err = stagedChanges.AddRelationshipChange(ctx, revisions.NewForTransactionID(createdTxn), relationship, tuple.UpdateOperationTouch); err != nil {
-				return changes, newRevision, err
+				return nil, 0, err
 			}
 		}
 
 		if deletedTxn > afterRevision && deletedTxn <= newRevision {
 			if err = stagedChanges.AddRelationshipChange(ctx, revisions.NewForTransactionID(deletedTxn), relationship, tuple.UpdateOperationDelete); err != nil {
-				return changes, newRevision, err
+				return nil, 0, err
 			}
 		}
 	}
-	if err = rows.Err(); err != nil {
-		return changes, newRevision, err
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
 	}
 
-	changes, err = stagedChanges.AsRevisionChanges(revisions.TransactionIDKeyLessThanFunc)
-	return changes, newRevision, err
+	return stagedChanges.AsRevisionChanges(revisions.TransactionIDKeyLessThanFunc), newRevision, nil
 }

--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -155,7 +156,12 @@ func (pgd *pgDatastore) Watch(
 					return
 				}
 
-				for _, changeToWrite := range changesToWrite {
+				for changeToWrite, err := range changesToWrite {
+					if err != nil {
+						errs <- err
+						return
+					}
+
 					if !sendChange(changeToWrite) {
 						return
 					}
@@ -242,7 +248,7 @@ func (pgd *pgDatastore) getNewRevisions(ctx context.Context, afterTX postgresRev
 	return ids, nil
 }
 
-func (pgd *pgDatastore) loadChanges(ctx context.Context, revisions []postgresRevision, options datastore.WatchOptions) ([]datastore.RevisionChanges, error) {
+func (pgd *pgDatastore) loadChanges(ctx context.Context, revisions []postgresRevision, options datastore.WatchOptions) (iter.Seq2[datastore.RevisionChanges, error], error) {
 	xmin := revisions[0].optionalTxID.Uint64
 	xmax := revisions[0].optionalTxID.Uint64
 	filter := make(map[uint64]int, len(revisions))
@@ -299,7 +305,7 @@ func (pgd *pgDatastore) loadChanges(ctx context.Context, revisions []postgresRev
 	// Reconcile the changes.
 	return tracked.AsRevisionChanges(func(lhs, rhs uint64) bool {
 		return filter[lhs] < filter[rhs]
-	})
+	}), nil
 }
 
 func (pgd *pgDatastore) loadRelationshipChanges(ctx context.Context, xmin uint64, xmax uint64, txidToRevision map[uint64]postgresRevision, filter map[uint64]int, tracked *common.Changes[postgresRevision, uint64]) error {

--- a/internal/datastore/spanner/watch.go
+++ b/internal/datastore/spanner/watch.go
@@ -370,12 +370,12 @@ func (sd *spannerDatastore) watch(
 					txnBuffer.Delete(txnID)
 
 					if !tracked.IsEmpty() {
-						changes, err := tracked.AsRevisionChanges(revisions.TimestampIDKeyLessThanFunc)
-						if err != nil {
-							return err
-						}
+						changes := tracked.AsRevisionChanges(revisions.TimestampIDKeyLessThanFunc)
+						for revChange, err := range changes {
+							if err != nil {
+								return err
+							}
 
-						for _, revChange := range changes {
 							if !sendChange(revChange) {
 								return datastore.NewWatchDisconnectedErr()
 							}


### PR DESCRIPTION
This should reduce memory usage a bit when reading the changes, as it can compute one-at-a-time
