### PR TITLE
chore: refactor dispatch/remote/cluster.go by using a concurrent map

### DIFF
--- a/internal/datastore/crdb/watch.go
+++ b/internal/datastore/crdb/watch.go
@@ -223,7 +223,7 @@ func (cds *crdbDatastore) watch(
 	cds.processChanges(ctx, changes, sendError, sendChange, opts, opts.EmissionStrategy == datastore.EmitImmediatelyStrategy)
 }
 
-// changeTracker takes care of accumulating received from CockroachDB until a checkpoint is emitted
+// changeTracker takes care of accumulating changes received from CockroachDB until a checkpoint is emitted
 type changeTracker[R datastore.Revision, K comparable] interface {
 	FilterAndRemoveRevisionChanges(lessThanFunc func(lhs, rhs K) bool, boundRev R) ([]datastore.RevisionChanges, error)
 	AddRelationshipChange(ctx context.Context, rev R, rel tuple.Relationship, op tuple.UpdateOperation) error

--- a/pkg/genutil/mapz/countingmap.go
+++ b/pkg/genutil/mapz/countingmap.go
@@ -11,6 +11,7 @@ type CountingMultiMap[T comparable, Q comparable] struct {
 }
 
 // NewCountingMultiMap constructs a new counting multimap.
+// Safe for concurrent use.
 func NewCountingMultiMap[T comparable, Q comparable]() *CountingMultiMap[T, Q] {
 	return &CountingMultiMap[T, Q]{
 		valuesByKey: map[T]*Set[Q]{},

--- a/pkg/genutil/mapz/multimap.go
+++ b/pkg/genutil/mapz/multimap.go
@@ -29,6 +29,7 @@ type ReadOnlyMultimap[T comparable, Q any] interface {
 }
 
 // NewMultiMap initializes a new MultiMap.
+// NOT safe for concurrent use.
 func NewMultiMap[T comparable, Q any]() *MultiMap[T, Q] {
 	return &MultiMap[T, Q]{items: map[T][]Q{}}
 }
@@ -40,6 +41,7 @@ func NewMultiMapWithCap[T comparable, Q any](capacity uint32) *MultiMap[T, Q] {
 }
 
 // MultiMap represents a map that can contain 1 or more values for each key.
+// NOT safe for concurrent use.
 type MultiMap[T comparable, Q any] struct {
 	items map[T][]Q
 }

--- a/pkg/genutil/mapz/set.go
+++ b/pkg/genutil/mapz/set.go
@@ -7,11 +7,13 @@ import (
 )
 
 // Set implements a very basic generic set.
+// NOT safe for concurrent use. Use xsync.NewMap for that.
 type Set[T comparable] struct {
 	values map[T]struct{}
 }
 
 // NewSet returns a new set.
+// NOT safe for concurrent use. Use xsync.NewMap for that.
 func NewSet[T comparable](items ...T) *Set[T] {
 	s := &Set[T]{
 		values: map[T]struct{}{},


### PR DESCRIPTION
Follow-up from [this](https://github.com/authzed/spicedb/pull/2543#discussion_r2308380947) and [this](https://github.com/authzed/internal/pull/8009/files#r2214412749)