### PR TITLE
Propagate cancellation errors in consistency middleware

### DIFF
--- a/pkg/middleware/consistency/consistency.go
+++ b/pkg/middleware/consistency/consistency.go
@@ -272,6 +272,9 @@ func rewriteDatastoreError(err error) error {
 	case errors.As(err, &datastore.ReadOnlyError{}):
 		return shared.ErrServiceReadOnly
 
+	case errors.Is(err, context.Canceled):
+		return status.Errorf(codes.Canceled, "%s", err)
+
 	default:
 		return status.Errorf(codes.Internal, "unexpected consistency middleware error: %s", err.Error())
 	}


### PR DESCRIPTION
## Description
When a request is cancelled, we propagate a `context.Canceled` error through the stack. This was getting incorrectly caught and turned into a standard 500 by the consistency middleware. This fixes that problem.

## Changes
* Add a test
* Fix the test
## Testing
Review.