### PR TITLE
Fix data race in trailer test

### DIFF
--- a/pkg/middleware/serverversion/serverversion_test.go
+++ b/pkg/middleware/serverversion/serverversion_test.go
@@ -91,6 +91,10 @@ func (s *serverVersionMiddlewareTestSuite) TestStreamInterceptor_WithVersionRequ
 	_, err = stream.Recv()
 	require.NoError(s.T(), err)
 
+	// Close the stream to ensure trailers are available
+	err = stream.CloseSend()
+	require.NoError(s.T(), err)
+
 	// Check that response metadata contains server version
 	header := stream.Trailer()
 


### PR DESCRIPTION
Fixes #2602 

## Description
Running `go test -race` on this file was enough to trigger the race detector, as was observed in the issue.

The fix is to wait for the stream to close before reading the trailers.

## Changes
* Close the stream before reading trailers
## Testing
Review.