### PR TITLE
fix: data races that occur when functions do not clone pointer object…

### DIFF
--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -196,7 +196,7 @@ func (cd *Dispatcher) DispatchCheck(ctx context.Context, req *v1.DispatchCheckRe
 
 	// Return both the computed and err in ALL cases: computed contains resolved
 	// metadata even if there was an error.
-	return computed, err
+	return computed.CloneVT(), err
 }
 
 // DispatchExpand implements dispatch.Expand interface and does not do any caching yet.

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -37,6 +37,7 @@ type Dispatcher interface {
 // Check interface describes just the methods required to dispatch check requests.
 type Check interface {
 	// DispatchCheck submits a single check request and returns its result.
+	// The result should be safe to access from multiple goroutines.
 	DispatchCheck(ctx context.Context, req *v1.DispatchCheckRequest) (*v1.DispatchCheckResponse, error)
 }
 

--- a/internal/dispatch/singleflight/singleflight.go
+++ b/internal/dispatch/singleflight/singleflight.go
@@ -88,7 +88,7 @@ func (d *Dispatcher) DispatchCheck(ctx context.Context, req *v1.DispatchCheckReq
 	}
 
 	singleFlightCount.WithLabelValues("DispatchCheck", strconv.FormatBool(isShared)).Inc()
-	return sharedResp, err
+	return sharedResp.CloneVT(), err
 }
 
 func (d *Dispatcher) DispatchExpand(ctx context.Context, req *v1.DispatchExpandRequest) (*v1.DispatchExpandResponse, error) {


### PR DESCRIPTION
…s before returning them

This is related to https://github.com/authzed/spicedb/issues/2579. I was able to reproduce one panic with running [this](https://github.com/authzed/spicedb/blob/main/CONTRIBUTING.md#test-a-local-change-with-docker-compose). But I haven't been able to reliably reproduce them, which makes me highly suspicious of the `singleflight` code.

When I ran this PR to reproduce the panic, I couldn't reproduce it anymore. However: **disclaimer**, I don't know if this PR is the end-game solution to those panics.

## Testing
If you undo the changes i made to the code, running the tests in this PR with `-race` should eventually show DATA RACE.

```
$ cd internal/dispatch/caching
$ go test . -race -run=TestConcurrentDebugInfoAccess -count=100
# github.com/authzed/spicedb/internal/dispatch/caching.test
ld: warning: '/private/var/folders/5p/328y159n1334j9czdhzl2ts40000gn/T/go-link-3411654366/000013.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
ok      github.com/authzed/spicedb/internal/dispatch/caching    5.425s
```