### PR TITLE
fix: error message when cannot run 'datastore gc' or 'datastore repair'

### DIFF
--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -23,7 +23,7 @@ func (t Test) All(ctx context.Context) {
 	c := Testcons{}
 	mg.CtxDeps(ctx, t.Unit, t.Integration, t.Steelthread, t.Image, t.Analyzers,
 		ds.Crdb, ds.Postgres, ds.Spanner, ds.Mysql,
-		c.Crdb, c.Spanner, c.Postgres, c.Mysql)
+		c.Crdb, c.Postgres, c.Spanner, c.Mysql)
 }
 
 // UnitCover Runs the unit tests and generates a coverage report
@@ -97,7 +97,7 @@ func (Test) E2e(ctx context.Context, crdbVersion string) error {
 	return goDirTest(ctx, "./e2e/newenemy", "./...")
 }
 
-// Integration Run integration tests with cover
+// IntegrationCover Run integration tests with cover
 func (Test) IntegrationCover(ctx context.Context) error {
 	mg.Deps(checkDocker)
 	args := []string{"-tags", "ci,docker", "-timeout", "15m", "-count=1"}

--- a/pkg/cmd/datastore_test.go
+++ b/pkg/cmd/datastore_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	datastoreTest "github.com/authzed/spicedb/internal/testserver/datastore"
+	"github.com/authzed/spicedb/pkg/cmd/datastore"
+)
+
+func TestExecuteGC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		cfgBuilder    func(t *testing.T) *datastore.Config
+		expectedError string
+	}{
+		{
+			name: "cockroachdb does not support garbage collection",
+			cfgBuilder: func(t *testing.T) *datastore.Config {
+				cfg := datastore.DefaultDatastoreConfig()
+				cfg.Engine = "cockroachdb"
+				runningDatastore := datastoreTest.RunDatastoreEngine(t, cfg.Engine)
+				db := runningDatastore.NewDatabase(t)
+				cfg.URI = db
+				return cfg
+			},
+			expectedError: "datastore of type 'cockroachdb' does not support garbage collection",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := tt.cfgBuilder(t)
+			err := executeGC(cfg)
+			require.ErrorContains(t, err, tt.expectedError)
+		})
+	}
+}
+
+func TestExecuteRepair(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		cfgBuilder    func(t *testing.T) *datastore.Config
+		expectedError string
+	}{
+		{
+			name: "cockroachdb does not support repair",
+			cfgBuilder: func(t *testing.T) *datastore.Config {
+				cfg := datastore.DefaultDatastoreConfig()
+				cfg.Engine = "cockroachdb"
+				runningDatastore := datastoreTest.RunDatastoreEngine(t, cfg.Engine)
+				db := runningDatastore.NewDatabase(t)
+				cfg.URI = db
+				return cfg
+			},
+			expectedError: "datastore of type 'cockroachdb' does not support the repair operation",
+		},
+		{
+			name: "postgres supports repair",
+			cfgBuilder: func(t *testing.T) *datastore.Config {
+				cfg := datastore.DefaultDatastoreConfig()
+				cfg.Engine = "postgres"
+				runningDatastore := datastoreTest.RunDatastoreEngine(t, cfg.Engine)
+				db := runningDatastore.NewDatabase(t)
+				cfg.URI = db
+				return cfg
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := tt.cfgBuilder(t)
+			err := executeRepair(cfg, []string{})
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.expectedError)
+		})
+	}
+}


### PR DESCRIPTION
Pre-reqs: https://github.com/authzed/spicedb/pull/2707

## Description

Fix error message that appears when trying to run `datastore gc` or `datastore repair` on datastores that don't support them.

Before
```
$ docker run --name cockroachdb -d --rm -p 26257:26257 -p 8080:8080 cockroachdb/cockroach:latest start-single-node --insecure --max-offset=50ms 

$  go run ./cmd/spicedb/main.go datastore gc \
--datastore-engine cockroachdb \
--datastore-conn-uri "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
...

ERR terminated with errors error="datastore of type *datastore.ctxProxy does not support garbage collection"                                                                                                     
exit status 1
```

After

```
$ docker run --name cockroachdb -d --rm -p 26257:26257 -p 8080:8080 cockroachdb/cockroach:latest start-single-node --insecure --max-offset=50ms 

$  go run ./cmd/spicedb/main.go datastore gc \
--datastore-engine cockroachdb \
--datastore-conn-uri "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
...

ERR terminated with errors error="datastore of type 'cockroachdb' does not support garbage collection"
exit status 1
```

~TO DO: the tests aren't running~ 🫠  fixed by removing the build tag on the test file
