### PR TITLE
chore: add chunk bytes library in prep for singleton schema work

### DIFF
--- a/internal/datastore/common/chunkbytes.go
+++ b/internal/datastore/common/chunkbytes.go
@@ -1,0 +1,349 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+)
+
+// ChunkedBytesTransaction defines the interface for executing SQL queries within a transaction.
+type ChunkedBytesTransaction interface {
+	// ExecuteWrite executes an INSERT query.
+	ExecuteWrite(ctx context.Context, builder sq.InsertBuilder) error
+
+	// ExecuteDelete executes a DELETE query.
+	ExecuteDelete(ctx context.Context, builder sq.DeleteBuilder) error
+
+	// ExecuteUpdate executes an UPDATE query.
+	ExecuteUpdate(ctx context.Context, builder sq.UpdateBuilder) error
+}
+
+// ChunkedBytesExecutor defines the interface for creating transactions for chunked byte operations.
+type ChunkedBytesExecutor interface {
+	// BeginTransaction starts a new transaction for chunked byte operations.
+	BeginTransaction(ctx context.Context) (ChunkedBytesTransaction, error)
+
+	// ExecuteRead executes a SELECT query and returns the results as a map of chunk index to chunk data.
+	ExecuteRead(ctx context.Context, builder sq.SelectBuilder) (map[int][]byte, error)
+}
+
+// WriteMode defines how chunked data should be written.
+type WriteMode int
+
+const (
+	// WriteModeInsertWithTombstones inserts new chunks and marks old chunks with a tombstone.
+	// Requires TombstoneColumn to be set in config.
+	WriteModeInsertWithTombstones WriteMode = iota
+
+	// WriteModeDeleteAndInsert deletes all existing chunks for the key before inserting new ones.
+	// Useful for replacing data completely.
+	WriteModeDeleteAndInsert
+)
+
+// SQLByteChunkerConfig contains the configuration for creating a SQLByteChunker.
+type SQLByteChunkerConfig[T any] struct {
+	// TableName is the name of the table storing the chunked data.
+	TableName string
+
+	// NameColumn is the column name that stores the identifier for the byte data.
+	NameColumn string
+
+	// ChunkIndexColumn is the column name that stores the chunk index (0-based).
+	ChunkIndexColumn string
+
+	// ChunkDataColumn is the column name that stores the chunk bytes.
+	ChunkDataColumn string
+
+	// MaxChunkSize is the maximum size in bytes for each chunk.
+	MaxChunkSize int
+
+	// PlaceholderFormat is the placeholder format for SQL queries (e.g., sq.Question, sq.Dollar).
+	PlaceholderFormat sq.PlaceholderFormat
+
+	// Executor is the executor for running SQL queries.
+	Executor ChunkedBytesExecutor
+
+	// WriteMode defines how chunked data should be written (insert-with-tombstones or delete-and-insert).
+	WriteMode WriteMode
+
+	// CreatedAtColumn is the column name that stores when a row was created (alive timestamp/transaction ID).
+	// Required when WriteMode is WriteModeInsertWithTombstones.
+	CreatedAtColumn string
+
+	// DeletedAtColumn is the column name that stores when a row was deleted (tombstone timestamp/transaction ID).
+	// Required when WriteMode is WriteModeInsertWithTombstones.
+	DeletedAtColumn string
+
+	// AliveValue is the value used to indicate a row has not been deleted yet (typically max int).
+	// Required when WriteMode is WriteModeInsertWithTombstones.
+	AliveValue T
+}
+
+// SQLByteChunker provides methods for reading and writing byte data
+// that is chunked across multiple rows in a SQL table.
+type SQLByteChunker[T any] struct {
+	config SQLByteChunkerConfig[T]
+}
+
+// MustNewSQLByteChunker creates a new SQLByteChunker with the specified configuration.
+// Panics if the configuration is invalid.
+func MustNewSQLByteChunker[T any](config SQLByteChunkerConfig[T]) *SQLByteChunker[T] {
+	if config.MaxChunkSize <= 0 {
+		panic("maxChunkSize must be greater than 0")
+	}
+	if config.TableName == "" {
+		panic("tableName cannot be empty")
+	}
+	if config.NameColumn == "" {
+		panic("nameColumn cannot be empty")
+	}
+	if config.ChunkIndexColumn == "" {
+		panic("chunkIndexColumn cannot be empty")
+	}
+	if config.ChunkDataColumn == "" {
+		panic("chunkDataColumn cannot be empty")
+	}
+	if config.PlaceholderFormat == nil {
+		panic("placeholderFormat cannot be nil")
+	}
+	if config.Executor == nil {
+		panic("executor cannot be nil")
+	}
+	if config.WriteMode == WriteModeInsertWithTombstones {
+		if config.CreatedAtColumn == "" {
+			panic("createdAtColumn is required when using WriteModeInsertWithTombstones")
+		}
+		if config.DeletedAtColumn == "" {
+			panic("deletedAtColumn is required when using WriteModeInsertWithTombstones")
+		}
+	}
+
+	return &SQLByteChunker[T]{
+		config: config,
+	}
+}
+
+// WriteChunkedBytes writes chunked byte data to the database within a transaction.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - name: The unique identifier for this byte data
+//   - data: The bytes to be chunked and stored
+//   - createdAtValue: The value for the created_at column (typically a transaction ID or timestamp).
+//     Required when using WriteModeInsertWithTombstones. For WriteModeDeleteAndInsert, this parameter is ignored.
+func (c *SQLByteChunker[T]) WriteChunkedBytes(
+	ctx context.Context,
+	name string,
+	data []byte,
+	createdAtValue T,
+) error {
+	if name == "" {
+		return errors.New("name cannot be empty")
+	}
+
+	// Begin transaction
+	txn, err := c.config.Executor.BeginTransaction(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	// Handle existing chunks based on write mode
+	switch c.config.WriteMode {
+	case WriteModeDeleteAndInsert:
+		// Delete all existing chunks
+		deleteBuilder := sq.StatementBuilder.
+			PlaceholderFormat(c.config.PlaceholderFormat).
+			Delete(c.config.TableName).
+			Where(sq.Eq{c.config.NameColumn: name})
+
+		if err := txn.ExecuteDelete(ctx, deleteBuilder); err != nil {
+			return fmt.Errorf("failed to delete existing chunks: %w", err)
+		}
+	case WriteModeInsertWithTombstones:
+		// Mark existing alive chunks with tombstone
+		updateBuilder := sq.StatementBuilder.
+			PlaceholderFormat(c.config.PlaceholderFormat).
+			Update(c.config.TableName).
+			Set(c.config.DeletedAtColumn, createdAtValue).
+			Where(sq.Eq{c.config.NameColumn: name}).
+			Where(sq.Eq{c.config.DeletedAtColumn: c.config.AliveValue})
+
+		if err := txn.ExecuteUpdate(ctx, updateBuilder); err != nil {
+			return fmt.Errorf("failed to tombstone existing chunks: %w", err)
+		}
+	}
+
+	// Build the insert query
+	insertBuilder := sq.StatementBuilder.
+		PlaceholderFormat(c.config.PlaceholderFormat).
+		Insert(c.config.TableName)
+
+	// Chunk the data
+	chunks := c.chunkData(data)
+	if len(chunks) == 0 {
+		// Handle empty data case - insert a single empty chunk
+		chunks = [][]byte{{}}
+	}
+
+	// Set up the columns - base columns plus created_at (if using tombstone mode)
+	columns := []string{c.config.NameColumn, c.config.ChunkIndexColumn, c.config.ChunkDataColumn}
+	if c.config.WriteMode == WriteModeInsertWithTombstones {
+		columns = append(columns, c.config.CreatedAtColumn)
+	}
+	insertBuilder = insertBuilder.Columns(columns...)
+
+	// Add each chunk as a row
+	for index, chunk := range chunks {
+		values := []any{name, index, chunk}
+
+		// Add created_at value if using tombstone mode (deleted_at is written automatically)
+		if c.config.WriteMode == WriteModeInsertWithTombstones {
+			values = append(values, createdAtValue)
+		}
+
+		insertBuilder = insertBuilder.Values(values...)
+	}
+
+	// Execute the insert
+	if err := txn.ExecuteWrite(ctx, insertBuilder); err != nil {
+		return fmt.Errorf("failed to insert chunks: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteChunkedBytes deletes or tombstones all chunks for a given name within a transaction.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - name: The unique identifier for the byte data to delete
+//   - deletedAtValue: The value to write to the deleted_at column (typically a transaction ID or timestamp).
+//     Required when using WriteModeInsertWithTombstones. For WriteModeDeleteAndInsert, this parameter is ignored.
+func (c *SQLByteChunker[T]) DeleteChunkedBytes(
+	ctx context.Context,
+	name string,
+	deletedAtValue T,
+) error {
+	if name == "" {
+		return errors.New("name cannot be empty")
+	}
+
+	// Begin transaction
+	txn, err := c.config.Executor.BeginTransaction(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	switch c.config.WriteMode {
+	case WriteModeDeleteAndInsert:
+		// Actually delete the chunks
+		deleteBuilder := sq.StatementBuilder.
+			PlaceholderFormat(c.config.PlaceholderFormat).
+			Delete(c.config.TableName).
+			Where(sq.Eq{c.config.NameColumn: name})
+
+		if err := txn.ExecuteDelete(ctx, deleteBuilder); err != nil {
+			return fmt.Errorf("failed to delete chunks: %w", err)
+		}
+	case WriteModeInsertWithTombstones:
+		// Mark alive chunks with tombstone by setting deleted_at column
+		updateBuilder := sq.StatementBuilder.
+			PlaceholderFormat(c.config.PlaceholderFormat).
+			Update(c.config.TableName).
+			Set(c.config.DeletedAtColumn, deletedAtValue).
+			Where(sq.Eq{c.config.NameColumn: name}).
+			Where(sq.Eq{c.config.DeletedAtColumn: c.config.AliveValue})
+
+		if err := txn.ExecuteUpdate(ctx, updateBuilder); err != nil {
+			return fmt.Errorf("failed to tombstone chunks: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ReadChunkedBytes reads and reassembles chunked byte data from the database.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - name: The unique identifier for the byte data to read
+//
+// Returns the reassembled byte data or an error if chunks are missing or invalid.
+func (c *SQLByteChunker[T]) ReadChunkedBytes(
+	ctx context.Context,
+	name string,
+) ([]byte, error) {
+	if name == "" {
+		return nil, errors.New("name cannot be empty")
+	}
+
+	selectBuilder := sq.StatementBuilder.
+		PlaceholderFormat(c.config.PlaceholderFormat).
+		Select(c.config.ChunkIndexColumn, c.config.ChunkDataColumn).
+		From(c.config.TableName).
+		Where(sq.Eq{c.config.NameColumn: name}).
+		OrderBy(c.config.ChunkIndexColumn + " ASC")
+
+	// Execute the query
+	chunks, err := c.config.Executor.ExecuteRead(ctx, selectBuilder)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read chunks: %w", err)
+	}
+
+	// Reassemble the chunks
+	data, err := c.reassembleChunks(chunks)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reassemble chunks: %w", err)
+	}
+
+	return data, nil
+}
+
+// reassembleChunks takes the chunks read from the database and reassembles them
+// into the original byte array. It validates that all chunks are present and in order.
+func (c *SQLByteChunker[T]) reassembleChunks(chunks map[int][]byte) ([]byte, error) {
+	if len(chunks) == 0 {
+		return nil, errors.New("no chunks found")
+	}
+
+	// Validate that we have all chunks from 0 to N-1 and calculate total size
+	maxIndex := -1
+	totalSize := 0
+	for index := range chunks {
+		maxIndex = max(maxIndex, index)
+		totalSize += len(chunks[index])
+	}
+
+	// Reassemble, while checking for missing chunks
+	result := make([]byte, 0, totalSize)
+	for i := 0; i <= maxIndex; i++ {
+		if _, exists := chunks[i]; !exists {
+			return nil, fmt.Errorf("missing chunk at index %d", i)
+		}
+		result = append(result, chunks[i]...)
+	}
+
+	return result, nil
+}
+
+// chunkData splits the data into chunks of maxChunkSize.
+func (c *SQLByteChunker[T]) chunkData(data []byte) [][]byte {
+	if len(data) == 0 {
+		return nil
+	}
+
+	numChunks := (len(data) + c.config.MaxChunkSize - 1) / c.config.MaxChunkSize
+	chunks := make([][]byte, 0, numChunks)
+
+	for i := 0; i < len(data); i += c.config.MaxChunkSize {
+		end := i + c.config.MaxChunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		chunks = append(chunks, data[i:end])
+	}
+
+	return chunks
+}

--- a/internal/datastore/common/chunkbytes_test.go
+++ b/internal/datastore/common/chunkbytes_test.go
@@ -1,0 +1,712 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTransaction is a fake implementation of ChunkedBytesTransaction for testing.
+type fakeTransaction struct {
+	writeErr      error
+	deleteErr     error
+	updateErr     error
+	capturedSQL   []string
+	capturedArgs  [][]any
+	deleteQueries []string
+	updateQueries []string
+}
+
+func (f *fakeTransaction) ExecuteWrite(ctx context.Context, builder sq.InsertBuilder) error {
+	sql, args, err := builder.ToSql()
+	if err != nil {
+		return err
+	}
+	f.capturedSQL = append(f.capturedSQL, sql)
+	f.capturedArgs = append(f.capturedArgs, args)
+	return f.writeErr
+}
+
+func (f *fakeTransaction) ExecuteDelete(ctx context.Context, builder sq.DeleteBuilder) error {
+	sql, args, err := builder.ToSql()
+	if err != nil {
+		return err
+	}
+	f.capturedSQL = append(f.capturedSQL, sql)
+	f.capturedArgs = append(f.capturedArgs, args)
+	f.deleteQueries = append(f.deleteQueries, sql)
+	return f.deleteErr
+}
+
+func (f *fakeTransaction) ExecuteUpdate(ctx context.Context, builder sq.UpdateBuilder) error {
+	sql, args, err := builder.ToSql()
+	if err != nil {
+		return err
+	}
+	f.capturedSQL = append(f.capturedSQL, sql)
+	f.capturedArgs = append(f.capturedArgs, args)
+	f.updateQueries = append(f.updateQueries, sql)
+	return f.updateErr
+}
+
+// fakeExecutor is a fake implementation of ChunkedBytesExecutor for testing.
+type fakeExecutor struct {
+	readResult  map[int][]byte
+	readErr     error
+	transaction *fakeTransaction
+}
+
+func (m *fakeExecutor) BeginTransaction(ctx context.Context) (ChunkedBytesTransaction, error) {
+	return m.transaction, nil
+}
+
+func (m *fakeExecutor) ExecuteRead(ctx context.Context, builder sq.SelectBuilder) (map[int][]byte, error) {
+	if m.readErr != nil {
+		return nil, m.readErr
+	}
+	return m.readResult, nil
+}
+
+func TestMustNewSQLByteChunker(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      SQLByteChunkerConfig[uint64]
+		shouldPanic bool
+	}{
+		{
+			name: "valid config - DeleteAndInsert mode",
+			config: SQLByteChunkerConfig[uint64]{
+				TableName:         "test_table",
+				NameColumn:        "name",
+				ChunkIndexColumn:  "chunk_index",
+				ChunkDataColumn:   "chunk_data",
+				MaxChunkSize:      1024,
+				PlaceholderFormat: sq.Question,
+				Executor:          &fakeExecutor{},
+				WriteMode:         WriteModeDeleteAndInsert,
+			},
+			shouldPanic: false,
+		},
+		{
+			name: "valid config - InsertWithTombstones mode",
+			config: SQLByteChunkerConfig[uint64]{
+				TableName:         "test_table",
+				NameColumn:        "name",
+				ChunkIndexColumn:  "chunk_index",
+				ChunkDataColumn:   "chunk_data",
+				MaxChunkSize:      1024,
+				PlaceholderFormat: sq.Question,
+				Executor:          &fakeExecutor{},
+				WriteMode:         WriteModeInsertWithTombstones,
+				CreatedAtColumn:   "created_at",
+				DeletedAtColumn:   "deleted_at",
+				AliveValue:        ^uint64(0), // max uint64
+			},
+			shouldPanic: false,
+		},
+		{
+			name: "invalid max chunk size",
+			config: SQLByteChunkerConfig[uint64]{
+				TableName:         "test_table",
+				NameColumn:        "name",
+				ChunkIndexColumn:  "chunk_index",
+				ChunkDataColumn:   "chunk_data",
+				MaxChunkSize:      0,
+				PlaceholderFormat: sq.Question,
+				Executor:          &fakeExecutor{},
+			},
+			shouldPanic: true,
+		},
+		{
+			name: "empty table name",
+			config: SQLByteChunkerConfig[uint64]{
+				TableName:         "",
+				NameColumn:        "name",
+				ChunkIndexColumn:  "chunk_index",
+				ChunkDataColumn:   "chunk_data",
+				MaxChunkSize:      1024,
+				PlaceholderFormat: sq.Question,
+				Executor:          &fakeExecutor{},
+			},
+			shouldPanic: true,
+		},
+		{
+			name: "nil placeholder format",
+			config: SQLByteChunkerConfig[uint64]{
+				TableName:         "test_table",
+				NameColumn:        "name",
+				ChunkIndexColumn:  "chunk_index",
+				ChunkDataColumn:   "chunk_data",
+				MaxChunkSize:      1024,
+				PlaceholderFormat: nil,
+				Executor:          &fakeExecutor{},
+			},
+			shouldPanic: true,
+		},
+		{
+			name: "nil executor",
+			config: SQLByteChunkerConfig[uint64]{
+				TableName:         "test_table",
+				NameColumn:        "name",
+				ChunkIndexColumn:  "chunk_index",
+				ChunkDataColumn:   "chunk_data",
+				MaxChunkSize:      1024,
+				PlaceholderFormat: sq.Question,
+				Executor:          nil,
+			},
+			shouldPanic: true,
+		},
+		{
+			name: "InsertWithTombstones without created_at column",
+			config: SQLByteChunkerConfig[uint64]{
+				TableName:         "test_table",
+				NameColumn:        "name",
+				ChunkIndexColumn:  "chunk_index",
+				ChunkDataColumn:   "chunk_data",
+				MaxChunkSize:      1024,
+				PlaceholderFormat: sq.Question,
+				Executor:          &fakeExecutor{},
+				WriteMode:         WriteModeInsertWithTombstones,
+				DeletedAtColumn:   "deleted_at",
+			},
+			shouldPanic: true,
+		},
+		{
+			name: "InsertWithTombstones without deleted_at column",
+			config: SQLByteChunkerConfig[uint64]{
+				TableName:         "test_table",
+				NameColumn:        "name",
+				ChunkIndexColumn:  "chunk_index",
+				ChunkDataColumn:   "chunk_data",
+				MaxChunkSize:      1024,
+				PlaceholderFormat: sq.Question,
+				Executor:          &fakeExecutor{},
+				WriteMode:         WriteModeInsertWithTombstones,
+				CreatedAtColumn:   "created_at",
+			},
+			shouldPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				require.Panics(t, func() {
+					MustNewSQLByteChunker(tt.config)
+				})
+			} else {
+				require.NotPanics(t, func() {
+					chunker := MustNewSQLByteChunker(tt.config)
+					require.NotNil(t, chunker)
+				})
+			}
+		})
+	}
+}
+
+func TestWriteChunkedBytes_InsertWithTombstones(t *testing.T) {
+	txn := &fakeTransaction{}
+	executor := &fakeExecutor{transaction: txn}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      10,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeInsertWithTombstones,
+		CreatedAtColumn:   "created_at",
+		DeletedAtColumn:   "deleted_at",
+		AliveValue:        ^uint64(0), // max uint64
+	})
+
+	data := []byte("Hello, World! This is a test.")
+	createdAt := uint64(123)
+	err := chunker.WriteChunkedBytes(context.Background(), "test-key", data, createdAt)
+	require.NoError(t, err)
+
+	// Should have 1 UPDATE (tombstone old) + 1 INSERT query
+	require.Len(t, txn.capturedSQL, 2)
+	require.Len(t, txn.updateQueries, 1)
+	require.Len(t, txn.deleteQueries, 0)
+
+	// Check the UPDATE query (tombstone old chunks that are alive)
+	updateSQL := txn.capturedSQL[0]
+	require.Contains(t, updateSQL, "UPDATE test_table")
+	require.Contains(t, updateSQL, "SET deleted_at = ?")
+	require.Contains(t, updateSQL, "WHERE name = ?")
+	require.Contains(t, updateSQL, "AND deleted_at = ?")
+	require.Equal(t, []any{createdAt, "test-key", ^uint64(0)}, txn.capturedArgs[0])
+
+	// Check the INSERT query
+	insertSQL := txn.capturedSQL[1]
+	require.Contains(t, insertSQL, "INSERT INTO test_table")
+	require.Contains(t, insertSQL, "name")
+	require.Contains(t, insertSQL, "chunk_index")
+	require.Contains(t, insertSQL, "chunk_data")
+	require.Contains(t, insertSQL, "created_at")
+
+	// Check that we have the right number of chunks (30 bytes / 10 = 3 chunks)
+	// Each chunk has 4 values: name, chunk_index, chunk_data, created_at
+	insertArgs := txn.capturedArgs[1]
+	require.Len(t, insertArgs, 12) // 3 chunks * 4 values per chunk
+
+	// Verify created_at values
+	require.Equal(t, "test-key", insertArgs[0]) // First chunk name
+	require.Equal(t, 0, insertArgs[1])          // First chunk index
+	require.Equal(t, createdAt, insertArgs[3])  // First chunk created_at
+	require.Equal(t, createdAt, insertArgs[7])  // Second chunk created_at
+	require.Equal(t, createdAt, insertArgs[11]) // Third chunk created_at
+}
+
+func TestWriteChunkedBytes_DeleteAndInsert(t *testing.T) {
+	txn := &fakeTransaction{}
+	executor := &fakeExecutor{transaction: txn}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      10,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeDeleteAndInsert,
+	})
+
+	data := []byte("Hello, World!")
+	err := chunker.WriteChunkedBytes(context.Background(), "test-key", data, 0)
+	require.NoError(t, err)
+
+	// Should have 1 DELETE + 1 INSERT query
+	require.Len(t, txn.capturedSQL, 2)
+	require.Len(t, txn.deleteQueries, 1)
+	require.Len(t, txn.updateQueries, 0)
+
+	// Check the DELETE query
+	deleteSQL := txn.capturedSQL[0]
+	require.Contains(t, deleteSQL, "DELETE FROM test_table")
+	require.Contains(t, deleteSQL, "name = ?")
+	require.Equal(t, []any{"test-key"}, txn.capturedArgs[0])
+
+	// Check the INSERT query
+	insertSQL := txn.capturedSQL[1]
+	require.Contains(t, insertSQL, "INSERT INTO test_table")
+	require.Contains(t, insertSQL, "(name,chunk_index,chunk_data)")
+
+	// Should have 2 chunks (13 bytes / 10 = 1.3 rounds up to 2)
+	insertArgs := txn.capturedArgs[1]
+	require.Len(t, insertArgs, 6) // 2 chunks * 3 values per chunk
+}
+
+func TestWriteChunkedBytes_EmptyData(t *testing.T) {
+	txn := &fakeTransaction{}
+	executor := &fakeExecutor{transaction: txn}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      10,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeDeleteAndInsert,
+	})
+
+	data := []byte{}
+	err := chunker.WriteChunkedBytes(context.Background(), "test-key", data, 0)
+	require.NoError(t, err)
+
+	// Should insert a single empty chunk
+	require.Len(t, txn.capturedSQL, 2) // DELETE + INSERT
+	insertArgs := txn.capturedArgs[1]
+	require.Len(t, insertArgs, 3) // 1 chunk * 3 values per chunk
+	require.Equal(t, "test-key", insertArgs[0])
+	require.Equal(t, 0, insertArgs[1])
+	require.Equal(t, []byte{}, insertArgs[2])
+}
+
+func TestWriteChunkedBytes_EmptyName(t *testing.T) {
+	txn := &fakeTransaction{}
+	executor := &fakeExecutor{transaction: txn}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      10,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeDeleteAndInsert,
+	})
+
+	err := chunker.WriteChunkedBytes(context.Background(), "", []byte("test"), 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name cannot be empty")
+}
+
+func TestWriteAndReadZeroByteChunk(t *testing.T) {
+	txn := &fakeTransaction{}
+	executor := &fakeExecutor{
+		transaction: txn,
+		readResult: map[int][]byte{
+			0: {}, // Zero-byte chunk from SQL
+		},
+	}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      10,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeDeleteAndInsert,
+	})
+
+	// Write zero-byte data
+	err := chunker.WriteChunkedBytes(context.Background(), "test-key", []byte{}, 0)
+	require.NoError(t, err)
+
+	// Verify that a single empty chunk was inserted
+	require.Len(t, txn.capturedSQL, 2) // DELETE + INSERT
+	insertArgs := txn.capturedArgs[1]
+	require.Len(t, insertArgs, 3) // 1 chunk * 3 values per chunk
+	require.Equal(t, "test-key", insertArgs[0])
+	require.Equal(t, 0, insertArgs[1])
+	require.Equal(t, []byte{}, insertArgs[2])
+
+	// Read it back
+	data, err := chunker.ReadChunkedBytes(context.Background(), "test-key")
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Len(t, data, 0)
+	require.Equal(t, []byte{}, data)
+}
+
+func TestReadChunkedBytes(t *testing.T) {
+	tests := []struct {
+		name          string
+		chunks        map[int][]byte
+		expectedData  []byte
+		expectedError string
+	}{
+		{
+			name: "single chunk",
+			chunks: map[int][]byte{
+				0: []byte("Hello, World!"),
+			},
+			expectedData: []byte("Hello, World!"),
+		},
+		{
+			name: "multiple chunks",
+			chunks: map[int][]byte{
+				0: []byte("Hello, "),
+				1: []byte("World! "),
+				2: []byte("Test."),
+			},
+			expectedData: []byte("Hello, World! Test."),
+		},
+		{
+			name: "empty chunk",
+			chunks: map[int][]byte{
+				0: {},
+			},
+			expectedData: []byte{},
+		},
+		{
+			name:          "no chunks",
+			chunks:        map[int][]byte{},
+			expectedError: "no chunks found",
+		},
+		{
+			name: "missing chunk in sequence",
+			chunks: map[int][]byte{
+				0: []byte("Hello"),
+				2: []byte("World"),
+			},
+			expectedError: "missing chunk at index 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &fakeExecutor{
+				readResult: tt.chunks,
+			}
+			chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+				TableName:         "test_table",
+				NameColumn:        "name",
+				ChunkIndexColumn:  "chunk_index",
+				ChunkDataColumn:   "chunk_data",
+				MaxChunkSize:      10,
+				PlaceholderFormat: sq.Question,
+				Executor:          executor,
+				WriteMode:         WriteModeDeleteAndInsert,
+			})
+
+			data, err := chunker.ReadChunkedBytes(context.Background(), "test-key")
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedData, data)
+			}
+		})
+	}
+}
+
+func TestReadChunkedBytes_EmptyName(t *testing.T) {
+	executor := &fakeExecutor{}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      10,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeDeleteAndInsert,
+	})
+
+	_, err := chunker.ReadChunkedBytes(context.Background(), "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name cannot be empty")
+}
+
+func TestReadChunkedBytes_ExecutorError(t *testing.T) {
+	executor := &fakeExecutor{
+		readErr: fmt.Errorf("database error"),
+	}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      10,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeDeleteAndInsert,
+	})
+
+	_, err := chunker.ReadChunkedBytes(context.Background(), "test-key")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read chunks")
+	require.Contains(t, err.Error(), "database error")
+}
+
+func TestDeleteChunkedBytes_DeleteAndInsert(t *testing.T) {
+	txn := &fakeTransaction{}
+	executor := &fakeExecutor{transaction: txn}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      10,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeDeleteAndInsert,
+	})
+
+	err := chunker.DeleteChunkedBytes(context.Background(), "test-key", 0)
+	require.NoError(t, err)
+
+	// Verify the DELETE query
+	require.Len(t, txn.capturedSQL, 1)
+	deleteSQL := txn.capturedSQL[0]
+	require.Contains(t, deleteSQL, "DELETE FROM test_table")
+	require.Contains(t, deleteSQL, "WHERE name = ?")
+	require.Equal(t, []any{"test-key"}, txn.capturedArgs[0])
+}
+
+func TestDeleteChunkedBytes_InsertWithTombstones(t *testing.T) {
+	txn := &fakeTransaction{}
+	executor := &fakeExecutor{transaction: txn}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      10,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeInsertWithTombstones,
+		CreatedAtColumn:   "created_at",
+		DeletedAtColumn:   "deleted_at",
+		AliveValue:        ^uint64(0), // max uint64
+	})
+
+	deletedAt := uint64(456)
+	err := chunker.DeleteChunkedBytes(context.Background(), "test-key", deletedAt)
+	require.NoError(t, err)
+
+	// Verify the UPDATE query (tombstone)
+	require.Len(t, txn.capturedSQL, 1)
+	updateSQL := txn.capturedSQL[0]
+	require.Contains(t, updateSQL, "UPDATE test_table")
+	require.Contains(t, updateSQL, "SET deleted_at = ?")
+	require.Contains(t, updateSQL, "WHERE name = ?")
+	require.Contains(t, updateSQL, "AND deleted_at = ?")
+	require.Equal(t, []any{deletedAt, "test-key", ^uint64(0)}, txn.capturedArgs[0])
+}
+
+func TestDeleteChunkedBytes_EmptyName(t *testing.T) {
+	txn := &fakeTransaction{}
+	executor := &fakeExecutor{transaction: txn}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      10,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeDeleteAndInsert,
+	})
+
+	err := chunker.DeleteChunkedBytes(context.Background(), "", 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name cannot be empty")
+}
+
+func TestChunkData(t *testing.T) {
+	executor := &fakeExecutor{}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      5,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeDeleteAndInsert,
+	})
+
+	tests := []struct {
+		name          string
+		data          []byte
+		expectedCount int
+		expectedSizes []int
+	}{
+		{
+			name:          "empty data",
+			data:          []byte{},
+			expectedCount: 0,
+			expectedSizes: []int{},
+		},
+		{
+			name:          "exact chunk size",
+			data:          []byte("12345"),
+			expectedCount: 1,
+			expectedSizes: []int{5},
+		},
+		{
+			name:          "multiple exact chunks",
+			data:          []byte("1234567890"),
+			expectedCount: 2,
+			expectedSizes: []int{5, 5},
+		},
+		{
+			name:          "partial last chunk",
+			data:          []byte("1234567"),
+			expectedCount: 2,
+			expectedSizes: []int{5, 2},
+		},
+		{
+			name:          "single byte",
+			data:          []byte("1"),
+			expectedCount: 1,
+			expectedSizes: []int{1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunks := chunker.chunkData(tt.data)
+			require.Len(t, chunks, tt.expectedCount)
+
+			for i, expectedSize := range tt.expectedSizes {
+				require.Len(t, chunks[i], expectedSize)
+			}
+
+			// Verify that reassembling gives us the original data
+			if tt.expectedCount > 0 {
+				var reassembled []byte
+				for _, chunk := range chunks {
+					reassembled = append(reassembled, chunk...)
+				}
+				require.Equal(t, tt.data, reassembled)
+			}
+		})
+	}
+}
+
+func TestWriteChunkedBytes_LargeData_DeleteAndInsert(t *testing.T) {
+	txn := &fakeTransaction{}
+	executor := &fakeExecutor{transaction: txn}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      100,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeDeleteAndInsert,
+	})
+
+	// Create 1KB of data
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	err := chunker.WriteChunkedBytes(context.Background(), "test-key", data, 0)
+	require.NoError(t, err)
+
+	// Should have 1 DELETE + 1 INSERT
+	// INSERT should have 11 chunks (1024 / 100 = 10.24, rounds up to 11)
+	require.Len(t, txn.capturedSQL, 2)
+	insertArgs := txn.capturedArgs[1]
+	require.Len(t, insertArgs, 33) // 11 chunks * 3 values per chunk
+}
+
+func TestWriteChunkedBytes_LargeData_InsertWithTombstones(t *testing.T) {
+	txn := &fakeTransaction{}
+	executor := &fakeExecutor{transaction: txn}
+	chunker := MustNewSQLByteChunker(SQLByteChunkerConfig[uint64]{
+		TableName:         "test_table",
+		NameColumn:        "name",
+		ChunkIndexColumn:  "chunk_index",
+		ChunkDataColumn:   "chunk_data",
+		MaxChunkSize:      100,
+		PlaceholderFormat: sq.Question,
+		Executor:          executor,
+		WriteMode:         WriteModeInsertWithTombstones,
+		CreatedAtColumn:   "created_at",
+		DeletedAtColumn:   "deleted_at",
+		AliveValue:        ^uint64(0),
+	})
+
+	// Create 1KB of data
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	createdAt := uint64(999)
+	err := chunker.WriteChunkedBytes(context.Background(), "test-key", data, createdAt)
+	require.NoError(t, err)
+
+	// Should have 1 UPDATE (tombstone) + 1 INSERT
+	// INSERT should have 11 chunks (1024 / 100 = 10.24, rounds up to 11)
+	require.Len(t, txn.capturedSQL, 2)
+	insertArgs := txn.capturedArgs[1]
+	require.Len(t, insertArgs, 44) // 11 chunks * 4 values per chunk (name, index, data, created_at)
+}


### PR DESCRIPTION
## Description

Adds a chunk bytes library to the common datastore code for easy storing and loading of byte data that will be chunked across multiple rows in the database, as some databases have soft or hard limits on the size of BLOB fields.

This will be used by singleton schemas to store schemas and, likely eventually, schema metadata

## Testing

Unit tests. This is very early and not used yet.
