### PR TITLE
feat: add support for riscv64 architecture

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -9,6 +9,7 @@ builds:
     goarch:
       - "amd64"
       - "arm64"
+      - "riscv64"
     mod_timestamp: "{{ .CommitTimestamp }}"
     ldflags:
       - "-s -w"
@@ -106,6 +107,37 @@ kos:
       - "linux/amd64"
     tags:
       - "v{{ .Version }}-amd64-debug"
+    creation_time: "{{ .CommitTimestamp }}"
+    ko_data_creation_time: "{{ .CommitTimestamp }}"
+    bare: true
+    sbom: "none"
+
+  # RISCV64
+  - id: "riscv64"
+    build: "spicedb"
+    repositories:
+      - "quay.io/authzed/spicedb-git"
+      - "ghcr.io/authzed/spicedb-git"
+      - "authzed/spicedb-git"
+    platforms:
+      - "linux/riscv64"
+    tags:
+      - "v{{ .Version }}-riscv64"
+    creation_time: "{{ .CommitTimestamp }}"
+    ko_data_creation_time: "{{ .CommitTimestamp }}"
+    bare: true
+    sbom: "none"
+  - id: "riscv64-debug"
+    build: "spicedb"
+    repositories:
+      - "quay.io/authzed/spicedb-git"
+      - "ghcr.io/authzed/spicedb-git"
+      - "authzed/spicedb-git"
+    base_image: "docker.io/busybox"
+    platforms:
+      - "linux/riscv64"
+    tags:
+      - "v{{ .Version }}-riscv64-debug"
     creation_time: "{{ .CommitTimestamp }}"
     ko_data_creation_time: "{{ .CommitTimestamp }}"
     bare: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,10 @@ builds:
     goarch:
       - "amd64"
       - "arm64"
+      - "riscv64"
+    ignore:
+      - goos: "darwin"
+        goarch: "riscv64"
     mod_timestamp: "{{ .CommitTimestamp }}"
     ldflags:
       - "-s -w"
@@ -160,40 +164,63 @@ dockers:
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--build-arg=BASE=cgr.dev/chainguard/busybox"
+  # RISCV64
+  - image_templates:
+      - &riscv64_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-riscv64"
+      - &riscv64_image_gh "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-riscv64"
+      - &riscv64_image_dh "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-riscv64"
+    dockerfile: *dockerfile
+    goos: "linux"
+    goarch: "riscv64"
+    use: "buildx"
+    build_flag_templates:
+      - "--platform=linux/riscv64"
+  # RISCV64 (debug)
+  - image_templates:
+      - &riscv64_debug_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-riscv64-debug"
+      - &riscv64_debug_image_gh "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-riscv64-debug"
+      - &riscv64_debug_image_dh "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-riscv64-debug"
+    dockerfile: *dockerfile
+    goos: "linux"
+    goarch: "riscv64"
+    use: "buildx"
+    build_flag_templates:
+      - "--platform=linux/riscv64"
+      - "--build-arg=BASE=cgr.dev/chainguard/busybox"
 docker_manifests:
   # Quay
   - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"
-    image_templates: [*amd_image_quay, *arm_image_quay]
+    image_templates: [*amd_image_quay, *arm_image_quay, *riscv64_image_quay]
   - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest"
-    image_templates: [*amd_image_quay, *arm_image_quay]
+    image_templates: [*amd_image_quay, *arm_image_quay, *riscv64_image_quay]
   # GitHub Registry
   - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"
-    image_templates: [*amd_image_gh, *arm_image_gh]
+    image_templates: [*amd_image_gh, *arm_image_gh, *riscv64_image_gh]
   - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest"
-    image_templates: [*amd_image_gh, *arm_image_gh]
+    image_templates: [*amd_image_gh, *arm_image_gh, *riscv64_image_gh]
   # Docker Hub
   - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"
-    image_templates: [*amd_image_dh, *arm_image_dh]
+    image_templates: [*amd_image_dh, *arm_image_dh, *riscv64_image_dh]
   - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest"
-    image_templates: [*amd_image_dh, *arm_image_dh]
+    image_templates: [*amd_image_dh, *arm_image_dh, *riscv64_image_dh]
 
   # Debug Images:
 
   # Quay (debug)
   - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
-    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
+    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay, *riscv64_debug_image_quay]
   - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
-    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
+    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay, *riscv64_debug_image_quay]
   # GitHub Registry
   - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
-    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
+    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh, *riscv64_debug_image_gh]
   - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
-    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
+    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh, *riscv64_debug_image_gh]
   # Docker Hub
   - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
-    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
+    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh, *riscv64_debug_image_dh]
   - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
