### PR TITLE
chore: fix bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -34,9 +34,9 @@ body:
       label: "What SpiceDB version are you using?"
       placeholder: "v1.25.0"
   - type: "textarea"
-    id: "version"
+    id: "config"
     validations:
-      required: true
+      required: false
     attributes:
       label: "What SpiceDB flags do you use?"
       placeholder: |-


### PR DESCRIPTION
I broke this in https://github.com/authzed/spicedb/commit/6966e50eb1f041d88a0e1e1cb664183161954e0f; fixing it

<img width="784" height="298" alt="image" src="https://github.com/user-attachments/assets/41064064-692c-4022-8b56-5c9a82ec8737" />