-    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
+    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh, *riscv64_debug_image_dh]
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
## Description

Add support for the `riscv64` architecture throughout the goreleaser pipeline by updating build settings, Docker image templates, manifest entries, and nightly release configurations.

- Add `riscv64` to the `goarch` list in both standard and nightly goreleaser build configurations
- Define `riscv64` Docker image builds (release and debug) with templates for Quay, GitHub Container Registry, and Docker Hub
- Include `riscv64` variants in Docker manifest listings for both release and debug tags across all registries
- Add `riscv64` targets in the nightly goreleaser config for both standard and debug image builds

## Testing

I am able to test goreleaser locally with

```bash
goreleaser release --snapshot --clean
```
```bash
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=1e1e81cbac3d93452ad41eba7f7c9129c89f2f3a branch=feat/riscv-support current_tag=v1.46.0 previous_tag=v1.45.4 dirty=true
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • dockers and docker_manifests are being phased out and will eventually be replaced by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info
    • dockers and docker_manifests are being phased out and will eventually be replaced by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info
    • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info
  • snapshotting
    • building snapshot...                           version=1.46.1-next
  • running before hooks
    • running                                        hook=go run mage.go gen:completions
    • running                                        hook=go run mage.go gen:manpages
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/spicedb_linux_arm64_v8.0/spicedb
    • building                                       binary=dist/spicedb_linux_riscv64_rva20u64/spicedb
    • building                                       binary=dist/spicedb_darwin_amd64_v1/spicedb
    • building                                       binary=dist/spicedb_darwin_arm64_v8.0/spicedb
    • building                                       binary=dist/spicedb_linux_amd64_v1/spicedb
      • took: 3m38s
  • archives
    • archiving                                      name=dist/spicedb_1.46.1-next_darwin_amd64.tar.gz
    • archiving                                      name=dist/spicedb_1.46.1-next_linux_arm64.tar.gz
    • archiving                                      name=dist/spicedb_1.46.1-next_linux_riscv64.tar.gz
    • archiving                                      name=dist/spicedb_1.46.1-next_linux_amd64.tar.gz
    • archiving                                      name=dist/spicedb_1.46.1-next_darwin_arm64.tar.gz
  • linux packages
    • creating                                       package=spicedb format=apk arch=amd64v1 file=dist/spicedb_1.46.1-next_linux_amd64.apk
    • creating                                       package=spicedb format=apk arch=riscv64 file=dist/spicedb_1.46.1-next_linux_riscv64.apk
    • creating                                       package=spicedb format=rpm arch=arm64v8.0 file=dist/spicedb_1.46.1-next_linux_arm64.rpm
    • creating                                       package=spicedb format=rpm arch=amd64v1 file=dist/spicedb_1.46.1-next_linux_amd64.rpm
    • creating                                       package=spicedb format=rpm arch=riscv64 file=dist/spicedb_1.46.1-next_linux_riscv64.rpm
    • creating                                       package=spicedb format=deb arch=riscv64 file=dist/spicedb_1.46.1-next_linux_riscv64.deb
    • creating                                       package=spicedb format=deb arch=arm64v8.0 file=dist/spicedb_1.46.1-next_linux_arm64.deb
    • creating                                       package=spicedb format=apk arch=arm64v8.0 file=dist/spicedb_1.46.1-next_linux_arm64.apk
    • creating                                       package=spicedb format=deb arch=amd64v1 file=dist/spicedb_1.46.1-next_linux_amd64.deb
  • snapcraft packages
  ⨯ release failed after 3m50s                       error=snapcraft not present in $PATH
```

## References

Resolves https://github.com/authzed/spicedb/issues/2591


```mermaid
sequenceDiagram
  autonumber
  actor Dev as Developer
  participant GR as GoReleaser
  participant Go as Go Toolchain
  participant Ko as ko/kos Builder
  participant Reg as Registries (quay, ghcr, docker)

  Dev->>GR: Trigger release (nightly/main)
  GR->>Go: Build binaries for goarch: amd64, arm64, riscv64
  Note over Go: darwin/riscv64 builds ignored

  alt Nightly kos builds
    GR->>Ko: Build image linux/riscv64 (standard)
    Ko->>Reg: Push tag vX.Y.Z-riscv64 (sbom: none)
    GR->>Ko: Build image linux/riscv64 (debug, base=busybox)
    Ko->>Reg: Push tag vX.Y.Z-riscv64-debug (sbom: none)
  else Main docker builds
    GR->>Ko: Build/publish per registry templates\n(standard + debug)
    Ko->>Reg: Push riscv64 images
    GR->>Reg: Create/update multi-arch manifests\n(includes riscv64)
  end

  Reg-->>Dev: Images and manifests available
```