### PR TITLE
chore: Enable protogetter linter and run fixes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,6 +32,7 @@ linters:
     - "prealloc"
     - "predeclared"
     - "promlinter"
+    - "protogetter"
     - "revive"
     - "rowserrcheck"
     - "spancheck"

--- a/cmd/spicedb/servetesting_integration_test.go
+++ b/cmd/spicedb/servetesting_integration_test.go
@@ -113,12 +113,12 @@ func TestTestServer(t *testing.T) {
 
 	v1Resp, err := v1client.CheckPermission(context.Background(), checkReq)
 	require.NoError(err)
-	require.Equal(v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, v1Resp.Permissionship)
+	require.Equal(v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, v1Resp.GetPermissionship())
 
 	// Ensure check against readonly works as well.
 	v1Resp, err = rov1client.CheckPermission(context.Background(), checkReq)
 	require.NoError(err)
-	require.Equal(v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, v1Resp.Permissionship)
+	require.Equal(v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, v1Resp.GetPermissionship())
 
 	// Try a call with a different auth header and ensure it fails.
 	authedConn, err := grpc.NewClient(fmt.Sprintf("localhost:%s", tester.readonlyPort),

--- a/cmd/spicedb/servetesting_race_test.go
+++ b/cmd/spicedb/servetesting_race_test.go
@@ -70,6 +70,6 @@ func TestCheckPermissionOnTesterNoFlakes(t *testing.T) {
 		conn.Close()
 
 		assert.NoError(t, err)
-		assert.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, result.Permissionship, "Error on attempt #%d", i)
+		assert.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, result.GetPermissionship(), "Error on attempt #%d", i)
 	}
 }

--- a/internal/caveats/builder_test.go
+++ b/internal/caveats/builder_test.go
@@ -223,10 +223,10 @@ func TestMustCaveatExprForTestingWithContext(t *testing.T) {
 	result := MustCaveatExprForTestingWithContext("test_caveat", context)
 	require.NotNil(t, result)
 	require.NotNil(t, result.GetCaveat())
-	require.Equal(t, "test_caveat", result.GetCaveat().CaveatName)
-	require.NotNil(t, result.GetCaveat().Context)
+	require.Equal(t, "test_caveat", result.GetCaveat().GetCaveatName())
+	require.NotNil(t, result.GetCaveat().GetContext())
 
-	contextMap := result.GetCaveat().Context.AsMap()
+	contextMap := result.GetCaveat().GetContext().AsMap()
 	require.Equal(t, "value1", contextMap["key1"])
 	require.Equal(t, float64(42), contextMap["key2"]) //nolint:testifyrequire these are known/static values
 }

--- a/internal/caveats/errors.go
+++ b/internal/caveats/errors.go
@@ -24,13 +24,13 @@ type EvaluationError struct {
 
 // MarshalZerologObject implements zerolog.LogObjectMarshaler
 func (err EvaluationError) MarshalZerologObject(e *zerolog.Event) {
-	e.Err(err.error).Str("caveat_name", err.caveatExpr.GetCaveat().CaveatName).Interface("context", err.caveatExpr.GetCaveat().Context)
+	e.Err(err.error).Str("caveat_name", err.caveatExpr.GetCaveat().GetCaveatName()).Interface("context", err.caveatExpr.GetCaveat().GetContext())
 }
 
 // DetailsMetadata returns the metadata for details for this error.
 func (err EvaluationError) DetailsMetadata() map[string]string {
 	return spiceerrors.CombineMetadata(err.evalErr, map[string]string{
-		"caveat_name": err.caveatExpr.GetCaveat().CaveatName,
+		"caveat_name": err.caveatExpr.GetCaveat().GetCaveatName(),
 	})
 }
 
@@ -47,7 +47,7 @@ func (err EvaluationError) GRPCStatus() *status.Status {
 
 func NewEvaluationError(caveatExpr *core.CaveatExpression, err caveats.EvaluationError) EvaluationError {
 	return EvaluationError{
-		fmt.Errorf("evaluation error for caveat %s: %w", caveatExpr.GetCaveat().CaveatName, err), caveatExpr, err,
+		fmt.Errorf("evaluation error for caveat %s: %w", caveatExpr.GetCaveat().GetCaveatName(), err), caveatExpr, err,
 	}
 }
 
@@ -61,8 +61,8 @@ type ParameterTypeError struct {
 // MarshalZerologObject implements zerolog.LogObjectMarshaler
 func (err ParameterTypeError) MarshalZerologObject(e *zerolog.Event) {
 	evt := e.Err(err.error).
-		Str("caveat_name", err.caveatExpr.GetCaveat().CaveatName).
-		Interface("context", err.caveatExpr.GetCaveat().Context)
+		Str("caveat_name", err.caveatExpr.GetCaveat().GetCaveatName()).
+		Interface("context", err.caveatExpr.GetCaveat().GetContext())
 
 	if err.conversionError != nil {
 		evt.Str("parameter_name", err.conversionError.ParameterName())
@@ -73,12 +73,12 @@ func (err ParameterTypeError) MarshalZerologObject(e *zerolog.Event) {
 func (err ParameterTypeError) DetailsMetadata() map[string]string {
 	if err.conversionError != nil {
 		return spiceerrors.CombineMetadata(err.conversionError, map[string]string{
-			"caveat_name": err.caveatExpr.GetCaveat().CaveatName,
+			"caveat_name": err.caveatExpr.GetCaveat().GetCaveatName(),
 		})
 	}
 
 	return map[string]string{
-		"caveat_name": err.caveatExpr.GetCaveat().CaveatName,
+		"caveat_name": err.caveatExpr.GetCaveat().GetCaveatName(),
 	}
 }
 
@@ -100,7 +100,7 @@ func NewParameterTypeError(caveatExpr *core.CaveatExpression, err error) Paramet
 	}
 
 	return ParameterTypeError{
-		fmt.Errorf("type error for parameters for caveat `%s`: %w", caveatExpr.GetCaveat().CaveatName, err),
+		fmt.Errorf("type error for parameters for caveat `%s`: %w", caveatExpr.GetCaveat().GetCaveatName(), err),
 		caveatExpr,
 		conversionError,
 	}

--- a/internal/datasets/subjectset_test.go
+++ b/internal/datasets/subjectset_test.go
@@ -1420,27 +1420,27 @@ func TestSubjectSetGet(t *testing.T) {
 
 	found, ok := ss.Get("first")
 	require.True(t, ok)
-	require.Equal(t, "first", found.SubjectId)
-	require.Nil(t, found.CaveatExpression)
+	require.Equal(t, "first", found.GetSubjectId())
+	require.Nil(t, found.GetCaveatExpression())
 
 	found, ok = ss.Get("second")
 	require.True(t, ok)
-	require.Equal(t, "second", found.SubjectId)
-	require.Nil(t, found.CaveatExpression)
+	require.Equal(t, "second", found.GetSubjectId())
+	require.Nil(t, found.GetCaveatExpression())
 
 	found, ok = ss.Get("third")
 	require.True(t, ok)
-	require.Equal(t, "third", found.SubjectId)
-	require.NotNil(t, found.CaveatExpression)
+	require.Equal(t, "third", found.GetSubjectId())
+	require.NotNil(t, found.GetCaveatExpression())
 
 	_, ok = ss.Get("fourth")
 	require.False(t, ok)
 
 	found, ok = ss.Get("*")
 	require.True(t, ok)
-	require.Equal(t, "*", found.SubjectId)
-	require.Nil(t, found.CaveatExpression)
-	require.Len(t, found.ExcludedSubjects, 2)
+	require.Equal(t, "*", found.GetSubjectId())
+	require.Nil(t, found.GetCaveatExpression())
+	require.Len(t, found.GetExcludedSubjects(), 2)
 }
 
 var testSets = [][]*v1.FoundSubject{

--- a/internal/datasets/subjectsetbyresourceid.go
+++ b/internal/datasets/subjectsetbyresourceid.go
@@ -49,7 +49,7 @@ func (ssr SubjectSetByResourceID) UnionWith(other map[string]*v1.FoundSubjects) 
 			return fmt.Errorf("received nil FoundSubjects in other map of SubjectSetByResourceID's UnionWith for key %s", resourceID)
 		}
 
-		for _, subject := range subjects.FoundSubjects {
+		for _, subject := range subjects.GetFoundSubjects() {
 			if err := ssr.add(resourceID, subject); err != nil {
 				return err
 			}

--- a/internal/datasets/subjectsetbyresourceid_test.go
+++ b/internal/datasets/subjectsetbyresourceid_test.go
@@ -36,11 +36,11 @@ func TestSubjectSetByResourceIDBasicOperations(t *testing.T) {
 	}
 	asMap := ssr.AsMap()
 
-	slices.SortFunc(expected["firstdoc"].FoundSubjects, testutil.CmpSubjects)
-	slices.SortFunc(expected["seconddoc"].FoundSubjects, testutil.CmpSubjects)
+	slices.SortFunc(expected["firstdoc"].GetFoundSubjects(), testutil.CmpSubjects)
+	slices.SortFunc(expected["seconddoc"].GetFoundSubjects(), testutil.CmpSubjects)
 
-	slices.SortFunc(asMap["firstdoc"].FoundSubjects, testutil.CmpSubjects)
-	slices.SortFunc(asMap["seconddoc"].FoundSubjects, testutil.CmpSubjects)
+	slices.SortFunc(asMap["firstdoc"].GetFoundSubjects(), testutil.CmpSubjects)
+	slices.SortFunc(asMap["seconddoc"].GetFoundSubjects(), testutil.CmpSubjects)
 
 	require.Equal(t, expected, asMap)
 }
@@ -67,7 +67,7 @@ func TestSubjectSetByResourceIDUnionWith(t *testing.T) {
 	require.NoError(t, err)
 
 	found := ssr.AsMap()
-	slices.SortFunc(found["firstdoc"].FoundSubjects, testutil.CmpSubjects)
+	slices.SortFunc(found["firstdoc"].GetFoundSubjects(), testutil.CmpSubjects)
 
 	require.Equal(t, map[string]*v1.FoundSubjects{
 		"firstdoc": {
@@ -216,8 +216,8 @@ func TestSubjectSetByResourceIDBasicCaveatedOperations(t *testing.T) {
 	}
 	asMap := ssr.AsMap()
 
-	slices.SortFunc(expected["firstdoc"].FoundSubjects, testutil.CmpSubjects)
-	slices.SortFunc(asMap["firstdoc"].FoundSubjects, testutil.CmpSubjects)
+	slices.SortFunc(expected["firstdoc"].GetFoundSubjects(), testutil.CmpSubjects)
+	slices.SortFunc(asMap["firstdoc"].GetFoundSubjects(), testutil.CmpSubjects)
 
 	require.Equal(t, expected, asMap)
 }

--- a/internal/datasets/subjectsetbytype.go
+++ b/internal/datasets/subjectsetbytype.go
@@ -70,7 +70,7 @@ func (s *SubjectByTypeSet) Map(mapper func(rr *core.RelationReference) (*core.Re
 			continue
 		}
 
-		key := tuple.JoinRelRef(updatedType.Namespace, updatedType.Relation)
+		key := tuple.JoinRelRef(updatedType.GetNamespace(), updatedType.GetRelation())
 		if existing, ok := mapped.byType[key]; ok {
 			cloned := subjectset.Clone()
 			if err := cloned.UnionWithSet(existing); err != nil {
@@ -96,7 +96,7 @@ func (s *SubjectByTypeSet) Len() int {
 
 // SubjectSetForType returns the subject set associated with the given subject type, if any.
 func (s *SubjectByTypeSet) SubjectSetForType(rr *core.RelationReference) (SubjectSet, bool) {
-	found, ok := s.byType[tuple.JoinRelRef(rr.Namespace, rr.Relation)]
+	found, ok := s.byType[tuple.JoinRelRef(rr.GetNamespace(), rr.GetRelation())]
 	return found, ok
 }
 

--- a/internal/datasets/subjectsetbytype_test.go
+++ b/internal/datasets/subjectsetbytype_test.go
@@ -25,10 +25,10 @@ func TestSubjectByTypeSet(t *testing.T) {
 			objectIds := make([]string, 0, len(subjects.AsSlice()))
 			for _, subject := range subjects.AsSlice() {
 				require.Empty(t, subject.GetExcludedSubjects())
-				objectIds = append(objectIds, subject.SubjectId)
+				objectIds = append(objectIds, subject.GetSubjectId())
 			}
 
-			if rr.Namespace == foundRR.Namespace && rr.Relation == foundRR.Relation {
+			if rr.GetNamespace() == foundRR.GetNamespace() && rr.GetRelation() == foundRR.GetRelation() {
 				sort.Strings(objectIds)
 				require.Equal(t, expected, objectIds)
 				wasFound = true
@@ -70,8 +70,8 @@ func TestSubjectByTypeSet(t *testing.T) {
 
 	// Map
 	mapped, err := set.Map(func(rr *core.RelationReference) (*core.RelationReference, error) {
-		if rr.Namespace == "document" {
-			return RR("doc", rr.Relation), nil
+		if rr.GetNamespace() == "document" {
+			return RR("doc", rr.GetRelation()), nil
 		}
 
 		return rr, nil
@@ -118,7 +118,7 @@ func TestSubjectSetMapOverSameSubjectDifferentRelation(t *testing.T) {
 
 	mapped, err := set.Map(func(rr *core.RelationReference) (*core.RelationReference, error) {
 		return &core.RelationReference{
-			Namespace: rr.Namespace,
+			Namespace: rr.GetNamespace(),
 			Relation:  "shared",
 		}, nil
 	})
@@ -126,7 +126,7 @@ func TestSubjectSetMapOverSameSubjectDifferentRelation(t *testing.T) {
 
 	foundSubjectIDs := mapz.NewSet[string]()
 	for _, sub := range mapped.byType["folder#shared"].AsSlice() {
-		foundSubjectIDs.Add(sub.SubjectId)
+		foundSubjectIDs.Add(sub.GetSubjectId())
 	}
 
 	require.ElementsMatch(t, []string{"folder1", "folder2"}, foundSubjectIDs.AsSlice())

--- a/internal/datastore/benchmark/driver_bench_test.go
+++ b/internal/datastore/benchmark/driver_bench_test.go
@@ -105,7 +105,7 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 					for n := 0; n < b.N; n++ {
 						randDocNum := rand.Intn(numDocuments) //nolint:gosec
 						iter, err := ds.SnapshotReader(headRev).QueryRelationships(ctx, datastore.RelationshipsFilter{
-							OptionalResourceType:     testfixtures.DocumentNS.Name,
+							OptionalResourceType:     testfixtures.DocumentNS.GetName(),
 							OptionalResourceIds:      []string{strconv.Itoa(randDocNum)},
 							OptionalResourceRelation: "viewer",
 						}, options.WithQueryShape(queryshape.AllSubjectsForResources))
@@ -121,7 +121,7 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 				b.Run("SnapshotReadOnlyNamespace", func(b *testing.B) {
 					for n := 0; n < b.N; n++ {
 						iter, err := ds.SnapshotReader(headRev).QueryRelationships(ctx, datastore.RelationshipsFilter{
-							OptionalResourceType: testfixtures.DocumentNS.Name,
+							OptionalResourceType: testfixtures.DocumentNS.GetName(),
 						}, options.WithQueryShape(queryshape.FindResourceOfType))
 						require.NoError(b, err)
 						var count int
@@ -137,7 +137,7 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 						b.Run(orderName, func(b *testing.B) {
 							for n := 0; n < b.N; n++ {
 								iter, err := ds.SnapshotReader(headRev).QueryRelationships(ctx, datastore.RelationshipsFilter{
-									OptionalResourceType: testfixtures.DocumentNS.Name,
+									OptionalResourceType: testfixtures.DocumentNS.GetName(),
 								}, options.WithSort(order), options.WithQueryShape(queryshape.FindResourceOfType))
 								require.NoError(b, err)
 								var count int
@@ -155,7 +155,7 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 						b.Run(orderName, func(b *testing.B) {
 							for n := 0; n < b.N; n++ {
 								iter, err := ds.SnapshotReader(headRev).QueryRelationships(ctx, datastore.RelationshipsFilter{
-									OptionalResourceType:     testfixtures.DocumentNS.Name,
+									OptionalResourceType:     testfixtures.DocumentNS.GetName(),
 									OptionalResourceRelation: "viewer",
 								}, options.WithSort(order), options.WithQueryShape(queryshape.Varying))
 								require.NoError(b, err)
@@ -175,7 +175,7 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 							for n := 0; n < b.N; n++ {
 								randDocNum := rand.Intn(numDocuments) //nolint:gosec
 								iter, err := ds.SnapshotReader(headRev).QueryRelationships(ctx, datastore.RelationshipsFilter{
-									OptionalResourceType:     testfixtures.DocumentNS.Name,
+									OptionalResourceType:     testfixtures.DocumentNS.GetName(),
 									OptionalResourceIds:      []string{strconv.Itoa(randDocNum)},
 									OptionalResourceRelation: "viewer",
 								}, options.WithSort(order), options.WithQueryShape(queryshape.AllSubjectsForResources))
@@ -192,7 +192,7 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 				b.Run("SnapshotReverseRead", func(b *testing.B) {
 					for n := 0; n < b.N; n++ {
 						iter, err := ds.SnapshotReader(headRev).ReverseQueryRelationships(ctx, datastore.SubjectsFilter{
-							SubjectType: testfixtures.UserNS.Name,
+							SubjectType: testfixtures.UserNS.GetName(),
 						}, options.WithSortForReverse(options.ByResource), options.WithQueryShapeForReverse(queryshape.Varying))
 						require.NoError(b, err)
 						var count int
@@ -274,12 +274,12 @@ func docViewer(documentID, userID string) tuple.Relationship {
 	return tuple.Relationship{
 		RelationshipReference: tuple.RelationshipReference{
 			Resource: tuple.ObjectAndRelation{
-				ObjectType: testfixtures.DocumentNS.Name,
+				ObjectType: testfixtures.DocumentNS.GetName(),
 				ObjectID:   documentID,
 				Relation:   "viewer",
 			},
 			Subject: tuple.ObjectAndRelation{
-				ObjectType: testfixtures.UserNS.Name,
+				ObjectType: testfixtures.UserNS.GetName(),
 				ObjectID:   userID,
 				Relation:   datastore.Ellipsis,
 			},

--- a/internal/datastore/common/changes.go
+++ b/internal/datastore/common/changes.go
@@ -252,30 +252,30 @@ func (ch *Changes[R, K]) AddChangedDefinition(
 
 	switch t := def.(type) {
 	case *core.NamespaceDefinition:
-		delete(record.namespacesDeleted, t.Name)
+		delete(record.namespacesDeleted, t.GetName())
 
-		if existing, ok := record.definitionsChanged[nsPrefix+t.Name]; ok {
+		if existing, ok := record.definitionsChanged[nsPrefix+t.GetName()]; ok {
 			if err := ch.adjustByteSize(existing, -1); err != nil {
 				return err
 			}
 		}
 
-		record.definitionsChanged[nsPrefix+t.Name] = t
+		record.definitionsChanged[nsPrefix+t.GetName()] = t
 
 		if err := ch.adjustByteSize(t, 1); err != nil {
 			return err
 		}
 
 	case *core.CaveatDefinition:
-		delete(record.caveatsDeleted, t.Name)
+		delete(record.caveatsDeleted, t.GetName())
 
-		if existing, ok := record.definitionsChanged[nsPrefix+t.Name]; ok {
+		if existing, ok := record.definitionsChanged[nsPrefix+t.GetName()]; ok {
 			if err := ch.adjustByteSize(existing, -1); err != nil {
 				return err
 			}
 		}
 
-		record.definitionsChanged[caveatPrefix+t.Name] = t
+		record.definitionsChanged[caveatPrefix+t.GetName()] = t
 
 		if err := ch.adjustByteSize(t, 1); err != nil {
 			return err

--- a/internal/datastore/common/errors.go
+++ b/internal/datastore/common/errors.go
@@ -122,12 +122,12 @@ func (err CreateRelationshipExistsError) GRPCStatus() *status.Status {
 			v1.ErrorReason_ERROR_REASON_ATTEMPT_TO_RECREATE_RELATIONSHIP,
 			map[string]string{
 				"relationship":       tuple.V1StringRelationshipWithoutCaveatOrExpiration(relationship),
-				"resource_type":      relationship.Resource.ObjectType,
-				"resource_object_id": relationship.Resource.ObjectId,
-				"resource_relation":  relationship.Relation,
-				"subject_type":       relationship.Subject.Object.ObjectType,
-				"subject_object_id":  relationship.Subject.Object.ObjectId,
-				"subject_relation":   relationship.Subject.OptionalRelation,
+				"resource_type":      relationship.GetResource().GetObjectType(),
+				"resource_object_id": relationship.GetResource().GetObjectId(),
+				"resource_relation":  relationship.GetRelation(),
+				"subject_type":       relationship.GetSubject().GetObject().GetObjectType(),
+				"subject_object_id":  relationship.GetSubject().GetObject().GetObjectId(),
+				"subject_relation":   relationship.GetSubject().GetOptionalRelation(),
 			},
 		),
 	)

--- a/internal/datastore/common/gc_test.go
+++ b/internal/datastore/common/gc_test.go
@@ -203,7 +203,7 @@ func TestGCFailureBackoff(t *testing.T) {
 			mf = metric
 		}
 	}
-	require.Greater(t, *(mf.GetMetric()[0].Counter.Value), 100.0, "MaxElapsedTime=1ns did not cause backoff to get ignored")
+	require.Greater(t, mf.GetMetric()[0].GetCounter().GetValue(), 100.0, "MaxElapsedTime=1ns did not cause backoff to get ignored")
 
 	localCounter = prometheus.NewCounter(gcFailureCounterConfig)
 	reg = prometheus.NewRegistry()
@@ -224,7 +224,7 @@ func TestGCFailureBackoff(t *testing.T) {
 			mf = metric
 		}
 	}
-	require.Less(t, *(mf.GetMetric()[0].Counter.Value), 3.0, "MaxElapsedTime=0 should have not caused backoff to get ignored")
+	require.Less(t, mf.GetMetric()[0].GetCounter().GetValue(), 3.0, "MaxElapsedTime=0 should have not caused backoff to get ignored")
 }
 
 // Ensure the garbage collector interval is reset after recovering from an

--- a/internal/datastore/common/sql.go
+++ b/internal/datastore/common/sql.go
@@ -641,16 +641,16 @@ func (sqf SchemaQueryFilterer) FilterWithSubjectsSelectors(selectors ...datastor
 // FilterToSubjectFilter returns a new SchemaQueryFilterer that is limited to resources with
 // subjects that match the specified filter.
 func (sqf SchemaQueryFilterer) FilterToSubjectFilter(filter *v1.SubjectFilter) SchemaQueryFilterer {
-	sqf.queryBuilder = sqf.queryBuilder.Where(sq.Eq{sqf.schema.ColUsersetNamespace: filter.SubjectType})
-	sqf.recordColumnValue(sqf.schema.ColUsersetNamespace, filter.SubjectType)
+	sqf.queryBuilder = sqf.queryBuilder.Where(sq.Eq{sqf.schema.ColUsersetNamespace: filter.GetSubjectType()})
+	sqf.recordColumnValue(sqf.schema.ColUsersetNamespace, filter.GetSubjectType())
 
-	if filter.OptionalSubjectId != "" {
-		sqf.queryBuilder = sqf.queryBuilder.Where(sq.Eq{sqf.schema.ColUsersetObjectID: filter.OptionalSubjectId})
-		sqf.recordColumnValue(sqf.schema.ColUsersetObjectID, filter.OptionalSubjectId)
+	if filter.GetOptionalSubjectId() != "" {
+		sqf.queryBuilder = sqf.queryBuilder.Where(sq.Eq{sqf.schema.ColUsersetObjectID: filter.GetOptionalSubjectId()})
+		sqf.recordColumnValue(sqf.schema.ColUsersetObjectID, filter.GetOptionalSubjectId())
 	}
 
-	if filter.OptionalRelation != nil {
-		dsRelationName := cmp.Or(filter.OptionalRelation.Relation, datastore.Ellipsis)
+	if filter.GetOptionalRelation() != nil {
+		dsRelationName := cmp.Or(filter.GetOptionalRelation().GetRelation(), datastore.Ellipsis)
 
 		sqf.queryBuilder = sqf.queryBuilder.Where(sq.Eq{sqf.schema.ColUsersetRelation: dsRelationName})
 		sqf.recordColumnValue(sqf.schema.ColUsersetRelation, datastore.Ellipsis)

--- a/internal/datastore/crdb/caveat.go
+++ b/internal/datastore/crdb/caveat.go
@@ -138,9 +138,9 @@ func (rwt *crdbReadWriteTXN) WriteCaveats(ctx context.Context, caveats []*core.C
 		if err != nil {
 			return fmt.Errorf(errWriteCaveat, err)
 		}
-		valuesToWrite := []any{caveat.Name, definitionBytes}
+		valuesToWrite := []any{caveat.GetName(), definitionBytes}
 		write = write.Values(valuesToWrite...)
-		writtenCaveatNames = append(writtenCaveatNames, caveat.Name)
+		writtenCaveatNames = append(writtenCaveatNames, caveat.GetName())
 	}
 
 	// store the new caveat

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -527,10 +527,10 @@ func RelationshipIntegrityInfoTest(t *testing.T, tester test.DatastoreTester) {
 	rel := slice[0]
 
 	require.NotNil(rel.OptionalIntegrity)
-	require.Equal("key1", rel.OptionalIntegrity.KeyId)
-	require.Equal([]byte("hash1"), rel.OptionalIntegrity.Hash)
+	require.Equal("key1", rel.OptionalIntegrity.GetKeyId())
+	require.Equal([]byte("hash1"), rel.OptionalIntegrity.GetHash())
 
-	require.LessOrEqual(math.Abs(float64(timestamp.Sub(rel.OptionalIntegrity.HashedAt.AsTime()).Milliseconds())), 1000.0)
+	require.LessOrEqual(math.Abs(float64(timestamp.Sub(rel.OptionalIntegrity.GetHashedAt().AsTime()).Milliseconds())), 1000.0)
 }
 
 type fakeSource struct {
@@ -590,10 +590,10 @@ func BulkRelationshipIntegrityInfoTest(t *testing.T, tester test.DatastoreTester
 	rel := slice[0]
 
 	require.NotNil(rel.OptionalIntegrity)
-	require.Equal("key1", rel.OptionalIntegrity.KeyId)
-	require.Equal([]byte("hash1"), rel.OptionalIntegrity.Hash)
+	require.Equal("key1", rel.OptionalIntegrity.GetKeyId())
+	require.Equal([]byte("hash1"), rel.OptionalIntegrity.GetHash())
 
-	require.LessOrEqual(math.Abs(float64(timestamp.Sub(rel.OptionalIntegrity.HashedAt.AsTime()).Milliseconds())), 1000.0)
+	require.LessOrEqual(math.Abs(float64(timestamp.Sub(rel.OptionalIntegrity.GetHashedAt().AsTime()).Milliseconds())), 1000.0)
 }
 
 func RelationshipIntegrityWatchTest(t *testing.T, tester test.DatastoreTester) {
@@ -637,10 +637,10 @@ func RelationshipIntegrityWatchTest(t *testing.T, tester test.DatastoreTester) {
 
 		rel := change.RelationshipChanges[0].Relationship
 		require.NotNil(rel.OptionalIntegrity)
-		require.Equal("key1", rel.OptionalIntegrity.KeyId)
-		require.Equal([]byte("hash1"), rel.OptionalIntegrity.Hash)
+		require.Equal("key1", rel.OptionalIntegrity.GetKeyId())
+		require.Equal([]byte("hash1"), rel.OptionalIntegrity.GetHash())
 
-		require.LessOrEqual(math.Abs(float64(timestamp.Sub(rel.OptionalIntegrity.HashedAt.AsTime()).Milliseconds())), 1000.0)
+		require.LessOrEqual(math.Abs(float64(timestamp.Sub(rel.OptionalIntegrity.GetHashedAt().AsTime()).Milliseconds())), 1000.0)
 	case err := <-errchan:
 		require.Failf("Failed waiting for changes with error", "error: %v", err)
 	case <-time.NewTimer(10 * time.Second).C:

--- a/internal/datastore/crdb/keys_test.go
+++ b/internal/datastore/crdb/keys_test.go
@@ -169,7 +169,7 @@ func TestOverlapKeysFromContext(t *testing.T) {
 			ctx := metadata.NewOutgoingContext(t.Context(), md)
 			resp, err := client.Ping(ctx, &testpb.PingRequest{})
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, resp.Value)
+			require.Equal(t, tt.expected, resp.GetValue())
 		})
 	}
 }

--- a/internal/datastore/memdb/caveat.go
+++ b/internal/datastore/memdb/caveat.go
@@ -101,7 +101,7 @@ func (r *memdbReader) LookupCaveatsWithNames(ctx context.Context, caveatNames []
 
 	toReturn := make([]datastore.RevisionedCaveat, 0, len(caveatNames))
 	for _, caveat := range allCaveats {
-		if allowedCaveatNames.Has(caveat.Definition.Name) {
+		if allowedCaveatNames.Has(caveat.Definition.GetName()) {
 			toReturn = append(toReturn, caveat)
 		}
 	}
@@ -121,15 +121,15 @@ func (rwt *memdbReadWriteTx) WriteCaveats(_ context.Context, caveats []*core.Cav
 func (rwt *memdbReadWriteTx) writeCaveat(tx *memdb.Txn, caveats []*core.CaveatDefinition) error {
 	caveatNames := mapz.NewSet[string]()
 	for _, coreCaveat := range caveats {
-		if !caveatNames.Add(coreCaveat.Name) {
-			return fmt.Errorf("duplicate caveat %s", coreCaveat.Name)
+		if !caveatNames.Add(coreCaveat.GetName()) {
+			return fmt.Errorf("duplicate caveat %s", coreCaveat.GetName())
 		}
 		marshalled, err := coreCaveat.MarshalVT()
 		if err != nil {
 			return err
 		}
 		c := caveat{
-			name:       coreCaveat.Name,
+			name:       coreCaveat.GetName(),
 			definition: marshalled,
 			revision:   rwt.newRevision,
 		}

--- a/internal/datastore/memdb/readonly.go
+++ b/internal/datastore/memdb/readonly.go
@@ -340,7 +340,7 @@ func (r *memdbReader) LookupNamespacesWithNames(_ context.Context, nsNames []str
 			return nil, err
 		}
 
-		if _, ok := nsNameMap[loaded.Name]; ok {
+		if _, ok := nsNameMap[loaded.GetName()]; ok {
 			nsDefs = append(nsDefs, datastore.RevisionedNamespace{
 				Definition:          loaded,
 				LastWrittenRevision: found.updated,

--- a/internal/datastore/memdb/readwrite.go
+++ b/internal/datastore/memdb/readwrite.go
@@ -40,9 +40,9 @@ func (rwt *memdbReadWriteTx) toIntegrity(mutation tuple.RelationshipUpdate) *rel
 	var ri *relationshipIntegrity
 	if mutation.Relationship.OptionalIntegrity != nil {
 		ri = &relationshipIntegrity{
-			keyID:     mutation.Relationship.OptionalIntegrity.KeyId,
-			hash:      mutation.Relationship.OptionalIntegrity.Hash,
-			timestamp: mutation.Relationship.OptionalIntegrity.HashedAt.AsTime(),
+			keyID:     mutation.Relationship.OptionalIntegrity.GetKeyId(),
+			hash:      mutation.Relationship.OptionalIntegrity.GetHash(),
+			timestamp: mutation.Relationship.OptionalIntegrity.GetHashedAt().AsTime(),
 		}
 	}
 	return ri
@@ -129,8 +129,8 @@ func (rwt *memdbReadWriteTx) toCaveatReference(mutation tuple.RelationshipUpdate
 	var cr *contextualizedCaveat
 	if mutation.Relationship.OptionalCaveat != nil {
 		cr = &contextualizedCaveat{
-			caveatName: mutation.Relationship.OptionalCaveat.CaveatName,
-			context:    mutation.Relationship.OptionalCaveat.Context.AsMap(),
+			caveatName: mutation.Relationship.OptionalCaveat.GetCaveatName(),
+			context:    mutation.Relationship.OptionalCaveat.GetContext().AsMap(),
 		}
 	}
 	return cr
@@ -287,7 +287,7 @@ func (rwt *memdbReadWriteTx) WriteNamespaces(_ context.Context, newConfigs ...*c
 			return err
 		}
 
-		newConfigEntry := &namespace{newConfig.Name, serialized, rwt.newRevision}
+		newConfigEntry := &namespace{newConfig.GetName(), serialized, rwt.newRevision}
 
 		err = tx.Insert(tableNamespace, newConfigEntry)
 		if err != nil {
@@ -364,25 +364,25 @@ func relationshipFilterFilterFunc(filter *v1.RelationshipFilter) func(any) bool 
 
 		// If it doesn't match one of the resource filters, filter it.
 		switch {
-		case filter.ResourceType != "" && filter.ResourceType != tuple.namespace:
+		case filter.GetResourceType() != "" && filter.GetResourceType() != tuple.namespace:
 			return true
-		case filter.OptionalResourceId != "" && filter.OptionalResourceId != tuple.resourceID:
+		case filter.GetOptionalResourceId() != "" && filter.GetOptionalResourceId() != tuple.resourceID:
 			return true
-		case filter.OptionalResourceIdPrefix != "" && !strings.HasPrefix(tuple.resourceID, filter.OptionalResourceIdPrefix):
+		case filter.GetOptionalResourceIdPrefix() != "" && !strings.HasPrefix(tuple.resourceID, filter.GetOptionalResourceIdPrefix()):
 			return true
-		case filter.OptionalRelation != "" && filter.OptionalRelation != tuple.relation:
+		case filter.GetOptionalRelation() != "" && filter.GetOptionalRelation() != tuple.relation:
 			return true
 		}
 
 		// If it doesn't match one of the subject filters, filter it.
-		if subjectFilter := filter.OptionalSubjectFilter; subjectFilter != nil {
+		if subjectFilter := filter.GetOptionalSubjectFilter(); subjectFilter != nil {
 			switch {
-			case subjectFilter.SubjectType != tuple.subjectNamespace:
+			case subjectFilter.GetSubjectType() != tuple.subjectNamespace:
 				return true
-			case subjectFilter.OptionalSubjectId != "" && subjectFilter.OptionalSubjectId != tuple.subjectObjectID:
+			case subjectFilter.GetOptionalSubjectId() != "" && subjectFilter.GetOptionalSubjectId() != tuple.subjectObjectID:
 				return true
-			case subjectFilter.OptionalRelation != nil &&
-				cmp.Or(subjectFilter.OptionalRelation.Relation, datastore.Ellipsis) != tuple.subjectRelation:
+			case subjectFilter.GetOptionalRelation() != nil &&
+				cmp.Or(subjectFilter.GetOptionalRelation().GetRelation(), datastore.Ellipsis) != tuple.subjectRelation:
 				return true
 			}
 		}

--- a/internal/datastore/mysql/caveat.go
+++ b/internal/datastore/mysql/caveat.go
@@ -125,8 +125,8 @@ func (rwt *mysqlReadWriteTXN) WriteCaveats(ctx context.Context, caveats []*core.
 			return fmt.Errorf("unable to write caveat: %w", err)
 		}
 
-		writeQuery = writeQuery.Values(newCaveat.Name, serialized, rwt.newTxnID)
-		caveatNamesToWrite = append(caveatNamesToWrite, newCaveat.Name)
+		writeQuery = writeQuery.Values(newCaveat.GetName(), serialized, rwt.newTxnID)
+		caveatNamesToWrite = append(caveatNamesToWrite, newCaveat.GetName())
 	}
 
 	err := rwt.deleteCaveatsFromNames(ctx, caveatNamesToWrite)

--- a/internal/datastore/mysql/readwrite.go
+++ b/internal/datastore/mysql/readwrite.go
@@ -312,8 +312,8 @@ func (rwt *mysqlReadWriteTXN) WriteRelationships(ctx context.Context, mutations 
 		var caveatName string
 		var caveatContext structpbWrapper
 		if rel.OptionalCaveat != nil {
-			caveatName = rel.OptionalCaveat.CaveatName
-			caveatContext = rel.OptionalCaveat.Context.AsMap()
+			caveatName = rel.OptionalCaveat.GetCaveatName()
+			caveatContext = rel.OptionalCaveat.GetContext().AsMap()
 		}
 		bulkWrite = bulkWrite.Values(
 			rel.Resource.ObjectType,
@@ -348,17 +348,17 @@ func (rwt *mysqlReadWriteTXN) WriteRelationships(ctx context.Context, mutations 
 func (rwt *mysqlReadWriteTXN) DeleteRelationships(ctx context.Context, filter *v1.RelationshipFilter, opts ...options.DeleteOptionsOption) (uint64, bool, error) {
 	// Add clauses for the ResourceFilter
 	query := rwt.DeleteRelsQuery
-	if filter.ResourceType != "" {
-		query = query.Where(sq.Eq{colNamespace: filter.ResourceType})
+	if filter.GetResourceType() != "" {
+		query = query.Where(sq.Eq{colNamespace: filter.GetResourceType()})
 	}
-	if filter.OptionalResourceId != "" {
-		query = query.Where(sq.Eq{colObjectID: filter.OptionalResourceId})
+	if filter.GetOptionalResourceId() != "" {
+		query = query.Where(sq.Eq{colObjectID: filter.GetOptionalResourceId()})
 	}
-	if filter.OptionalRelation != "" {
-		query = query.Where(sq.Eq{colRelation: filter.OptionalRelation})
+	if filter.GetOptionalRelation() != "" {
+		query = query.Where(sq.Eq{colRelation: filter.GetOptionalRelation()})
 	}
-	if filter.OptionalResourceIdPrefix != "" {
-		likeClause, err := common.BuildLikePrefixClause(colObjectID, filter.OptionalResourceIdPrefix)
+	if filter.GetOptionalResourceIdPrefix() != "" {
+		likeClause, err := common.BuildLikePrefixClause(colObjectID, filter.GetOptionalResourceIdPrefix())
 		if err != nil {
 			return 0, false, fmt.Errorf(errUnableToDeleteRelationships, err)
 		}
@@ -366,13 +366,13 @@ func (rwt *mysqlReadWriteTXN) DeleteRelationships(ctx context.Context, filter *v
 	}
 
 	// Add clauses for the SubjectFilter
-	if subjectFilter := filter.OptionalSubjectFilter; subjectFilter != nil {
-		query = query.Where(sq.Eq{colUsersetNamespace: subjectFilter.SubjectType})
-		if subjectFilter.OptionalSubjectId != "" {
-			query = query.Where(sq.Eq{colUsersetObjectID: subjectFilter.OptionalSubjectId})
+	if subjectFilter := filter.GetOptionalSubjectFilter(); subjectFilter != nil {
+		query = query.Where(sq.Eq{colUsersetNamespace: subjectFilter.GetSubjectType()})
+		if subjectFilter.GetOptionalSubjectId() != "" {
+			query = query.Where(sq.Eq{colUsersetObjectID: subjectFilter.GetOptionalSubjectId()})
 		}
-		if relationFilter := subjectFilter.OptionalRelation; relationFilter != nil {
-			query = query.Where(sq.Eq{colUsersetRelation: cmp.Or(relationFilter.Relation, datastore.Ellipsis)})
+		if relationFilter := subjectFilter.GetOptionalRelation(); relationFilter != nil {
+			query = query.Where(sq.Eq{colUsersetRelation: cmp.Or(relationFilter.GetRelation(), datastore.Ellipsis)})
 		}
 	}
 
@@ -426,8 +426,8 @@ func (rwt *mysqlReadWriteTXN) WriteNamespaces(ctx context.Context, newNamespaces
 			return fmt.Errorf(errUnableToWriteConfig, err)
 		}
 
-		deletedNamespaceClause = append(deletedNamespaceClause, sq.Eq{colNamespace: newNamespace.Name})
-		writeQuery = writeQuery.Values(newNamespace.Name, serialized, rwt.newTxnID)
+		deletedNamespaceClause = append(deletedNamespaceClause, sq.Eq{colNamespace: newNamespace.GetName()})
+		writeQuery = writeQuery.Values(newNamespace.GetName(), serialized, rwt.newTxnID)
 	}
 
 	delSQL, delArgs, err := rwt.DeleteNamespaceQuery.
@@ -540,8 +540,8 @@ func (rwt *mysqlReadWriteTXN) BulkLoad(ctx context.Context, iter datastore.BulkW
 			var caveatName string
 			var caveatContext structpbWrapper
 			if rel.OptionalCaveat != nil {
-				caveatName = rel.OptionalCaveat.CaveatName
-				caveatContext = rel.OptionalCaveat.Context.AsMap()
+				caveatName = rel.OptionalCaveat.GetCaveatName()
+				caveatContext = rel.OptionalCaveat.GetContext().AsMap()
 			}
 			args = append(args,
 				rel.Resource.ObjectType,

--- a/internal/datastore/postgres/caveat.go
+++ b/internal/datastore/postgres/caveat.go
@@ -123,10 +123,10 @@ func (rwt *pgReadWriteTXN) WriteCaveats(ctx context.Context, caveats []*core.Cav
 		if err != nil {
 			return fmt.Errorf(errWriteCaveats, err)
 		}
-		valuesToWrite := []any{caveat.Name, definitionBytes}
+		valuesToWrite := []any{caveat.GetName(), definitionBytes}
 		write = write.Values(valuesToWrite...)
-		if !writtenCaveatNames.Add(caveat.Name) {
-			return fmt.Errorf("duplicate caveat name %q", caveat.Name)
+		if !writtenCaveatNames.Add(caveat.GetName()) {
+			return fmt.Errorf("duplicate caveat name %q", caveat.GetName())
 		}
 	}
 

--- a/internal/datastore/postgres/common/bulk.go
+++ b/internal/datastore/postgres/common/bulk.go
@@ -34,8 +34,8 @@ func (tg *tupleSourceAdapter) Values() ([]any, error) {
 	var caveatName string
 	var caveatContext map[string]any
 	if tg.current.OptionalCaveat != nil {
-		caveatName = tg.current.OptionalCaveat.CaveatName
-		caveatContext = tg.current.OptionalCaveat.Context.AsMap()
+		caveatName = tg.current.OptionalCaveat.GetCaveatName()
+		caveatContext = tg.current.OptionalCaveat.GetContext().AsMap()
 	}
 
 	tg.valuesBuffer[0] = tg.current.Resource.ObjectType
@@ -49,9 +49,9 @@ func (tg *tupleSourceAdapter) Values() ([]any, error) {
 	tg.valuesBuffer[8] = tg.current.OptionalExpiration
 
 	if len(tg.colNames) > 9 && tg.current.OptionalIntegrity != nil {
-		tg.valuesBuffer[9] = tg.current.OptionalIntegrity.KeyId
-		tg.valuesBuffer[10] = tg.current.OptionalIntegrity.Hash
-		tg.valuesBuffer[11] = tg.current.OptionalIntegrity.HashedAt.AsTime()
+		tg.valuesBuffer[9] = tg.current.OptionalIntegrity.GetKeyId()
+		tg.valuesBuffer[10] = tg.current.OptionalIntegrity.GetHash()
+		tg.valuesBuffer[11] = tg.current.OptionalIntegrity.GetHashedAt().AsTime()
 	}
 
 	return tg.valuesBuffer, nil

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -1463,12 +1463,12 @@ func BenchmarkPostgresQuery(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, err := ds.SnapshotReader(revision).QueryRelationships(context.Background(), datastore.RelationshipsFilter{
-				OptionalResourceType: testfixtures.DocumentNS.Name,
+				OptionalResourceType: testfixtures.DocumentNS.GetName(),
 			}, options.WithQueryShape(queryshape.FindResourceOfType))
 			require.NoError(err)
 			for rel, err := range iter {
 				require.NoError(err)
-				require.Equal(testfixtures.DocumentNS.Name, rel.Resource.ObjectType)
+				require.Equal(testfixtures.DocumentNS.GetName(), rel.Resource.ObjectType)
 			}
 		}
 	})
@@ -1511,7 +1511,7 @@ func datastoreWithInterceptorAndTestData(t *testing.T, interceptor pgcommon.Quer
 			rtu := tuple.Touch(tuple.Relationship{
 				RelationshipReference: tuple.RelationshipReference{
 					Resource: tuple.ObjectAndRelation{
-						ObjectType: testfixtures.DocumentNS.Name,
+						ObjectType: testfixtures.DocumentNS.GetName(),
 						ObjectID:   fmt.Sprintf("doc%d", i),
 						Relation:   "reader",
 					},
@@ -1564,7 +1564,7 @@ func datastoreWithInterceptorAndTestData(t *testing.T, interceptor pgcommon.Quer
 			rtu := tuple.Delete(tuple.Relationship{
 				RelationshipReference: tuple.RelationshipReference{
 					Resource: tuple.ObjectAndRelation{
-						ObjectType: testfixtures.DocumentNS.Name,
+						ObjectType: testfixtures.DocumentNS.GetName(),
 						ObjectID:   fmt.Sprintf("doc%d", i),
 						Relation:   "reader",
 					},
@@ -1602,7 +1602,7 @@ func datastoreWithInterceptorAndTestData(t *testing.T, interceptor pgcommon.Quer
 			rtu := tuple.Touch(tuple.Relationship{
 				RelationshipReference: tuple.RelationshipReference{
 					Resource: tuple.ObjectAndRelation{
-						ObjectType: testfixtures.DocumentNS.Name,
+						ObjectType: testfixtures.DocumentNS.GetName(),
 						ObjectID:   fmt.Sprintf("doc%d", i),
 						Relation:   "reader",
 					},

--- a/internal/datastore/postgres/readwrite.go
+++ b/internal/datastore/postgres/readwrite.go
@@ -88,8 +88,8 @@ func appendForInsertion(builder sq.InsertBuilder, tpl tuple.Relationship) sq.Ins
 	var caveatName string
 	var caveatContext map[string]any
 	if tpl.OptionalCaveat != nil {
-		caveatName = tpl.OptionalCaveat.CaveatName
-		caveatContext = tpl.OptionalCaveat.Context.AsMap()
+		caveatName = tpl.OptionalCaveat.GetCaveatName()
+		caveatContext = tpl.OptionalCaveat.GetContext().AsMap()
 	}
 
 	valuesToWrite := []any{
@@ -134,7 +134,7 @@ func (rwt *pgReadWriteTXN) collectSimplifiedTouchTypes(ctx context.Context, muta
 
 	nsDefByName := make(map[string]*core.NamespaceDefinition, len(namespaces))
 	for _, ns := range namespaces {
-		nsDefByName[ns.Definition.Name] = ns.Definition
+		nsDefByName[ns.Definition.GetName()] = ns.Definition
 	}
 
 	for _, mut := range mutations {
@@ -160,7 +160,7 @@ func (rwt *pgReadWriteTXN) collectSimplifiedTouchTypes(ctx context.Context, muta
 		}
 
 		if notAllowed {
-			relationSupportSimplifiedTouch.Add(nsDef.Name + "#" + rel.Resource.Relation + "@" + rel.Subject.ObjectType)
+			relationSupportSimplifiedTouch.Add(nsDef.GetName() + "#" + rel.Resource.Relation + "@" + rel.Subject.ObjectType)
 			continue
 		}
 	}
@@ -449,17 +449,17 @@ func (rwt *pgReadWriteTXN) deleteRelationshipsWithLimit(ctx context.Context, fil
 	// Construct a select query for the relationships to be removed.
 	query := selectForDelete
 
-	if filter.ResourceType != "" {
-		query = query.Where(sq.Eq{schema.ColNamespace: filter.ResourceType})
+	if filter.GetResourceType() != "" {
+		query = query.Where(sq.Eq{schema.ColNamespace: filter.GetResourceType()})
 	}
-	if filter.OptionalResourceId != "" {
-		query = query.Where(sq.Eq{schema.ColObjectID: filter.OptionalResourceId})
+	if filter.GetOptionalResourceId() != "" {
+		query = query.Where(sq.Eq{schema.ColObjectID: filter.GetOptionalResourceId()})
 	}
-	if filter.OptionalRelation != "" {
-		query = query.Where(sq.Eq{schema.ColRelation: filter.OptionalRelation})
+	if filter.GetOptionalRelation() != "" {
+		query = query.Where(sq.Eq{schema.ColRelation: filter.GetOptionalRelation()})
 	}
-	if filter.OptionalResourceIdPrefix != "" {
-		likeClause, err := common.BuildLikePrefixClause(schema.ColObjectID, filter.OptionalResourceIdPrefix)
+	if filter.GetOptionalResourceIdPrefix() != "" {
+		likeClause, err := common.BuildLikePrefixClause(schema.ColObjectID, filter.GetOptionalResourceIdPrefix())
 		if err != nil {
 			return 0, false, fmt.Errorf(errUnableToDeleteRelationships, err)
 		}
@@ -467,13 +467,13 @@ func (rwt *pgReadWriteTXN) deleteRelationshipsWithLimit(ctx context.Context, fil
 	}
 
 	// Add clauses for the SubjectFilter
-	if subjectFilter := filter.OptionalSubjectFilter; subjectFilter != nil {
-		query = query.Where(sq.Eq{schema.ColUsersetNamespace: subjectFilter.SubjectType})
-		if subjectFilter.OptionalSubjectId != "" {
-			query = query.Where(sq.Eq{schema.ColUsersetObjectID: subjectFilter.OptionalSubjectId})
+	if subjectFilter := filter.GetOptionalSubjectFilter(); subjectFilter != nil {
+		query = query.Where(sq.Eq{schema.ColUsersetNamespace: subjectFilter.GetSubjectType()})
+		if subjectFilter.GetOptionalSubjectId() != "" {
+			query = query.Where(sq.Eq{schema.ColUsersetObjectID: subjectFilter.GetOptionalSubjectId()})
 		}
-		if relationFilter := subjectFilter.OptionalRelation; relationFilter != nil {
-			query = query.Where(sq.Eq{schema.ColUsersetRelation: cmp.Or(relationFilter.Relation, datastore.Ellipsis)})
+		if relationFilter := subjectFilter.GetOptionalRelation(); relationFilter != nil {
+			query = query.Where(sq.Eq{schema.ColUsersetRelation: cmp.Or(relationFilter.GetRelation(), datastore.Ellipsis)})
 		}
 	}
 
@@ -518,17 +518,17 @@ func (rwt *pgReadWriteTXN) deleteRelationshipsWithLimit(ctx context.Context, fil
 func (rwt *pgReadWriteTXN) deleteRelationships(ctx context.Context, filter *v1.RelationshipFilter) (uint64, error) {
 	// Add clauses for the ResourceFilter
 	query := deleteTuple
-	if filter.ResourceType != "" {
-		query = query.Where(sq.Eq{schema.ColNamespace: filter.ResourceType})
+	if filter.GetResourceType() != "" {
+		query = query.Where(sq.Eq{schema.ColNamespace: filter.GetResourceType()})
 	}
-	if filter.OptionalResourceId != "" {
-		query = query.Where(sq.Eq{schema.ColObjectID: filter.OptionalResourceId})
+	if filter.GetOptionalResourceId() != "" {
+		query = query.Where(sq.Eq{schema.ColObjectID: filter.GetOptionalResourceId()})
 	}
-	if filter.OptionalRelation != "" {
-		query = query.Where(sq.Eq{schema.ColRelation: filter.OptionalRelation})
+	if filter.GetOptionalRelation() != "" {
+		query = query.Where(sq.Eq{schema.ColRelation: filter.GetOptionalRelation()})
 	}
-	if filter.OptionalResourceIdPrefix != "" {
-		likeClause, err := common.BuildLikePrefixClause(schema.ColObjectID, filter.OptionalResourceIdPrefix)
+	if filter.GetOptionalResourceIdPrefix() != "" {
+		likeClause, err := common.BuildLikePrefixClause(schema.ColObjectID, filter.GetOptionalResourceIdPrefix())
 		if err != nil {
 			return 0, fmt.Errorf(errUnableToDeleteRelationships, err)
 		}
@@ -536,13 +536,13 @@ func (rwt *pgReadWriteTXN) deleteRelationships(ctx context.Context, filter *v1.R
 	}
 
 	// Add clauses for the SubjectFilter
-	if subjectFilter := filter.OptionalSubjectFilter; subjectFilter != nil {
-		query = query.Where(sq.Eq{schema.ColUsersetNamespace: subjectFilter.SubjectType})
-		if subjectFilter.OptionalSubjectId != "" {
-			query = query.Where(sq.Eq{schema.ColUsersetObjectID: subjectFilter.OptionalSubjectId})
+	if subjectFilter := filter.GetOptionalSubjectFilter(); subjectFilter != nil {
+		query = query.Where(sq.Eq{schema.ColUsersetNamespace: subjectFilter.GetSubjectType()})
+		if subjectFilter.GetOptionalSubjectId() != "" {
+			query = query.Where(sq.Eq{schema.ColUsersetObjectID: subjectFilter.GetOptionalSubjectId()})
 		}
-		if relationFilter := subjectFilter.OptionalRelation; relationFilter != nil {
-			query = query.Where(sq.Eq{schema.ColUsersetRelation: cmp.Or(relationFilter.Relation, datastore.Ellipsis)})
+		if relationFilter := subjectFilter.GetOptionalRelation(); relationFilter != nil {
+			query = query.Where(sq.Eq{schema.ColUsersetRelation: cmp.Or(relationFilter.GetRelation(), datastore.Ellipsis)})
 		}
 	}
 
@@ -574,9 +574,9 @@ func (rwt *pgReadWriteTXN) WriteNamespaces(ctx context.Context, newConfigs ...*c
 			return fmt.Errorf(errUnableToWriteConfig, err)
 		}
 
-		deletedNamespaceClause = append(deletedNamespaceClause, sq.Eq{schema.ColNamespace: newNamespace.Name})
+		deletedNamespaceClause = append(deletedNamespaceClause, sq.Eq{schema.ColNamespace: newNamespace.GetName()})
 
-		valuesToWrite := []any{newNamespace.Name, serialized}
+		valuesToWrite := []any{newNamespace.GetName(), serialized}
 
 		writeQuery = writeQuery.Values(valuesToWrite...)
 	}
@@ -791,8 +791,8 @@ func exactRelationshipDifferentCaveatAndExpirationClause(r tuple.Relationship) s
 	var caveatName string
 	var caveatContext map[string]any
 	if r.OptionalCaveat != nil {
-		caveatName = r.OptionalCaveat.CaveatName
-		caveatContext = r.OptionalCaveat.Context.AsMap()
+		caveatName = r.OptionalCaveat.GetCaveatName()
+		caveatContext = r.OptionalCaveat.GetContext().AsMap()
 	}
 
 	expiration := r.OptionalExpiration

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -199,15 +199,15 @@ func parseRevisionProto(revisionStr string) (datastore.Revision, error) {
 		return datastore.NoRevision, fmt.Errorf(errRevisionFormat, err)
 	}
 
-	xminInt, err := safecast.Convert[int64](decoded.Xmin)
+	xminInt, err := safecast.Convert[int64](decoded.GetXmin())
 	if err != nil {
 		return datastore.NoRevision, spiceerrors.MustBugf("could not cast xmin to int64")
 	}
 
 	var xips []uint64
-	if len(decoded.RelativeXips) > 0 {
-		xips = make([]uint64, len(decoded.RelativeXips))
-		for i, relativeXip := range decoded.RelativeXips {
+	if len(decoded.GetRelativeXips()) > 0 {
+		xips = make([]uint64, len(decoded.GetRelativeXips()))
+		for i, relativeXip := range decoded.GetRelativeXips() {
 			xip := xminInt + relativeXip
 			uintXip, err := safecast.Convert[uint64](xip)
 			if err != nil {
@@ -217,19 +217,19 @@ func parseRevisionProto(revisionStr string) (datastore.Revision, error) {
 		}
 	}
 
-	xmax, err := safecast.Convert[uint64](xminInt + decoded.RelativeXmax)
+	xmax, err := safecast.Convert[uint64](xminInt + decoded.GetRelativeXmax())
 	if err != nil {
 		return datastore.NoRevision, spiceerrors.MustBugf("could not cast xmax to int64")
 	}
 
 	return postgresRevision{
 		snapshot: pgSnapshot{
-			xmin:    decoded.Xmin,
+			xmin:    decoded.GetXmin(),
 			xmax:    xmax,
 			xipList: xips,
 		},
-		optionalTxID:           xid8{Uint64: decoded.OptionalTxid, Valid: decoded.OptionalTxid != 0},
-		optionalNanosTimestamp: decoded.OptionalTimestamp,
+		optionalTxID:           xid8{Uint64: decoded.GetOptionalTxid(), Valid: decoded.GetOptionalTxid() != 0},
+		optionalNanosTimestamp: decoded.GetOptionalTimestamp(),
 	}, nil
 }
 

--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -442,7 +442,7 @@ func (pgd *pgDatastore) loadNamespaceChanges(ctx context.Context, xmin uint64, x
 			}
 		}
 		if _, found := filter[deletedXID.Uint64]; found {
-			err := tracked.AddDeletedNamespace(ctx, txidToRevision[deletedXID.Uint64], loaded.Name)
+			err := tracked.AddDeletedNamespace(ctx, txidToRevision[deletedXID.Uint64], loaded.GetName())
 			if err != nil {
 				return err
 			}
@@ -501,7 +501,7 @@ func (pgd *pgDatastore) loadCaveatChanges(ctx context.Context, xmin uint64, xmax
 			}
 		}
 		if _, found := filter[deletedXID.Uint64]; found {
-			err := tracked.AddDeletedCaveat(ctx, txidToRevision[deletedXID.Uint64], loaded.Name)
+			err := tracked.AddDeletedCaveat(ctx, txidToRevision[deletedXID.Uint64], loaded.GetName())
 			if err != nil {
 				return err
 			}

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -42,21 +42,21 @@ var (
 )
 
 func filterToAttributes(filter *v1.RelationshipFilter) []attribute.KeyValue {
-	attrs := []attribute.KeyValue{common.ObjNamespaceNameKey.String(filter.ResourceType)}
-	if filter.OptionalResourceId != "" {
-		attrs = append(attrs, common.ObjIDKey.String(filter.OptionalResourceId))
+	attrs := []attribute.KeyValue{common.ObjNamespaceNameKey.String(filter.GetResourceType())}
+	if filter.GetOptionalResourceId() != "" {
+		attrs = append(attrs, common.ObjIDKey.String(filter.GetOptionalResourceId()))
 	}
-	if filter.OptionalRelation != "" {
-		attrs = append(attrs, common.ObjRelationNameKey.String(filter.OptionalRelation))
+	if filter.GetOptionalRelation() != "" {
+		attrs = append(attrs, common.ObjRelationNameKey.String(filter.GetOptionalRelation()))
 	}
 
-	if subjectFilter := filter.OptionalSubjectFilter; subjectFilter != nil {
-		attrs = append(attrs, common.SubNamespaceNameKey.String(subjectFilter.SubjectType))
-		if subjectFilter.OptionalSubjectId != "" {
-			attrs = append(attrs, common.SubObjectIDKey.String(subjectFilter.OptionalSubjectId))
+	if subjectFilter := filter.GetOptionalSubjectFilter(); subjectFilter != nil {
+		attrs = append(attrs, common.SubNamespaceNameKey.String(subjectFilter.GetSubjectType()))
+		if subjectFilter.GetOptionalSubjectId() != "" {
+			attrs = append(attrs, common.SubObjectIDKey.String(subjectFilter.GetOptionalSubjectId()))
 		}
-		if relationFilter := subjectFilter.OptionalRelation; relationFilter != nil {
-			attrs = append(attrs, common.SubRelationNameKey.String(relationFilter.Relation))
+		if relationFilter := subjectFilter.GetOptionalRelation(); relationFilter != nil {
+			attrs = append(attrs, common.SubRelationNameKey.String(relationFilter.GetRelation()))
 		}
 	}
 	return attrs
@@ -314,7 +314,7 @@ func (rwt *observableRWT) StoreCounterValue(ctx context.Context, name string, va
 func (rwt *observableRWT) WriteCaveats(ctx context.Context, caveats []*core.CaveatDefinition) error {
 	caveatNames := make([]string, 0, len(caveats))
 	for _, caveat := range caveats {
-		caveatNames = append(caveatNames, caveat.Name)
+		caveatNames = append(caveatNames, caveat.GetName())
 	}
 
 	ctx, closer := observe(ctx, "WriteCaveats", "", trace.WithAttributes(
@@ -346,7 +346,7 @@ func (rwt *observableRWT) WriteRelationships(ctx context.Context, mutations []tu
 func (rwt *observableRWT) WriteNamespaces(ctx context.Context, newConfigs ...*core.NamespaceDefinition) error {
 	nsNames := make([]string, 0, len(newConfigs))
 	for _, ns := range newConfigs {
-		nsNames = append(nsNames, ns.Name)
+		nsNames = append(nsNames, ns.GetName())
 	}
 
 	ctx, closer := observe(ctx, "WriteNamespaces", "", trace.WithAttributes(

--- a/internal/datastore/proxy/relationshipintegrity.go
+++ b/internal/datastore/proxy/relationshipintegrity.go
@@ -220,7 +220,7 @@ func (r *relationshipIntegrityProxy) Statistics(ctx context.Context) (datastore.
 
 func (r *relationshipIntegrityProxy) validateRelationTuple(rel tuple.Relationship) error {
 	// Ensure the relationship has integrity data.
-	if rel.OptionalIntegrity == nil || len(rel.OptionalIntegrity.Hash) == 0 || rel.OptionalIntegrity.KeyId == "" {
+	if rel.OptionalIntegrity == nil || len(rel.OptionalIntegrity.GetHash()) == 0 || rel.OptionalIntegrity.GetKeyId() == "" {
 		str, err := tuple.String(rel)
 		if err != nil {
 			return err
@@ -229,18 +229,18 @@ func (r *relationshipIntegrityProxy) validateRelationTuple(rel tuple.Relationshi
 		return fmt.Errorf("relationship %s is missing required integrity data", str)
 	}
 
-	hashWithoutByte := rel.OptionalIntegrity.Hash[1:]
-	if rel.OptionalIntegrity.Hash[0] != versionByte || len(hashWithoutByte) != hashLength {
+	hashWithoutByte := rel.OptionalIntegrity.GetHash()[1:]
+	if rel.OptionalIntegrity.GetHash()[0] != versionByte || len(hashWithoutByte) != hashLength {
 		return fmt.Errorf("relationship %v has invalid integrity data", rel)
 	}
 
 	// Validate the integrity of the relationship.
-	key, err := r.lookupKey(rel.OptionalIntegrity.KeyId)
+	key, err := r.lookupKey(rel.OptionalIntegrity.GetKeyId())
 	if err != nil {
 		return err
 	}
 
-	if key.expiredAt != nil && key.expiredAt.Before(rel.OptionalIntegrity.HashedAt.AsTime()) {
+	if key.expiredAt != nil && key.expiredAt.Before(rel.OptionalIntegrity.GetHashedAt().AsTime()) {
 		return fmt.Errorf("relationship %s is signed by an expired key", rel)
 	}
 

--- a/internal/datastore/proxy/schemacaching/estimatedsize_test.go
+++ b/internal/datastore/proxy/schemacaching/estimatedsize_test.go
@@ -55,7 +55,7 @@ func TestEstimatedDefinitionSizes(t *testing.T) {
 
 			for _, nsDef := range fullyResolved.NamespaceDefinitions {
 				nsDef := nsDef
-				t.Run("namespace "+nsDef.Name, func(t *testing.T) {
+				t.Run("namespace "+nsDef.GetName(), func(t *testing.T) {
 					serialized, _ := nsDef.MarshalVT()
 					sizevt := nsDef.SizeVT()
 					estimated := estimatedNamespaceDefinitionSize(sizevt)
@@ -91,7 +91,7 @@ func TestEstimatedDefinitionSizes(t *testing.T) {
 
 			for _, caveatDef := range fullyResolved.CaveatDefinitions {
 				caveatDef := caveatDef
-				t.Run("caveat "+caveatDef.Name, func(t *testing.T) {
+				t.Run("caveat "+caveatDef.GetName(), func(t *testing.T) {
 					t.Parallel()
 
 					serialized, _ := caveatDef.MarshalVT()

--- a/internal/datastore/proxy/schemacaching/standardcache.go
+++ b/internal/datastore/proxy/schemacaching/standardcache.go
@@ -269,7 +269,7 @@ func (rwt *definitionCachingRWT) WriteNamespaces(ctx context.Context, newConfigs
 	}
 
 	for _, nsDef := range newConfigs {
-		rwt.definitionCache.Delete("namespace:" + nsDef.Name)
+		rwt.definitionCache.Delete("namespace:" + nsDef.GetName())
 	}
 
 	return nil
@@ -281,7 +281,7 @@ func (rwt *definitionCachingRWT) WriteCaveats(ctx context.Context, newConfigs []
 	}
 
 	for _, caveatDef := range newConfigs {
-		rwt.definitionCache.Delete("caveat:" + caveatDef.Name)
+		rwt.definitionCache.Delete("caveat:" + caveatDef.GetName())
 	}
 
 	return nil

--- a/internal/datastore/proxy/schemacaching/standardcaching_test.go
+++ b/internal/datastore/proxy/schemacaching/standardcaching_test.go
@@ -585,6 +585,6 @@ func TestMixedInvalidNamespacesInCache(t *testing.T) {
 	// We're asserting that we find the thing we're looking for and don't receive a notfound value
 	found, err := dsReader.LookupNamespacesWithNames(ctx, []string{invalidNamespace, validNamespace})
 	require.Len(found, 1)
-	require.Equal(validNamespace, found[0].Definition.Name)
+	require.Equal(validNamespace, found[0].Definition.GetName())
 	require.NoError(err)
 }

--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -205,7 +205,7 @@ func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 			}
 
 			for _, namespaceDef := range namespaces {
-				err := p.namespaceCache.updateDefinition(namespaceDef.Definition.Name, namespaceDef.Definition, false, headRev)
+				err := p.namespaceCache.updateDefinition(namespaceDef.Definition.GetName(), namespaceDef.Definition, false, headRev)
 				if err != nil {
 					p.namespaceCache.setFallbackMode()
 					p.caveatCache.setFallbackMode()
@@ -227,7 +227,7 @@ func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 			}
 
 			for _, caveatDef := range caveats {
-				err := p.caveatCache.updateDefinition(caveatDef.Definition.Name, caveatDef.Definition, false, headRev)
+				err := p.caveatCache.updateDefinition(caveatDef.Definition.GetName(), caveatDef.Definition, false, headRev)
 				if err != nil {
 					p.namespaceCache.setFallbackMode()
 					p.caveatCache.setFallbackMode()
@@ -285,14 +285,14 @@ func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 					for _, changeDef := range ss.ChangedDefinitions {
 						switch t := changeDef.(type) {
 						case *core.NamespaceDefinition:
-							err := p.namespaceCache.updateDefinition(t.Name, t, false, ss.Revision)
+							err := p.namespaceCache.updateDefinition(t.GetName(), t, false, ss.Revision)
 							if err != nil {
 								p.namespaceCache.setFallbackMode()
 								log.Warn().Err(err).Msg("received error in schema watch")
 							}
 
 						case *core.CaveatDefinition:
-							err := p.caveatCache.updateDefinition(t.Name, t, false, ss.Revision)
+							err := p.caveatCache.updateDefinition(t.GetName(), t, false, ss.Revision)
 							if err != nil {
 								p.caveatCache.setFallbackMode()
 								log.Warn().Err(err).Msg("received error in schema watch")

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -50,7 +50,7 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 	// Ensure that reading at rev 2 returns found.
 	nsDef, _, err := wcache.SnapshotReader(rev("2")).ReadNamespaceByName(t.Context(), "somenamespace")
 	require.NoError(t, err)
-	require.Equal(t, "somenamespace", nsDef.Name)
+	require.Equal(t, "somenamespace", nsDef.GetName())
 
 	// Disable reads.
 	fakeDS.disableReads()
@@ -67,7 +67,7 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 	// require a datastore fallback read because the cache is not yet checkedpointed to that revision.
 	nsDef, _, err = wcache.SnapshotReader(rev("3")).ReadNamespaceByName(t.Context(), "somenamespace")
 	require.NoError(t, err)
-	require.Equal(t, "somenamespace", nsDef.Name)
+	require.Equal(t, "somenamespace", nsDef.GetName())
 
 	// Checkpoint to rev 4.
 	fakeDS.sendCheckpoint(rev("4"))
@@ -79,12 +79,12 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 	// Read again, which should now be via the cache.
 	nsDef, _, err = wcache.SnapshotReader(rev("3.0000000005")).ReadNamespaceByName(t.Context(), "somenamespace")
 	require.NoError(t, err)
-	require.Equal(t, "somenamespace", nsDef.Name)
+	require.Equal(t, "somenamespace", nsDef.GetName())
 
 	// Read via a lookup.
 	nsDefs, err := wcache.SnapshotReader(rev("3.0000000005")).LookupNamespacesWithNames(t.Context(), []string{"somenamespace"})
 	require.NoError(t, err)
-	require.Equal(t, "somenamespace", nsDefs[0].Definition.Name)
+	require.Equal(t, "somenamespace", nsDefs[0].Definition.GetName())
 
 	// Delete the namespace at revision 5.
 	fakeDS.updateNamespace("somenamespace", nil, rev("5"))
@@ -92,7 +92,7 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 	// Re-read at an earlier revision.
 	nsDef, _, err = wcache.SnapshotReader(rev("3.0000000005")).ReadNamespaceByName(t.Context(), "somenamespace")
 	require.NoError(t, err)
-	require.Equal(t, "somenamespace", nsDef.Name)
+	require.Equal(t, "somenamespace", nsDef.GetName())
 
 	// Read at revision 5.
 	_, _, err = wcache.SnapshotReader(rev("5")).ReadNamespaceByName(t.Context(), "somenamespace")
@@ -110,7 +110,7 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 	// Read at revision 6.
 	caveatDef, _, err := wcache.SnapshotReader(rev("6")).ReadCaveatByName(t.Context(), "somecaveat")
 	require.NoError(t, err)
-	require.Equal(t, "somecaveat", caveatDef.Name)
+	require.Equal(t, "somecaveat", caveatDef.GetName())
 
 	// Attempt to read at revision 1, which should require a read.
 	_, _, err = wcache.SnapshotReader(rev("1")).ReadCaveatByName(t.Context(), "somecaveat")
@@ -160,7 +160,7 @@ func TestWatchingCacheParallelOperations(t *testing.T) {
 		// Read again (which should be found now)
 		nsDef, _, err := wcache.SnapshotReader(rev("2")).ReadNamespaceByName(t.Context(), "somenamespace")
 		firstErrs <- err
-		firstNsDefNames <- nsDef.Name
+		firstNsDefNames <- nsDef.GetName()
 	})()
 
 	go (func() {
@@ -256,7 +256,7 @@ func TestWatchingCacheParallelReaderWriter(t *testing.T) {
 
 			nsDef, _, err := wcache.SnapshotReader(headRevision).ReadNamespaceByName(t.Context(), "somenamespace")
 			snapshotReaderErrors <- err
-			namespaceNames <- nsDef.Name
+			namespaceNames <- nsDef.GetName()
 		}
 
 		wg.Done()
@@ -363,7 +363,7 @@ func TestWatchingCachePrepopulated(t *testing.T) {
 	// Ensure the namespace is found.
 	def, _, err := wcache.SnapshotReader(rev("4")).ReadNamespaceByName(t.Context(), "somenamespace")
 	require.NoError(t, err)
-	require.Equal(t, "somenamespace", def.Name)
+	require.Equal(t, "somenamespace", def.GetName())
 
 	// Close the proxy and ensure the background goroutines are terminated.
 	wcache.Close()

--- a/internal/datastore/spanner/caveat.go
+++ b/internal/datastore/spanner/caveat.go
@@ -93,10 +93,10 @@ func (rwt spannerReadWriteTXN) WriteCaveats(_ context.Context, caveats []*core.C
 	names := map[string]struct{}{}
 	mutations := make([]*spanner.Mutation, 0, len(caveats))
 	for _, caveat := range caveats {
-		if _, ok := names[caveat.Name]; ok {
-			return fmt.Errorf(errUnableToWriteCaveat, fmt.Errorf("duplicate caveats in input: %s", caveat.Name))
+		if _, ok := names[caveat.GetName()]; ok {
+			return fmt.Errorf(errUnableToWriteCaveat, fmt.Errorf("duplicate caveats in input: %s", caveat.GetName()))
 		}
-		names[caveat.Name] = struct{}{}
+		names[caveat.GetName()] = struct{}{}
 		serialized, err := caveat.MarshalVT()
 		if err != nil {
 			return fmt.Errorf(errUnableToWriteCaveat, err)
@@ -105,7 +105,7 @@ func (rwt spannerReadWriteTXN) WriteCaveats(_ context.Context, caveats []*core.C
 		mutations = append(mutations, spanner.InsertOrUpdate(
 			tableCaveat,
 			[]string{colName, colCaveatDefinition, colCaveatTS},
-			[]any{caveat.Name, serialized, spanner.CommitTimestamp},
+			[]any{caveat.GetName(), serialized, spanner.CommitTimestamp},
 		))
 	}
 

--- a/internal/datastore/spanner/caveat_test.go
+++ b/internal/datastore/spanner/caveat_test.go
@@ -23,17 +23,17 @@ func TestContextualizedCaveatFrom(t *testing.T) {
 	res, err = ContextualizedCaveatFrom(spanner.NullString{StringVal: "test", Valid: true}, spanner.NullJSON{Value: nil, Valid: true})
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	require.Equal(t, "test", res.CaveatName)
-	require.NotNil(t, res.Context)
-	require.Empty(t, res.Context.Fields)
+	require.Equal(t, "test", res.GetCaveatName())
+	require.NotNil(t, res.GetContext())
+	require.Empty(t, res.GetContext().GetFields())
 
 	res, err = ContextualizedCaveatFrom(
 		spanner.NullString{StringVal: "test", Valid: true},
 		spanner.NullJSON{Value: map[string]any{"key": "val"}, Valid: true})
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	require.Equal(t, "test", res.CaveatName)
-	require.NotNil(t, res.Context)
-	require.Len(t, res.Context.Fields, 1)
-	require.Equal(t, "val", res.Context.Fields["key"].GetStringValue())
+	require.Equal(t, "test", res.GetCaveatName())
+	require.NotNil(t, res.GetContext())
+	require.Len(t, res.GetContext().GetFields(), 1)
+	require.Equal(t, "val", res.GetContext().GetFields()["key"].GetStringValue())
 }

--- a/internal/datastore/spanner/readwrite.go
+++ b/internal/datastore/spanner/readwrite.go
@@ -287,17 +287,17 @@ type builder[T any] interface {
 
 func applyFilterToQuery[T builder[T]](query T, filter *v1.RelationshipFilter) (T, error) {
 	// Add clauses for the ResourceFilter
-	if filter.ResourceType != "" {
-		query = query.Where(sq.Eq{colNamespace: filter.ResourceType})
+	if filter.GetResourceType() != "" {
+		query = query.Where(sq.Eq{colNamespace: filter.GetResourceType()})
 	}
-	if filter.OptionalResourceId != "" {
-		query = query.Where(sq.Eq{colObjectID: filter.OptionalResourceId})
+	if filter.GetOptionalResourceId() != "" {
+		query = query.Where(sq.Eq{colObjectID: filter.GetOptionalResourceId()})
 	}
-	if filter.OptionalRelation != "" {
-		query = query.Where(sq.Eq{colRelation: filter.OptionalRelation})
+	if filter.GetOptionalRelation() != "" {
+		query = query.Where(sq.Eq{colRelation: filter.GetOptionalRelation()})
 	}
-	if filter.OptionalResourceIdPrefix != "" {
-		likeClause, err := common.BuildLikePrefixClause(colObjectID, filter.OptionalResourceIdPrefix)
+	if filter.GetOptionalResourceIdPrefix() != "" {
+		likeClause, err := common.BuildLikePrefixClause(colObjectID, filter.GetOptionalResourceIdPrefix())
 		if err != nil {
 			return query, fmt.Errorf(errUnableToDeleteRelationships, err)
 		}
@@ -305,13 +305,13 @@ func applyFilterToQuery[T builder[T]](query T, filter *v1.RelationshipFilter) (T
 	}
 
 	// Add clauses for the SubjectFilter
-	if subjectFilter := filter.OptionalSubjectFilter; subjectFilter != nil {
-		query = query.Where(sq.Eq{colUsersetNamespace: subjectFilter.SubjectType})
-		if subjectFilter.OptionalSubjectId != "" {
-			query = query.Where(sq.Eq{colUsersetObjectID: subjectFilter.OptionalSubjectId})
+	if subjectFilter := filter.GetOptionalSubjectFilter(); subjectFilter != nil {
+		query = query.Where(sq.Eq{colUsersetNamespace: subjectFilter.GetSubjectType()})
+		if subjectFilter.GetOptionalSubjectId() != "" {
+			query = query.Where(sq.Eq{colUsersetObjectID: subjectFilter.GetOptionalSubjectId()})
 		}
-		if relationFilter := subjectFilter.OptionalRelation; relationFilter != nil {
-			query = query.Where(sq.Eq{colUsersetRelation: cmp.Or(relationFilter.Relation, datastore.Ellipsis)})
+		if relationFilter := subjectFilter.GetOptionalRelation(); relationFilter != nil {
+			query = query.Where(sq.Eq{colUsersetRelation: cmp.Or(relationFilter.GetRelation(), datastore.Ellipsis)})
 		}
 	}
 
@@ -346,9 +346,9 @@ func caveatVals(r tuple.Relationship) []any {
 	if r.OptionalCaveat == nil {
 		return []any{"", nil}
 	}
-	vals := []any{r.OptionalCaveat.CaveatName}
-	if r.OptionalCaveat.Context != nil {
-		vals = append(vals, spanner.NullJSON{Value: r.OptionalCaveat.Context, Valid: true})
+	vals := []any{r.OptionalCaveat.GetCaveatName()}
+	if r.OptionalCaveat.GetContext() != nil {
+		vals = append(vals, spanner.NullJSON{Value: r.OptionalCaveat.GetContext(), Valid: true})
 	} else {
 		vals = append(vals, nil)
 	}
@@ -366,7 +366,7 @@ func (rwt spannerReadWriteTXN) WriteNamespaces(_ context.Context, newConfigs ...
 		mutations = append(mutations, spanner.InsertOrUpdate(
 			tableNamespace,
 			[]string{colNamespaceName, colNamespaceConfig, colTimestamp},
-			[]any{newConfig.Name, serialized, spanner.CommitTimestamp},
+			[]any{newConfig.GetName(), serialized, spanner.CommitTimestamp},
 		))
 	}
 
@@ -386,7 +386,7 @@ func (rwt spannerReadWriteTXN) DeleteNamespaces(ctx context.Context, nsNames []s
 	if len(namespaces) != len(nsNames) {
 		expectedNamespaceNames := mapz.NewSet[string](nsNames...)
 		for _, ns := range namespaces {
-			expectedNamespaceNames.Delete(ns.Definition.Name)
+			expectedNamespaceNames.Delete(ns.Definition.GetName())
 		}
 
 		return fmt.Errorf(errUnableToDeleteConfig, fmt.Errorf("namespaces not found: %v", expectedNamespaceNames.AsSlice()))

--- a/internal/datastore/spanner/stats.go
+++ b/internal/datastore/spanner/stats.go
@@ -96,9 +96,9 @@ func (sd *spannerDatastore) Statistics(ctx context.Context) (datastore.Stats, er
 				return err
 			}
 
-			relationshipByteCount := len(nextTuple.ResourceAndRelation.Namespace) + len(nextTuple.ResourceAndRelation.ObjectId) +
-				len(nextTuple.ResourceAndRelation.Relation) + len(nextTuple.Subject.Namespace) + len(nextTuple.Subject.ObjectId) +
-				len(nextTuple.Subject.Relation)
+			relationshipByteCount := len(nextTuple.GetResourceAndRelation().GetNamespace()) + len(nextTuple.GetResourceAndRelation().GetObjectId()) +
+				len(nextTuple.GetResourceAndRelation().GetRelation()) + len(nextTuple.GetSubject().GetNamespace()) + len(nextTuple.GetSubject().GetObjectId()) +
+				len(nextTuple.GetSubject().GetRelation())
 
 			totalRelationships++
 			totalByteCount += relationshipByteCount

--- a/internal/developmentmembership/foundsubject.go
+++ b/internal/developmentmembership/foundsubject.go
@@ -10,7 +10,7 @@ import (
 
 // NewFoundSubject creates a new FoundSubject for a subject and a set of its resources.
 func NewFoundSubject(subject *core.DirectSubject, resources ...tuple.ObjectAndRelation) FoundSubject {
-	return FoundSubject{tuple.FromCoreObjectAndRelation(subject.Subject), nil, subject.CaveatExpression, NewONRSet(resources...)}
+	return FoundSubject{tuple.FromCoreObjectAndRelation(subject.GetSubject()), nil, subject.GetCaveatExpression(), NewONRSet(resources...)}
 }
 
 // FoundSubject contains a single found subject and all the relationships in which that subject

--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -157,15 +157,15 @@ func (cd *Dispatcher) DispatchCheck(ctx context.Context, req *v1.DispatchCheckRe
 			return &v1.DispatchCheckResponse{Metadata: &v1.ResponseMeta{}}, err
 		}
 
-		if req.Metadata.DepthRemaining >= response.Metadata.DepthRequired {
+		if req.GetMetadata().GetDepthRemaining() >= response.GetMetadata().GetDepthRequired() {
 			cd.checkFromCacheCounter.Inc()
 			// If debugging is requested, add the req and the response to the trace.
-			if req.Debug == v1.DispatchCheckRequest_ENABLE_BASIC_DEBUGGING {
+			if req.GetDebug() == v1.DispatchCheckRequest_ENABLE_BASIC_DEBUGGING {
 				nodeID := nodeid.Get()
 				response.Metadata.DebugInfo = &v1.DebugInformation{
 					Check: &v1.CheckDebugTrace{
 						Request:        req,
-						Results:        maps.Clone(response.ResultsByResourceId),
+						Results:        maps.Clone(response.GetResultsByResourceId()),
 						IsCachedResult: true,
 						SourceId:       nodeID,
 					},
@@ -182,7 +182,7 @@ func (cd *Dispatcher) DispatchCheck(ctx context.Context, req *v1.DispatchCheckRe
 	// We only want to cache the result if there was no error
 	if err == nil {
 		adjustedComputed := computed.CloneVT()
-		adjustedComputed.Metadata.CachedDispatchCount = adjustedComputed.Metadata.DispatchCount
+		adjustedComputed.Metadata.CachedDispatchCount = adjustedComputed.GetMetadata().GetDispatchCount()
 		adjustedComputed.Metadata.DispatchCount = 0
 		adjustedComputed.Metadata.DebugInfo = nil
 
@@ -244,7 +244,7 @@ func (cd *Dispatcher) DispatchLookupResources2(req *v1.DispatchLookupResources2R
 		Ctx:    stream.Context(),
 		Processor: func(result *v1.DispatchLookupResources2Response) (*v1.DispatchLookupResources2Response, bool, error) {
 			adjustedResult := result.CloneVT()
-			adjustedResult.Metadata.CachedDispatchCount = adjustedResult.Metadata.DispatchCount
+			adjustedResult.Metadata.CachedDispatchCount = adjustedResult.GetMetadata().GetDispatchCount()
 			adjustedResult.Metadata.DispatchCount = 0
 			adjustedResult.Metadata.DebugInfo = nil
 
@@ -368,7 +368,7 @@ func (cd *Dispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsReque
 		Ctx:    stream.Context(),
 		Processor: func(result *v1.DispatchLookupSubjectsResponse) (*v1.DispatchLookupSubjectsResponse, bool, error) {
 			adjustedResult := result.CloneVT()
-			adjustedResult.Metadata.CachedDispatchCount = adjustedResult.Metadata.DispatchCount
+			adjustedResult.Metadata.CachedDispatchCount = adjustedResult.GetMetadata().GetDispatchCount()
 			adjustedResult.Metadata.DispatchCount = 0
 			adjustedResult.Metadata.DebugInfo = nil
 

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -139,7 +139,7 @@ func TestMaxDepthCaching(t *testing.T) {
 					},
 				})
 				require.NoError(err)
-				require.Equal(v1.ResourceCheckResult_MEMBER, resp.ResultsByResourceId[parsed.ObjectID].Membership)
+				require.Equal(v1.ResourceCheckResult_MEMBER, resp.GetResultsByResourceId()[parsed.ObjectID].GetMembership())
 
 				// We have to sleep a while to let the cache converge
 				time.Sleep(10 * time.Millisecond)

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -94,7 +94,7 @@ func CheckDepth(ctx context.Context, req DispatchableRequest) error {
 		return errors.New("request missing metadata")
 	}
 
-	if metadata.DepthRemaining == 0 {
+	if metadata.GetDepthRemaining() == 0 {
 		return NewMaxDepthExceededError(req)
 	}
 
@@ -104,7 +104,7 @@ func CheckDepth(ctx context.Context, req DispatchableRequest) error {
 // AddResponseMetadata adds the metadata found in the incoming metadata to the existing
 // metadata, *modifying it in place*.
 func AddResponseMetadata(existing *v1.ResponseMeta, incoming *v1.ResponseMeta) {
-	existing.DispatchCount += incoming.DispatchCount
-	existing.CachedDispatchCount += incoming.CachedDispatchCount
-	existing.DepthRequired = max(existing.DepthRequired, incoming.DepthRequired)
+	existing.DispatchCount += incoming.GetDispatchCount()
+	existing.CachedDispatchCount += incoming.GetCachedDispatchCount()
+	existing.DepthRequired = max(existing.GetDepthRequired(), incoming.GetDepthRequired())
 }

--- a/internal/dispatch/graph/dispatch_test.go
+++ b/internal/dispatch/graph/dispatch_test.go
@@ -52,8 +52,8 @@ func TestDispatchChunking(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, checkResult)
-			require.NotEmpty(t, checkResult.ResultsByResourceId, "expected membership for resource %s", tpl.Resource.ObjectID)
-			require.Equal(t, v1.ResourceCheckResult_MEMBER, checkResult.ResultsByResourceId[tpl.Resource.ObjectID].Membership)
+			require.NotEmpty(t, checkResult.GetResultsByResourceId(), "expected membership for resource %s", tpl.Resource.ObjectID)
+			require.Equal(t, v1.ResourceCheckResult_MEMBER, checkResult.GetResultsByResourceId()[tpl.Resource.ObjectID].GetMembership())
 		}
 	})
 
@@ -100,9 +100,9 @@ func TestDispatchChunking(t *testing.T) {
 			require.NoError(t, err)
 			res := stream.Results()
 			require.Len(t, res, 1)
-			require.Len(t, res[0].FoundSubjectsByResourceId, 1)
-			require.NotNil(t, res[0].FoundSubjectsByResourceId["res1"])
-			require.Len(t, res[0].FoundSubjectsByResourceId["res1"].FoundSubjects, math.MaxUint16+1)
+			require.Len(t, res[0].GetFoundSubjectsByResourceId(), 1)
+			require.NotNil(t, res[0].GetFoundSubjectsByResourceId()["res1"])
+			require.Len(t, res[0].GetFoundSubjectsByResourceId()["res1"].GetFoundSubjects(), math.MaxUint16+1)
 		}
 	})
 }

--- a/internal/dispatch/graph/lookupresources2_test.go
+++ b/internal/dispatch/graph/lookupresources2_test.go
@@ -209,10 +209,10 @@ func TestSimpleLookupResourcesWithCursor2(t *testing.T) {
 
 			require.Len(stream.Results(), 1)
 
-			found.Insert(stream.Results()[0].Resource.ResourceId)
+			found.Insert(stream.Results()[0].GetResource().GetResourceId())
 			require.Equal(tc.expectedFirst, found.AsSlice())
 
-			cursor := stream.Results()[0].AfterResponseCursor
+			cursor := stream.Results()[0].GetAfterResponseCursor()
 			require.NotNil(cursor)
 
 			stream = dispatch.NewCollectingDispatchStream[*v1.DispatchLookupResources2Response](ctx)
@@ -232,7 +232,7 @@ func TestSimpleLookupResourcesWithCursor2(t *testing.T) {
 			require.NoError(err)
 
 			for _, result := range stream.Results() {
-				found.Insert(result.Resource.ResourceId)
+				found.Insert(result.GetResource().GetResourceId())
 			}
 
 			foundResults := found.AsSlice()
@@ -268,7 +268,7 @@ func TestLookupResourcesCursorStability2(t *testing.T) {
 	require.NoError(err)
 	require.Len(stream.Results(), 2)
 
-	cursor := stream.Results()[1].AfterResponseCursor
+	cursor := stream.Results()[1].GetAfterResponseCursor()
 	require.NotNil(cursor)
 
 	// Make the same request and ensure the cursor has not changed.
@@ -290,7 +290,7 @@ func TestLookupResourcesCursorStability2(t *testing.T) {
 	require.NoError(err)
 	require.Len(stream.Results(), 2)
 
-	cursorAgain := stream.Results()[1].AfterResponseCursor
+	cursorAgain := stream.Results()[1].GetAfterResponseCursor()
 	require.NotNil(cursor)
 	require.Equal(cursor, cursorAgain)
 }
@@ -302,10 +302,10 @@ func processResults2(stream *dispatch.CollectingDispatchStream[*v1.DispatchLooku
 	var maxCachedDispatchCount uint32
 	for _, result := range stream.Results() {
 		result.Resource.ForSubjectIds = nil
-		foundResources = append(foundResources, result.Resource)
-		maxDepthRequired = max(maxDepthRequired, result.Metadata.DepthRequired)
-		maxDispatchCount = max(maxDispatchCount, result.Metadata.DispatchCount)
-		maxCachedDispatchCount = max(maxCachedDispatchCount, result.Metadata.CachedDispatchCount)
+		foundResources = append(foundResources, result.GetResource())
+		maxDepthRequired = max(maxDepthRequired, result.GetMetadata().GetDepthRequired())
+		maxDispatchCount = max(maxDispatchCount, result.GetMetadata().GetDispatchCount())
+		maxCachedDispatchCount = max(maxCachedDispatchCount, result.GetMetadata().GetCachedDispatchCount())
 	}
 	return foundResources, maxDepthRequired, maxDispatchCount, maxCachedDispatchCount
 }
@@ -805,9 +805,9 @@ func TestLookupResources2OverSchemaWithCursors(t *testing.T) {
 						foundChunks = append(foundChunks, stream.Results())
 
 						for _, result := range stream.Results() {
-							require.ElementsMatch(tc.expectedMissingFields, result.Resource.MissingContextParams)
-							foundResourceIDs.Insert(result.Resource.ResourceId)
-							currentCursor = result.AfterResponseCursor
+							require.ElementsMatch(tc.expectedMissingFields, result.GetResource().GetMissingContextParams())
+							foundResourceIDs.Insert(result.GetResource().GetResourceId())
+							currentCursor = result.GetAfterResponseCursor()
 						}
 
 						if pageSize == 0 || len(stream.Results()) < pageSize {
@@ -1389,12 +1389,12 @@ func TestLookupResources2EnsureCheckHints(t *testing.T) {
 
 			foundResourceIDs := mapz.NewSet[string]()
 			for _, result := range stream.Results() {
-				if len(result.Resource.MissingContextParams) > 0 {
-					foundResourceIDs.Insert(result.Resource.ResourceId + "[" + strings.Join(result.Resource.MissingContextParams, ",") + "]")
+				if len(result.GetResource().GetMissingContextParams()) > 0 {
+					foundResourceIDs.Insert(result.GetResource().GetResourceId() + "[" + strings.Join(result.GetResource().GetMissingContextParams(), ",") + "]")
 					continue
 				}
 
-				foundResourceIDs.Insert(result.Resource.ResourceId)
+				foundResourceIDs.Insert(result.GetResource().GetResourceId())
 			}
 
 			foundResourceIDsSlice := foundResourceIDs.AsSlice()
@@ -1506,10 +1506,10 @@ func processResults(stream *dispatch.CollectingDispatchStream[*v1.DispatchLookup
 	var maxDispatchCount uint32
 	var maxCachedDispatchCount uint32
 	for _, result := range stream.Results() {
-		foundResources = append(foundResources, result.Resource)
-		maxDepthRequired = max(maxDepthRequired, result.Metadata.DepthRequired)
-		maxDispatchCount = max(maxDispatchCount, result.Metadata.DispatchCount)
-		maxCachedDispatchCount = max(maxCachedDispatchCount, result.Metadata.CachedDispatchCount)
+		foundResources = append(foundResources, result.GetResource())
+		maxDepthRequired = max(maxDepthRequired, result.GetMetadata().GetDepthRequired())
+		maxDispatchCount = max(maxDispatchCount, result.GetMetadata().GetDispatchCount())
+		maxCachedDispatchCount = max(maxCachedDispatchCount, result.GetMetadata().GetCachedDispatchCount())
 	}
 	return foundResources, maxDepthRequired, maxDispatchCount, maxCachedDispatchCount
 }

--- a/internal/dispatch/graph/lookupresources3_test.go
+++ b/internal/dispatch/graph/lookupresources3_test.go
@@ -201,10 +201,10 @@ func TestSimpleLookupResourcesWithCursor3(t *testing.T) {
 
 			require.Equal(1, len(stream.Results()))
 
-			found.Insert(stream.Results()[0].Items[0].ResourceId)
+			found.Insert(stream.Results()[0].GetItems()[0].GetResourceId())
 			require.Equal(tc.expectedFirst, found.AsSlice())
 
-			cursor := stream.Results()[0].Items[0].AfterResponseCursorSections
+			cursor := stream.Results()[0].GetItems()[0].GetAfterResponseCursorSections()
 			require.NotNil(cursor)
 
 			stream = dispatch.NewCloningCollectingDispatchStream[*v1.DispatchLookupResources3Response](ctx)
@@ -224,8 +224,8 @@ func TestSimpleLookupResourcesWithCursor3(t *testing.T) {
 			require.NoError(err)
 
 			for _, result := range stream.Results() {
-				for _, item := range result.Items {
-					found.Insert(item.ResourceId)
+				for _, item := range result.GetItems() {
+					found.Insert(item.GetResourceId())
 				}
 			}
 
@@ -240,11 +240,11 @@ func TestSimpleLookupResourcesWithCursor3(t *testing.T) {
 func processResults3(stream *dispatch.CloningCollectingDispatchStream[*v1.DispatchLookupResources3Response]) []*v1.PossibleResource {
 	foundResources := []*v1.PossibleResource{}
 	for _, result := range stream.Results() {
-		for _, item := range result.Items {
+		for _, item := range result.GetItems() {
 			foundResources = append(foundResources, &v1.PossibleResource{
-				ResourceId:           item.ResourceId,
+				ResourceId:           item.GetResourceId(),
 				ForSubjectIds:        nil,
-				MissingContextParams: item.MissingContextParams,
+				MissingContextParams: item.GetMissingContextParams(),
 			})
 		}
 	}
@@ -743,10 +743,10 @@ func TestLookupResources3OverSchemaWithCursors(t *testing.T) {
 
 						itemCount := 0
 						for _, result := range stream.Results() {
-							for _, item := range result.Items {
-								require.ElementsMatch(tc.expectedMissingFields, item.MissingContextParams)
-								foundResourceIDs.Insert(item.ResourceId)
-								currentCursor = item.AfterResponseCursorSections
+							for _, item := range result.GetItems() {
+								require.ElementsMatch(tc.expectedMissingFields, item.GetMissingContextParams())
+								foundResourceIDs.Insert(item.GetResourceId())
+								currentCursor = item.GetAfterResponseCursorSections()
 								itemCount++
 							}
 						}
@@ -763,7 +763,7 @@ func TestLookupResources3OverSchemaWithCursors(t *testing.T) {
 					for _, chunk := range foundChunks[0 : len(foundChunks)-1] {
 						chunkItemCount := 0
 						for _, result := range chunk {
-							chunkItemCount += len(result.Items)
+							chunkItemCount += len(result.GetItems())
 						}
 						require.Equal(pageSize, chunkItemCount)
 					}
@@ -1300,13 +1300,13 @@ func TestLookupResources3EnsureCheckHints(t *testing.T) {
 
 			foundResourceIDs := mapz.NewSet[string]()
 			for _, result := range stream.Results() {
-				for _, item := range result.Items {
-					if len(item.MissingContextParams) > 0 {
-						foundResourceIDs.Insert(item.ResourceId + "[" + strings.Join(item.MissingContextParams, ",") + "]")
+				for _, item := range result.GetItems() {
+					if len(item.GetMissingContextParams()) > 0 {
+						foundResourceIDs.Insert(item.GetResourceId() + "[" + strings.Join(item.GetMissingContextParams(), ",") + "]")
 						continue
 					}
 
-					foundResourceIDs.Insert(item.ResourceId)
+					foundResourceIDs.Insert(item.GetResourceId())
 				}
 			}
 

--- a/internal/dispatch/graph/lookupsubjects_test.go
+++ b/internal/dispatch/graph/lookupsubjects_test.go
@@ -155,14 +155,14 @@ func TestSimpleLookupSubjects(t *testing.T) {
 
 			foundSubjectIds := []string{}
 			for _, result := range stream.Results() {
-				results, ok := result.FoundSubjectsByResourceId[tc.resourceID]
+				results, ok := result.GetFoundSubjectsByResourceId()[tc.resourceID]
 				if ok {
-					for _, found := range results.FoundSubjects {
-						if len(found.ExcludedSubjects) > 0 {
+					for _, found := range results.GetFoundSubjects() {
+						if len(found.GetExcludedSubjects()) > 0 {
 							continue
 						}
 
-						foundSubjectIds = append(foundSubjectIds, found.SubjectId)
+						foundSubjectIds = append(foundSubjectIds, found.GetSubjectId())
 					}
 				}
 			}
@@ -185,7 +185,7 @@ func TestSimpleLookupSubjects(t *testing.T) {
 				})
 
 				require.NoError(err)
-				require.Equal(v1.ResourceCheckResult_MEMBER, checkResult.ResultsByResourceId[tc.resourceID].Membership)
+				require.Equal(v1.ResourceCheckResult_MEMBER, checkResult.GetResultsByResourceId()[tc.resourceID].GetMembership())
 			}
 			dis.Close()
 		})
@@ -274,7 +274,7 @@ func TestLookupSubjectsDispatchCount(t *testing.T) {
 
 			require.NoError(err)
 			for _, result := range stream.Results() {
-				require.LessOrEqual(int(result.Metadata.DispatchCount), tc.expectedDispatchCount, "Found dispatch count greater than expected")
+				require.LessOrEqual(int(result.GetMetadata().GetDispatchCount()), tc.expectedDispatchCount, "Found dispatch count greater than expected")
 			}
 		})
 	}
@@ -1027,8 +1027,8 @@ func TestLookupSubjectsOverSchema(t *testing.T) {
 
 			results := []*v1.FoundSubject{}
 			for _, streamResult := range stream.Results() {
-				for _, foundSubjects := range streamResult.FoundSubjectsByResourceId {
-					results = append(results, foundSubjects.FoundSubjects...)
+				for _, foundSubjects := range streamResult.GetFoundSubjectsByResourceId() {
+					results = append(results, foundSubjects.GetFoundSubjects()...)
 				}
 			}
 

--- a/internal/dispatch/keys/computed.go
+++ b/internal/dispatch/keys/computed.go
@@ -37,11 +37,11 @@ var cachePrefixes = []cachePrefix{
 
 // checkRequestToKey converts a check request into a cache key based on the relation
 func checkRequestToKey(req *v1.DispatchCheckRequest, option dispatchCacheKeyHashComputeOption) DispatchCacheKey {
-	return dispatchCacheKeyHash(checkViaRelationPrefix, req.Metadata.AtRevision, option,
-		hashableRelationReference{req.ResourceRelation},
-		hashableIds(req.ResourceIds),
-		hashableOnr{req.Subject},
-		hashableResultSetting(req.ResultsSetting),
+	return dispatchCacheKeyHash(checkViaRelationPrefix, req.GetMetadata().GetAtRevision(), option,
+		hashableRelationReference{req.GetResourceRelation()},
+		hashableIds(req.GetResourceIds()),
+		hashableOnr{req.GetSubject()},
+		hashableResultSetting(req.GetResultsSetting()),
 	)
 }
 
@@ -49,16 +49,16 @@ func checkRequestToKey(req *v1.DispatchCheckRequest, option dispatchCacheKeyHash
 // on the canonical key.
 func checkRequestToKeyWithCanonical(req *v1.DispatchCheckRequest, canonicalKey string) (DispatchCacheKey, error) {
 	// NOTE: canonical cache keys are only unique *within* a version of a namespace.
-	cacheKey := dispatchCacheKeyHash(checkViaCanonicalPrefix, req.Metadata.AtRevision, computeBothHashes,
-		hashableString(req.ResourceRelation.Namespace),
+	cacheKey := dispatchCacheKeyHash(checkViaCanonicalPrefix, req.GetMetadata().GetAtRevision(), computeBothHashes,
+		hashableString(req.GetResourceRelation().GetNamespace()),
 		hashableString(canonicalKey),
-		hashableIds(req.ResourceIds),
-		hashableOnr{req.Subject},
-		hashableResultSetting(req.ResultsSetting),
+		hashableIds(req.GetResourceIds()),
+		hashableOnr{req.GetSubject()},
+		hashableResultSetting(req.GetResultsSetting()),
 	)
 
 	if canonicalKey == "" {
-		return cacheKey, spiceerrors.MustBugf("given empty canonical key for request: %s => %s", req.ResourceRelation, tuple.StringCoreONR(req.Subject))
+		return cacheKey, spiceerrors.MustBugf("given empty canonical key for request: %s => %s", req.GetResourceRelation(), tuple.StringCoreONR(req.GetSubject()))
 	}
 
 	return cacheKey, nil
@@ -66,42 +66,42 @@ func checkRequestToKeyWithCanonical(req *v1.DispatchCheckRequest, canonicalKey s
 
 // expandRequestToKey converts an expand request into a cache key
 func expandRequestToKey(req *v1.DispatchExpandRequest, option dispatchCacheKeyHashComputeOption) DispatchCacheKey {
-	return dispatchCacheKeyHash(expandPrefix, req.Metadata.AtRevision, option,
-		hashableOnr{req.ResourceAndRelation},
+	return dispatchCacheKeyHash(expandPrefix, req.GetMetadata().GetAtRevision(), option,
+		hashableOnr{req.GetResourceAndRelation()},
 	)
 }
 
 // lookupResourcesRequest2ToKey converts a lookup request into a cache key
 func lookupResourcesRequest2ToKey(req *v1.DispatchLookupResources2Request, option dispatchCacheKeyHashComputeOption) DispatchCacheKey {
-	return dispatchCacheKeyHash(lookupPrefix, req.Metadata.AtRevision, option,
-		hashableRelationReference{req.ResourceRelation},
-		hashableRelationReference{req.SubjectRelation},
-		hashableIds(req.SubjectIds),
-		hashableOnr{req.TerminalSubject},
-		hashableContext{HashableContext: caveats.HashableContext{Struct: req.Context}}, // NOTE: context is included here because lookup does a single dispatch
-		hashableCursor{req.OptionalCursor},
-		hashableLimit(req.OptionalLimit),
+	return dispatchCacheKeyHash(lookupPrefix, req.GetMetadata().GetAtRevision(), option,
+		hashableRelationReference{req.GetResourceRelation()},
+		hashableRelationReference{req.GetSubjectRelation()},
+		hashableIds(req.GetSubjectIds()),
+		hashableOnr{req.GetTerminalSubject()},
+		hashableContext{HashableContext: caveats.HashableContext{Struct: req.GetContext()}}, // NOTE: context is included here because lookup does a single dispatch
+		hashableCursor{req.GetOptionalCursor()},
+		hashableLimit(req.GetOptionalLimit()),
 	)
 }
 
 // lookupResourcesRequest3ToKey converts a lookup request into a cache key
 func lookupResourcesRequest3ToKey(req *v1.DispatchLookupResources3Request, option dispatchCacheKeyHashComputeOption) DispatchCacheKey {
-	return dispatchCacheKeyHash(lookupPrefix, req.Metadata.AtRevision, option,
-		hashableRelationReference{req.ResourceRelation},
-		hashableRelationReference{req.SubjectRelation},
-		hashableIds(req.SubjectIds),
-		hashableOnr{req.TerminalSubject},
-		hashableContext{HashableContext: caveats.HashableContext{Struct: req.Context}}, // NOTE: context is included here because lookup does a single dispatch
-		hashableCursorSections{req.OptionalCursor},
-		hashableLimit(req.OptionalLimit),
+	return dispatchCacheKeyHash(lookupPrefix, req.GetMetadata().GetAtRevision(), option,
+		hashableRelationReference{req.GetResourceRelation()},
+		hashableRelationReference{req.GetSubjectRelation()},
+		hashableIds(req.GetSubjectIds()),
+		hashableOnr{req.GetTerminalSubject()},
+		hashableContext{HashableContext: caveats.HashableContext{Struct: req.GetContext()}}, // NOTE: context is included here because lookup does a single dispatch
+		hashableCursorSections{req.GetOptionalCursor()},
+		hashableLimit(req.GetOptionalLimit()),
 	)
 }
 
 // lookupSubjectsRequestToKey converts a lookup subjects request into a cache key
 func lookupSubjectsRequestToKey(req *v1.DispatchLookupSubjectsRequest, option dispatchCacheKeyHashComputeOption) DispatchCacheKey {
-	return dispatchCacheKeyHash(lookupSubjectsPrefix, req.Metadata.AtRevision, option,
-		hashableRelationReference{req.ResourceRelation},
-		hashableRelationReference{req.SubjectRelation},
-		hashableIds(req.ResourceIds),
+	return dispatchCacheKeyHash(lookupSubjectsPrefix, req.GetMetadata().GetAtRevision(), option,
+		hashableRelationReference{req.GetResourceRelation()},
+		hashableRelationReference{req.GetSubjectRelation()},
+		hashableIds(req.GetResourceIds()),
 	)
 }

--- a/internal/dispatch/keys/computed_test.go
+++ b/internal/dispatch/keys/computed_test.go
@@ -433,14 +433,14 @@ var generatorFuncs = map[string]generatorFunc{
 		return checkRequestToKey(&v1.DispatchCheckRequest{
 				ResourceRelation: resourceRelation,
 				ResourceIds:      resourceIds,
-				Subject:          ONR(subjectRelation.Namespace, subjectIds[0], subjectRelation.Relation),
+				Subject:          ONR(subjectRelation.GetNamespace(), subjectIds[0], subjectRelation.GetRelation()),
 				Metadata:         metadata,
 			}, computeBothHashes), []string{
-				resourceRelation.Namespace,
-				resourceRelation.Relation,
-				subjectRelation.Namespace,
+				resourceRelation.GetNamespace(),
+				resourceRelation.GetRelation(),
+				subjectRelation.GetNamespace(),
 				subjectIds[0],
-				subjectRelation.Relation,
+				subjectRelation.GetRelation(),
 			}
 	},
 
@@ -455,15 +455,15 @@ var generatorFuncs = map[string]generatorFunc{
 		key, _ := checkRequestToKeyWithCanonical(&v1.DispatchCheckRequest{
 			ResourceRelation: resourceRelation,
 			ResourceIds:      resourceIds,
-			Subject:          ONR(subjectRelation.Namespace, subjectIds[0], subjectRelation.Relation),
+			Subject:          ONR(subjectRelation.GetNamespace(), subjectIds[0], subjectRelation.GetRelation()),
 			Metadata:         metadata,
-		}, resourceRelation.Relation)
+		}, resourceRelation.GetRelation())
 		return key, append([]string{
-			resourceRelation.Namespace,
-			resourceRelation.Relation,
-			subjectRelation.Namespace,
+			resourceRelation.GetNamespace(),
+			resourceRelation.GetRelation(),
+			subjectRelation.GetNamespace(),
 			subjectIds[0],
-			subjectRelation.Relation,
+			subjectRelation.GetRelation(),
 		}, resourceIds...)
 	},
 
@@ -479,14 +479,14 @@ var generatorFuncs = map[string]generatorFunc{
 				ResourceRelation: resourceRelation,
 				SubjectRelation:  subjectRelation,
 				SubjectIds:       subjectIds,
-				TerminalSubject:  ONR(subjectRelation.Namespace, subjectIds[0], subjectRelation.Relation),
+				TerminalSubject:  ONR(subjectRelation.GetNamespace(), subjectIds[0], subjectRelation.GetRelation()),
 				Metadata:         metadata,
 			}, computeBothHashes), []string{
-				resourceRelation.Namespace,
-				resourceRelation.Relation,
-				subjectRelation.Namespace,
+				resourceRelation.GetNamespace(),
+				resourceRelation.GetRelation(),
+				subjectRelation.GetNamespace(),
 				subjectIds[0],
-				subjectRelation.Relation,
+				subjectRelation.GetRelation(),
 			}
 	},
 
@@ -499,12 +499,12 @@ var generatorFuncs = map[string]generatorFunc{
 		metadata *v1.ResolverMeta,
 	) (DispatchCacheKey, []string) {
 		return expandRequestToKey(&v1.DispatchExpandRequest{
-				ResourceAndRelation: ONR(resourceRelation.Namespace, resourceIds[0], resourceRelation.Relation),
+				ResourceAndRelation: ONR(resourceRelation.GetNamespace(), resourceIds[0], resourceRelation.GetRelation()),
 				Metadata:            metadata,
 			}, computeBothHashes), []string{
-				resourceRelation.Namespace,
+				resourceRelation.GetNamespace(),
 				resourceIds[0],
-				resourceRelation.Relation,
+				resourceRelation.GetRelation(),
 			}
 	},
 
@@ -522,10 +522,10 @@ var generatorFuncs = map[string]generatorFunc{
 				ResourceIds:      resourceIds,
 				Metadata:         metadata,
 			}, computeBothHashes), append([]string{
-				resourceRelation.Namespace,
-				resourceRelation.Relation,
-				subjectRelation.Namespace,
-				subjectRelation.Relation,
+				resourceRelation.GetNamespace(),
+				resourceRelation.GetRelation(),
+				subjectRelation.GetNamespace(),
+				subjectRelation.GetRelation(),
 			}, resourceIds...)
 	},
 }

--- a/internal/dispatch/keys/keys.go
+++ b/internal/dispatch/keys/keys.go
@@ -98,11 +98,11 @@ func (c *CanonicalKeyHandler) CheckCacheKey(ctx context.Context, req *v1.Dispatc
 	// NOTE: We do not use the canonicalized cache key when checking within the same namespace, as
 	// we may get different results if the subject being checked matches the resource exactly, e.g.
 	// a check for `somenamespace:someobject#somerel@somenamespace:someobject#somerel`.
-	if req.ResourceRelation.Namespace != req.Subject.Namespace {
+	if req.GetResourceRelation().GetNamespace() != req.GetSubject().GetNamespace() {
 		// Load the relation to get its computed cache key, if any.
 		ds := datastoremw.MustFromContext(ctx)
 
-		revision, err := ds.RevisionFromString(req.Metadata.AtRevision)
+		revision, err := ds.RevisionFromString(req.GetMetadata().GetAtRevision())
 		if err != nil {
 			return emptyDispatchCacheKey, err
 		}
@@ -110,16 +110,16 @@ func (c *CanonicalKeyHandler) CheckCacheKey(ctx context.Context, req *v1.Dispatc
 
 		_, relation, err := namespace.ReadNamespaceAndRelation(
 			ctx,
-			req.ResourceRelation.Namespace,
-			req.ResourceRelation.Relation,
+			req.GetResourceRelation().GetNamespace(),
+			req.GetResourceRelation().GetRelation(),
 			r,
 		)
 		if err != nil {
 			return emptyDispatchCacheKey, err
 		}
 
-		if relation.CanonicalCacheKey != "" {
-			return checkRequestToKeyWithCanonical(req, relation.CanonicalCacheKey)
+		if relation.GetCanonicalCacheKey() != "" {
+			return checkRequestToKeyWithCanonical(req, relation.GetCanonicalCacheKey())
 		}
 	}
 

--- a/internal/dispatch/remote/cluster_test.go
+++ b/internal/dispatch/remote/cluster_test.go
@@ -84,7 +84,7 @@ func (fds *fakeDispatchSvc) DispatchLookupSubjects(req *v1.DispatchLookupSubject
 		time.Sleep(fds.sleepTime)
 		if err := srv.Send(&v1.DispatchLookupSubjectsResponse{
 			FoundSubjectsByResourceId: map[string]*v1.FoundSubjects{
-				req.ResourceIds[0]: {
+				req.GetResourceIds()[0]: {
 					FoundSubjects: []*v1.FoundSubject{
 						{
 							SubjectId: fmt.Sprintf("%d", i),
@@ -218,7 +218,7 @@ func TestDispatchTimeout(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, resp)
-				require.GreaterOrEqual(t, resp.Metadata.DispatchCount, uint32(1))
+				require.GreaterOrEqual(t, resp.GetMetadata().GetDispatchCount(), uint32(1))
 			}
 
 			// Invoke a dispatched "LookupSubjects" and test as well.
@@ -348,7 +348,7 @@ func TestCheckSecondaryDispatch(t *testing.T) {
 
 			resp, err := dispatcher.DispatchCheck(t.Context(), tc.request)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedResult, resp.Metadata.DispatchCount)
+			require.Equal(t, tc.expectedResult, resp.GetMetadata().GetDispatchCount())
 		})
 	}
 }
@@ -624,7 +624,7 @@ func TestLRSecondaryDispatch(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Len(t, stream.Results(), 2)
-				require.Equal(t, tc.expectedDispatchCount, stream.Results()[0].Metadata.DispatchCount)
+				require.Equal(t, tc.expectedDispatchCount, stream.Results()[0].GetMetadata().GetDispatchCount())
 			}
 		})
 	}
@@ -672,8 +672,8 @@ func TestLRDispatchFallbackToPrimary(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, stream.Results(), int(results))
-	require.Equal(t, uint32(1), stream.Results()[0].Metadata.DispatchCount)
-	require.Equal(t, "0", stream.Results()[0].Resource.ResourceId)
+	require.Equal(t, uint32(1), stream.Results()[0].GetMetadata().GetDispatchCount())
+	require.Equal(t, "0", stream.Results()[0].GetResource().GetResourceId())
 }
 
 func TestLSSecondaryDispatch(t *testing.T) {
@@ -752,7 +752,7 @@ func TestLSSecondaryDispatch(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Len(t, stream.Results(), 2)
-				require.Equal(t, tc.expectedDispatchCount, stream.Results()[0].Metadata.DispatchCount)
+				require.Equal(t, tc.expectedDispatchCount, stream.Results()[0].GetMetadata().GetDispatchCount())
 			}
 		})
 	}
@@ -795,8 +795,8 @@ func TestLSDispatchFallbackToPrimary(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, stream.Results(), int(results))
-	require.Equal(t, uint32(1), stream.Results()[0].Metadata.DispatchCount)
-	require.Equal(t, "0", stream.Results()[0].FoundSubjectsByResourceId["foo"].FoundSubjects[0].SubjectId)
+	require.Equal(t, uint32(1), stream.Results()[0].GetMetadata().GetDispatchCount())
+	require.Equal(t, "0", stream.Results()[0].GetFoundSubjectsByResourceId()["foo"].GetFoundSubjects()[0].GetSubjectId())
 }
 
 func TestCheckUsesDelayByDefaultForPrimary(t *testing.T) {
@@ -826,7 +826,7 @@ func TestCheckUsesDelayByDefaultForPrimary(t *testing.T) {
 		Subject:          &corev1.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
 	})
 	require.NoError(t, err)
-	require.Equal(t, uint32(2), resp.Metadata.DispatchCount)
+	require.Equal(t, uint32(2), resp.GetMetadata().GetDispatchCount())
 
 	// Ensure the digest for the check was updated.
 	cast := dispatcher.(*clusterDispatcher)
@@ -869,7 +869,7 @@ func TestStreamingDispatchDelayByDefaultForPrimary(t *testing.T) {
 	}, stream)
 	require.NoError(t, err)
 
-	require.Equal(t, uint32(2), stream.Results()[0].Metadata.DispatchCount)
+	require.Equal(t, uint32(2), stream.Results()[0].GetMetadata().GetDispatchCount())
 	require.Len(t, stream.Results(), 2)
 
 	// Ensure the digest for the lookupsubjects was updated.
@@ -949,7 +949,7 @@ func TestCheckUsesMaximumDelayByDefaultForPrimary(t *testing.T) {
 		Subject:          &corev1.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
 	})
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), resp.Metadata.DispatchCount)
+	require.Equal(t, uint32(1), resp.GetMetadata().GetDispatchCount())
 }
 
 func connectionForDispatching(t *testing.T, svc v1.DispatchServiceServer) *grpc.ClientConn {
@@ -1086,7 +1086,7 @@ func TestCheckToUnsupportedRemovesHedgingDelay(t *testing.T) {
 		Subject:          &corev1.ObjectAndRelation{Namespace: "foo", ObjectId: "bar", Relation: "..."},
 	})
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), resp.Metadata.DispatchCount)
+	require.Equal(t, uint32(1), resp.GetMetadata().GetDispatchCount())
 
 	// Ensure the resource relation was marked as unsupported.
 	cast := dispatcher.(*clusterDispatcher)
@@ -1103,7 +1103,7 @@ func TestCheckToUnsupportedRemovesHedgingDelay(t *testing.T) {
 	})
 	endTime := time.Now()
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), resp.Metadata.DispatchCount)
+	require.Equal(t, uint32(1), resp.GetMetadata().GetDispatchCount())
 	require.LessOrEqual(t, endTime.Sub(startTime), 25*time.Millisecond)
 }
 

--- a/internal/dispatch/singleflight/singleflight_test.go
+++ b/internal/dispatch/singleflight/singleflight_test.go
@@ -340,8 +340,8 @@ func assertCounterWithLabel(t *testing.T, gatherer prometheus.Gatherer, expected
 	found := false
 	require.Len(t, mf.GetMetric(), expectedMetricsCount)
 	for _, metric := range mf.GetMetric() {
-		for _, label := range metric.Label {
-			if *label.Value == labelName {
+		for _, label := range metric.GetLabel() {
+			if label.GetValue() == labelName {
 				found = true
 			}
 		}

--- a/internal/graph/checkdispatchset.go
+++ b/internal/graph/checkdispatchset.go
@@ -76,7 +76,7 @@ func (s *checkDispatchSet) addForRelationship(rel tuple.Relationship) {
 	// Add the subject ID to the map of subjects for the type of subject.
 	siac := subjectIDAndHasCaveat{
 		objectID:           rel.Subject.ObjectID,
-		hasIncomingCaveats: rel.OptionalCaveat != nil && rel.OptionalCaveat.CaveatName != "",
+		hasIncomingCaveats: rel.OptionalCaveat != nil && rel.OptionalCaveat.GetCaveatName() != "",
 	}
 
 	subjectIDsForType, ok := s.bySubjectType[rel.Subject.RelationReference()]

--- a/internal/graph/computed/computecheck_test.go
+++ b/internal/graph/computed/computecheck_test.go
@@ -840,10 +840,10 @@ func TestComputeCheckWithCaveats(t *testing.T) {
 						require.Equal(t, err.Error(), r.error)
 					} else {
 						require.NoError(t, err)
-						require.Equal(t, v1.ResourceCheckResult_Membership_name[int32(r.member)], v1.ResourceCheckResult_Membership_name[int32(result.Membership)], "mismatch for %s with context %v", r.check, r.context)
+						require.Equal(t, v1.ResourceCheckResult_Membership_name[int32(r.member)], v1.ResourceCheckResult_Membership_name[int32(result.GetMembership())], "mismatch for %s with context %v", r.check, r.context)
 
-						if result.Membership == v1.ResourceCheckResult_CAVEATED_MEMBER {
-							foundFields := result.MissingExprFields
+						if result.GetMembership() == v1.ResourceCheckResult_CAVEATED_MEMBER {
+							foundFields := result.GetMissingExprFields()
 							sort.Strings(foundFields)
 							sort.Strings(r.expectedMissingFields)
 
@@ -928,10 +928,10 @@ func TestComputeBulkCheck(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.Equal(t, v1.ResourceCheckResult_MEMBER, resp["direct"].Membership)
-	require.Equal(t, v1.ResourceCheckResult_MEMBER, resp["first"].Membership)
-	require.Equal(t, v1.ResourceCheckResult_CAVEATED_MEMBER, resp["second"].Membership)
-	require.Equal(t, v1.ResourceCheckResult_NOT_MEMBER, resp["third"].Membership)
+	require.Equal(t, v1.ResourceCheckResult_MEMBER, resp["direct"].GetMembership())
+	require.Equal(t, v1.ResourceCheckResult_MEMBER, resp["first"].GetMembership())
+	require.Equal(t, v1.ResourceCheckResult_CAVEATED_MEMBER, resp["second"].GetMembership())
+	require.Equal(t, v1.ResourceCheckResult_NOT_MEMBER, resp["third"].GetMembership())
 }
 
 func writeCaveatedTuples(ctx context.Context, _ *testing.T, ds datastore.Datastore, schema string, updates []caveatedUpdate) (datastore.Revision, error) {

--- a/internal/graph/cursors.go
+++ b/internal/graph/cursors.go
@@ -40,7 +40,7 @@ type cursorInformation struct {
 // newCursorInformation constructs a new cursorInformation struct from the incoming cursor (which
 // may be nil)
 func newCursorInformation(incomingCursor *v1.Cursor, limits *limitTracker, dispatchCursorVersion uint32) (cursorInformation, error) {
-	if incomingCursor != nil && incomingCursor.DispatchVersion != dispatchCursorVersion {
+	if incomingCursor != nil && incomingCursor.GetDispatchVersion() != dispatchCursorVersion {
 		return cursorInformation{}, NewInvalidCursorErr(dispatchCursorVersion, incomingCursor)
 	}
 
@@ -77,11 +77,11 @@ func (ci cursorInformation) withClonedLimits() cursorInformation {
 // headSectionValue returns the string value found at the head of the incoming cursor.
 // If the incoming cursor is empty, returns empty.
 func (ci cursorInformation) headSectionValue() (string, bool) {
-	if ci.currentCursor == nil || len(ci.currentCursor.Sections) < 1 {
+	if ci.currentCursor == nil || len(ci.currentCursor.GetSections()) < 1 {
 		return "", false
 	}
 
-	return ci.currentCursor.Sections[0], true
+	return ci.currentCursor.GetSections()[0], true
 }
 
 // integerSectionValue returns the *integer* found  at the head of the incoming cursor.
@@ -108,12 +108,12 @@ func (ci cursorInformation) withOutgoingSection(value string) (cursorInformation
 	ocs = append(ocs, ci.outgoingCursorSections...)
 	ocs = append(ocs, value)
 
-	if ci.currentCursor != nil && len(ci.currentCursor.Sections) > 0 {
+	if ci.currentCursor != nil && len(ci.currentCursor.GetSections()) > 0 {
 		// If the cursor already has values, replace them with those specified.
 		return cursorInformation{
 			currentCursor: &v1.Cursor{
 				DispatchVersion: ci.dispatchCursorVersion,
-				Sections:        ci.currentCursor.Sections[1:],
+				Sections:        ci.currentCursor.GetSections()[1:],
 			},
 			outgoingCursorSections: ocs,
 			limits:                 ci.limits,
@@ -268,20 +268,20 @@ func withSubsetInCursor(
 
 // combineCursors combines the given cursors into one resulting cursor.
 func combineCursors(cursor *v1.Cursor, toAdd *v1.Cursor) (*v1.Cursor, error) {
-	if toAdd == nil || len(toAdd.Sections) == 0 {
+	if toAdd == nil || len(toAdd.GetSections()) == 0 {
 		return nil, spiceerrors.MustBugf("supplied toAdd cursor was nil or empty")
 	}
 
-	if cursor == nil || len(cursor.Sections) == 0 {
+	if cursor == nil || len(cursor.GetSections()) == 0 {
 		return toAdd, nil
 	}
 
-	sections := make([]string, 0, len(cursor.Sections)+len(toAdd.Sections))
-	sections = append(sections, cursor.Sections...)
-	sections = append(sections, toAdd.Sections...)
+	sections := make([]string, 0, len(cursor.GetSections())+len(toAdd.GetSections()))
+	sections = append(sections, cursor.GetSections()...)
+	sections = append(sections, toAdd.GetSections()...)
 
 	return &v1.Cursor{
-		DispatchVersion: toAdd.DispatchVersion,
+		DispatchVersion: toAdd.GetDispatchVersion(),
 		Sections:        sections,
 	}, nil
 }

--- a/internal/graph/cursors_test.go
+++ b/internal/graph/cursors_test.go
@@ -23,16 +23,16 @@ func TestCursorProduction(t *testing.T) {
 	require.NoError(t, err)
 
 	cursor := ci.responsePartialCursor()
-	require.Equal(t, uint32(42), cursor.DispatchVersion)
-	require.Empty(t, cursor.Sections)
+	require.Equal(t, uint32(42), cursor.GetDispatchVersion())
+	require.Empty(t, cursor.GetSections())
 
 	cci, err := ci.withOutgoingSection("4")
 	require.NoError(t, err)
 
 	ccursor := cci.responsePartialCursor()
 
-	require.Equal(t, uint32(42), ccursor.DispatchVersion)
-	require.Equal(t, []string{"4"}, ccursor.Sections)
+	require.Equal(t, uint32(42), ccursor.GetDispatchVersion())
+	require.Equal(t, []string{"4"}, ccursor.GetSections())
 }
 
 func TestCursorDifferentDispatchVersion(t *testing.T) {
@@ -158,7 +158,7 @@ func TestCombineCursors(t *testing.T) {
 
 	combined, err := combineCursors(cursor1, cursor2)
 	require.NoError(t, err)
-	require.Equal(t, []string{"a", "b", "c", "d", "e", "f"}, combined.Sections)
+	require.Equal(t, []string{"a", "b", "c", "d", "e", "f"}, combined.GetSections())
 }
 
 func TestCombineCursorsWithNil(t *testing.T) {
@@ -169,7 +169,7 @@ func TestCombineCursorsWithNil(t *testing.T) {
 
 	combined, err := combineCursors(nil, cursor2)
 	require.NoError(t, err)
-	require.Equal(t, []string{"d", "e", "f"}, combined.Sections)
+	require.Equal(t, []string{"d", "e", "f"}, combined.GetSections())
 }
 
 func TestWithParallelizedStreamingIterableInCursor(t *testing.T) {

--- a/internal/graph/errors.go
+++ b/internal/graph/errors.go
@@ -194,7 +194,7 @@ type InvalidCursorError struct {
 // NewInvalidCursorErr constructs a new unimplemented error.
 func NewInvalidCursorErr(dispatchCursorVersion uint32, cursor *dispatch.Cursor) error {
 	return InvalidCursorError{
-		error: fmt.Errorf("the supplied cursor is no longer valid: found version %d, expected version %d", cursor.DispatchVersion, dispatchCursorVersion),
+		error: fmt.Errorf("the supplied cursor is no longer valid: found version %d, expected version %d", cursor.GetDispatchVersion(), dispatchCursorVersion),
 	}
 }
 

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -47,9 +47,9 @@ type ExpandReducer func(
 
 func decrementDepth(md *v1.ResolverMeta) *v1.ResolverMeta {
 	return &v1.ResolverMeta{
-		AtRevision:     md.AtRevision,
-		DepthRemaining: md.DepthRemaining - 1,
-		TraversalBloom: md.TraversalBloom,
+		AtRevision:     md.GetAtRevision(),
+		DepthRemaining: md.GetDepthRemaining() - 1,
+		TraversalBloom: md.GetTraversalBloom(),
 	}
 }
 
@@ -61,28 +61,28 @@ func ensureMetadata(subProblemMetadata *v1.ResponseMeta) *v1.ResponseMeta {
 	}
 
 	return &v1.ResponseMeta{
-		DispatchCount:       subProblemMetadata.DispatchCount,
-		DepthRequired:       subProblemMetadata.DepthRequired,
-		CachedDispatchCount: subProblemMetadata.CachedDispatchCount,
-		DebugInfo:           subProblemMetadata.DebugInfo,
+		DispatchCount:       subProblemMetadata.GetDispatchCount(),
+		DepthRequired:       subProblemMetadata.GetDepthRequired(),
+		CachedDispatchCount: subProblemMetadata.GetCachedDispatchCount(),
+		DebugInfo:           subProblemMetadata.GetDebugInfo(),
 	}
 }
 
 func addCallToResponseMetadata(metadata *v1.ResponseMeta) *v1.ResponseMeta {
 	// + 1 for the current call.
 	return &v1.ResponseMeta{
-		DispatchCount:       metadata.DispatchCount + 1,
-		DepthRequired:       metadata.DepthRequired + 1,
-		CachedDispatchCount: metadata.CachedDispatchCount,
-		DebugInfo:           metadata.DebugInfo,
+		DispatchCount:       metadata.GetDispatchCount() + 1,
+		DepthRequired:       metadata.GetDepthRequired() + 1,
+		CachedDispatchCount: metadata.GetCachedDispatchCount(),
+		DebugInfo:           metadata.GetDebugInfo(),
 	}
 }
 
 func addAdditionalDepthRequired(metadata *v1.ResponseMeta) *v1.ResponseMeta {
 	return &v1.ResponseMeta{
-		DispatchCount:       metadata.DispatchCount,
-		DepthRequired:       metadata.DepthRequired + 1,
-		CachedDispatchCount: metadata.CachedDispatchCount,
-		DebugInfo:           metadata.DebugInfo,
+		DispatchCount:       metadata.GetDispatchCount(),
+		DepthRequired:       metadata.GetDepthRequired() + 1,
+		CachedDispatchCount: metadata.GetCachedDispatchCount(),
+		DebugInfo:           metadata.GetDebugInfo(),
 	}
 }

--- a/internal/graph/hints/checkhints.go
+++ b/internal/graph/hints/checkhints.go
@@ -37,12 +37,12 @@ func CheckHintForArrow(resourceType string, resourceID string, tuplesetRelation 
 
 // AsCheckHintForComputedUserset returns the resourceID if the checkHint is for the given relation and subject.
 func AsCheckHintForComputedUserset(checkHint *v1.CheckHint, resourceType string, relationName string, subject tuple.ObjectAndRelation) (string, bool) {
-	if checkHint.TtuComputedUsersetRelation != "" {
+	if checkHint.GetTtuComputedUsersetRelation() != "" {
 		return "", false
 	}
 
-	if checkHint.Resource.Namespace == resourceType && checkHint.Resource.Relation == relationName && checkHint.Subject.EqualVT(subject.ToCoreONR()) {
-		return checkHint.Resource.ObjectId, true
+	if checkHint.GetResource().GetNamespace() == resourceType && checkHint.GetResource().GetRelation() == relationName && checkHint.GetSubject().EqualVT(subject.ToCoreONR()) {
+		return checkHint.GetResource().GetObjectId(), true
 	}
 
 	return "", false
@@ -50,12 +50,12 @@ func AsCheckHintForComputedUserset(checkHint *v1.CheckHint, resourceType string,
 
 // AsCheckHintForArrow returns the resourceID if the checkHint is for the given arrow and subject.
 func AsCheckHintForArrow(checkHint *v1.CheckHint, resourceType string, tuplesetRelation string, computedUsersetRelation string, subject tuple.ObjectAndRelation) (string, bool) {
-	if checkHint.TtuComputedUsersetRelation != computedUsersetRelation {
+	if checkHint.GetTtuComputedUsersetRelation() != computedUsersetRelation {
 		return "", false
 	}
 
-	if checkHint.Resource.Namespace == resourceType && checkHint.Resource.Relation == tuplesetRelation && checkHint.Subject.EqualVT(subject.ToCoreONR()) {
-		return checkHint.Resource.ObjectId, true
+	if checkHint.GetResource().GetNamespace() == resourceType && checkHint.GetResource().GetRelation() == tuplesetRelation && checkHint.GetSubject().EqualVT(subject.ToCoreONR()) {
+		return checkHint.GetResource().GetObjectId(), true
 	}
 
 	return "", false

--- a/internal/graph/hints/checkhints_test.go
+++ b/internal/graph/hints/checkhints_test.go
@@ -144,12 +144,12 @@ func TestCheckHintForComputedUserset(t *testing.T) {
 
 	checkHint := CheckHintForComputedUserset(resourceType, resourceID, relation, subject, result)
 
-	require.Equal(t, resourceType, checkHint.Resource.Namespace)
-	require.Equal(t, resourceID, checkHint.Resource.ObjectId)
-	require.Equal(t, relation, checkHint.Resource.Relation)
-	require.Equal(t, subject.ToCoreONR(), checkHint.Subject)
-	require.Equal(t, result, checkHint.Result)
-	require.Empty(t, checkHint.TtuComputedUsersetRelation)
+	require.Equal(t, resourceType, checkHint.GetResource().GetNamespace())
+	require.Equal(t, resourceID, checkHint.GetResource().GetObjectId())
+	require.Equal(t, relation, checkHint.GetResource().GetRelation())
+	require.Equal(t, subject.ToCoreONR(), checkHint.GetSubject())
+	require.Equal(t, result, checkHint.GetResult())
+	require.Empty(t, checkHint.GetTtuComputedUsersetRelation())
 
 	resourceID, ok := AsCheckHintForComputedUserset(checkHint, resourceType, relation, subject)
 	require.True(t, ok)
@@ -168,12 +168,12 @@ func TestCheckHintForArrow(t *testing.T) {
 
 	checkHint := CheckHintForArrow(resourceType, resourceID, tuplesetRelation, computedUsersetRelation, subject, result)
 
-	require.Equal(t, resourceType, checkHint.Resource.Namespace)
-	require.Equal(t, resourceID, checkHint.Resource.ObjectId)
-	require.Equal(t, tuplesetRelation, checkHint.Resource.Relation)
-	require.Equal(t, subject.ToCoreONR(), checkHint.Subject)
-	require.Equal(t, result, checkHint.Result)
-	require.Equal(t, computedUsersetRelation, checkHint.TtuComputedUsersetRelation)
+	require.Equal(t, resourceType, checkHint.GetResource().GetNamespace())
+	require.Equal(t, resourceID, checkHint.GetResource().GetObjectId())
+	require.Equal(t, tuplesetRelation, checkHint.GetResource().GetRelation())
+	require.Equal(t, subject.ToCoreONR(), checkHint.GetSubject())
+	require.Equal(t, result, checkHint.GetResult())
+	require.Equal(t, computedUsersetRelation, checkHint.GetTtuComputedUsersetRelation())
 
 	resourceID, ok := AsCheckHintForArrow(checkHint, resourceType, tuplesetRelation, computedUsersetRelation, subject)
 	require.True(t, ok)

--- a/internal/graph/resourcesubjectsmap2.go
+++ b/internal/graph/resourcesubjectsmap2.go
@@ -71,7 +71,7 @@ func subjectIDsToResourcesMap2(resourceType *core.RelationReference, subjectIDs 
 // the resource of the relationship to the subject, as well as whether the relationship was caveated.
 func (rsm resourcesSubjectMap2) addRelationship(rel tuple.Relationship, missingContextParameters []string) error {
 	spiceerrors.DebugAssertf(func() bool {
-		return rel.Resource.ObjectType == rsm.resourceType.Namespace && rel.Resource.Relation == rsm.resourceType.Relation
+		return rel.Resource.ObjectType == rsm.resourceType.GetNamespace() && rel.Resource.Relation == rsm.resourceType.GetRelation()
 	}, "invalid relationship for addRelationship. expected: %v, found: %v", rsm.resourceType, rel.Resource)
 
 	spiceerrors.DebugAssertf(func() bool {
@@ -143,9 +143,9 @@ func (rsm dispatchableResourcesSubjectMap2) filterSubjectIDsToDispatch(dispatche
 	filtered := make([]string, 0, len(resourceIDs))
 	for _, resourceID := range resourceIDs {
 		if dispatched.Add(&core.ObjectAndRelation{
-			Namespace: dispatchSubjectType.Namespace,
+			Namespace: dispatchSubjectType.GetNamespace(),
 			ObjectId:  resourceID,
-			Relation:  dispatchSubjectType.Relation,
+			Relation:  dispatchSubjectType.GetRelation(),
 		}) {
 			filtered = append(filtered, resourceID)
 		}
@@ -213,7 +213,7 @@ func (rsm dispatchableResourcesSubjectMap2) mapPossibleResource(foundResource *v
 	nonCaveatedSubjectIDs := mapz.NewSet[string]()
 	missingContextParameters := mapz.NewSet[string]()
 
-	for _, forSubjectID := range foundResource.ForSubjectIds {
+	for _, forSubjectID := range foundResource.GetForSubjectIds() {
 		// Map from the incoming subject ID to the subject ID(s) that caused the dispatch.
 		infos, ok := rsm.resourcesAndSubjects.Get(forSubjectID)
 		if !ok {
@@ -233,7 +233,7 @@ func (rsm dispatchableResourcesSubjectMap2) mapPossibleResource(foundResource *v
 	// If there are some non-caveated IDs, return those and mark as the parent status.
 	if nonCaveatedSubjectIDs.Len() > 0 {
 		return &v1.PossibleResource{
-			ResourceId:    foundResource.ResourceId,
+			ResourceId:    foundResource.GetResourceId(),
 			ForSubjectIds: nonCaveatedSubjectIDs.AsSlice(),
 		}, nil
 	}
@@ -241,7 +241,7 @@ func (rsm dispatchableResourcesSubjectMap2) mapPossibleResource(foundResource *v
 	// Otherwise, everything is caveated, so return the full set of subject IDs and mark
 	// as a check is required.
 	return &v1.PossibleResource{
-		ResourceId:           foundResource.ResourceId,
+		ResourceId:           foundResource.GetResourceId(),
 		ForSubjectIds:        forSubjectIDs.AsSlice(),
 		MissingContextParams: missingContextParameters.AsSlice(),
 	}, nil

--- a/internal/graph/resourcesubjectsmap2_test.go
+++ b/internal/graph/resourcesubjectsmap2_test.go
@@ -19,8 +19,8 @@ func TestResourcesSubjectsMap2Basic(t *testing.T) {
 		Relation:  "view",
 	})
 
-	require.Equal(t, "document", rsm.resourceType.Namespace)
-	require.Equal(t, "view", rsm.resourceType.Relation)
+	require.Equal(t, "document", rsm.resourceType.GetNamespace())
+	require.Equal(t, "view", rsm.resourceType.GetRelation())
 	require.Equal(t, 0, rsm.len())
 
 	rsm.addSubjectIDAsFoundResourceID("first")
@@ -157,7 +157,7 @@ func TestResourcesSubjectsMap2MapFoundResources(t *testing.T) {
 			expected := make([]*v1.PossibleResource, 0, len(tc.expected))
 			for _, expectedResource := range tc.expected {
 				cloned := expectedResource.CloneVT()
-				sort.Strings(cloned.ForSubjectIds)
+				sort.Strings(cloned.GetForSubjectIds())
 				expected = append(expected, cloned)
 			}
 
@@ -171,8 +171,8 @@ func TestResourcesSubjectsMap2MapFoundResources(t *testing.T) {
 			}
 
 			for _, r := range resources {
-				sort.Strings(r.ForSubjectIds)
-				sort.Strings(r.MissingContextParams)
+				sort.Strings(r.GetForSubjectIds())
+				sort.Strings(r.GetMissingContextParams())
 			}
 
 			testutil.RequireProtoSlicesEqual(t, expected, resources, sortPossibleByResource, "different resources")
@@ -221,5 +221,5 @@ func TestFilterSubjectIDsToDispatch(t *testing.T) {
 }
 
 func sortPossibleByResource(first *v1.PossibleResource, second *v1.PossibleResource) int {
-	return strings.Compare(first.ResourceId, second.ResourceId)
+	return strings.Compare(first.GetResourceId(), second.GetResourceId())
 }

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -70,10 +70,10 @@ func (s *Server) computeDiagnostics(ctx context.Context, uri lsp.DocumentURI) ([
 			diagnostics = append(diagnostics, lsp.Diagnostic{
 				Severity: lsp.Error,
 				Range: lsp.Range{
-					Start: lsp.Position{Line: int(devErr.Line) - 1, Character: int(devErr.Column) - 1},
-					End:   lsp.Position{Line: int(devErr.Line) - 1, Character: int(devErr.Column) - 1},
+					Start: lsp.Position{Line: int(devErr.GetLine()) - 1, Character: int(devErr.GetColumn()) - 1},
+					End:   lsp.Position{Line: int(devErr.GetLine()) - 1, Character: int(devErr.GetColumn()) - 1},
 				},
-				Message: devErr.Message,
+				Message: devErr.GetMessage(),
 			})
 		}
 
@@ -88,10 +88,10 @@ func (s *Server) computeDiagnostics(ctx context.Context, uri lsp.DocumentURI) ([
 				diagnostics = append(diagnostics, lsp.Diagnostic{
 					Severity: lsp.Warning,
 					Range: lsp.Range{
-						Start: lsp.Position{Line: int(devWarning.Line) - 1, Character: int(devWarning.Column) - 1},
-						End:   lsp.Position{Line: int(devWarning.Line) - 1, Character: int(devWarning.Column) - 1},
+						Start: lsp.Position{Line: int(devWarning.GetLine()) - 1, Character: int(devWarning.GetColumn()) - 1},
+						End:   lsp.Position{Line: int(devWarning.GetLine()) - 1, Character: int(devWarning.GetColumn()) - 1},
 					},
-					Message: devWarning.Message,
+					Message: devWarning.GetMessage(),
 				})
 			}
 		}

--- a/internal/middleware/perfinsights/perfinsights_test.go
+++ b/internal/middleware/perfinsights/perfinsights_test.go
@@ -95,11 +95,11 @@ func TestObserveShapeLatency(t *testing.T) {
 
 		require.Equal(t, io_prometheus_client.MetricType_HISTOGRAM, metric.GetType())
 
-		require.Equal(t, uint64(1), metric.GetMetric()[0].Histogram.GetSampleCount())
-		require.Equal(t, float64(0.1), metric.GetMetric()[0].Histogram.GetSampleSum()) //nolint:testifylint this value is set directly by test code
-		require.Equal(t, "testMethod", metric.GetMetric()[0].Label[0].GetValue())
+		require.Equal(t, uint64(1), metric.GetMetric()[0].GetHistogram().GetSampleCount())
+		require.Equal(t, float64(0.1), metric.GetMetric()[0].GetHistogram().GetSampleSum()) //nolint:testifylint this value is set directly by test code
+		require.Equal(t, "testMethod", metric.GetMetric()[0].GetLabel()[0].GetValue())
 
-		for _, label := range metric.GetMetric()[0].Label {
+		for _, label := range metric.GetMetric()[0].GetLabel() {
 			if label.GetName() == "api_kind" {
 				require.Equal(t, "testMethod", label.GetValue())
 				continue

--- a/internal/middleware/pertoken/pertoken_test.go
+++ b/internal/middleware/pertoken/pertoken_test.go
@@ -42,7 +42,7 @@ func (t testServer) Ping(ctx context.Context, req *testpb.PingRequest) (*testpb.
 		return nil, errors.New("no datastore in context")
 	}
 
-	if req.Value == "createrel" {
+	if req.GetValue() == "createrel" {
 		// Create a new relationship in the datastore
 		_, err := ds.ReadWriteTx(ctx, func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
 			return tx.WriteRelationships(ctx, []tuple.RelationshipUpdate{
@@ -163,28 +163,28 @@ validation: null
 func (s *perTokenMiddlewareTestSuite) TestUnaryInterceptor_WithMissingToken() {
 	resp, err := s.Client.Ping(s.SimpleCtx(), &testpb.PingRequest{Value: "test"})
 	s.Require().NoError(err)
-	s.Require().Equal("3", resp.Value)
+	s.Require().Equal("3", resp.GetValue())
 }
 
 func (s *perTokenMiddlewareTestSuite) TestUnaryInterceptor_WithEmptyToken() {
 	ctx := metadata.AppendToOutgoingContext(s.SimpleCtx(), "authorization", "")
 	resp, err := s.Client.Ping(ctx, &testpb.PingRequest{Value: "test"})
 	s.Require().NoError(err)
-	s.Require().Equal("3", resp.Value)
+	s.Require().Equal("3", resp.GetValue())
 }
 
 func (s *perTokenMiddlewareTestSuite) TestUnaryInterceptor_WithIncorrectToken() {
 	ctx := metadata.AppendToOutgoingContext(s.SimpleCtx(), "authorization", "missingbearer")
 	resp, err := s.Client.Ping(ctx, &testpb.PingRequest{Value: "test"})
 	s.Require().NoError(err)
-	s.Require().Equal("3", resp.Value)
+	s.Require().Equal("3", resp.GetValue())
 }
 
 func (s *perTokenMiddlewareTestSuite) TestUnaryInterceptor_WithDefinedToken() {
 	ctx := metadata.AppendToOutgoingContext(s.SimpleCtx(), "authorization", "bearer sometoken")
 	resp, err := s.Client.Ping(ctx, &testpb.PingRequest{Value: "test"})
 	s.Require().NoError(err)
-	s.Require().Equal("3", resp.Value)
+	s.Require().Equal("3", resp.GetValue())
 }
 
 func (s *perTokenMiddlewareTestSuite) TestUnaryInterceptor_WithDifferentToken() {
@@ -192,11 +192,11 @@ func (s *perTokenMiddlewareTestSuite) TestUnaryInterceptor_WithDifferentToken() 
 	ctx := metadata.AppendToOutgoingContext(s.SimpleCtx(), "authorization", "bearer sometoken")
 	resp, err := s.Client.Ping(ctx, &testpb.PingRequest{Value: "createrel"})
 	s.Require().NoError(err)
-	s.Require().Equal("4", resp.Value)
+	s.Require().Equal("4", resp.GetValue())
 
 	// Connect with a different token, which should not see the new relationship.
 	ctx = metadata.AppendToOutgoingContext(s.SimpleCtx(), "authorization", "bearer differenttoken")
 	resp, err = s.Client.Ping(ctx, &testpb.PingRequest{Value: "test"})
 	s.Require().NoError(err)
-	s.Require().Equal("3", resp.Value)
+	s.Require().Equal("3", resp.GetValue())
 }

--- a/internal/middleware/streamtimeout/streamtimeout_test.go
+++ b/internal/middleware/streamtimeout/streamtimeout_test.go
@@ -83,7 +83,7 @@ func (s *testSuite) TestStreamTimeout() {
 
 		// Ensure that we produced a *maximum* of 6 responses (timeout is 50ms and each response
 		// should take 10ms * counter). This ensures that we timed out (roughly) when expected.
-		maxCounter = resp.Counter
+		maxCounter = resp.GetCounter()
 		s.Require().LessOrEqual(maxCounter, int32(6), "stream was not properly canceled: %d", maxCounter)
 	}
 }

--- a/internal/middleware/usagemetrics/usagemetrics.go
+++ b/internal/middleware/usagemetrics/usagemetrics.go
@@ -56,11 +56,11 @@ func (r *serverReporter) PostCall(_ error, _ time.Duration) {
 		responseMeta = &dispatch.ResponseMeta{}
 	}
 
-	DispatchedCountHistogram.WithLabelValues(r.methodName, "false").Observe(float64(responseMeta.DispatchCount))
-	DispatchedCountHistogram.WithLabelValues(r.methodName, "true").Observe(float64(responseMeta.CachedDispatchCount))
+	DispatchedCountHistogram.WithLabelValues(r.methodName, "false").Observe(float64(responseMeta.GetDispatchCount()))
+	DispatchedCountHistogram.WithLabelValues(r.methodName, "true").Observe(float64(responseMeta.GetCachedDispatchCount()))
 	err := responsemeta.SetResponseTrailerMetadata(r.ctx, map[responsemeta.ResponseMetadataTrailerKey]string{
-		responsemeta.DispatchedOperationsCount: strconv.Itoa(int(responseMeta.DispatchCount)),
-		responsemeta.CachedOperationsCount:     strconv.Itoa(int(responseMeta.CachedDispatchCount)),
+		responsemeta.DispatchedOperationsCount: strconv.Itoa(int(responseMeta.GetDispatchCount())),
+		responsemeta.CachedOperationsCount:     strconv.Itoa(int(responseMeta.GetCachedDispatchCount())),
 	})
 	if err != nil {
 		// if context is cancelled, the stream will be closed, and gRPC will return ErrIllegalHeaderWrite (which is private)

--- a/internal/namespace/aliasing.go
+++ b/internal/namespace/aliasing.go
@@ -14,43 +14,43 @@ func computePermissionAliases(typeDefinition *schema.ValidatedDefinition) (map[s
 	done := map[string]struct{}{}
 	unresolvedAliases := map[string]string{}
 
-	for _, rel := range typeDefinition.Namespace().Relation {
+	for _, rel := range typeDefinition.Namespace().GetRelation() {
 		// Ensure the relation has a rewrite...
 		if rel.GetUsersetRewrite() == nil {
-			done[rel.Name] = struct{}{}
+			done[rel.GetName()] = struct{}{}
 			continue
 		}
 
 		// ... with a union ...
 		union := rel.GetUsersetRewrite().GetUnion()
 		if union == nil {
-			done[rel.Name] = struct{}{}
+			done[rel.GetName()] = struct{}{}
 			continue
 		}
 
 		// ... with a single child ...
-		if len(union.Child) != 1 {
-			done[rel.Name] = struct{}{}
+		if len(union.GetChild()) != 1 {
+			done[rel.GetName()] = struct{}{}
 			continue
 		}
 
 		// ... that is a computed userset.
-		computedUserset := union.Child[0].GetComputedUserset()
+		computedUserset := union.GetChild()[0].GetComputedUserset()
 		if computedUserset == nil {
-			done[rel.Name] = struct{}{}
+			done[rel.GetName()] = struct{}{}
 			continue
 		}
 
 		// If the aliased item is a relation, then we've found the alias target.
 		aliasedPermOrRel := computedUserset.GetRelation()
 		if !typeDefinition.IsPermission(aliasedPermOrRel) {
-			done[rel.Name] = struct{}{}
-			aliases[rel.Name] = aliasedPermOrRel
+			done[rel.GetName()] = struct{}{}
+			aliases[rel.GetName()] = aliasedPermOrRel
 			continue
 		}
 
 		// Otherwise, add the permission to the working set.
-		unresolvedAliases[rel.Name] = aliasedPermOrRel
+		unresolvedAliases[rel.GetName()] = aliasedPermOrRel
 	}
 
 	for len(unresolvedAliases) > 0 {
@@ -74,7 +74,7 @@ func computePermissionAliases(typeDefinition *schema.ValidatedDefinition) (map[s
 				keys = append(keys, key)
 			}
 			sort.Strings(keys)
-			return nil, NewPermissionsCycleErr(typeDefinition.Namespace().Name, keys)
+			return nil, NewPermissionsCycleErr(typeDefinition.Namespace().GetName(), keys)
 		}
 	}
 

--- a/internal/namespace/annotate.go
+++ b/internal/namespace/annotate.go
@@ -15,12 +15,12 @@ func AnnotateNamespace(def *schema.ValidatedDefinition) error {
 		return cerr
 	}
 
-	for _, rel := range def.Namespace().Relation {
-		if alias, ok := aliases[rel.Name]; ok {
+	for _, rel := range def.Namespace().GetRelation() {
+		if alias, ok := aliases[rel.GetName()]; ok {
 			rel.AliasingRelation = alias
 		}
 
-		if cacheKey, ok := cacheKeys[rel.Name]; ok {
+		if cacheKey, ok := cacheKeys[rel.GetName()]; ok {
 			rel.CanonicalCacheKey = cacheKey
 		}
 	}

--- a/internal/namespace/caveats.go
+++ b/internal/namespace/caveats.go
@@ -15,42 +15,42 @@ import (
 // definition, including usage of the parameters.
 func ValidateCaveatDefinition(ts *caveattypes.TypeSet, caveat *core.CaveatDefinition) error {
 	// Ensure all parameters are used by the caveat expression itself.
-	parameterTypes, err := caveattypes.DecodeParameterTypes(ts, caveat.ParameterTypes)
+	parameterTypes, err := caveattypes.DecodeParameterTypes(ts, caveat.GetParameterTypes())
 	if err != nil {
 		return schema.NewTypeWithSourceError(
-			fmt.Errorf("could not decode caveat parameters `%s`: %w", caveat.Name, err),
+			fmt.Errorf("could not decode caveat parameters `%s`: %w", caveat.GetName(), err),
 			caveat,
-			caveat.Name,
+			caveat.GetName(),
 		)
 	}
 
-	deserialized, err := caveats.DeserializeCaveatWithTypeSet(ts, caveat.SerializedExpression, parameterTypes)
+	deserialized, err := caveats.DeserializeCaveatWithTypeSet(ts, caveat.GetSerializedExpression(), parameterTypes)
 	if err != nil {
 		return schema.NewTypeWithSourceError(
-			fmt.Errorf("could not decode caveat `%s`: %w", caveat.Name, err),
+			fmt.Errorf("could not decode caveat `%s`: %w", caveat.GetName(), err),
 			caveat,
-			caveat.Name,
+			caveat.GetName(),
 		)
 	}
 
-	if len(caveat.ParameterTypes) == 0 {
+	if len(caveat.GetParameterTypes()) == 0 {
 		return schema.NewTypeWithSourceError(
-			fmt.Errorf("caveat `%s` must have at least one parameter defined", caveat.Name),
+			fmt.Errorf("caveat `%s` must have at least one parameter defined", caveat.GetName()),
 			caveat,
-			caveat.Name,
+			caveat.GetName(),
 		)
 	}
 
-	referencedNames, err := deserialized.ReferencedParameters(slices.Collect(maps.Keys(caveat.ParameterTypes)))
+	referencedNames, err := deserialized.ReferencedParameters(slices.Collect(maps.Keys(caveat.GetParameterTypes())))
 	if err != nil {
 		return err
 	}
 
-	for paramName, paramType := range caveat.ParameterTypes {
+	for paramName, paramType := range caveat.GetParameterTypes() {
 		_, err := caveattypes.DecodeParameterType(ts, paramType)
 		if err != nil {
 			return schema.NewTypeWithSourceError(
-				fmt.Errorf("type error for parameter `%s` for caveat `%s`: %w", paramName, caveat.Name, err),
+				fmt.Errorf("type error for parameter `%s` for caveat `%s`: %w", paramName, caveat.GetName(), err),
 				caveat,
 				paramName,
 			)
@@ -58,7 +58,7 @@ func ValidateCaveatDefinition(ts *caveattypes.TypeSet, caveat *core.CaveatDefini
 
 		if !referencedNames.Has(paramName) {
 			return schema.NewTypeWithSourceError(
-				NewUnusedCaveatParameterErr(caveat.Name, paramName),
+				NewUnusedCaveatParameterErr(caveat.GetName(), paramName),
 				caveat,
 				paramName,
 			)

--- a/internal/namespace/caveats_test.go
+++ b/internal/namespace/caveats_test.go
@@ -48,7 +48,7 @@ func TestValidateCaveatDefinition(t *testing.T) {
 
 	for _, tc := range tcs {
 		tc := tc
-		t.Run(tc.caveat.Name, func(t *testing.T) {
+		t.Run(tc.caveat.GetName(), func(t *testing.T) {
 			err := ValidateCaveatDefinition(caveattypes.Default.TypeSet, tc.caveat)
 			if tc.expectedError != "" {
 				require.Error(t, err)

--- a/internal/namespace/test/serialization_test.go
+++ b/internal/namespace/test/serialization_test.go
@@ -94,23 +94,23 @@ func TestSerialization(t *testing.T) {
 				for _, objectDef := range compiled.ObjectDefinitions {
 					protoSerialized, err := proto.Marshal(objectDef)
 					require.NoError(err)
-					err = os.WriteFile(fmt.Sprintf("testdata/proto/%s-definition-%s.proto", test.schema, objectDef.Name), protoSerialized, 0o600)
+					err = os.WriteFile(fmt.Sprintf("testdata/proto/%s-definition-%s.proto", test.schema, objectDef.GetName()), protoSerialized, 0o600)
 					require.NoError(err)
 
 					vtSerialized, err := objectDef.MarshalVT()
 					require.NoError(err)
-					err = os.WriteFile(fmt.Sprintf("testdata/proto/%s-definition-%s.vtproto", test.schema, objectDef.Name), vtSerialized, 0o600)
+					err = os.WriteFile(fmt.Sprintf("testdata/proto/%s-definition-%s.vtproto", test.schema, objectDef.GetName()), vtSerialized, 0o600)
 					require.NoError(err)
 				}
 				for _, caveatDef := range compiled.CaveatDefinitions {
 					protoSerialized, err := proto.Marshal(caveatDef)
 					require.NoError(err)
-					err = os.WriteFile(fmt.Sprintf("testdata/proto/%s-caveat-%s.proto", test.schema, caveatDef.Name), protoSerialized, 0o600)
+					err = os.WriteFile(fmt.Sprintf("testdata/proto/%s-caveat-%s.proto", test.schema, caveatDef.GetName()), protoSerialized, 0o600)
 					require.NoError(err)
 
 					vtSerialized, err := caveatDef.MarshalVT()
 					require.NoError(err)
-					err = os.WriteFile(fmt.Sprintf("testdata/proto/%s-caveat-%s.vtproto", test.schema, caveatDef.Name), vtSerialized, 0o600)
+					err = os.WriteFile(fmt.Sprintf("testdata/proto/%s-caveat-%s.vtproto", test.schema, caveatDef.GetName()), vtSerialized, 0o600)
 					require.NoError(err)
 				}
 			} else {

--- a/internal/namespace/util.go
+++ b/internal/namespace/util.go
@@ -25,8 +25,8 @@ func ReadNamespaceAndRelation(
 		return nil, nil, err
 	}
 
-	for _, rel := range config.Relation {
-		if rel.Name == relation {
+	for _, rel := range config.GetRelation() {
+		if rel.GetName() == relation {
 			return config, rel, nil
 		}
 	}
@@ -68,7 +68,7 @@ func CheckNamespaceAndRelations(ctx context.Context, checks []TypeAndRelationToC
 
 	mappedNamespaces := make(map[string]*core.NamespaceDefinition, len(namespaces))
 	for _, namespace := range namespaces {
-		mappedNamespaces[namespace.Definition.Name] = namespace.Definition
+		mappedNamespaces[namespace.Definition.GetName()] = namespace.Definition
 	}
 
 	for _, toCheck := range checks {
@@ -82,8 +82,8 @@ func CheckNamespaceAndRelations(ctx context.Context, checks []TypeAndRelationToC
 		}
 
 		foundRelation := false
-		for _, rel := range nsDef.Relation {
-			if rel.Name == toCheck.RelationName {
+		for _, rel := range nsDef.GetRelation() {
+			if rel.GetName() == toCheck.RelationName {
 				foundRelation = true
 				break
 			}
@@ -119,8 +119,8 @@ func CheckNamespaceAndRelation(
 		return nil
 	}
 
-	for _, rel := range config.Relation {
-		if rel.Name == relation {
+	for _, rel := range config.GetRelation() {
+		if rel.GetName() == relation {
 			return nil
 		}
 	}
@@ -134,11 +134,11 @@ func CheckNamespaceAndRelation(
 func ListReferencedNamespaces(nsdefs []*core.NamespaceDefinition) []string {
 	referencedNamespaceNamesSet := mapz.NewSet[string]()
 	for _, nsdef := range nsdefs {
-		referencedNamespaceNamesSet.Insert(nsdef.Name)
+		referencedNamespaceNamesSet.Insert(nsdef.GetName())
 
-		for _, relation := range nsdef.Relation {
+		for _, relation := range nsdef.GetRelation() {
 			if relation.GetTypeInformation() != nil {
-				for _, allowedRel := range relation.GetTypeInformation().AllowedDirectRelations {
+				for _, allowedRel := range relation.GetTypeInformation().GetAllowedDirectRelations() {
 					referencedNamespaceNamesSet.Insert(allowedRel.GetNamespace())
 				}
 			}

--- a/internal/relationships/errors.go
+++ b/internal/relationships/errors.go
@@ -45,12 +45,12 @@ func NewInvalidSubjectTypeError(
 		allowedCaveatsForSubject := mapz.NewSet[string]()
 
 		for _, allowedType := range allowedTypes {
-			if allowedType.RequiredCaveat != nil &&
-				allowedType.RequiredCaveat.CaveatName != "" &&
-				allowedType.Namespace == relationship.Subject.ObjectType &&
+			if allowedType.GetRequiredCaveat() != nil &&
+				allowedType.GetRequiredCaveat().GetCaveatName() != "" &&
+				allowedType.GetNamespace() == relationship.Subject.ObjectType &&
 				allowedType.GetRelation() == relationship.Subject.Relation &&
-				(allowedType.RequiredExpiration != nil) == (relationship.OptionalExpiration != nil) {
-				allowedCaveatsForSubject.Add(allowedType.RequiredCaveat.CaveatName)
+				(allowedType.GetRequiredExpiration() != nil) == (relationship.OptionalExpiration != nil) {
+				allowedCaveatsForSubject.Add(allowedType.GetRequiredCaveat().GetCaveatName())
 			}
 		}
 
@@ -173,7 +173,7 @@ func NewCaveatNotFoundError(relationship tuple.Relationship) CaveatNotFoundError
 	return CaveatNotFoundError{
 		error: fmt.Errorf(
 			"the caveat `%s` was not found for relationship `%s`",
-			relationship.OptionalCaveat.CaveatName,
+			relationship.OptionalCaveat.GetCaveatName(),
 			tuple.MustString(relationship),
 		),
 		relationship: relationship,
@@ -188,7 +188,7 @@ func (err CaveatNotFoundError) GRPCStatus() *status.Status {
 		spiceerrors.ForReason(
 			v1.ErrorReason_ERROR_REASON_UNKNOWN_CAVEAT,
 			map[string]string{
-				"caveat_name": err.relationship.OptionalCaveat.CaveatName,
+				"caveat_name": err.relationship.OptionalCaveat.GetCaveatName(),
 			},
 		),
 	)

--- a/internal/relationships/validation.go
+++ b/internal/relationships/validation.go
@@ -94,7 +94,7 @@ func loadNamespacesAndCaveats(ctx context.Context, rels []tuple.Relationship, re
 		referencedNamespaceNames.Insert(rel.Resource.ObjectType)
 		referencedNamespaceNames.Insert(rel.Subject.ObjectType)
 		if hasNonEmptyCaveatContext(rel) {
-			referencedCaveatNamesWithContext.Insert(rel.OptionalCaveat.CaveatName)
+			referencedCaveatNamesWithContext.Insert(rel.OptionalCaveat.GetCaveatName())
 		}
 	}
 
@@ -115,7 +115,7 @@ func loadNamespacesAndCaveats(ctx context.Context, rels []tuple.Relationship, re
 				return nil, nil, err
 			}
 
-			referencedNamespaceMap[nsDef.Definition.Name] = nts
+			referencedNamespaceMap[nsDef.Definition.GetName()] = nts
 		}
 	}
 
@@ -127,7 +127,7 @@ func loadNamespacesAndCaveats(ctx context.Context, rels []tuple.Relationship, re
 
 		referencedCaveatMap = make(map[string]*core.CaveatDefinition, len(foundCaveats))
 		for _, caveatDef := range foundCaveats {
-			referencedCaveatMap[caveatDef.Definition.Name] = caveatDef.Definition
+			referencedCaveatMap[caveatDef.Definition.GetName()] = caveatDef.Definition
 		}
 	}
 	return referencedNamespaceMap, referencedCaveatMap, nil
@@ -191,7 +191,7 @@ func ValidateOneRelationship(
 	// Validate the subject against the allowed relation(s).
 	var caveat *core.AllowedCaveat
 	if rel.OptionalCaveat != nil {
-		caveat = ns.AllowedCaveat(rel.OptionalCaveat.CaveatName)
+		caveat = ns.AllowedCaveat(rel.OptionalCaveat.GetCaveatName())
 	}
 
 	var relationToCheck *core.AllowedRelation
@@ -250,7 +250,7 @@ func ValidateOneRelationship(
 
 	// Validate caveat and its context, if applicable.
 	if hasNonEmptyCaveatContext(rel) {
-		caveat, ok := caveatMap[rel.OptionalCaveat.CaveatName]
+		caveat, ok := caveatMap[rel.OptionalCaveat.GetCaveatName()]
 		if !ok {
 			// Should ideally never happen since the caveat is type checked above, but just in case.
 			return NewCaveatNotFoundError(rel)
@@ -259,8 +259,8 @@ func ValidateOneRelationship(
 		// Verify that the provided context information matches the types of the parameters defined.
 		_, err := caveats.ConvertContextToParameters(
 			caveatTypeSet,
-			rel.OptionalCaveat.Context.AsMap(),
-			caveat.ParameterTypes,
+			rel.OptionalCaveat.GetContext().AsMap(),
+			caveat.GetParameterTypes(),
 			caveats.ErrorForUnknownParameters,
 		)
 		if err != nil {
@@ -273,7 +273,7 @@ func ValidateOneRelationship(
 
 func hasNonEmptyCaveatContext(relationship tuple.Relationship) bool {
 	return relationship.OptionalCaveat != nil &&
-		relationship.OptionalCaveat.CaveatName != "" &&
-		relationship.OptionalCaveat.Context != nil &&
-		len(relationship.OptionalCaveat.Context.GetFields()) > 0
+		relationship.OptionalCaveat.GetCaveatName() != "" &&
+		relationship.OptionalCaveat.GetContext() != nil &&
+		len(relationship.OptionalCaveat.GetContext().GetFields()) > 0
 }

--- a/internal/services/integrationtesting/cert_test.go
+++ b/internal/services/integrationtesting/cert_test.go
@@ -214,9 +214,9 @@ func TestCertRotation(t *testing.T) {
 				AtLeastAsFresh: zedtoken.MustNewFromRevisionForTesting(revision),
 			},
 		},
-		Resource:   rel.Resource,
+		Resource:   rel.GetResource(),
 		Permission: "viewer",
-		Subject:    rel.Subject,
+		Subject:    rel.GetSubject(),
 	})
 	require.NoError(t, err)
 
@@ -267,9 +267,9 @@ func TestCertRotation(t *testing.T) {
 					AtLeastAsFresh: zedtoken.MustNewFromRevisionForTesting(revision),
 				},
 			},
-			Resource:   rel.Resource,
+			Resource:   rel.GetResource(),
 			Permission: "viewer",
-			Subject:    rel.Subject,
+			Subject:    rel.GetSubject(),
 		})
 		require.NoError(t, err)
 		time.Sleep(initialValidDuration)

--- a/internal/services/integrationtesting/consistencytestutil/accessibilityset.go
+++ b/internal/services/integrationtesting/consistencytestutil/accessibilityset.go
@@ -118,15 +118,15 @@ func BuildAccessibilitySet(t *testing.T, ccd ConsistencyClusterAndData) *Accessi
 
 	for _, resourceType := range ccd.Populated.NamespaceDefinitions {
 		for _, possibleResourceID := range allObjectIds.AsSlice() {
-			for _, relationOrPermission := range resourceType.Relation {
+			for _, relationOrPermission := range resourceType.GetRelation() {
 				for _, subject := range subjectsByNamespace.Values() {
 					if subject.ObjectID == tuple.PublicWildcard {
 						continue
 					}
 
 					resourceRelation := tuple.RelationReference{
-						ObjectType: resourceType.Name,
-						Relation:   relationOrPermission.Name,
+						ObjectType: resourceType.GetName(),
+						Relation:   relationOrPermission.GetName(),
 					}
 
 					results, err := dispatcher.DispatchCheck(ccd.Ctx, &dispatchv1.DispatchCheckRequest{
@@ -143,9 +143,9 @@ func BuildAccessibilitySet(t *testing.T, ccd ConsistencyClusterAndData) *Accessi
 					require.NoError(t, err)
 
 					resourceAndRelation := tuple.ObjectAndRelation{
-						ObjectType: resourceType.Name,
+						ObjectType: resourceType.GetName(),
 						ObjectID:   possibleResourceID,
-						Relation:   relationOrPermission.Name,
+						Relation:   relationOrPermission.GetName(),
 					}
 					permString := tuple.MustString(tuple.Relationship{
 						RelationshipReference: tuple.RelationshipReference{
@@ -154,8 +154,8 @@ func BuildAccessibilitySet(t *testing.T, ccd ConsistencyClusterAndData) *Accessi
 						},
 					})
 
-					if result, ok := results.ResultsByResourceId[possibleResourceID]; ok {
-						membership := result.Membership
+					if result, ok := results.GetResultsByResourceId()[possibleResourceID]; ok {
+						membership := result.GetMembership()
 						uncomputedPermissionshipByRelationship[permString] = membership
 
 						// If the subject is caveated, run a computed check to determine if it
@@ -175,7 +175,7 @@ func BuildAccessibilitySet(t *testing.T, ccd ConsistencyClusterAndData) *Accessi
 								100,
 							)
 							require.NoError(t, err)
-							membership = cr.Membership
+							membership = cr.GetMembership()
 						}
 
 						permissionshipByRelationship[permString] = membership
@@ -374,7 +374,7 @@ func isAccessibleViaWildcardOnly(
 	})
 	require.NoError(t, err)
 
-	subjectsFound, err := developmentmembership.AccessibleExpansionSubjects(resp.TreeNode)
+	subjectsFound, err := developmentmembership.AccessibleExpansionSubjects(resp.GetTreeNode())
 	require.NoError(t, err)
 	return !subjectsFound.Contains(subject)
 }

--- a/internal/services/integrationtesting/consistencytestutil/servicetester.go
+++ b/internal/services/integrationtesting/consistencytestutil/servicetester.go
@@ -87,7 +87,7 @@ func (v1st v1ServiceTester) Check(ctx context.Context, resource tuple.ObjectAndR
 	if err != nil {
 		return v1.CheckPermissionResponse_PERMISSIONSHIP_UNSPECIFIED, err
 	}
-	return checkResp.Permissionship, nil
+	return checkResp.GetPermissionship(), nil
 }
 
 func (v1st v1ServiceTester) Expand(ctx context.Context, resource tuple.ObjectAndRelation, atRevision datastore.Revision) (*core.RelationTupleTreeNode, error) {
@@ -106,7 +106,7 @@ func (v1st v1ServiceTester) Expand(ctx context.Context, resource tuple.ObjectAnd
 	if err != nil {
 		return nil, err
 	}
-	return v1svc.TranslateRelationshipTree(expandResp.TreeRoot), nil
+	return v1svc.TranslateRelationshipTree(expandResp.GetTreeRoot()), nil
 }
 
 func (v1st v1ServiceTester) Write(ctx context.Context, relationship tuple.Relationship) error {
@@ -154,7 +154,7 @@ func (v1st v1ServiceTester) Read(_ context.Context, namespaceName string, atRevi
 			return nil, err
 		}
 
-		rels = append(rels, tuple.FromV1Relationship(resp.Relationship))
+		rels = append(rels, tuple.FromV1Relationship(resp.GetRelationship()))
 	}
 
 	return rels, nil
@@ -206,7 +206,7 @@ func (v1st v1ServiceTester) LookupResources(_ context.Context, resourceRelation 
 		}
 
 		found = append(found, resp)
-		lastCursor = resp.AfterResultCursor
+		lastCursor = resp.GetAfterResultCursor()
 	}
 	return found, lastCursor, nil
 }
@@ -251,7 +251,7 @@ func (v1st v1ServiceTester) LookupSubjects(_ context.Context, resource tuple.Obj
 			return nil, err
 		}
 
-		found[resp.Subject.SubjectObjectId] = resp
+		found[resp.GetSubject().GetSubjectObjectId()] = resp
 	}
 	return found, nil
 }
@@ -269,7 +269,7 @@ func (v1st v1ServiceTester) BulkCheck(ctx context.Context, items []*v1.BulkCheck
 		return nil, err
 	}
 
-	return result.Pairs, nil
+	return result.GetPairs(), nil
 }
 
 func (v1st v1ServiceTester) CheckBulk(ctx context.Context, items []*v1.CheckBulkPermissionsRequestItem, atRevision datastore.Revision) ([]*v1.CheckBulkPermissionsPair, error) {
@@ -285,5 +285,5 @@ func (v1st v1ServiceTester) CheckBulk(ctx context.Context, items []*v1.CheckBulk
 		return nil, err
 	}
 
-	return result.Pairs, nil
+	return result.GetPairs(), nil
 }

--- a/internal/services/integrationtesting/dispatch_test.go
+++ b/internal/services/integrationtesting/dispatch_test.go
@@ -64,7 +64,7 @@ func TestDispatchIntegration(t *testing.T) {
 				cresp, err := client.CheckPermission(context.Background(), &v1.CheckPermissionRequest{
 					Consistency: &v1.Consistency{
 						Requirement: &v1.Consistency_AtLeastAsFresh{
-							AtLeastAsFresh: resp.WrittenAt,
+							AtLeastAsFresh: resp.GetWrittenAt(),
 						},
 					},
 					Resource: &v1.ObjectReference{
@@ -80,12 +80,12 @@ func TestDispatchIntegration(t *testing.T) {
 					},
 				})
 				require.NoError(t, err)
-				require.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, cresp.Permissionship)
+				require.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, cresp.GetPermissionship())
 
 				cresp2, err := client.CheckPermission(context.Background(), &v1.CheckPermissionRequest{
 					Consistency: &v1.Consistency{
 						Requirement: &v1.Consistency_AtLeastAsFresh{
-							AtLeastAsFresh: resp.WrittenAt,
+							AtLeastAsFresh: resp.GetWrittenAt(),
 						},
 					},
 					Resource: &v1.ObjectReference{
@@ -101,7 +101,7 @@ func TestDispatchIntegration(t *testing.T) {
 					},
 				})
 				require.NoError(t, err)
-				require.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, cresp2.Permissionship)
+				require.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, cresp2.GetPermissionship())
 			},
 		},
 		{
@@ -129,7 +129,7 @@ func TestDispatchIntegration(t *testing.T) {
 				cresp, err := client.CheckPermission(context.Background(), &v1.CheckPermissionRequest{
 					Consistency: &v1.Consistency{
 						Requirement: &v1.Consistency_AtLeastAsFresh{
-							AtLeastAsFresh: resp.WrittenAt,
+							AtLeastAsFresh: resp.GetWrittenAt(),
 						},
 					},
 					Resource: &v1.ObjectReference{
@@ -145,7 +145,7 @@ func TestDispatchIntegration(t *testing.T) {
 					},
 				})
 				require.NoError(t, err)
-				require.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION, cresp.Permissionship)
+				require.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION, cresp.GetPermissionship())
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestDispatchIntegration(t *testing.T) {
 				_, cerr := client.CheckPermission(context.Background(), &v1.CheckPermissionRequest{
 					Consistency: &v1.Consistency{
 						Requirement: &v1.Consistency_AtLeastAsFresh{
-							AtLeastAsFresh: resp.WrittenAt,
+							AtLeastAsFresh: resp.GetWrittenAt(),
 						},
 					},
 					Resource: &v1.ObjectReference{
@@ -309,7 +309,7 @@ func TestDispatchIntegration(t *testing.T) {
 					},
 				})
 				require.NoError(t, derr)
-				require.NotNil(t, resp.DeletedAt)
+				require.NotNil(t, resp.GetDeletedAt())
 			},
 		},
 	}

--- a/internal/services/integrationtesting/ops_test.go
+++ b/internal/services/integrationtesting/ops_test.go
@@ -832,5 +832,5 @@ func (st v1OpsTester) ReadSchema(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return resp.SchemaText, nil
+	return resp.GetSchemaText(), nil
 }

--- a/internal/services/integrationtesting/perf_test.go
+++ b/internal/services/integrationtesting/perf_test.go
@@ -62,9 +62,9 @@ func TestBurst(t *testing.T) {
 								AtLeastAsFresh: zedtoken.MustNewFromRevisionForTesting(revision),
 							},
 						},
-						Resource:   rel.Resource,
+						Resource:   rel.GetResource(),
 						Permission: "viewer",
-						Subject:    rel.Subject,
+						Subject:    rel.GetSubject(),
 					})
 					require.NoError(t, err)
 				}()

--- a/internal/services/v1/debug_unit_test.go
+++ b/internal/services/v1/debug_unit_test.go
@@ -77,8 +77,8 @@ func TestConvertCheckTrace_MultipleResourceIds_RequireAllResults(t *testing.T) {
 			req.NoError(err)
 
 			// Verify the expected result
-			req.Equal(tt.expectedResult, converted.Result)
-			req.Equal("resource1,resource2,resource3", converted.Resource.ObjectId)
+			req.Equal(tt.expectedResult, converted.GetResult())
+			req.Equal("resource1,resource2,resource3", converted.GetResource().GetObjectId())
 		})
 	}
 }

--- a/internal/services/v1/errors.go
+++ b/internal/services/v1/errors.go
@@ -185,34 +185,34 @@ func NewPreconditionFailedErr(precondition *v1.Precondition) error {
 // GRPCStatus implements retrieving the gRPC status for the error.
 func (err PreconditionFailedError) GRPCStatus() *status.Status {
 	metadata := map[string]string{
-		"precondition_operation": v1.Precondition_Operation_name[int32(err.precondition.Operation)],
+		"precondition_operation": v1.Precondition_Operation_name[int32(err.precondition.GetOperation())],
 	}
 
-	if err.precondition.Filter.ResourceType != "" {
-		metadata["precondition_resource_type"] = err.precondition.Filter.ResourceType
+	if err.precondition.GetFilter().GetResourceType() != "" {
+		metadata["precondition_resource_type"] = err.precondition.GetFilter().GetResourceType()
 	}
 
-	if err.precondition.Filter.OptionalResourceId != "" {
-		metadata["precondition_resource_id"] = err.precondition.Filter.OptionalResourceId
+	if err.precondition.GetFilter().GetOptionalResourceId() != "" {
+		metadata["precondition_resource_id"] = err.precondition.GetFilter().GetOptionalResourceId()
 	}
 
-	if err.precondition.Filter.OptionalResourceIdPrefix != "" {
-		metadata["precondition_resource_id_prefix"] = err.precondition.Filter.OptionalResourceIdPrefix
+	if err.precondition.GetFilter().GetOptionalResourceIdPrefix() != "" {
+		metadata["precondition_resource_id_prefix"] = err.precondition.GetFilter().GetOptionalResourceIdPrefix()
 	}
 
-	if err.precondition.Filter.OptionalRelation != "" {
-		metadata["precondition_relation"] = err.precondition.Filter.OptionalRelation
+	if err.precondition.GetFilter().GetOptionalRelation() != "" {
+		metadata["precondition_relation"] = err.precondition.GetFilter().GetOptionalRelation()
 	}
 
-	if err.precondition.Filter.OptionalSubjectFilter != nil {
-		metadata["precondition_subject_type"] = err.precondition.Filter.OptionalSubjectFilter.SubjectType
+	if err.precondition.GetFilter().GetOptionalSubjectFilter() != nil {
+		metadata["precondition_subject_type"] = err.precondition.GetFilter().GetOptionalSubjectFilter().GetSubjectType()
 
-		if err.precondition.Filter.OptionalSubjectFilter.OptionalSubjectId != "" {
-			metadata["precondition_subject_id"] = err.precondition.Filter.OptionalSubjectFilter.OptionalSubjectId
+		if err.precondition.GetFilter().GetOptionalSubjectFilter().GetOptionalSubjectId() != "" {
+			metadata["precondition_subject_id"] = err.precondition.GetFilter().GetOptionalSubjectFilter().GetOptionalSubjectId()
 		}
 
-		if err.precondition.Filter.OptionalSubjectFilter.OptionalRelation != nil {
-			metadata["precondition_subject_relation"] = err.precondition.Filter.OptionalSubjectFilter.OptionalRelation.Relation
+		if err.precondition.GetFilter().GetOptionalSubjectFilter().GetOptionalRelation() != nil {
+			metadata["precondition_subject_relation"] = err.precondition.GetFilter().GetOptionalSubjectFilter().GetOptionalRelation().GetRelation()
 		}
 	}
 
@@ -237,7 +237,7 @@ func NewDuplicateRelationshipErr(update *v1.RelationshipUpdate) DuplicateRelatio
 	return DuplicateRelationErrorshipError{
 		error: fmt.Errorf(
 			"found more than one update with relationship `%s` in this request; a relationship can only be specified in an update once per overall WriteRelationships request",
-			tuple.V1StringRelationshipWithoutCaveatOrExpiration(update.Relationship),
+			tuple.V1StringRelationshipWithoutCaveatOrExpiration(update.GetRelationship()),
 		),
 		update: update,
 	}
@@ -251,8 +251,8 @@ func (err DuplicateRelationErrorshipError) GRPCStatus() *status.Status {
 		spiceerrors.ForReason(
 			v1.ErrorReason_ERROR_REASON_UPDATES_ON_SAME_RELATIONSHIP,
 			map[string]string{
-				"definition_name": err.update.Relationship.Resource.ObjectType,
-				"relationship":    tuple.MustV1StringRelationship(err.update.Relationship),
+				"definition_name": err.update.GetRelationship().GetResource().GetObjectType(),
+				"relationship":    tuple.MustV1StringRelationship(err.update.GetRelationship()),
 			},
 		),
 	)
@@ -271,7 +271,7 @@ func NewMaxRelationshipContextError(update *v1.RelationshipUpdate, maxAllowedSiz
 	return ErrMaxRelationshipContextError{
 		error: fmt.Errorf(
 			"provided relationship `%s` exceeded maximum allowed caveat size of %d",
-			tuple.V1StringRelationshipWithoutCaveatOrExpiration(update.Relationship),
+			tuple.V1StringRelationshipWithoutCaveatOrExpiration(update.GetRelationship()),
 			maxAllowedSize,
 		),
 		update:         update,
@@ -287,9 +287,9 @@ func (err ErrMaxRelationshipContextError) GRPCStatus() *status.Status {
 		spiceerrors.ForReason(
 			v1.ErrorReason_ERROR_REASON_MAX_RELATIONSHIP_CONTEXT_SIZE,
 			map[string]string{
-				"relationship":     tuple.V1StringRelationshipWithoutCaveatOrExpiration(err.update.Relationship),
+				"relationship":     tuple.V1StringRelationshipWithoutCaveatOrExpiration(err.update.GetRelationship()),
 				"max_allowed_size": strconv.Itoa(err.maxAllowedSize),
-				"context_size":     strconv.Itoa(proto.Size(err.update.Relationship)),
+				"context_size":     strconv.Itoa(proto.Size(err.update.GetRelationship())),
 			},
 		),
 	)
@@ -318,26 +318,26 @@ func NewCouldNotTransactionallyDeleteErr(filter *v1.RelationshipFilter, limit ui
 func (err CouldNotTransactionallyDeleteError) GRPCStatus() *status.Status {
 	metadata := map[string]string{
 		"limit":                strconv.Itoa(int(err.limit)),
-		"filter_resource_type": err.filter.ResourceType,
+		"filter_resource_type": err.filter.GetResourceType(),
 	}
 
-	if err.filter.OptionalResourceId != "" {
-		metadata["filter_resource_id"] = err.filter.OptionalResourceId
+	if err.filter.GetOptionalResourceId() != "" {
+		metadata["filter_resource_id"] = err.filter.GetOptionalResourceId()
 	}
 
-	if err.filter.OptionalRelation != "" {
-		metadata["filter_relation"] = err.filter.OptionalRelation
+	if err.filter.GetOptionalRelation() != "" {
+		metadata["filter_relation"] = err.filter.GetOptionalRelation()
 	}
 
-	if err.filter.OptionalSubjectFilter != nil {
-		metadata["filter_subject_type"] = err.filter.OptionalSubjectFilter.SubjectType
+	if err.filter.GetOptionalSubjectFilter() != nil {
+		metadata["filter_subject_type"] = err.filter.GetOptionalSubjectFilter().GetSubjectType()
 
-		if err.filter.OptionalSubjectFilter.OptionalSubjectId != "" {
-			metadata["filter_subject_id"] = err.filter.OptionalSubjectFilter.OptionalSubjectId
+		if err.filter.GetOptionalSubjectFilter().GetOptionalSubjectId() != "" {
+			metadata["filter_subject_id"] = err.filter.GetOptionalSubjectFilter().GetOptionalSubjectId()
 		}
 
-		if err.filter.OptionalSubjectFilter.OptionalRelation != nil {
-			metadata["filter_subject_relation"] = err.filter.OptionalSubjectFilter.OptionalRelation.Relation
+		if err.filter.GetOptionalSubjectFilter().GetOptionalRelation() != nil {
+			metadata["filter_subject_relation"] = err.filter.GetOptionalSubjectFilter().GetOptionalRelation().GetRelation()
 		}
 	}
 

--- a/internal/services/v1/expreflection_test.go
+++ b/internal/services/v1/expreflection_test.go
@@ -568,9 +568,9 @@ func TestExpConvertDiff(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			testutil.RequireProtoEqual(t, tc.expectedResponse, &v1.ExperimentalDiffSchemaResponse{Diffs: resp.Diffs}, "got mismatch")
+			testutil.RequireProtoEqual(t, tc.expectedResponse, &v1.ExperimentalDiffSchemaResponse{Diffs: resp.GetDiffs()}, "got mismatch")
 
-			for _, diff := range resp.Diffs {
+			for _, diff := range resp.GetDiffs() {
 				name := reflect.TypeOf(diff.GetDiff()).String()
 				encounteredDiffTypes.Add(strings.ToLower(strings.Split(name, "_")[1]))
 			}

--- a/internal/services/v1/grouping.go
+++ b/internal/services/v1/grouping.go
@@ -34,17 +34,17 @@ func groupItems(ctx context.Context, params groupingParameters, items []*v1.Chec
 		}
 
 		if _, ok := res[hash]; !ok {
-			caveatContext, err := GetCaveatContext(ctx, item.Context, params.maxCaveatContextSize)
+			caveatContext, err := GetCaveatContext(ctx, item.GetContext(), params.maxCaveatContextSize)
 			if err != nil {
 				return nil, err
 			}
 
 			res[hash] = &groupedCheckParameters{
 				params:      checkParametersFromCheckBulkPermissionsRequestItem(item, params, caveatContext),
-				resourceIDs: []string{item.Resource.ObjectId},
+				resourceIDs: []string{item.GetResource().GetObjectId()},
 			}
 		} else {
-			res[hash].resourceIDs = append(res[hash].resourceIDs, item.Resource.ObjectId)
+			res[hash].resourceIDs = append(res[hash].resourceIDs, item.GetResource().GetObjectId())
 		}
 	}
 
@@ -62,8 +62,8 @@ func checkParametersFromCheckBulkPermissionsRequestItem(
 	}
 
 	return &computed.CheckParameters{
-		ResourceType:  tuple.RR(bc.Resource.ObjectType, bc.Permission),
-		Subject:       tuple.ONR(bc.Subject.Object.ObjectType, bc.Subject.Object.ObjectId, normalizeSubjectRelation(bc.Subject)),
+		ResourceType:  tuple.RR(bc.GetResource().GetObjectType(), bc.GetPermission()),
+		Subject:       tuple.ONR(bc.GetSubject().GetObject().GetObjectType(), bc.GetSubject().GetObject().GetObjectId(), normalizeSubjectRelation(bc.GetSubject())),
 		CaveatContext: caveatContext,
 		AtRevision:    params.atRevision,
 		MaximumDepth:  params.maximumAPIDepth,

--- a/internal/services/v1/grouping_test.go
+++ b/internal/services/v1/grouping_test.go
@@ -185,12 +185,12 @@ func TestGroupItems(t *testing.T) {
 				require.NoError(t, err)
 
 				item := &v1.CheckBulkPermissionsRequestItem{
-					Resource:   rel.Resource,
-					Permission: rel.Relation,
-					Subject:    rel.Subject,
+					Resource:   rel.GetResource(),
+					Permission: rel.GetRelation(),
+					Subject:    rel.GetSubject(),
 				}
-				if rel.OptionalCaveat != nil {
-					item.Context = rel.OptionalCaveat.Context
+				if rel.GetOptionalCaveat() != nil {
+					item.Context = rel.GetOptionalCaveat().GetContext()
 				}
 				items = append(items, item)
 			}
@@ -260,10 +260,10 @@ func TestCaveatContextSizeLimitIsEnforced(t *testing.T) {
 
 	items := []*v1.CheckBulkPermissionsRequestItem{
 		{
-			Resource:   rel.Resource,
-			Permission: rel.Relation,
-			Subject:    rel.Subject,
-			Context:    rel.OptionalCaveat.Context,
+			Resource:   rel.GetResource(),
+			Permission: rel.GetRelation(),
+			Subject:    rel.GetSubject(),
+			Context:    rel.GetOptionalCaveat().GetContext(),
 		},
 	}
 	_, err = groupItems(t.Context(), cp, items)

--- a/internal/services/v1/hash.go
+++ b/internal/services/v1/hash.go
@@ -14,56 +14,56 @@ import (
 
 func computeCheckBulkPermissionsItemHashWithoutResourceID(req *v1.CheckBulkPermissionsRequestItem) (string, error) {
 	return computeCallHash("v1.checkbulkpermissionsrequestitem", nil, map[string]any{
-		"resource-type":    req.Resource.ObjectType,
-		"permission":       req.Permission,
-		"subject-type":     req.Subject.Object.ObjectType,
-		"subject-id":       req.Subject.Object.ObjectId,
-		"subject-relation": req.Subject.OptionalRelation,
-		"context":          req.Context,
+		"resource-type":    req.GetResource().GetObjectType(),
+		"permission":       req.GetPermission(),
+		"subject-type":     req.GetSubject().GetObject().GetObjectType(),
+		"subject-id":       req.GetSubject().GetObject().GetObjectId(),
+		"subject-relation": req.GetSubject().GetOptionalRelation(),
+		"context":          req.GetContext(),
 	})
 }
 
 func computeCheckBulkPermissionsItemHash(req *v1.CheckBulkPermissionsRequestItem) (string, error) {
 	return computeCallHash("v1.checkbulkpermissionsrequestitem", nil, map[string]any{
-		"resource-type":    req.Resource.ObjectType,
-		"resource-id":      req.Resource.ObjectId,
-		"permission":       req.Permission,
-		"subject-type":     req.Subject.Object.ObjectType,
-		"subject-id":       req.Subject.Object.ObjectId,
-		"subject-relation": req.Subject.OptionalRelation,
-		"context":          req.Context,
+		"resource-type":    req.GetResource().GetObjectType(),
+		"resource-id":      req.GetResource().GetObjectId(),
+		"permission":       req.GetPermission(),
+		"subject-type":     req.GetSubject().GetObject().GetObjectType(),
+		"subject-id":       req.GetSubject().GetObject().GetObjectId(),
+		"subject-relation": req.GetSubject().GetOptionalRelation(),
+		"context":          req.GetContext(),
 	})
 }
 
 func computeReadRelationshipsRequestHash(req *v1.ReadRelationshipsRequest) (string, error) {
-	osf := req.RelationshipFilter.OptionalSubjectFilter
+	osf := req.GetRelationshipFilter().GetOptionalSubjectFilter()
 	if osf == nil {
 		osf = &v1.SubjectFilter{}
 	}
 
 	srf := "(none)"
-	if osf.OptionalRelation != nil {
-		srf = osf.OptionalRelation.Relation
+	if osf.GetOptionalRelation() != nil {
+		srf = osf.GetOptionalRelation().GetRelation()
 	}
 
-	return computeCallHash("v1.readrelationships", req.Consistency, map[string]any{
-		"filter-resource-type": req.RelationshipFilter.ResourceType,
-		"filter-relation":      req.RelationshipFilter.OptionalRelation,
-		"filter-resource-id":   req.RelationshipFilter.OptionalResourceId,
-		"subject-type":         osf.SubjectType,
+	return computeCallHash("v1.readrelationships", req.GetConsistency(), map[string]any{
+		"filter-resource-type": req.GetRelationshipFilter().GetResourceType(),
+		"filter-relation":      req.GetRelationshipFilter().GetOptionalRelation(),
+		"filter-resource-id":   req.GetRelationshipFilter().GetOptionalResourceId(),
+		"subject-type":         osf.GetSubjectType(),
 		"subject-relation":     srf,
-		"subject-resource-id":  osf.OptionalSubjectId,
-		"limit":                req.OptionalLimit,
+		"subject-resource-id":  osf.GetOptionalSubjectId(),
+		"limit":                req.GetOptionalLimit(),
 	})
 }
 
 func computeLRRequestHash(req *v1.LookupResourcesRequest) (string, error) {
-	return computeCallHash("v1.lookupresources", req.Consistency, map[string]any{
-		"resource-type": req.ResourceObjectType,
-		"permission":    req.Permission,
-		"subject":       tuple.V1StringSubjectRef(req.Subject),
-		"limit":         req.OptionalLimit,
-		"context":       req.Context,
+	return computeCallHash("v1.lookupresources", req.GetConsistency(), map[string]any{
+		"resource-type": req.GetResourceObjectType(),
+		"permission":    req.GetPermission(),
+		"subject":       tuple.V1StringSubjectRef(req.GetSubject()),
+		"limit":         req.GetOptionalLimit(),
+		"context":       req.GetContext(),
 	})
 }
 

--- a/internal/services/v1/metadata_test.go
+++ b/internal/services/v1/metadata_test.go
@@ -224,7 +224,7 @@ func TestAllMethodsReturnMetadata(t *testing.T) {
 
 				var trailer metadata.MD
 				_, err = client.WriteSchema(ctx, &v1.WriteSchemaRequest{
-					Schema: resp.SchemaText + "\ndefinition foo {}",
+					Schema: resp.GetSchemaText() + "\ndefinition foo {}",
 				}, grpc.Trailer(&trailer))
 				require.NoError(t, err)
 				return trailer

--- a/internal/services/v1/permissions_queryplan.go
+++ b/internal/services/v1/permissions_queryplan.go
@@ -47,13 +47,13 @@ func (ps *permissionServer) checkPermissionWithQueryPlan(ctx context.Context, re
 
 	// Build iterator tree from schema
 	// TODO: Better iterator caching
-	it, err := query.BuildIteratorFromSchema(fullSchema, req.Resource.ObjectType, req.Permission)
+	it, err := query.BuildIteratorFromSchema(fullSchema, req.GetResource().GetObjectType(), req.GetPermission())
 	if err != nil {
 		return nil, ps.rewriteError(ctx, err)
 	}
 
 	// Parse caveat context if provided
-	caveatContext, err := GetCaveatContext(ctx, req.Context, ps.config.MaxCaveatContextSize)
+	caveatContext, err := GetCaveatContext(ctx, req.GetContext(), ps.config.MaxCaveatContextSize)
 	if err != nil {
 		return nil, ps.rewriteError(ctx, err)
 	}
@@ -69,14 +69,14 @@ func (ps *permissionServer) checkPermissionWithQueryPlan(ctx context.Context, re
 
 	// Execute the check
 	resource := query.Object{
-		ObjectType: req.Resource.ObjectType,
-		ObjectID:   req.Resource.ObjectId,
+		ObjectType: req.GetResource().GetObjectType(),
+		ObjectID:   req.GetResource().GetObjectId(),
 	}
 
 	subject := query.ObjectAndRelation{
-		ObjectType: req.Subject.Object.ObjectType,
-		ObjectID:   req.Subject.Object.ObjectId,
-		Relation:   normalizeSubjectRelation(req.Subject),
+		ObjectType: req.GetSubject().GetObject().GetObjectType(),
+		ObjectID:   req.GetSubject().GetObject().GetObjectId(),
+		Relation:   normalizeSubjectRelation(req.GetSubject()),
 	}
 
 	pathSeq, err := qctx.Check(it, []query.Object{resource}, subject)

--- a/internal/services/v1/preconditions.go
+++ b/internal/services/v1/preconditions.go
@@ -21,7 +21,7 @@ func checkPreconditions(
 	preconditions []*v1.Precondition,
 ) error {
 	for _, precond := range preconditions {
-		dsFilter, err := datastore.RelationshipsFilterFromPublicFilter(precond.Filter)
+		dsFilter, err := datastore.RelationshipsFilterFromPublicFilter(precond.GetFilter())
 		if err != nil {
 			return fmt.Errorf("error converting filter: %w", err)
 		}
@@ -36,7 +36,7 @@ func checkPreconditions(
 			return fmt.Errorf("error reading relationships from iterator: %w", err)
 		}
 
-		switch precond.Operation {
+		switch precond.GetOperation() {
 		case v1.Precondition_OPERATION_MUST_NOT_MATCH:
 			if ok {
 				return NewPreconditionFailedErr(precond)
@@ -46,7 +46,7 @@ func checkPreconditions(
 				return NewPreconditionFailedErr(precond)
 			}
 		default:
-			return fmt.Errorf("unspecified precondition operation: %s", precond.Operation)
+			return fmt.Errorf("unspecified precondition operation: %s", precond.GetOperation())
 		}
 	}
 

--- a/internal/services/v1/reflectionapi.go
+++ b/internal/services/v1/reflectionapi.go
@@ -31,24 +31,24 @@ type schemaFilters struct {
 
 func newSchemaFilters(filters []*v1.ReflectionSchemaFilter) (*schemaFilters, error) {
 	for _, filter := range filters {
-		if filter.OptionalDefinitionNameFilter != "" {
-			if filter.OptionalCaveatNameFilter != "" {
+		if filter.GetOptionalDefinitionNameFilter() != "" {
+			if filter.GetOptionalCaveatNameFilter() != "" {
 				return nil, NewInvalidFilterErr("cannot filter by both definition and caveat name", filter.String())
 			}
 		}
 
-		if filter.OptionalRelationNameFilter != "" {
-			if filter.OptionalDefinitionNameFilter == "" {
+		if filter.GetOptionalRelationNameFilter() != "" {
+			if filter.GetOptionalDefinitionNameFilter() == "" {
 				return nil, NewInvalidFilterErr("relation name match requires definition name match", filter.String())
 			}
 
-			if filter.OptionalPermissionNameFilter != "" {
+			if filter.GetOptionalPermissionNameFilter() != "" {
 				return nil, NewInvalidFilterErr("cannot filter by both relation and permission name", filter.String())
 			}
 		}
 
-		if filter.OptionalPermissionNameFilter != "" {
-			if filter.OptionalDefinitionNameFilter == "" {
+		if filter.GetOptionalPermissionNameFilter() != "" {
+			if filter.GetOptionalDefinitionNameFilter() == "" {
 				return nil, NewInvalidFilterErr("permission name match requires definition name match", filter.String())
 			}
 		}
@@ -63,7 +63,7 @@ func (sf *schemaFilters) HasNamespaces() bool {
 	}
 
 	for _, filter := range sf.filters {
-		if filter.OptionalDefinitionNameFilter != "" {
+		if filter.GetOptionalDefinitionNameFilter() != "" {
 			return true
 		}
 	}
@@ -77,7 +77,7 @@ func (sf *schemaFilters) HasCaveats() bool {
 	}
 
 	for _, filter := range sf.filters {
-		if filter.OptionalCaveatNameFilter != "" {
+		if filter.GetOptionalCaveatNameFilter() != "" {
 			return true
 		}
 	}
@@ -92,12 +92,12 @@ func (sf *schemaFilters) HasNamespace(namespaceName string) bool {
 
 	hasDefinitionFilter := false
 	for _, filter := range sf.filters {
-		if filter.OptionalDefinitionNameFilter == "" {
+		if filter.GetOptionalDefinitionNameFilter() == "" {
 			continue
 		}
 
 		hasDefinitionFilter = true
-		isMatch := strings.HasPrefix(namespaceName, filter.OptionalDefinitionNameFilter)
+		isMatch := strings.HasPrefix(namespaceName, filter.GetOptionalDefinitionNameFilter())
 		if isMatch {
 			return true
 		}
@@ -113,12 +113,12 @@ func (sf *schemaFilters) HasCaveat(caveatName string) bool {
 
 	hasCaveatFilter := false
 	for _, filter := range sf.filters {
-		if filter.OptionalCaveatNameFilter == "" {
+		if filter.GetOptionalCaveatNameFilter() == "" {
 			continue
 		}
 
 		hasCaveatFilter = true
-		isMatch := strings.HasPrefix(caveatName, filter.OptionalCaveatNameFilter)
+		isMatch := strings.HasPrefix(caveatName, filter.GetOptionalCaveatNameFilter())
 		if isMatch {
 			return true
 		}
@@ -134,17 +134,17 @@ func (sf *schemaFilters) HasRelation(namespaceName, relationName string) bool {
 
 	hasRelationFilter := false
 	for _, filter := range sf.filters {
-		if filter.OptionalRelationNameFilter == "" {
+		if filter.GetOptionalRelationNameFilter() == "" {
 			continue
 		}
 
 		hasRelationFilter = true
-		isMatch := strings.HasPrefix(relationName, filter.OptionalRelationNameFilter)
+		isMatch := strings.HasPrefix(relationName, filter.GetOptionalRelationNameFilter())
 		if !isMatch {
 			continue
 		}
 
-		isMatch = strings.HasPrefix(namespaceName, filter.OptionalDefinitionNameFilter)
+		isMatch = strings.HasPrefix(namespaceName, filter.GetOptionalDefinitionNameFilter())
 		if isMatch {
 			return true
 		}
@@ -160,17 +160,17 @@ func (sf *schemaFilters) HasPermission(namespaceName, permissionName string) boo
 
 	hasPermissionFilter := false
 	for _, filter := range sf.filters {
-		if filter.OptionalPermissionNameFilter == "" {
+		if filter.GetOptionalPermissionNameFilter() == "" {
 			continue
 		}
 
 		hasPermissionFilter = true
-		isMatch := strings.HasPrefix(permissionName, filter.OptionalPermissionNameFilter)
+		isMatch := strings.HasPrefix(permissionName, filter.GetOptionalPermissionNameFilter())
 		if !isMatch {
 			continue
 		}
 
-		isMatch = strings.HasPrefix(namespaceName, filter.OptionalDefinitionNameFilter)
+		isMatch = strings.HasPrefix(namespaceName, filter.GetOptionalDefinitionNameFilter())
 		if isMatch {
 			return true
 		}
@@ -490,7 +490,7 @@ func convertDiff(
 					Diff: &v1.ReflectionSchemaDiff_CaveatParameterTypeChanged{
 						CaveatParameterTypeChanged: &v1.ReflectionCaveatParameterTypeChange{
 							Parameter:    paramDef,
-							PreviousType: previousParamDef.Type,
+							PreviousType: previousParamDef.GetType(),
 						},
 					},
 				})
@@ -542,16 +542,16 @@ func namespaceAPIReprForName(namespaceName string, schema *diff.DiffableSchema) 
 }
 
 func namespaceAPIRepr(nsDef *core.NamespaceDefinition, schemaFilters *schemaFilters) (*v1.ReflectionDefinition, error) {
-	if schemaFilters != nil && !schemaFilters.HasNamespace(nsDef.Name) {
+	if schemaFilters != nil && !schemaFilters.HasNamespace(nsDef.GetName()) {
 		return nil, nil
 	}
 
-	relations := make([]*v1.ReflectionRelation, 0, len(nsDef.Relation))
-	permissions := make([]*v1.ReflectionPermission, 0, len(nsDef.Relation))
+	relations := make([]*v1.ReflectionRelation, 0, len(nsDef.GetRelation()))
+	permissions := make([]*v1.ReflectionPermission, 0, len(nsDef.GetRelation()))
 
-	for _, rel := range nsDef.Relation {
+	for _, rel := range nsDef.GetRelation() {
 		if namespace.GetRelationKind(rel) == iv1.RelationMetadata_PERMISSION {
-			permission, err := permissionAPIRepr(rel, nsDef.Name, schemaFilters)
+			permission, err := permissionAPIRepr(rel, nsDef.GetName(), schemaFilters)
 			if err != nil {
 				return nil, err
 			}
@@ -562,7 +562,7 @@ func namespaceAPIRepr(nsDef *core.NamespaceDefinition, schemaFilters *schemaFilt
 			continue
 		}
 
-		relation, err := relationAPIRepr(rel, nsDef.Name, schemaFilters)
+		relation, err := relationAPIRepr(rel, nsDef.GetName(), schemaFilters)
 		if err != nil {
 			return nil, err
 		}
@@ -572,9 +572,9 @@ func namespaceAPIRepr(nsDef *core.NamespaceDefinition, schemaFilters *schemaFilt
 		}
 	}
 
-	comments := namespace.GetComments(nsDef.Metadata)
+	comments := namespace.GetComments(nsDef.GetMetadata())
 	return &v1.ReflectionDefinition{
-		Name:        nsDef.Name,
+		Name:        nsDef.GetName(),
 		Comment:     strings.Join(comments, "\n"),
 		Relations:   relations,
 		Permissions: permissions,
@@ -583,13 +583,13 @@ func namespaceAPIRepr(nsDef *core.NamespaceDefinition, schemaFilters *schemaFilt
 
 // permissionAPIRepr builds an API representation of a permission.
 func permissionAPIRepr(relation *core.Relation, parentDefName string, schemaFilters *schemaFilters) (*v1.ReflectionPermission, error) {
-	if schemaFilters != nil && !schemaFilters.HasPermission(parentDefName, relation.Name) {
+	if schemaFilters != nil && !schemaFilters.HasPermission(parentDefName, relation.GetName()) {
 		return nil, nil
 	}
 
-	comments := namespace.GetComments(relation.Metadata)
+	comments := namespace.GetComments(relation.GetMetadata())
 	return &v1.ReflectionPermission{
-		Name:                 relation.Name,
+		Name:                 relation.GetName(),
 		Comment:              strings.Join(comments, "\n"),
 		ParentDefinitionName: parentDefName,
 	}, nil
@@ -597,23 +597,23 @@ func permissionAPIRepr(relation *core.Relation, parentDefName string, schemaFilt
 
 // relationAPIRepresentation builds an API representation of a relation.
 func relationAPIRepr(relation *core.Relation, parentDefName string, schemaFilters *schemaFilters) (*v1.ReflectionRelation, error) {
-	if schemaFilters != nil && !schemaFilters.HasRelation(parentDefName, relation.Name) {
+	if schemaFilters != nil && !schemaFilters.HasRelation(parentDefName, relation.GetName()) {
 		return nil, nil
 	}
 
-	comments := namespace.GetComments(relation.Metadata)
+	comments := namespace.GetComments(relation.GetMetadata())
 
 	var subjectTypes []*v1.ReflectionTypeReference
-	if relation.TypeInformation != nil {
-		subjectTypes = make([]*v1.ReflectionTypeReference, 0, len(relation.TypeInformation.AllowedDirectRelations))
-		for _, subjectType := range relation.TypeInformation.AllowedDirectRelations {
+	if relation.GetTypeInformation() != nil {
+		subjectTypes = make([]*v1.ReflectionTypeReference, 0, len(relation.GetTypeInformation().GetAllowedDirectRelations()))
+		for _, subjectType := range relation.GetTypeInformation().GetAllowedDirectRelations() {
 			typeref := typeAPIRepr(subjectType)
 			subjectTypes = append(subjectTypes, typeref)
 		}
 	}
 
 	return &v1.ReflectionRelation{
-		Name:                 relation.Name,
+		Name:                 relation.GetName(),
 		Comment:              strings.Join(comments, "\n"),
 		ParentDefinitionName: parentDefName,
 		SubjectTypes:         subjectTypes,
@@ -623,7 +623,7 @@ func relationAPIRepr(relation *core.Relation, parentDefName string, schemaFilter
 // typeAPIRepr builds an API representation of a type.
 func typeAPIRepr(subjectType *core.AllowedRelation) *v1.ReflectionTypeReference {
 	typeref := &v1.ReflectionTypeReference{
-		SubjectDefinitionName: subjectType.Namespace,
+		SubjectDefinitionName: subjectType.GetNamespace(),
 		Typeref:               &v1.ReflectionTypeReference_IsTerminalSubject{},
 	}
 
@@ -638,7 +638,7 @@ func typeAPIRepr(subjectType *core.AllowedRelation) *v1.ReflectionTypeReference 
 	}
 
 	if subjectType.GetRequiredCaveat() != nil {
-		typeref.OptionalCaveatName = subjectType.GetRequiredCaveat().CaveatName
+		typeref.OptionalCaveatName = subjectType.GetRequiredCaveat().GetCaveatName()
 	}
 
 	return typeref
@@ -656,18 +656,18 @@ func caveatAPIReprForName(caveatName string, schema *diff.DiffableSchema, caveat
 
 // caveatAPIRepr builds an API representation of a caveat.
 func caveatAPIRepr(caveatDef *core.CaveatDefinition, schemaFilters *schemaFilters, caveatTypeSet *caveattypes.TypeSet) (*v1.ReflectionCaveat, error) {
-	if schemaFilters != nil && !schemaFilters.HasCaveat(caveatDef.Name) {
+	if schemaFilters != nil && !schemaFilters.HasCaveat(caveatDef.GetName()) {
 		return nil, nil
 	}
 
-	parameters := make([]*v1.ReflectionCaveatParameter, 0, len(caveatDef.ParameterTypes))
-	paramNames := slices.Collect(maps.Keys(caveatDef.ParameterTypes))
+	parameters := make([]*v1.ReflectionCaveatParameter, 0, len(caveatDef.GetParameterTypes()))
+	paramNames := slices.Collect(maps.Keys(caveatDef.GetParameterTypes()))
 	sort.Strings(paramNames)
 
 	for _, paramName := range paramNames {
-		paramType, ok := caveatDef.ParameterTypes[paramName]
+		paramType, ok := caveatDef.GetParameterTypes()[paramName]
 		if !ok {
-			return nil, spiceerrors.MustBugf("parameter %q not found in caveat %q", paramName, caveatDef.Name)
+			return nil, spiceerrors.MustBugf("parameter %q not found in caveat %q", paramName, caveatDef.GetName())
 		}
 
 		decoded, err := caveattypes.DecodeParameterType(caveatTypeSet, paramType)
@@ -678,16 +678,16 @@ func caveatAPIRepr(caveatDef *core.CaveatDefinition, schemaFilters *schemaFilter
 		parameters = append(parameters, &v1.ReflectionCaveatParameter{
 			Name:             paramName,
 			Type:             decoded.String(),
-			ParentCaveatName: caveatDef.Name,
+			ParentCaveatName: caveatDef.GetName(),
 		})
 	}
 
-	parameterTypes, err := caveattypes.DecodeParameterTypes(caveatTypeSet, caveatDef.ParameterTypes)
+	parameterTypes, err := caveattypes.DecodeParameterTypes(caveatTypeSet, caveatDef.GetParameterTypes())
 	if err != nil {
 		return nil, spiceerrors.MustBugf("invalid caveat parameters: %v", err)
 	}
 
-	deserializedReflectionression, err := caveats.DeserializeCaveatWithTypeSet(caveatTypeSet, caveatDef.SerializedExpression, parameterTypes)
+	deserializedReflectionression, err := caveats.DeserializeCaveatWithTypeSet(caveatTypeSet, caveatDef.GetSerializedExpression(), parameterTypes)
 	if err != nil {
 		return nil, spiceerrors.MustBugf("invalid caveat expression bytes: %v", err)
 	}
@@ -697,9 +697,9 @@ func caveatAPIRepr(caveatDef *core.CaveatDefinition, schemaFilters *schemaFilter
 		return nil, spiceerrors.MustBugf("invalid caveat expression: %v", err)
 	}
 
-	comments := namespace.GetComments(caveatDef.Metadata)
+	comments := namespace.GetComments(caveatDef.GetMetadata())
 	return &v1.ReflectionCaveat{
-		Name:       caveatDef.Name,
+		Name:       caveatDef.GetName(),
 		Comment:    strings.Join(comments, "\n"),
 		Parameters: parameters,
 		Expression: exprString,
@@ -713,7 +713,7 @@ func caveatAPIParamRepr(paramName, parentCaveatName string, schema *diff.Diffabl
 		return nil, spiceerrors.MustBugf("caveat %q not found in schema", parentCaveatName)
 	}
 
-	paramType, ok := caveatDef.ParameterTypes[paramName]
+	paramType, ok := caveatDef.GetParameterTypes()[paramName]
 	if !ok {
 		return nil, spiceerrors.MustBugf("parameter %q not found in caveat %q", paramName, parentCaveatName)
 	}

--- a/internal/services/v1/reflectionapi_test.go
+++ b/internal/services/v1/reflectionapi_test.go
@@ -567,12 +567,12 @@ func TestConvertDiff(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			require.NotNil(t, resp.ReadAt)
+			require.NotNil(t, resp.GetReadAt())
 			resp.ReadAt = nil
 
 			testutil.RequireProtoEqual(t, tc.expectedResponse, resp, "got mismatch")
 
-			for _, diff := range resp.Diffs {
+			for _, diff := range resp.GetDiffs() {
 				name := reflect.TypeOf(diff.GetDiff()).String()
 				encounteredDiffTypes.Add(strings.ToLower(strings.Split(name, "_")[1]))
 			}

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -42,7 +42,7 @@ func TestReadRelationships(t *testing.T) {
 	}{
 		{
 			"namespace only",
-			&v1.RelationshipFilter{ResourceType: tf.DocumentNS.Name},
+			&v1.RelationshipFilter{ResourceType: tf.DocumentNS.GetName()},
 			codes.OK,
 			map[string]struct{}{
 				"document:ownerplan#viewer@user:owner":                       {},
@@ -62,7 +62,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"namespace and object id",
 			&v1.RelationshipFilter{
-				ResourceType:       tf.DocumentNS.Name,
+				ResourceType:       tf.DocumentNS.GetName(),
 				OptionalResourceId: "healthplan",
 			},
 			codes.OK,
@@ -73,7 +73,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"namespace and relation",
 			&v1.RelationshipFilter{
-				ResourceType:     tf.DocumentNS.Name,
+				ResourceType:     tf.DocumentNS.GetName(),
 				OptionalRelation: "parent",
 			},
 			codes.OK,
@@ -149,7 +149,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"namespace and userset",
 			&v1.RelationshipFilter{
-				ResourceType: tf.DocumentNS.Name,
+				ResourceType: tf.DocumentNS.GetName(),
 				OptionalSubjectFilter: &v1.SubjectFilter{
 					SubjectType:       "folder",
 					OptionalSubjectId: "plans",
@@ -164,7 +164,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"multiple filters",
 			&v1.RelationshipFilter{
-				ResourceType:       tf.DocumentNS.Name,
+				ResourceType:       tf.DocumentNS.GetName(),
 				OptionalResourceId: "masterplan",
 				OptionalSubjectFilter: &v1.SubjectFilter{
 					SubjectType:       "folder",
@@ -179,7 +179,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"bad objectId",
 			&v1.RelationshipFilter{
-				ResourceType:       tf.DocumentNS.Name,
+				ResourceType:       tf.DocumentNS.GetName(),
 				OptionalResourceId: "🍣",
 				OptionalSubjectFilter: &v1.SubjectFilter{
 					SubjectType:       "folder",
@@ -192,7 +192,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"bad object relation",
 			&v1.RelationshipFilter{
-				ResourceType:     tf.DocumentNS.Name,
+				ResourceType:     tf.DocumentNS.GetName(),
 				OptionalRelation: "ad",
 			},
 			codes.InvalidArgument,
@@ -201,7 +201,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"bad subject filter",
 			&v1.RelationshipFilter{
-				ResourceType:       tf.DocumentNS.Name,
+				ResourceType:       tf.DocumentNS.GetName(),
 				OptionalResourceId: "ma",
 				OptionalSubjectFilter: &v1.SubjectFilter{
 					SubjectType: "doesnotexist",
@@ -213,7 +213,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"empty argument for required filter value",
 			&v1.RelationshipFilter{
-				ResourceType:          tf.DocumentNS.Name,
+				ResourceType:          tf.DocumentNS.GetName(),
 				OptionalSubjectFilter: &v1.SubjectFilter{},
 			},
 			codes.InvalidArgument,
@@ -222,7 +222,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"bad relation filter",
 			&v1.RelationshipFilter{
-				ResourceType: tf.DocumentNS.Name,
+				ResourceType: tf.DocumentNS.GetName(),
 				OptionalSubjectFilter: &v1.SubjectFilter{
 					SubjectType: "folder",
 					OptionalRelation: &v1.SubjectFilter_RelationFilter{
@@ -244,7 +244,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"missing relation",
 			&v1.RelationshipFilter{
-				ResourceType:     tf.DocumentNS.Name,
+				ResourceType:     tf.DocumentNS.GetName(),
 				OptionalRelation: "invalidrelation",
 			},
 			codes.FailedPrecondition,
@@ -253,7 +253,7 @@ func TestReadRelationships(t *testing.T) {
 		{
 			"missing subject relation",
 			&v1.RelationshipFilter{
-				ResourceType: tf.DocumentNS.Name,
+				ResourceType: tf.DocumentNS.GetName(),
 				OptionalSubjectFilter: &v1.SubjectFilter{
 					SubjectType: "folder",
 					OptionalRelation: &v1.SubjectFilter_RelationFilter{
@@ -330,9 +330,9 @@ func TestReadRelationships(t *testing.T) {
 									dsFilter, err := datastore.RelationshipsFilterFromPublicFilter(tc.filter)
 									require.NoError(err)
 
-									require.True(dsFilter.Test(tuple.FromV1Relationship(rel.Relationship)), "relationship did not match filter: %v", rel.Relationship)
+									require.True(dsFilter.Test(tuple.FromV1Relationship(rel.GetRelationship())), "relationship did not match filter: %v", rel.GetRelationship())
 
-									relString := tuple.MustV1RelString(rel.Relationship)
+									relString := tuple.MustV1RelString(rel.GetRelationship())
 									_, found := tc.expected[relString]
 									require.True(found, "relationship was not expected: %s", relString)
 
@@ -340,7 +340,7 @@ func TestReadRelationships(t *testing.T) {
 									require.True(notFoundTwice, "relationship was received from service twice: %s", relString)
 
 									delete(testExpected, relString)
-									currentCursor = rel.AfterResultCursor
+									currentCursor = rel.GetAfterResultCursor()
 									foundCount++
 								}
 
@@ -418,8 +418,8 @@ func TestWriteRelationships(t *testing.T) {
 		}},
 	})
 	require.NoError(err)
-	require.NotNil(resp.WrittenAt)
-	require.NotEmpty(resp.WrittenAt.Token)
+	require.NotNil(resp.GetWrittenAt())
+	require.NotEmpty(resp.GetWrittenAt().GetToken())
 
 	// Ensure the written relationships exist
 	for _, tpl := range toWrite {
@@ -435,7 +435,7 @@ func TestWriteRelationships(t *testing.T) {
 		rel, err := stream.Recv()
 		require.NoError(err)
 
-		relStr, err := tuple.V1StringRelationship(rel.Relationship)
+		relStr, err := tuple.V1StringRelationship(rel.GetRelationship())
 		require.NoError(err)
 		require.Equal(tuple.MustString(tpl), relStr)
 
@@ -454,7 +454,7 @@ func TestWriteRelationships(t *testing.T) {
 		// Ensure the relationship was deleted
 		stream, err = client.ReadRelationships(t.Context(), &v1.ReadRelationshipsRequest{
 			Consistency: &v1.Consistency{
-				Requirement: &v1.Consistency_AtLeastAsFresh{AtLeastAsFresh: deleted.WrittenAt},
+				Requirement: &v1.Consistency_AtLeastAsFresh{AtLeastAsFresh: deleted.GetWrittenAt()},
 			},
 			RelationshipFilter: findWritten,
 		})
@@ -503,7 +503,7 @@ func TestWriteExpiringRelationships(t *testing.T) {
 	req.NoError(err)
 
 	// read relationship back
-	relRead := readFirst(req, client, resp.WrittenAt, relWritten)
+	relRead := readFirst(req, client, resp.GetWrittenAt(), relWritten)
 	req.True(proto.Equal(relWritten, relRead))
 }
 
@@ -547,7 +547,7 @@ func TestWriteCaveatedRelationships(t *testing.T) {
 			req.NoError(err)
 
 			// read relationship back
-			relRead := readFirst(req, client, resp.WrittenAt, relWritten)
+			relRead := readFirst(req, client, resp.GetWrittenAt(), relWritten)
 			req.True(proto.Equal(relWritten, relRead))
 
 			// issue the deletion
@@ -570,7 +570,7 @@ func TestWriteCaveatedRelationships(t *testing.T) {
 			stream, err := client.ReadRelationships(t.Context(), &v1.ReadRelationshipsRequest{
 				Consistency: &v1.Consistency{
 					Requirement: &v1.Consistency_AtExactSnapshot{
-						AtExactSnapshot: resp.WrittenAt,
+						AtExactSnapshot: resp.GetWrittenAt(),
 					},
 				},
 				RelationshipFilter: tuple.RelToFilter(relWritten),
@@ -596,7 +596,7 @@ func readFirst(require *require.Assertions, client v1.PermissionsServiceClient, 
 
 	result, err := stream.Recv()
 	require.NoError(err)
-	return result.Relationship
+	return result.GetRelationship()
 }
 
 func precondFilter(resType, resID, relation, subType, subID string, subRel *string) *v1.RelationshipFilter {
@@ -710,7 +710,7 @@ func relationshipForBulkTesting(nsAndRel struct {
 			nsAndRel.namespace,
 			strconv.Itoa(i),
 			nsAndRel.relation,
-			tf.UserNS.Name,
+			tf.UserNS.GetName(),
 			strconv.Itoa(i),
 			"",
 			"test",
@@ -723,7 +723,7 @@ func relationshipForBulkTesting(nsAndRel struct {
 			nsAndRel.namespace,
 			strconv.Itoa(i),
 			nsAndRel.relation,
-			tf.UserNS.Name,
+			tf.UserNS.GetName(),
 			strconv.Itoa(i),
 			"",
 			time.Now().Add(time.Hour),
@@ -734,7 +734,7 @@ func relationshipForBulkTesting(nsAndRel struct {
 		nsAndRel.namespace,
 		strconv.Itoa(i),
 		nsAndRel.relation,
-		tf.UserNS.Name,
+		tf.UserNS.GetName(),
 		strconv.Itoa(i),
 		"",
 	)
@@ -1267,14 +1267,14 @@ func TestDeleteRelationships(t *testing.T) {
 					return
 				}
 				require.NoError(err)
-				require.NotNil(resp.DeletedAt)
+				require.NotNil(resp.GetDeletedAt())
 
-				rev, _, err := zedtoken.DecodeRevision(resp.DeletedAt, ds)
+				rev, _, err := zedtoken.DecodeRevision(resp.GetDeletedAt(), ds)
 				require.NoError(err)
 				require.True(rev.GreaterThan(revision))
 
-				require.Equal(uint64(len(tc.deleted)), resp.RelationshipsDeletedCount)
-				require.Equal(standardTuplesWithout(tc.deleted), readAll(require, client, resp.DeletedAt))
+				require.Equal(uint64(len(tc.deleted)), resp.GetRelationshipsDeletedCount())
+				require.Equal(standardTuplesWithout(tc.deleted), readAll(require, client, resp.GetDeletedAt()))
 			})
 		}
 	}
@@ -1386,20 +1386,20 @@ func TestDeleteRelationshipsBeyondLimitPartial(t *testing.T) {
 				require.LessOrEqual(len(beforeDelete)-len(afterDelete), batchSize)
 
 				bs := safecast.RequireConvert[uint64](t, batchSize)
-				require.LessOrEqual(resp.RelationshipsDeletedCount, bs)
+				require.LessOrEqual(resp.GetRelationshipsDeletedCount(), bs)
 
 				if i == 0 {
-					require.Equal(v1.DeleteRelationshipsResponse_DELETION_PROGRESS_PARTIAL, resp.DeletionProgress)
+					require.Equal(v1.DeleteRelationshipsResponse_DELETION_PROGRESS_PARTIAL, resp.GetDeletionProgress())
 				}
 
-				if resp.DeletionProgress == v1.DeleteRelationshipsResponse_DELETION_PROGRESS_COMPLETE {
+				if resp.GetDeletionProgress() == v1.DeleteRelationshipsResponse_DELETION_PROGRESS_COMPLETE {
 					require.NoError(err)
-					require.NotNil(resp.DeletedAt)
+					require.NotNil(resp.GetDeletedAt())
 
-					rev, _, err := zedtoken.DecodeRevision(resp.DeletedAt, ds)
+					rev, _, err := zedtoken.DecodeRevision(resp.GetDeletedAt(), ds)
 					require.NoError(err)
 					require.True(rev.GreaterThan(revision))
-					require.Equal(standardTuplesWithout(expected), readAll(require, client, resp.DeletedAt))
+					require.Equal(standardTuplesWithout(expected), readAll(require, client, resp.GetDeletedAt()))
 					break
 				}
 			}
@@ -1512,7 +1512,7 @@ func TestWriteRelationshipsWithMetadata(t *testing.T) {
 
 	resp, err := stream.Recv()
 	require.NoError(err)
-	require.Equal(metadata, resp.OptionalTransactionMetadata)
+	require.Equal(metadata, resp.GetOptionalTransactionMetadata())
 }
 
 func TestWriteRelationshipsMetadataOverLimit(t *testing.T) {
@@ -1804,7 +1804,7 @@ func readOfType(require *require.Assertions, resourceType string, client v1.Perm
 		}
 		require.NoError(err)
 
-		got[tuple.MustV1RelString(rel.Relationship)] = struct{}{}
+		got[tuple.MustV1RelString(rel.GetRelationship())] = struct{}{}
 	}
 	return got
 }
@@ -2357,7 +2357,7 @@ func TestReadRelationshipsWithTraitsAndFilters(t *testing.T) {
 
 				require.NoError(err)
 
-				relString := tuple.MustV1RelString(rel.Relationship)
+				relString := tuple.MustV1RelString(rel.GetRelationship())
 				actualRelationships = append(actualRelationships, relString)
 			}
 

--- a/internal/services/v1/schema_test.go
+++ b/internal/services/v1/schema_test.go
@@ -27,8 +27,8 @@ func TestSchemaWriteNoPrefix(t *testing.T) {
 		Schema: `definition user {}`,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, resp.WrittenAt)
-	require.NotEmpty(t, resp.WrittenAt.Token)
+	require.NotNil(t, resp.GetWrittenAt())
+	require.NotEmpty(t, resp.GetWrittenAt().GetToken())
 }
 
 func TestSchemaWriteInvalidSchema(t *testing.T) {
@@ -75,14 +75,14 @@ func TestSchemaWriteAndReadBack(t *testing.T) {
 		Schema: userSchema,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, writeResp.WrittenAt)
-	require.NotEmpty(t, writeResp.WrittenAt.Token)
+	require.NotNil(t, writeResp.GetWrittenAt())
+	require.NotEmpty(t, writeResp.GetWrittenAt().GetToken())
 
 	readback, err := client.ReadSchema(t.Context(), &v1.ReadSchemaRequest{})
 	require.NoError(t, err)
-	require.Equal(t, userSchema, readback.SchemaText)
-	require.NotNil(t, readback.ReadAt)
-	require.NotEmpty(t, readback.ReadAt.Token)
+	require.Equal(t, userSchema, readback.GetSchemaText())
+	require.NotNil(t, readback.GetReadAt())
+	require.NotEmpty(t, readback.GetReadAt().GetToken())
 }
 
 func TestSchemaDeleteRelation(t *testing.T) {
@@ -101,8 +101,8 @@ func TestSchemaDeleteRelation(t *testing.T) {
 		}`,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, writeResp.WrittenAt)
-	require.NotEmpty(t, writeResp.WrittenAt.Token)
+	require.NotNil(t, writeResp.GetWrittenAt())
+	require.NotEmpty(t, writeResp.GetWrittenAt().GetToken())
 
 	// Write a relationship for one of the relations.
 	_, err = v1client.WriteRelationships(t.Context(), &v1.WriteRelationshipsRequest{
@@ -131,8 +131,8 @@ func TestSchemaDeleteRelation(t *testing.T) {
 		}`,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, updateResp.WrittenAt)
-	require.NotEmpty(t, updateResp.WrittenAt.Token)
+	require.NotNil(t, updateResp.GetWrittenAt())
+	require.NotEmpty(t, updateResp.GetWrittenAt().GetToken())
 
 	// Delete the relationship.
 	_, err = v1client.WriteRelationships(t.Context(), &v1.WriteRelationshipsRequest{
@@ -149,8 +149,8 @@ func TestSchemaDeleteRelation(t *testing.T) {
 			definition example/document {}`,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, deleteRelResp.WrittenAt)
-	require.NotEmpty(t, deleteRelResp.WrittenAt.Token)
+	require.NotNil(t, deleteRelResp.GetWrittenAt())
+	require.NotEmpty(t, deleteRelResp.GetWrittenAt().GetToken())
 }
 
 func TestSchemaDeletePermission(t *testing.T) {
@@ -298,7 +298,7 @@ func TestSchemaDeleteDefinition(t *testing.T) {
 	// Ensure it was deleted.
 	readback, err := client.ReadSchema(t.Context(), &v1.ReadSchemaRequest{})
 	require.NoError(t, err)
-	require.Equal(t, `definition example/user {}`, readback.SchemaText)
+	require.Equal(t, `definition example/user {}`, readback.GetSchemaText())
 }
 
 func TestSchemaRemoveWildcard(t *testing.T) {
@@ -359,7 +359,7 @@ definition example/user {}`
 	// Ensure it was deleted.
 	readback, err := client.ReadSchema(t.Context(), &v1.ReadSchemaRequest{})
 	require.NoError(t, err)
-	require.Equal(t, newSchema, readback.SchemaText)
+	require.Equal(t, newSchema, readback.GetSchemaText())
 }
 
 func TestSchemaEmpty(t *testing.T) {
@@ -406,8 +406,8 @@ func TestSchemaEmpty(t *testing.T) {
 		Schema: ``,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, emptyResp.WrittenAt)
-	require.NotEmpty(t, emptyResp.WrittenAt.Token)
+	require.NotNil(t, emptyResp.GetWrittenAt())
+	require.NotEmpty(t, emptyResp.GetWrittenAt().GetToken())
 
 	// Ensure it was deleted.
 	_, err = client.ReadSchema(t.Context(), &v1.ReadSchemaRequest{})
@@ -519,7 +519,7 @@ definition user {}`
 	// Ensure it was deleted.
 	readback, err := client.ReadSchema(t.Context(), &v1.ReadSchemaRequest{})
 	require.NoError(t, err)
-	require.Equal(t, newSchema, readback.SchemaText)
+	require.Equal(t, newSchema, readback.GetSchemaText())
 }
 
 func TestSchemaUnchangedNamespaces(t *testing.T) {
@@ -641,7 +641,7 @@ func TestSchemaChangeExpiration(t *testing.T) {
 	// Ensure it was deleted.
 	readback, err := client.ReadSchema(t.Context(), &v1.ReadSchemaRequest{})
 	require.NoError(t, err)
-	require.Equal(t, newSchema, readback.SchemaText)
+	require.Equal(t, newSchema, readback.GetSchemaText())
 
 	// Add the relationship back without expiration.
 	toWriteWithoutExp := tuple.MustParse("document:somedoc#somerelation@user:tom")
@@ -700,7 +700,7 @@ func TestSchemaChangeExpirationAllowed(t *testing.T) {
 	// Ensure it was deleted.
 	readback, err := client.ReadSchema(t.Context(), &v1.ReadSchemaRequest{})
 	require.NoError(t, err)
-	require.Equal(t, newSchema, readback.SchemaText)
+	require.Equal(t, newSchema, readback.GetSchemaText())
 }
 
 func TestSchemaDiff(t *testing.T) {
@@ -787,7 +787,7 @@ func TestSchemaDiff(t *testing.T) {
 				grpcutil.RequireStatus(t, tt.expectedCode, err)
 			} else {
 				require.NoError(t, err)
-				require.NotNil(t, actual.ReadAt)
+				require.NotNil(t, actual.GetReadAt())
 				actual.ReadAt = nil
 
 				testutil.RequireProtoEqual(t, tt.expectedResponse, actual, "mismatch in response")
@@ -1200,7 +1200,7 @@ definition user {}`,
 				grpcutil.RequireStatus(t, tt.expectedCode, err)
 			} else {
 				require.NoError(t, err)
-				require.NotNil(t, actual.ReadAt)
+				require.NotNil(t, actual.GetReadAt())
 				actual.ReadAt = nil
 
 				testutil.RequireProtoEqual(t, tt.expectedResponse, actual, "mismatch in response")
@@ -1432,7 +1432,7 @@ func TestDependentRelations(t *testing.T) {
 				grpcutil.RequireStatus(t, tc.expectedCode, err)
 			} else {
 				require.NoError(t, err)
-				require.NotNil(t, actual.ReadAt)
+				require.NotNil(t, actual.GetReadAt())
 				actual.ReadAt = nil
 
 				testutil.RequireProtoEqual(t, &v1.DependentRelationsResponse{
@@ -1632,7 +1632,7 @@ func TestComputablePermissions(t *testing.T) {
 				grpcutil.RequireStatus(t, tc.expectedCode, err)
 			} else {
 				require.NoError(t, err)
-				require.NotNil(t, actual.ReadAt)
+				require.NotNil(t, actual.GetReadAt())
 				actual.ReadAt = nil
 
 				testutil.RequireProtoEqual(t, &v1.ComputablePermissionsResponse{

--- a/internal/services/v1/watch_test.go
+++ b/internal/services/v1/watch_test.go
@@ -423,9 +423,9 @@ definition document {
 				require.Len(received, len(tc.expectedWatchResponses))
 
 				for i, expectedWatchResponse := range tc.expectedWatchResponses {
-					require.Equal(sortUpdates(expectedWatchResponse.Updates), sortUpdates(received[i].GetUpdates()))
-					require.Equal(expectedWatchResponse.SchemaUpdated, received[i].GetSchemaUpdated())
-					require.Equal(expectedWatchResponse.IsCheckpoint, received[i].GetIsCheckpoint())
+					require.Equal(sortUpdates(expectedWatchResponse.GetUpdates()), sortUpdates(received[i].GetUpdates()))
+					require.Equal(expectedWatchResponse.GetSchemaUpdated(), received[i].GetSchemaUpdated())
+					require.Equal(expectedWatchResponse.GetIsCheckpoint(), received[i].GetIsCheckpoint())
 				}
 			} else {
 				_, err := stream.Recv()
@@ -440,7 +440,7 @@ func sortUpdates(in []*v1.RelationshipUpdate) []*v1.RelationshipUpdate {
 	out = append(out, in...)
 	sort.Slice(out, func(i, j int) bool {
 		left, right := out[i], out[j]
-		compareResult := strings.Compare(tuple.MustV1RelString(left.Relationship), tuple.MustV1RelString(right.Relationship))
+		compareResult := strings.Compare(tuple.MustV1RelString(left.GetRelationship()), tuple.MustV1RelString(right.GetRelationship()))
 		if compareResult < 0 {
 			return true
 		}
@@ -448,7 +448,7 @@ func sortUpdates(in []*v1.RelationshipUpdate) []*v1.RelationshipUpdate {
 			return false
 		}
 
-		return left.Operation < right.Operation
+		return left.GetOperation() < right.GetOperation()
 	})
 
 	return out

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -183,23 +183,23 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 				return fmt.Errorf("error writing metric: %w", err)
 			}
 
-			buckets := make(map[float64]uint64, len(m.Histogram.Bucket))
-			for _, bucket := range m.Histogram.Bucket {
-				buckets[*bucket.UpperBound] = *bucket.CumulativeCount
+			buckets := make(map[float64]uint64, len(m.GetHistogram().GetBucket()))
+			for _, bucket := range m.GetHistogram().GetBucket() {
+				buckets[bucket.GetUpperBound()] = bucket.GetCumulativeCount()
 			}
 
 			dynamicLabels := make([]string, len(usagemetrics.DispatchedCountLabels))
 			for i, labelName := range usagemetrics.DispatchedCountLabels {
-				for _, labelVal := range m.Label {
-					if *labelVal.Name == labelName {
-						dynamicLabels[i] = *labelVal.Value
+				for _, labelVal := range m.GetLabel() {
+					if labelVal.GetName() == labelName {
+						dynamicLabels[i] = labelVal.GetValue()
 					}
 				}
 			}
 			ch <- prometheus.MustNewConstHistogram(
 				c.dispatchedDesc,
-				*m.Histogram.SampleCount,
-				*m.Histogram.SampleSum,
+				m.GetHistogram().GetSampleCount(),
+				m.GetHistogram().GetSampleSum(),
 				buckets,
 				dynamicLabels...,
 			)

--- a/internal/telemetry/reporter_test.go
+++ b/internal/telemetry/reporter_test.go
@@ -120,9 +120,9 @@ func TestDiscoverTimeseries(t *testing.T) {
 	require.Len(t, ts, 2)
 
 	for _, timeSeries := range ts {
-		require.NotEmpty(t, timeSeries.Labels)
-		require.Len(t, timeSeries.Samples, 1)
-		require.NotZero(t, timeSeries.Samples[0].Timestamp)
+		require.NotEmpty(t, timeSeries.GetLabels())
+		require.Len(t, timeSeries.GetSamples(), 1)
+		require.NotZero(t, timeSeries.GetSamples()[0].GetTimestamp())
 	}
 }
 
@@ -361,12 +361,12 @@ func TestConvertLabels(t *testing.T) {
 			// Convert to map for easier comparison since order might vary
 			resultMap := make(map[string]string)
 			for _, label := range result {
-				resultMap[label.Name] = label.Value
+				resultMap[label.GetName()] = label.GetValue()
 			}
 
 			expectedMap := make(map[string]string)
 			for _, label := range tt.expected {
-				expectedMap[label.Name] = label.Value
+				expectedMap[label.GetName()] = label.GetValue()
 			}
 
 			require.Equal(t, expectedMap, resultMap)

--- a/internal/testserver/datastore/spanner.go
+++ b/internal/testserver/datastore/spanner.go
@@ -127,14 +127,14 @@ func (b *spannerTest) NewDatabase(t testing.TB) string {
 
 	dbID := "fake-database-id"
 	op, err := adminClient.CreateDatabase(ctx, &adminpb.CreateDatabaseRequest{
-		Parent:          spannerInstance.Name,
+		Parent:          spannerInstance.GetName(),
 		CreateStatement: "CREATE DATABASE `" + dbID + "`",
 	})
 	require.NoError(t, err)
 
 	db, err := op.Wait(ctx)
 	require.NoError(t, err)
-	return db.Name
+	return db.GetName()
 }
 
 func (b *spannerTest) NewDatastore(t testing.TB, initFunc InitFunc) datastore.Datastore {

--- a/pkg/caveats/compile.go
+++ b/pkg/caveats/compile.go
@@ -103,7 +103,7 @@ func (cc CompiledCaveat) ReferencedParameters(parameters []string) (*mapz.Set[st
 		return nil, err
 	}
 
-	referencedParameters(definedParameters, checked.Expr, referencedParams)
+	referencedParameters(definedParameters, checked.GetExpr(), referencedParams)
 	return referencedParams, nil
 }
 
@@ -224,5 +224,5 @@ func DeserializeCaveatWithEnviroment(env *Environment, serialized []byte) (*Comp
 	}
 
 	ast := cel.CheckedExprToAst(caveat.GetCel())
-	return &CompiledCaveat{celEnv, ast, caveat.Name}, nil
+	return &CompiledCaveat{celEnv, ast, caveat.GetName()}, nil
 }

--- a/pkg/caveats/context_hash.go
+++ b/pkg/caveats/context_hash.go
@@ -63,7 +63,7 @@ func (hsv hashableStructValue) AppendToHash(hasher HasherInterface) {
 		hasher.WriteString(strconv.FormatBool(t.BoolValue))
 
 	case *structpb.Value_ListValue:
-		for _, value := range t.ListValue.Values {
+		for _, value := range t.ListValue.GetValues() {
 			hashableStructValue{value}.AppendToHash(hasher)
 			hasher.WriteString(",")
 		}

--- a/pkg/caveats/parameters.go
+++ b/pkg/caveats/parameters.go
@@ -67,10 +67,10 @@ func ConvertContextToParameters(
 // ParameterTypeString returns the string form of the type reference.
 func ParameterTypeString(typeRef *core.CaveatTypeReference) string {
 	var sb strings.Builder
-	sb.WriteString(typeRef.TypeName)
-	if len(typeRef.ChildTypes) > 0 {
+	sb.WriteString(typeRef.GetTypeName())
+	if len(typeRef.GetChildTypes()) > 0 {
 		sb.WriteString("<")
-		for idx, childType := range typeRef.ChildTypes {
+		for idx, childType := range typeRef.GetChildTypes() {
 			if idx > 0 {
 				sb.WriteString(", ")
 			}

--- a/pkg/caveats/structure.go
+++ b/pkg/caveats/structure.go
@@ -15,40 +15,40 @@ func referencedParameters(definedParameters *mapz.Set[string], expr *exprpb.Expr
 		return
 	}
 
-	switch t := expr.ExprKind.(type) {
+	switch t := expr.GetExprKind().(type) {
 	case *exprpb.Expr_ConstExpr:
 		// nothing to do
 
 	case *exprpb.Expr_IdentExpr:
-		if definedParameters.Has(t.IdentExpr.Name) {
-			referencedParams.Add(t.IdentExpr.Name)
+		if definedParameters.Has(t.IdentExpr.GetName()) {
+			referencedParams.Add(t.IdentExpr.GetName())
 		}
 
 	case *exprpb.Expr_SelectExpr:
-		referencedParameters(definedParameters, t.SelectExpr.Operand, referencedParams)
+		referencedParameters(definedParameters, t.SelectExpr.GetOperand(), referencedParams)
 
 	case *exprpb.Expr_CallExpr:
-		referencedParameters(definedParameters, t.CallExpr.Target, referencedParams)
-		for _, arg := range t.CallExpr.Args {
+		referencedParameters(definedParameters, t.CallExpr.GetTarget(), referencedParams)
+		for _, arg := range t.CallExpr.GetArgs() {
 			referencedParameters(definedParameters, arg, referencedParams)
 		}
 
 	case *exprpb.Expr_ListExpr:
-		for _, elem := range t.ListExpr.Elements {
+		for _, elem := range t.ListExpr.GetElements() {
 			referencedParameters(definedParameters, elem, referencedParams)
 		}
 
 	case *exprpb.Expr_StructExpr:
-		for _, entry := range t.StructExpr.Entries {
-			referencedParameters(definedParameters, entry.Value, referencedParams)
+		for _, entry := range t.StructExpr.GetEntries() {
+			referencedParameters(definedParameters, entry.GetValue(), referencedParams)
 		}
 
 	case *exprpb.Expr_ComprehensionExpr:
-		referencedParameters(definedParameters, t.ComprehensionExpr.AccuInit, referencedParams)
-		referencedParameters(definedParameters, t.ComprehensionExpr.IterRange, referencedParams)
-		referencedParameters(definedParameters, t.ComprehensionExpr.LoopCondition, referencedParams)
-		referencedParameters(definedParameters, t.ComprehensionExpr.LoopStep, referencedParams)
-		referencedParameters(definedParameters, t.ComprehensionExpr.Result, referencedParams)
+		referencedParameters(definedParameters, t.ComprehensionExpr.GetAccuInit(), referencedParams)
+		referencedParameters(definedParameters, t.ComprehensionExpr.GetIterRange(), referencedParams)
+		referencedParameters(definedParameters, t.ComprehensionExpr.GetLoopCondition(), referencedParams)
+		referencedParameters(definedParameters, t.ComprehensionExpr.GetLoopStep(), referencedParams)
+		referencedParameters(definedParameters, t.ComprehensionExpr.GetResult(), referencedParams)
 
 	default:
 		panic(fmt.Sprintf("unknown CEL expression kind: %T", t))

--- a/pkg/caveats/types/encoding.go
+++ b/pkg/caveats/types/encoding.go
@@ -31,22 +31,22 @@ func EncodeParameterType(varType VariableType) *core.CaveatTypeReference {
 
 // DecodeParameterType decodes the core caveat parameter type into an internal caveat type.
 func DecodeParameterType(ts *TypeSet, parameterType *core.CaveatTypeReference) (*VariableType, error) {
-	typeDef, ok := ts.definitions[parameterType.TypeName]
+	typeDef, ok := ts.definitions[parameterType.GetTypeName()]
 	if !ok {
-		return nil, fmt.Errorf("unknown caveat parameter type `%s`", parameterType.TypeName)
+		return nil, fmt.Errorf("unknown caveat parameter type `%s`", parameterType.GetTypeName())
 	}
 
-	if len(parameterType.ChildTypes) != int(typeDef.childTypeCount) {
+	if len(parameterType.GetChildTypes()) != int(typeDef.childTypeCount) {
 		return nil, fmt.Errorf(
 			"caveat parameter type `%s` requires %d child types; found %d",
-			parameterType.TypeName,
-			len(parameterType.ChildTypes),
+			parameterType.GetTypeName(),
+			len(parameterType.GetChildTypes()),
 			typeDef.childTypeCount,
 		)
 	}
 
 	childTypes := make([]VariableType, 0, typeDef.childTypeCount)
-	for _, encodedChildType := range parameterType.ChildTypes {
+	for _, encodedChildType := range parameterType.GetChildTypes() {
 		childType, err := DecodeParameterType(ts, encodedChildType)
 		if err != nil {
 			return nil, err

--- a/pkg/cmd/datastore/datastore_test.go
+++ b/pkg/cmd/datastore/datastore_test.go
@@ -30,7 +30,7 @@ func TestLoadDatastoreFromFileContents(t *testing.T) {
 	namespaces, err := ds.SnapshotReader(revision).ListAllNamespaces(ctx)
 	require.NoError(t, err)
 	require.Len(t, namespaces, 1)
-	require.Equal(t, "user", namespaces[0].Definition.Name)
+	require.Equal(t, "user", namespaces[0].Definition.GetName())
 }
 
 func TestLoadDatastoreFromFile(t *testing.T) {
@@ -51,7 +51,7 @@ func TestLoadDatastoreFromFile(t *testing.T) {
 	namespaces, err := ds.SnapshotReader(revision).ListAllNamespaces(ctx)
 	require.NoError(t, err)
 	require.Len(t, namespaces, 1)
-	require.Equal(t, "user", namespaces[0].Definition.Name)
+	require.Equal(t, "user", namespaces[0].Definition.GetName())
 }
 
 func TestLoadDatastoreFromFileAndContents(t *testing.T) {
@@ -73,7 +73,7 @@ func TestLoadDatastoreFromFileAndContents(t *testing.T) {
 	namespaces, err := ds.SnapshotReader(revision).ListAllNamespaces(ctx)
 	require.NoError(t, err)
 	require.Len(t, namespaces, 2)
-	namespaceNames := []string{namespaces[0].Definition.Name, namespaces[1].Definition.Name}
+	namespaceNames := []string{namespaces[0].Definition.GetName(), namespaces[1].Definition.GetName()}
 	require.Contains(t, namespaceNames, "user")
 	require.Contains(t, namespaceNames, "repository")
 }

--- a/pkg/composableschemadsl/compiler/compiler_test.go
+++ b/pkg/composableschemadsl/compiler/compiler_test.go
@@ -1317,22 +1317,22 @@ func TestCompile(t *testing.T) {
 					if caveatDef, ok := def.(*core.CaveatDefinition); ok {
 						expectedCaveatDef, ok := expectedDef.(*core.CaveatDefinition)
 						require.True(ok, "definition is not a caveat def")
-						require.Equal(expectedCaveatDef.Name, caveatDef.Name)
-						require.Len(caveatDef.ParameterTypes, len(expectedCaveatDef.ParameterTypes))
+						require.Equal(expectedCaveatDef.GetName(), caveatDef.GetName())
+						require.Len(caveatDef.GetParameterTypes(), len(expectedCaveatDef.GetParameterTypes()))
 
-						for expectedParamName, expectedParam := range expectedCaveatDef.ParameterTypes {
-							foundParam, ok := caveatDef.ParameterTypes[expectedParamName]
+						for expectedParamName, expectedParam := range expectedCaveatDef.GetParameterTypes() {
+							foundParam, ok := caveatDef.GetParameterTypes()[expectedParamName]
 							require.True(ok, "missing parameter %s", expectedParamName)
 							testutil.RequireProtoEqual(t, expectedParam, foundParam, "mismatch type for parameter %s", expectedParamName)
 						}
 
-						parameterTypes, err := caveattypes.DecodeParameterTypes(caveattypes.Default.TypeSet, caveatDef.ParameterTypes)
+						parameterTypes, err := caveattypes.DecodeParameterTypes(caveattypes.Default.TypeSet, caveatDef.GetParameterTypes())
 						require.NoError(err)
 
-						expectedDecoded, err := caveats.DeserializeCaveatWithDefaultTypeSet(expectedCaveatDef.SerializedExpression, parameterTypes)
+						expectedDecoded, err := caveats.DeserializeCaveatWithDefaultTypeSet(expectedCaveatDef.GetSerializedExpression(), parameterTypes)
 						require.NoError(err)
 
-						foundDecoded, err := caveats.DeserializeCaveatWithDefaultTypeSet(caveatDef.SerializedExpression, parameterTypes)
+						foundDecoded, err := caveats.DeserializeCaveatWithDefaultTypeSet(caveatDef.GetSerializedExpression(), parameterTypes)
 						require.NoError(err)
 
 						expectedExprString, err := expectedDecoded.ExprString()

--- a/pkg/composableschemadsl/compiler/translator.go
+++ b/pkg/composableschemadsl/compiler/translator.go
@@ -213,7 +213,7 @@ func translateCaveatDefinition(tctx *translationContext, defNode *dslNode) (*cor
 		return nil, err
 	}
 
-	def.Metadata = addComments(def.Metadata, defNode)
+	def.Metadata = addComments(def.GetMetadata(), defNode)
 	def.SourcePosition = getSourcePosition(defNode, tctx.mapper)
 	return def, nil
 }
@@ -261,7 +261,7 @@ func translateObjectDefinition(tctx *translationContext, defNode *dslNode) (*cor
 
 	if len(relationsAndPermissions) == 0 {
 		ns := namespace.Namespace(nspath)
-		ns.Metadata = addComments(ns.Metadata, defNode)
+		ns.Metadata = addComments(ns.GetMetadata(), defNode)
 		ns.SourcePosition = getSourcePosition(defNode, tctx.mapper)
 
 		if !tctx.skipValidate {
@@ -274,7 +274,7 @@ func translateObjectDefinition(tctx *translationContext, defNode *dslNode) (*cor
 	}
 
 	ns := namespace.Namespace(nspath, relationsAndPermissions...)
-	ns.Metadata = addComments(ns.Metadata, defNode)
+	ns.Metadata = addComments(ns.GetMetadata(), defNode)
 	ns.SourcePosition = getSourcePosition(defNode, tctx.mapper)
 
 	if !tctx.skipValidate {
@@ -378,7 +378,7 @@ func translateRelationOrPermission(tctx *translationContext, relOrPermNode *dslN
 		if err != nil {
 			return nil, err
 		}
-		rel.Metadata = addComments(rel.Metadata, relOrPermNode)
+		rel.Metadata = addComments(rel.GetMetadata(), relOrPermNode)
 		rel.SourcePosition = getSourcePosition(relOrPermNode, tctx.mapper)
 		return rel, err
 
@@ -387,7 +387,7 @@ func translateRelationOrPermission(tctx *translationContext, relOrPermNode *dslN
 		if err != nil {
 			return nil, err
 		}
-		rel.Metadata = addComments(rel.Metadata, relOrPermNode)
+		rel.Metadata = addComments(rel.GetMetadata(), relOrPermNode)
 		rel.SourcePosition = getSourcePosition(relOrPermNode, tctx.mapper)
 		return rel, err
 
@@ -501,8 +501,8 @@ func collapseOps(op *core.SetOperation_Child, handler func(rewrite *core.Userset
 		return []*core.SetOperation_Child{op}
 	}
 
-	collapsed := make([]*core.SetOperation_Child, 0, len(operation.Child))
-	for _, child := range operation.Child {
+	collapsed := make([]*core.SetOperation_Child, 0, len(operation.GetChild()))
+	for _, child := range operation.GetChild() {
 		collapsed = append(collapsed, collapseOps(child, handler)...)
 	}
 	return collapsed

--- a/pkg/cursor/cursor_test.go
+++ b/pkg/cursor/cursor_test.go
@@ -59,7 +59,7 @@ func TestEncodeDecode(t *testing.T) {
 			require.NotNil(decoded)
 			require.Equal(map[string]string{"some": "flag"}, flags)
 
-			require.Equal(tc.sections, decoded.Sections)
+			require.Equal(tc.sections, decoded.GetSections())
 
 			decodedRev, _, err := DecodeToDispatchRevision(context.Background(), encoded, revisions.CommonDecoder{
 				Kind: revisions.TransactionID,
@@ -137,7 +137,7 @@ func TestDecode(t *testing.T) {
 
 			require.NoError(err)
 			require.NotNil(decoded)
-			require.Equal(testCase.expectedSections, decoded.Sections)
+			require.Equal(testCase.expectedSections, decoded.GetSections())
 
 			decodedRev, _, err := DecodeToDispatchRevision(context.Background(), &v1.Cursor{
 				Token: testCase.token,

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -204,12 +204,12 @@ func (rf RelationshipsFilter) Test(relationship tuple.Relationship) bool {
 		// No caveat filter, so no need to check.
 
 	case CaveatFilterOptionHasMatchingCaveat:
-		if relationship.OptionalCaveat == nil || relationship.OptionalCaveat.CaveatName != rf.OptionalCaveatNameFilter.CaveatName {
+		if relationship.OptionalCaveat == nil || relationship.OptionalCaveat.GetCaveatName() != rf.OptionalCaveatNameFilter.CaveatName {
 			return false
 		}
 
 	case CaveatFilterOptionNoCaveat:
-		if relationship.OptionalCaveat != nil && relationship.OptionalCaveat.CaveatName != "" {
+		if relationship.OptionalCaveat != nil && relationship.OptionalCaveat.GetCaveatName() != "" {
 			return false
 		}
 	}
@@ -251,11 +251,11 @@ func WithNoCaveat() CaveatNameFilter {
 // CoreFilterFromRelationshipFilter constructs a core RelationshipFilter from a V1 RelationshipsFilter.
 func CoreFilterFromRelationshipFilter(filter *v1.RelationshipFilter) *core.RelationshipFilter {
 	return &core.RelationshipFilter{
-		ResourceType:             filter.ResourceType,
-		OptionalResourceId:       filter.OptionalResourceId,
-		OptionalResourceIdPrefix: filter.OptionalResourceIdPrefix,
-		OptionalRelation:         filter.OptionalRelation,
-		OptionalSubjectFilter:    coreFilterFromSubjectsFilter(filter.OptionalSubjectFilter),
+		ResourceType:             filter.GetResourceType(),
+		OptionalResourceId:       filter.GetOptionalResourceId(),
+		OptionalResourceIdPrefix: filter.GetOptionalResourceIdPrefix(),
+		OptionalRelation:         filter.GetOptionalRelation(),
+		OptionalSubjectFilter:    coreFilterFromSubjectsFilter(filter.GetOptionalSubjectFilter()),
 	}
 }
 
@@ -265,9 +265,9 @@ func coreFilterFromSubjectsFilter(filter *v1.SubjectFilter) *core.SubjectFilter 
 	}
 
 	return &core.SubjectFilter{
-		SubjectType:       filter.SubjectType,
-		OptionalSubjectId: filter.OptionalSubjectId,
-		OptionalRelation:  coreFilterFromSubjectRelationFilter(filter.OptionalRelation),
+		SubjectType:       filter.GetSubjectType(),
+		OptionalSubjectId: filter.GetOptionalSubjectId(),
+		OptionalRelation:  coreFilterFromSubjectRelationFilter(filter.GetOptionalRelation()),
 	}
 }
 
@@ -277,28 +277,28 @@ func coreFilterFromSubjectRelationFilter(filter *v1.SubjectFilter_RelationFilter
 	}
 
 	return &core.SubjectFilter_RelationFilter{
-		Relation: filter.Relation,
+		Relation: filter.GetRelation(),
 	}
 }
 
 // RelationshipsFilterFromCoreFilter constructs a datastore RelationshipsFilter from a core RelationshipFilter.
 func RelationshipsFilterFromCoreFilter(filter *core.RelationshipFilter) (RelationshipsFilter, error) {
 	var resourceIds []string
-	if filter.OptionalResourceId != "" {
-		resourceIds = []string{filter.OptionalResourceId}
+	if filter.GetOptionalResourceId() != "" {
+		resourceIds = []string{filter.GetOptionalResourceId()}
 	}
 
 	var subjectsSelectors []SubjectsSelector
-	if filter.OptionalSubjectFilter != nil {
+	if filter.GetOptionalSubjectFilter() != nil {
 		var subjectIds []string
-		if filter.OptionalSubjectFilter.OptionalSubjectId != "" {
-			subjectIds = []string{filter.OptionalSubjectFilter.OptionalSubjectId}
+		if filter.GetOptionalSubjectFilter().GetOptionalSubjectId() != "" {
+			subjectIds = []string{filter.GetOptionalSubjectFilter().GetOptionalSubjectId()}
 		}
 
 		relationFilter := SubjectRelationFilter{}
 
-		if filter.OptionalSubjectFilter.OptionalRelation != nil {
-			relation := filter.OptionalSubjectFilter.OptionalRelation.GetRelation()
+		if filter.GetOptionalSubjectFilter().GetOptionalRelation() != nil {
+			relation := filter.GetOptionalSubjectFilter().GetOptionalRelation().GetRelation()
 			if relation != "" {
 				relationFilter = relationFilter.WithNonEllipsisRelation(relation)
 			} else {
@@ -307,25 +307,25 @@ func RelationshipsFilterFromCoreFilter(filter *core.RelationshipFilter) (Relatio
 		}
 
 		subjectsSelectors = append(subjectsSelectors, SubjectsSelector{
-			OptionalSubjectType: filter.OptionalSubjectFilter.SubjectType,
+			OptionalSubjectType: filter.GetOptionalSubjectFilter().GetSubjectType(),
 			OptionalSubjectIds:  subjectIds,
 			RelationFilter:      relationFilter,
 		})
 	}
 
-	if filter.OptionalResourceId != "" && filter.OptionalResourceIdPrefix != "" {
+	if filter.GetOptionalResourceId() != "" && filter.GetOptionalResourceIdPrefix() != "" {
 		return RelationshipsFilter{}, errors.New("cannot specify both OptionalResourceId and OptionalResourceIDPrefix")
 	}
 
-	if filter.ResourceType == "" && filter.OptionalRelation == "" && len(resourceIds) == 0 && filter.OptionalResourceIdPrefix == "" && len(subjectsSelectors) == 0 {
+	if filter.GetResourceType() == "" && filter.GetOptionalRelation() == "" && len(resourceIds) == 0 && filter.GetOptionalResourceIdPrefix() == "" && len(subjectsSelectors) == 0 {
 		return RelationshipsFilter{}, errors.New("at least one filter field must be set")
 	}
 
 	return RelationshipsFilter{
-		OptionalResourceType:      filter.ResourceType,
+		OptionalResourceType:      filter.GetResourceType(),
 		OptionalResourceIds:       resourceIds,
-		OptionalResourceIDPrefix:  filter.OptionalResourceIdPrefix,
-		OptionalResourceRelation:  filter.OptionalRelation,
+		OptionalResourceIDPrefix:  filter.GetOptionalResourceIdPrefix(),
+		OptionalResourceRelation:  filter.GetOptionalRelation(),
 		OptionalSubjectsSelectors: subjectsSelectors,
 	}, nil
 }
@@ -333,21 +333,21 @@ func RelationshipsFilterFromCoreFilter(filter *core.RelationshipFilter) (Relatio
 // RelationshipsFilterFromPublicFilter constructs a datastore RelationshipsFilter from an API-defined RelationshipFilter.
 func RelationshipsFilterFromPublicFilter(filter *v1.RelationshipFilter) (RelationshipsFilter, error) {
 	var resourceIds []string
-	if filter.OptionalResourceId != "" {
-		resourceIds = []string{filter.OptionalResourceId}
+	if filter.GetOptionalResourceId() != "" {
+		resourceIds = []string{filter.GetOptionalResourceId()}
 	}
 
 	var subjectsSelectors []SubjectsSelector
-	if filter.OptionalSubjectFilter != nil {
+	if filter.GetOptionalSubjectFilter() != nil {
 		var subjectIds []string
-		if filter.OptionalSubjectFilter.OptionalSubjectId != "" {
-			subjectIds = []string{filter.OptionalSubjectFilter.OptionalSubjectId}
+		if filter.GetOptionalSubjectFilter().GetOptionalSubjectId() != "" {
+			subjectIds = []string{filter.GetOptionalSubjectFilter().GetOptionalSubjectId()}
 		}
 
 		relationFilter := SubjectRelationFilter{}
 
-		if filter.OptionalSubjectFilter.OptionalRelation != nil {
-			relation := filter.OptionalSubjectFilter.OptionalRelation.GetRelation()
+		if filter.GetOptionalSubjectFilter().GetOptionalRelation() != nil {
+			relation := filter.GetOptionalSubjectFilter().GetOptionalRelation().GetRelation()
 			if relation != "" {
 				relationFilter = relationFilter.WithNonEllipsisRelation(relation)
 			} else {
@@ -356,25 +356,25 @@ func RelationshipsFilterFromPublicFilter(filter *v1.RelationshipFilter) (Relatio
 		}
 
 		subjectsSelectors = append(subjectsSelectors, SubjectsSelector{
-			OptionalSubjectType: filter.OptionalSubjectFilter.SubjectType,
+			OptionalSubjectType: filter.GetOptionalSubjectFilter().GetSubjectType(),
 			OptionalSubjectIds:  subjectIds,
 			RelationFilter:      relationFilter,
 		})
 	}
 
-	if filter.OptionalResourceId != "" && filter.OptionalResourceIdPrefix != "" {
+	if filter.GetOptionalResourceId() != "" && filter.GetOptionalResourceIdPrefix() != "" {
 		return RelationshipsFilter{}, errors.New("cannot specify both OptionalResourceId and OptionalResourceIDPrefix")
 	}
 
-	if filter.ResourceType == "" && filter.OptionalRelation == "" && len(resourceIds) == 0 && filter.OptionalResourceIdPrefix == "" && len(subjectsSelectors) == 0 {
+	if filter.GetResourceType() == "" && filter.GetOptionalRelation() == "" && len(resourceIds) == 0 && filter.GetOptionalResourceIdPrefix() == "" && len(subjectsSelectors) == 0 {
 		return RelationshipsFilter{}, errors.New("at least one filter field must be set")
 	}
 
 	return RelationshipsFilter{
-		OptionalResourceType:      filter.ResourceType,
+		OptionalResourceType:      filter.GetResourceType(),
 		OptionalResourceIds:       resourceIds,
-		OptionalResourceIDPrefix:  filter.OptionalResourceIdPrefix,
-		OptionalResourceRelation:  filter.OptionalRelation,
+		OptionalResourceIDPrefix:  filter.GetOptionalResourceIdPrefix(),
+		OptionalResourceRelation:  filter.GetOptionalRelation(),
 		OptionalSubjectsSelectors: subjectsSelectors,
 	}, nil
 }

--- a/pkg/datastore/errors.go
+++ b/pkg/datastore/errors.go
@@ -242,21 +242,21 @@ func (err CounterAlreadyRegisteredError) DetailsMetadata() map[string]string {
 	subjectType := ""
 	subjectID := ""
 	subjectRelation := ""
-	if err.filter.OptionalSubjectFilter != nil {
-		subjectType = err.filter.OptionalSubjectFilter.SubjectType
-		subjectID = err.filter.OptionalSubjectFilter.OptionalSubjectId
+	if err.filter.GetOptionalSubjectFilter() != nil {
+		subjectType = err.filter.GetOptionalSubjectFilter().GetSubjectType()
+		subjectID = err.filter.GetOptionalSubjectFilter().GetOptionalSubjectId()
 
-		if err.filter.OptionalSubjectFilter.GetOptionalRelation() != nil {
-			subjectRelation = err.filter.OptionalSubjectFilter.GetOptionalRelation().Relation
+		if err.filter.GetOptionalSubjectFilter().GetOptionalRelation() != nil {
+			subjectRelation = err.filter.GetOptionalSubjectFilter().GetOptionalRelation().GetRelation()
 		}
 	}
 
 	return map[string]string{
 		"counter_name":                  err.counterName,
-		"new_filter_resource_type":      err.filter.ResourceType,
-		"new_filter_resource_id":        err.filter.OptionalResourceId,
-		"new_filter_resource_id_prefix": err.filter.OptionalResourceIdPrefix,
-		"new_filter_relation":           err.filter.OptionalRelation,
+		"new_filter_resource_type":      err.filter.GetResourceType(),
+		"new_filter_resource_id":        err.filter.GetOptionalResourceId(),
+		"new_filter_resource_id_prefix": err.filter.GetOptionalResourceIdPrefix(),
+		"new_filter_relation":           err.filter.GetOptionalRelation(),
 		"new_filter_subject_type":       subjectType,
 		"new_filter_subject_id":         subjectID,
 		"new_filter_subject_relation":   subjectRelation,

--- a/pkg/datastore/stats.go
+++ b/pkg/datastore/stats.go
@@ -13,7 +13,7 @@ func ComputeObjectTypeStats(objTypes []RevisionedNamespace) []ObjectTypeStat {
 	for _, objType := range objTypes {
 		var relations, permissions uint32
 
-		for _, rel := range objType.Definition.Relation {
+		for _, rel := range objType.Definition.GetRelation() {
 			if namespace.GetRelationKind(rel) == iv1.RelationMetadata_PERMISSION {
 				permissions++
 			} else {

--- a/pkg/datastore/test/basic.go
+++ b/pkg/datastore/test/basic.go
@@ -44,7 +44,7 @@ func DeleteAllDataTest(t *testing.T, tester DatastoreTester) {
 	for _, nsDef := range nsDefs {
 		iter, err := reader.QueryRelationships(
 			ctx,
-			datastore.RelationshipsFilter{OptionalResourceType: nsDef.Definition.Name},
+			datastore.RelationshipsFilter{OptionalResourceType: nsDef.Definition.GetName()},
 			options.WithQueryShape(queryshape.FindResourceOfType),
 		)
 		require.NoError(t, err)
@@ -72,7 +72,7 @@ func DeleteAllDataTest(t *testing.T, tester DatastoreTester) {
 	for _, nsDef := range nsDefs {
 		iter, err := reader.QueryRelationships(
 			ctx,
-			datastore.RelationshipsFilter{OptionalResourceType: nsDef.Definition.Name},
+			datastore.RelationshipsFilter{OptionalResourceType: nsDef.Definition.GetName()},
 			options.WithQueryShape(queryshape.FindResourceOfType),
 		)
 		require.NoError(t, err)

--- a/pkg/datastore/test/bulk.go
+++ b/pkg/datastore/test/bulk.go
@@ -33,9 +33,9 @@ func BulkUploadTest(t *testing.T, tester DatastoreTester) {
 
 			ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
 			bulkSource := testfixtures.NewBulkRelationshipGenerator(
-				testfixtures.DocumentNS.Name,
+				testfixtures.DocumentNS.GetName(),
 				"viewer",
-				testfixtures.UserNS.Name,
+				testfixtures.UserNS.GetName(),
 				tc,
 				t,
 			)
@@ -55,7 +55,7 @@ func BulkUploadTest(t *testing.T, tester DatastoreTester) {
 			require.NoError(err)
 
 			iter, err := ds.SnapshotReader(head).QueryRelationships(ctx, datastore.RelationshipsFilter{
-				OptionalResourceType: testfixtures.DocumentNS.Name,
+				OptionalResourceType: testfixtures.DocumentNS.GetName(),
 			}, options.WithQueryShape(queryshape.FindResourceOfType))
 			require.NoError(err)
 
@@ -95,9 +95,9 @@ func BulkUploadAlreadyExistsSameCallErrorTest(t *testing.T, tester DatastoreTest
 
 	_, err = ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 		inserted, err := rwt.BulkLoad(ctx, testfixtures.NewBulkRelationshipGenerator(
-			testfixtures.DocumentNS.Name,
+			testfixtures.DocumentNS.GetName(),
 			"viewer",
-			testfixtures.UserNS.Name,
+			testfixtures.UserNS.GetName(),
 			1,
 			t,
 		))
@@ -105,9 +105,9 @@ func BulkUploadAlreadyExistsSameCallErrorTest(t *testing.T, tester DatastoreTest
 		require.Equal(uint64(1), inserted)
 
 		_, serr := rwt.BulkLoad(ctx, testfixtures.NewBulkRelationshipGenerator(
-			testfixtures.DocumentNS.Name,
+			testfixtures.DocumentNS.GetName(),
 			"viewer",
-			testfixtures.UserNS.Name,
+			testfixtures.UserNS.GetName(),
 			1,
 			t,
 		))
@@ -132,9 +132,9 @@ func BulkUploadWithCaveats(t *testing.T, tester DatastoreTester) {
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
 	bulkSource := testfixtures.NewBulkRelationshipGenerator(
-		testfixtures.DocumentNS.Name,
+		testfixtures.DocumentNS.GetName(),
 		"caveated_viewer",
-		testfixtures.UserNS.Name,
+		testfixtures.UserNS.GetName(),
 		tc,
 		t,
 	)
@@ -150,7 +150,7 @@ func BulkUploadWithCaveats(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 
 	iter, err := ds.SnapshotReader(lastRevision).QueryRelationships(ctx, datastore.RelationshipsFilter{
-		OptionalResourceType: testfixtures.DocumentNS.Name,
+		OptionalResourceType: testfixtures.DocumentNS.GetName(),
 	}, options.WithQueryShape(queryshape.FindResourceOfType))
 	require.NoError(err)
 
@@ -158,9 +158,9 @@ func BulkUploadWithCaveats(t *testing.T, tester DatastoreTester) {
 		require.NoError(err)
 		require.Nil(found.OptionalExpiration)
 		require.NotNil(found.OptionalCaveat)
-		require.NotEmpty(found.OptionalCaveat.CaveatName)
-		require.NotNil(found.OptionalCaveat.Context)
-		require.Equal(map[string]any{"secret": "1235"}, found.OptionalCaveat.Context.AsMap())
+		require.NotEmpty(found.OptionalCaveat.GetCaveatName())
+		require.NotNil(found.OptionalCaveat.GetContext())
+		require.Equal(map[string]any{"secret": "1235"}, found.OptionalCaveat.GetContext().AsMap())
 	}
 }
 
@@ -174,9 +174,9 @@ func BulkUploadWithExpiration(t *testing.T, tester DatastoreTester) {
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
 	bulkSource := testfixtures.NewBulkRelationshipGenerator(
-		testfixtures.DocumentNS.Name,
+		testfixtures.DocumentNS.GetName(),
 		"expired_viewer",
-		testfixtures.UserNS.Name,
+		testfixtures.UserNS.GetName(),
 		tc,
 		t,
 	)
@@ -192,7 +192,7 @@ func BulkUploadWithExpiration(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 
 	iter, err := ds.SnapshotReader(lastRevision).QueryRelationships(ctx, datastore.RelationshipsFilter{
-		OptionalResourceType: testfixtures.DocumentNS.Name,
+		OptionalResourceType: testfixtures.DocumentNS.GetName(),
 	}, options.WithQueryShape(queryshape.FindResourceOfType))
 	require.NoError(err)
 
@@ -212,9 +212,9 @@ func BulkUploadEditCaveat(t *testing.T, tester DatastoreTester) {
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
 	bulkSource := testfixtures.NewBulkRelationshipGenerator(
-		testfixtures.DocumentNS.Name,
+		testfixtures.DocumentNS.GetName(),
 		"caveated_viewer",
-		testfixtures.UserNS.Name,
+		testfixtures.UserNS.GetName(),
 		tc,
 		t,
 	)
@@ -229,7 +229,7 @@ func BulkUploadEditCaveat(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 
 	iter, err := ds.SnapshotReader(lastRevision).QueryRelationships(ctx, datastore.RelationshipsFilter{
-		OptionalResourceType: testfixtures.DocumentNS.Name,
+		OptionalResourceType: testfixtures.DocumentNS.GetName(),
 	}, options.WithQueryShape(queryshape.FindResourceOfType))
 	require.NoError(err)
 
@@ -239,7 +239,7 @@ func BulkUploadEditCaveat(t *testing.T, tester DatastoreTester) {
 		require.NoError(err)
 
 		updates = append(updates, tuple.Touch(found.WithCaveat(&core.ContextualizedCaveat{
-			CaveatName: testfixtures.CaveatDef.Name,
+			CaveatName: testfixtures.CaveatDef.GetName(),
 			Context:    nil,
 		})))
 	}
@@ -254,7 +254,7 @@ func BulkUploadEditCaveat(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 
 	iter, err = ds.SnapshotReader(lastRevision).QueryRelationships(ctx, datastore.RelationshipsFilter{
-		OptionalResourceType: testfixtures.DocumentNS.Name,
+		OptionalResourceType: testfixtures.DocumentNS.GetName(),
 	}, options.WithQueryShape(queryshape.FindResourceOfType))
 	require.NoError(err)
 
@@ -262,7 +262,7 @@ func BulkUploadEditCaveat(t *testing.T, tester DatastoreTester) {
 	for found, err := range iter {
 		require.NoError(err)
 		require.NotNil(found.OptionalCaveat)
-		require.NotEmpty(found.OptionalCaveat.CaveatName)
+		require.NotEmpty(found.OptionalCaveat.GetCaveatName())
 		foundChanged++
 	}
 
@@ -281,9 +281,9 @@ func BulkUploadAlreadyExistsErrorTest(t *testing.T, tester DatastoreTester) {
 	// Bulk write a single relationship.
 	_, err = ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 		inserted, err := rwt.BulkLoad(ctx, testfixtures.NewBulkRelationshipGenerator(
-			testfixtures.DocumentNS.Name,
+			testfixtures.DocumentNS.GetName(),
 			"viewer",
-			testfixtures.UserNS.Name,
+			testfixtures.UserNS.GetName(),
 			1,
 			t,
 		))
@@ -296,9 +296,9 @@ func BulkUploadAlreadyExistsErrorTest(t *testing.T, tester DatastoreTester) {
 	// Bulk write it again and ensure we get the expected error.
 	_, err = ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 		_, serr := rwt.BulkLoad(ctx, testfixtures.NewBulkRelationshipGenerator(
-			testfixtures.DocumentNS.Name,
+			testfixtures.DocumentNS.GetName(),
 			"viewer",
-			testfixtures.UserNS.Name,
+			testfixtures.UserNS.GetName(),
 			1,
 			t,
 		))

--- a/pkg/datastore/test/counters.go
+++ b/pkg/datastore/test/counters.go
@@ -26,7 +26,7 @@ func RelationshipCounterOverExpiredTest(t *testing.T, tester DatastoreTester) {
 	// Register the filter.
 	_, err = ds.ReadWriteTx(t.Context(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
 		err := tx.RegisterCounter(ctx, "document", &core.RelationshipFilter{
-			ResourceType: testfixtures.DocumentNS.Name,
+			ResourceType: testfixtures.DocumentNS.GetName(),
 		})
 		require.NoError(t, err)
 		return nil
@@ -47,7 +47,7 @@ func RelationshipCounterOverExpiredTest(t *testing.T, tester DatastoreTester) {
 
 	expectedCount := 0
 	iter, err := reader.QueryRelationships(t.Context(), datastore.RelationshipsFilter{
-		OptionalResourceType: testfixtures.DocumentNS.Name,
+		OptionalResourceType: testfixtures.DocumentNS.GetName(),
 	}, options.WithQueryShape(queryshape.FindResourceOfType))
 	require.NoError(t, err)
 
@@ -85,7 +85,7 @@ func RegisterRelationshipCountersInParallelTest(t *testing.T, tester DatastoreTe
 			defer wg.Done()
 			_, err := ds.ReadWriteTx(t.Context(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
 				return tx.RegisterCounter(ctx, "document", &core.RelationshipFilter{
-					ResourceType: testfixtures.DocumentNS.Name,
+					ResourceType: testfixtures.DocumentNS.GetName(),
 				})
 			})
 			if err != nil {
@@ -123,13 +123,13 @@ func RelationshipCountersTest(t *testing.T, tester DatastoreTester) {
 	// Register the filter.
 	updatedRev, err := ds.ReadWriteTx(t.Context(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
 		err := tx.RegisterCounter(ctx, "document", &core.RelationshipFilter{
-			ResourceType: testfixtures.DocumentNS.Name,
+			ResourceType: testfixtures.DocumentNS.GetName(),
 		})
 		require.NoError(t, err)
 
 		// Register another filter.
 		err = tx.RegisterCounter(ctx, "another", &core.RelationshipFilter{
-			ResourceType: testfixtures.FolderNS.Name,
+			ResourceType: testfixtures.FolderNS.GetName(),
 		})
 		require.NoError(t, err)
 
@@ -140,7 +140,7 @@ func RelationshipCountersTest(t *testing.T, tester DatastoreTester) {
 	// Try to register again.
 	_, err = ds.ReadWriteTx(t.Context(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
 		err := tx.RegisterCounter(ctx, "document", &core.RelationshipFilter{
-			ResourceType: testfixtures.DocumentNS.Name,
+			ResourceType: testfixtures.DocumentNS.GetName(),
 		})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "counter with name `document` already registered")
@@ -153,7 +153,7 @@ func RelationshipCountersTest(t *testing.T, tester DatastoreTester) {
 
 	expectedCount := 0
 	iter, err := reader.QueryRelationships(t.Context(), datastore.RelationshipsFilter{
-		OptionalResourceType: testfixtures.DocumentNS.Name,
+		OptionalResourceType: testfixtures.DocumentNS.GetName(),
 	}, options.WithQueryShape(queryshape.FindResourceOfType))
 	require.NoError(t, err)
 
@@ -169,7 +169,7 @@ func RelationshipCountersTest(t *testing.T, tester DatastoreTester) {
 	// Call another filter.
 	expectedCount = 0
 	iter, err = reader.QueryRelationships(t.Context(), datastore.RelationshipsFilter{
-		OptionalResourceType: testfixtures.FolderNS.Name,
+		OptionalResourceType: testfixtures.FolderNS.GetName(),
 	}, options.WithQueryShape(queryshape.FindResourceOfType))
 	require.NoError(t, err)
 
@@ -218,9 +218,9 @@ func RelationshipCountersWithOddFilterTest(t *testing.T, tester DatastoreTester)
 	// Register the filter.
 	updatedRev, err := ds.ReadWriteTx(t.Context(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
 		err := tx.RegisterCounter(ctx, "somefilter", &core.RelationshipFilter{
-			ResourceType: testfixtures.DocumentNS.Name,
+			ResourceType: testfixtures.DocumentNS.GetName(),
 			OptionalSubjectFilter: &core.SubjectFilter{
-				SubjectType: testfixtures.UserNS.Name,
+				SubjectType: testfixtures.UserNS.GetName(),
 			},
 		})
 		require.NoError(t, err)
@@ -233,10 +233,10 @@ func RelationshipCountersWithOddFilterTest(t *testing.T, tester DatastoreTester)
 
 	expectedCount := 0
 	iter, err := reader.QueryRelationships(t.Context(), datastore.RelationshipsFilter{
-		OptionalResourceType: testfixtures.DocumentNS.Name,
+		OptionalResourceType: testfixtures.DocumentNS.GetName(),
 		OptionalSubjectsSelectors: []datastore.SubjectsSelector{
 			{
-				OptionalSubjectType: testfixtures.UserNS.Name,
+				OptionalSubjectType: testfixtures.UserNS.GetName(),
 			},
 		},
 	}, options.WithQueryShape(queryshape.Varying))
@@ -275,7 +275,7 @@ func UpdateRelationshipCounterTest(t *testing.T, tester DatastoreTester) {
 	// Register filter.
 	updatedRev, err := ds.ReadWriteTx(t.Context(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
 		err := tx.RegisterCounter(ctx, "somedocfilter", &core.RelationshipFilter{
-			ResourceType: testfixtures.DocumentNS.Name,
+			ResourceType: testfixtures.DocumentNS.GetName(),
 		})
 		require.NoError(t, err)
 		return nil
@@ -316,7 +316,7 @@ func UpdateRelationshipCounterTest(t *testing.T, tester DatastoreTester) {
 	// Register a new filter.
 	newFilterRev, err := ds.ReadWriteTx(t.Context(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
 		err := tx.RegisterCounter(ctx, "another", &core.RelationshipFilter{
-			ResourceType: testfixtures.FolderNS.Name,
+			ResourceType: testfixtures.FolderNS.GetName(),
 		})
 		require.NoError(t, err)
 		return nil

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -22,12 +22,12 @@ import (
 
 var (
 	testNamespace = ns.Namespace("foo/bar",
-		ns.MustRelation("editor", nil, ns.AllowedRelation(testUserNS.Name, "...")),
+		ns.MustRelation("editor", nil, ns.AllowedRelation(testUserNS.GetName(), "...")),
 	)
 
-	updatedNamespace = ns.Namespace(testNamespace.Name,
-		ns.MustRelation("reader", nil, ns.AllowedRelation(testUserNS.Name, "...")),
-		ns.MustRelation("editor", nil, ns.AllowedRelation(testUserNS.Name, "...")),
+	updatedNamespace = ns.Namespace(testNamespace.GetName(),
+		ns.MustRelation("reader", nil, ns.AllowedRelation(testUserNS.GetName(), "...")),
+		ns.MustRelation("editor", nil, ns.AllowedRelation(testUserNS.GetName(), "...")),
 	)
 )
 
@@ -74,7 +74,7 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	nsDefs, err = ds.SnapshotReader(writtenRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	require.Len(nsDefs, 1)
-	require.Equal(testUserNS.Name, nsDefs[0].Definition.Name)
+	require.Equal(testUserNS.GetName(), nsDefs[0].Definition.GetName())
 
 	secondWritten, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 		return rwt.WriteNamespaces(ctx, testNamespace)
@@ -86,14 +86,14 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 	require.Len(nsDefs, 2)
 
-	_, _, err = ds.SnapshotReader(writtenRev).ReadNamespaceByName(ctx, testNamespace.Name)
+	_, _, err = ds.SnapshotReader(writtenRev).ReadNamespaceByName(ctx, testNamespace.GetName())
 	require.Error(err)
 
 	nsDefs, err = ds.SnapshotReader(writtenRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	require.Len(nsDefs, 1)
 
-	found, createdRev, err := ds.SnapshotReader(secondWritten).ReadNamespaceByName(ctx, testNamespace.Name)
+	found, createdRev, err := ds.SnapshotReader(secondWritten).ReadNamespaceByName(ctx, testNamespace.GetName())
 	require.NoError(err)
 	require.False(createdRev.GreaterThan(secondWritten))
 	require.True(createdRev.GreaterThan(startRevision))
@@ -105,7 +105,7 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	})
 	require.NoError(err)
 
-	checkUpdated, createdRev, err := ds.SnapshotReader(updatedRevision).ReadNamespaceByName(ctx, testNamespace.Name)
+	checkUpdated, createdRev, err := ds.SnapshotReader(updatedRevision).ReadNamespaceByName(ctx, testNamespace.GetName())
 	require.NoError(err)
 	require.False(createdRev.GreaterThan(updatedRevision))
 	require.True(createdRev.GreaterThan(startRevision))
@@ -121,16 +121,16 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	checkOldList, err := ds.SnapshotReader(writtenRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	require.Len(checkOldList, 1)
-	require.Equal(testUserNS.Name, checkOldList[0].Definition.Name)
+	require.Equal(testUserNS.GetName(), checkOldList[0].Definition.GetName())
 	require.Empty(cmp.Diff(testUserNS, checkOldList[0].Definition, protocmp.Transform()))
 
-	checkLookup, err := ds.SnapshotReader(secondWritten).LookupNamespacesWithNames(ctx, []string{testNamespace.Name})
+	checkLookup, err := ds.SnapshotReader(secondWritten).LookupNamespacesWithNames(ctx, []string{testNamespace.GetName()})
 	require.NoError(err)
 	require.Len(checkLookup, 1)
-	require.Equal(testNamespace.Name, checkLookup[0].Definition.Name)
+	require.Equal(testNamespace.GetName(), checkLookup[0].Definition.GetName())
 	require.Empty(cmp.Diff(testNamespace, checkLookup[0].Definition, protocmp.Transform()))
 
-	checkLookupMultiple, err := ds.SnapshotReader(secondWritten).LookupNamespacesWithNames(ctx, []string{testNamespace.Name, testUserNS.Name})
+	checkLookupMultiple, err := ds.SnapshotReader(secondWritten).LookupNamespacesWithNames(ctx, []string{testNamespace.GetName(), testUserNS.GetName()})
 	require.NoError(err)
 	require.Len(checkLookupMultiple, 2)
 
@@ -162,15 +162,15 @@ func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	tRequire.RelationshipExists(ctx, folderTpl, revision)
 
 	deletedRev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-		return rwt.DeleteNamespaces(ctx, []string{testfixtures.DocumentNS.Name}, datastore.DeleteNamespacesAndRelationships)
+		return rwt.DeleteNamespaces(ctx, []string{testfixtures.DocumentNS.GetName()}, datastore.DeleteNamespacesAndRelationships)
 	})
 	require.NoError(err)
 	require.True(deletedRev.GreaterThan(revision))
 
-	_, _, err = ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.DocumentNS.Name)
+	_, _, err = ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.DocumentNS.GetName())
 	require.ErrorAs(err, &datastore.NamespaceNotFoundError{})
 
-	found, nsCreatedRev, err := ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.FolderNS.Name)
+	found, nsCreatedRev, err := ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.FolderNS.GetName())
 	require.NoError(err)
 	require.NotNil(found)
 	require.True(nsCreatedRev.LessThan(deletedRev))
@@ -178,14 +178,14 @@ func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	allNamespaces, err := ds.SnapshotReader(deletedRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	for _, ns := range allNamespaces {
-		require.NotEqual(testfixtures.DocumentNS.Name, ns.Definition.Name, "deleted namespace '%s' should not be in namespace list", ns.Definition.Name)
+		require.NotEqual(testfixtures.DocumentNS.GetName(), ns.Definition.GetName(), "deleted namespace '%s' should not be in namespace list", ns.Definition.GetName())
 	}
 
 	deletedRevision, err := ds.HeadRevision(ctx)
 	require.NoError(err)
 
 	iter, err := ds.SnapshotReader(deletedRevision).QueryRelationships(ctx, datastore.RelationshipsFilter{
-		OptionalResourceType: testfixtures.DocumentNS.Name,
+		OptionalResourceType: testfixtures.DocumentNS.GetName(),
 	}, options.WithQueryShape(queryshape.FindResourceOfType))
 	require.NoError(err)
 	tRequire.VerifyIteratorResults(iter)
@@ -209,15 +209,15 @@ func NamespaceDeleteNoRelationshipsTest(t *testing.T, tester DatastoreTester) {
 	tRequire.NoRelationshipExists(ctx, docTpl, revision)
 
 	deletedRev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-		return rwt.DeleteNamespaces(ctx, []string{testfixtures.DocumentNS.Name}, datastore.DeleteNamespacesOnly)
+		return rwt.DeleteNamespaces(ctx, []string{testfixtures.DocumentNS.GetName()}, datastore.DeleteNamespacesOnly)
 	})
 	require.NoError(err)
 	require.True(deletedRev.GreaterThan(revision))
 
-	_, _, err = ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.DocumentNS.Name)
+	_, _, err = ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.DocumentNS.GetName())
 	require.ErrorAs(err, &datastore.NamespaceNotFoundError{})
 
-	found, nsCreatedRev, err := ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.FolderNS.Name)
+	found, nsCreatedRev, err := ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.FolderNS.GetName())
 	require.NoError(err)
 	require.NotNil(found)
 	require.True(nsCreatedRev.LessThan(deletedRev))
@@ -225,7 +225,7 @@ func NamespaceDeleteNoRelationshipsTest(t *testing.T, tester DatastoreTester) {
 	allNamespaces, err := ds.SnapshotReader(deletedRev).ListAllNamespaces(ctx)
 	require.NoError(err)
 	for _, ns := range allNamespaces {
-		require.NotEqual(testfixtures.DocumentNS.Name, ns.Definition.Name, "deleted namespace '%s' should not be in namespace list", ns.Definition.Name)
+		require.NotEqual(testfixtures.DocumentNS.GetName(), ns.Definition.GetName(), "deleted namespace '%s' should not be in namespace list", ns.Definition.GetName())
 	}
 }
 
@@ -241,7 +241,7 @@ func NamespaceMultiDeleteTest(t *testing.T, tester DatastoreTester) {
 
 	nsNames := make([]string, 0, len(namespaces))
 	for _, ns := range namespaces {
-		nsNames = append(nsNames, ns.Definition.Name)
+		nsNames = append(nsNames, ns.Definition.GetName())
 	}
 
 	deletedRev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
@@ -265,12 +265,12 @@ func EmptyNamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	ctx := t.Context()
 
 	deletedRev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-		return rwt.DeleteNamespaces(ctx, []string{testfixtures.UserNS.Name}, datastore.DeleteNamespacesAndRelationships)
+		return rwt.DeleteNamespaces(ctx, []string{testfixtures.UserNS.GetName()}, datastore.DeleteNamespacesAndRelationships)
 	})
 	require.NoError(err)
 	require.True(deletedRev.GreaterThan(revision))
 
-	_, _, err = ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.UserNS.Name)
+	_, _, err = ds.SnapshotReader(deletedRev).ReadNamespaceByName(ctx, testfixtures.UserNS.GetName())
 	require.ErrorAs(err, &datastore.NamespaceNotFoundError{})
 }
 
@@ -360,13 +360,13 @@ definition document {
 
 	// Read the namespace definition back from the datastore and compare.
 	nsConfig := compiled.ObjectDefinitions[0]
-	readNsDef, _, err := ds.SnapshotReader(updatedRevision).ReadNamespaceByName(ctx, nsConfig.Name)
+	readNsDef, _, err := ds.SnapshotReader(updatedRevision).ReadNamespaceByName(ctx, nsConfig.GetName())
 	require.NoError(err)
 	testutil.RequireProtoEqual(t, nsConfig, readNsDef, "found changed namespace definition")
 
 	// Read the caveat back from the datastore and compare.
 	caveatDef := compiled.CaveatDefinitions[0]
-	readCaveatDef, _, err := ds.SnapshotReader(updatedRevision).ReadCaveatByName(ctx, caveatDef.Name)
+	readCaveatDef, _, err := ds.SnapshotReader(updatedRevision).ReadCaveatByName(ctx, caveatDef.GetName())
 	require.NoError(err)
 	testutil.RequireProtoEqual(t, caveatDef, readCaveatDef, "found changed caveat definition")
 

--- a/pkg/datastore/test/pagination.go
+++ b/pkg/datastore/test/pagination.go
@@ -23,13 +23,13 @@ func OrderingTest(t *testing.T, tester DatastoreTester) {
 		resourceType string
 		ordering     options.SortOrder
 	}{
-		{testfixtures.DocumentNS.Name, options.ByResource},
-		{testfixtures.FolderNS.Name, options.ByResource},
-		{testfixtures.UserNS.Name, options.ByResource},
+		{testfixtures.DocumentNS.GetName(), options.ByResource},
+		{testfixtures.FolderNS.GetName(), options.ByResource},
+		{testfixtures.UserNS.GetName(), options.ByResource},
 
-		{testfixtures.DocumentNS.Name, options.BySubject},
-		{testfixtures.FolderNS.Name, options.BySubject},
-		{testfixtures.UserNS.Name, options.BySubject},
+		{testfixtures.DocumentNS.GetName(), options.BySubject},
+		{testfixtures.FolderNS.GetName(), options.BySubject},
+		{testfixtures.UserNS.GetName(), options.BySubject},
 	}
 
 	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
@@ -71,9 +71,9 @@ func OrderingTest(t *testing.T, tester DatastoreTester) {
 
 func LimitTest(t *testing.T, tester DatastoreTester) {
 	testCases := []string{
-		testfixtures.DocumentNS.Name,
-		testfixtures.UserNS.Name,
-		testfixtures.FolderNS.Name,
+		testfixtures.DocumentNS.GetName(),
+		testfixtures.UserNS.GetName(),
+		testfixtures.FolderNS.GetName(),
 	}
 
 	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
@@ -151,25 +151,25 @@ var orderedTestCases = []struct {
 }{
 	{
 		"document resources by resource",
-		testfixtures.DocumentNS.Name,
+		testfixtures.DocumentNS.GetName(),
 		options.ByResource,
 		true,
 	},
 	{
 		"folder resources by resource",
-		testfixtures.FolderNS.Name,
+		testfixtures.FolderNS.GetName(),
 		options.ByResource,
 		true,
 	},
 	{
 		"user resources by resource",
-		testfixtures.UserNS.Name,
+		testfixtures.UserNS.GetName(),
 		options.ByResource,
 		true,
 	},
 	{
 		"resources with user subject",
-		testfixtures.UserNS.Name,
+		testfixtures.UserNS.GetName(),
 		options.ByResource,
 		false,
 	},
@@ -295,7 +295,7 @@ func ReverseQueryFilteredOverMultipleValuesCursorTest(t *testing.T, tester Datas
 				iter, err := reader.ReverseQueryRelationships(
 					t.Context(),
 					datastore.SubjectsFilter{
-						SubjectType:        testfixtures.UserNS.Name,
+						SubjectType:        testfixtures.UserNS.GetName(),
 						OptionalSubjectIds: []string{"alice", "tom", "fred", "*"},
 					},
 					options.WithResRelation(&options.ResourceRelation{
@@ -362,7 +362,7 @@ func ReverseQueryCursorTest(t *testing.T, tester DatastoreTester) {
 				iter, err := reader.ReverseQueryRelationships(
 					t.Context(),
 					datastore.SubjectsFilter{
-						SubjectType: testfixtures.UserNS.Name,
+						SubjectType: testfixtures.UserNS.GetName(),
 					},
 					options.WithSortForReverse(sortBy),
 					options.WithLimitForReverse(&limit),

--- a/pkg/datastore/test/revisions.go
+++ b/pkg/datastore/test/revisions.go
@@ -200,7 +200,7 @@ func RevisionGCTest(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 
 	// check that we can read a caveat whose revision has been garbage collectged
-	_, _, err = ds.SnapshotReader(head).ReadCaveatByName(ctx, testCaveat.Name)
+	_, _, err = ds.SnapshotReader(head).ReadCaveatByName(ctx, testCaveat.GetName())
 	require.NoError(err, "expected previously written caveat should exist at head")
 
 	// check that we can read the namespace which had its revision garbage collected

--- a/pkg/datastore/util.go
+++ b/pkg/datastore/util.go
@@ -29,12 +29,12 @@ func DeleteAllData(ctx context.Context, ds Datastore) error {
 		namespaceNames := make([]string, 0, len(nsDefs))
 		for _, nsDef := range nsDefs {
 			_, _, err = rwt.DeleteRelationships(ctx, &v1.RelationshipFilter{
-				ResourceType: nsDef.Definition.Name,
+				ResourceType: nsDef.Definition.GetName(),
 			})
 			if err != nil {
 				return err
 			}
-			namespaceNames = append(namespaceNames, nsDef.Definition.Name)
+			namespaceNames = append(namespaceNames, nsDef.Definition.GetName())
 		}
 
 		// Delete all caveats.
@@ -45,7 +45,7 @@ func DeleteAllData(ctx context.Context, ds Datastore) error {
 
 		caveatNames := make([]string, 0, len(caveatDefs))
 		for _, caveatDef := range caveatDefs {
-			caveatNames = append(caveatNames, caveatDef.Definition.Name)
+			caveatNames = append(caveatNames, caveatDef.Definition.GetName())
 		}
 
 		if err := rwt.DeleteCaveats(ctx, caveatNames); err != nil {

--- a/pkg/development/assertions_test.go
+++ b/pkg/development/assertions_test.go
@@ -106,8 +106,8 @@ definition document {
 	adErrs, err := RunAllAssertions(devCtx, assertions)
 	require.NoError(t, err)
 	require.Len(t, adErrs, 1)
-	require.Equal(t, devinterface.DeveloperError_UNKNOWN_RELATION, adErrs[0].Kind)
-	require.Contains(t, adErrs[0].Message, "cannot specify a caveat on an assertion")
+	require.Equal(t, devinterface.DeveloperError_UNKNOWN_RELATION, adErrs[0].GetKind())
+	require.Contains(t, adErrs[0].GetMessage(), "cannot specify a caveat on an assertion")
 }
 
 func TestRunAllAssertionsFailure(t *testing.T) {
@@ -136,6 +136,6 @@ definition document {
 	adErrs, err := RunAllAssertions(devCtx, assertions)
 	require.NoError(t, err)
 	require.Len(t, adErrs, 1)
-	require.Equal(t, devinterface.DeveloperError_ASSERTION_FAILED, adErrs[0].Kind)
-	require.Contains(t, adErrs[0].Message, "Expected relation or permission")
+	require.Equal(t, devinterface.DeveloperError_ASSERTION_FAILED, adErrs[0].GetKind())
+	require.Contains(t, adErrs[0].GetMessage(), "Expected relation or permission")
 }

--- a/pkg/development/check.go
+++ b/pkg/development/check.go
@@ -44,10 +44,10 @@ func RunCheck(devContext *DevContext, resource tuple.ObjectAndRelation, subject 
 	}
 
 	reader := devContext.Datastore.SnapshotReader(devContext.Revision)
-	converted, err := v1.ConvertCheckDispatchDebugInformation(ctx, caveattypes.Default.TypeSet, caveatContext, meta.DebugInfo, reader)
+	converted, err := v1.ConvertCheckDispatchDebugInformation(ctx, caveattypes.Default.TypeSet, caveatContext, meta.GetDebugInfo(), reader)
 	if err != nil {
 		return CheckResult{v1dispatch.ResourceCheckResult_NOT_MEMBER, nil, nil, nil}, err
 	}
 
-	return CheckResult{cr.Membership, cr.MissingExprFields, meta.DebugInfo, converted}, nil
+	return CheckResult{cr.GetMembership(), cr.GetMissingExprFields(), meta.GetDebugInfo(), converted}, nil
 }

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -75,7 +75,7 @@ func NewDevContext(ctx context.Context, requestContext *devinterface.RequestCont
 
 func newDevContextWithDatastore(ctx context.Context, requestContext *devinterface.RequestContext, ds datastore.Datastore) (*DevContext, *devinterface.DeveloperErrors, error) {
 	// Compile the schema and load its caveats and namespaces into the datastore.
-	compiled, devError, err := CompileSchema(requestContext.Schema)
+	compiled, devError, err := CompileSchema(requestContext.GetSchema())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,8 +92,8 @@ func newDevContextWithDatastore(ctx context.Context, requestContext *devinterfac
 		}
 
 		// Load the test relationships into the datastore.
-		relationships := make([]tuple.Relationship, 0, len(requestContext.Relationships))
-		for _, rel := range requestContext.Relationships {
+		relationships := make([]tuple.Relationship, 0, len(requestContext.GetRelationships()))
+		for _, rel := range requestContext.GetRelationships() {
 			if err := rel.Validate(); err != nil {
 				inputErrors = append(inputErrors, &devinterface.DeveloperError{
 					Message: err.Error(),
@@ -300,7 +300,7 @@ func loadCompiled(
 				Message: cverr.Error(),
 				Kind:    devinterface.DeveloperError_SCHEMA_ISSUE,
 				Source:  devinterface.DeveloperError_SCHEMA,
-				Context: caveatDef.Name,
+				Context: caveatDef.GetName(),
 			})
 		}
 	}
@@ -334,7 +334,7 @@ func loadCompiled(
 				Message: terr.Error(),
 				Kind:    devinterface.DeveloperError_SCHEMA_ISSUE,
 				Source:  devinterface.DeveloperError_SCHEMA,
-				Context: nsDef.Name,
+				Context: nsDef.GetName(),
 			})
 			continue
 		}
@@ -371,7 +371,7 @@ func loadCompiled(
 				Message: tverr.Error(),
 				Kind:    devinterface.DeveloperError_SCHEMA_ISSUE,
 				Source:  devinterface.DeveloperError_SCHEMA,
-				Context: nsDef.Name,
+				Context: nsDef.GetName(),
 			})
 		}
 	}
@@ -403,7 +403,7 @@ func distinguishGraphError(ctx context.Context, dispatchError error, source devi
 	}
 
 	details, ok := spiceerrors.GetDetails[*errdetails.ErrorInfo](dispatchError)
-	if ok && details.Reason == "ERROR_REASON_MAXIMUM_DEPTH_EXCEEDED" {
+	if ok && details.GetReason() == "ERROR_REASON_MAXIMUM_DEPTH_EXCEEDED" {
 		status, _ := status.FromError(dispatchError)
 		return &devinterface.DeveloperError{
 			Message: status.Message(),

--- a/pkg/development/devcontext_test.go
+++ b/pkg/development/devcontext_test.go
@@ -23,8 +23,8 @@ func TestNewDevContextWithInvalidSchema(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, devErrs)
-	require.Len(t, devErrs.InputErrors, 1)
-	require.Equal(t, devinterface.DeveloperError_SCHEMA_ISSUE, devErrs.InputErrors[0].Kind)
+	require.Len(t, devErrs.GetInputErrors(), 1)
+	require.Equal(t, devinterface.DeveloperError_SCHEMA_ISSUE, devErrs.GetInputErrors()[0].GetKind())
 }
 
 func TestNewDevContextWithInvalidRelationship(t *testing.T) {
@@ -51,8 +51,8 @@ definition document {
 
 	require.NoError(t, err)
 	require.NotNil(t, devErrs)
-	require.Len(t, devErrs.InputErrors, 1)
-	require.Equal(t, devinterface.DeveloperError_UNKNOWN_OBJECT_TYPE, devErrs.InputErrors[0].Kind)
+	require.Len(t, devErrs.GetInputErrors(), 1)
+	require.Equal(t, devinterface.DeveloperError_UNKNOWN_OBJECT_TYPE, devErrs.GetInputErrors()[0].GetKind())
 }
 
 func TestDevContextDispose(t *testing.T) {
@@ -90,30 +90,30 @@ func TestDistinguishGraphError(t *testing.T) {
 	devErr, wireErr := DistinguishGraphError(devCtx, nsErr, devinterface.DeveloperError_ASSERTION, 1, 2, "context")
 	require.NoError(t, wireErr)
 	require.NotNil(t, devErr)
-	require.Equal(t, devinterface.DeveloperError_UNKNOWN_OBJECT_TYPE, devErr.Kind)
-	require.Equal(t, uint32(1), devErr.Line)
-	require.Equal(t, uint32(2), devErr.Column)
-	require.Equal(t, "context", devErr.Context)
+	require.Equal(t, devinterface.DeveloperError_UNKNOWN_OBJECT_TYPE, devErr.GetKind())
+	require.Equal(t, uint32(1), devErr.GetLine())
+	require.Equal(t, uint32(2), devErr.GetColumn())
+	require.Equal(t, "context", devErr.GetContext())
 
 	// Test with relation not found error
 	relErr := namespace.NewRelationNotFoundErr("namespace", "unknown")
 	devErr, wireErr = DistinguishGraphError(devCtx, relErr, devinterface.DeveloperError_ASSERTION, 3, 4, "context2")
 	require.NoError(t, wireErr)
 	require.NotNil(t, devErr)
-	require.Equal(t, devinterface.DeveloperError_UNKNOWN_RELATION, devErr.Kind)
-	require.Equal(t, uint32(3), devErr.Line)
-	require.Equal(t, uint32(4), devErr.Column)
-	require.Equal(t, "context2", devErr.Context)
+	require.Equal(t, devinterface.DeveloperError_UNKNOWN_RELATION, devErr.GetKind())
+	require.Equal(t, uint32(3), devErr.GetLine())
+	require.Equal(t, uint32(4), devErr.GetColumn())
+	require.Equal(t, "context2", devErr.GetContext())
 
 	// Test with max depth exceeded error
 	maxDepthErr := dispatch.NewMaxDepthExceededError(nil)
 	devErr, wireErr = DistinguishGraphError(devCtx, maxDepthErr, devinterface.DeveloperError_ASSERTION, 5, 6, "context3")
 	require.NoError(t, wireErr)
 	require.NotNil(t, devErr)
-	require.Equal(t, devinterface.DeveloperError_MAXIMUM_RECURSION, devErr.Kind)
-	require.Equal(t, uint32(5), devErr.Line)
-	require.Equal(t, uint32(6), devErr.Column)
-	require.Equal(t, "context3", devErr.Context)
+	require.Equal(t, devinterface.DeveloperError_MAXIMUM_RECURSION, devErr.GetKind())
+	require.Equal(t, uint32(5), devErr.GetLine())
+	require.Equal(t, uint32(6), devErr.GetColumn())
+	require.Equal(t, "context3", devErr.GetContext())
 
 	// Test with generic error (should return wire error)
 	genericErr := errors.New("some generic error")
@@ -173,8 +173,8 @@ definition document {
 
 	require.NoError(t, err)
 	require.NotNil(t, devErrs)
-	require.Len(t, devErrs.InputErrors, 1)
-	require.Equal(t, devinterface.DeveloperError_SCHEMA_ISSUE, devErrs.InputErrors[0].Kind)
+	require.Len(t, devErrs.GetInputErrors(), 1)
+	require.Equal(t, devinterface.DeveloperError_SCHEMA_ISSUE, devErrs.GetInputErrors()[0].GetKind())
 }
 
 func TestNewDevContextWithRelationshipValidationError(t *testing.T) {
@@ -202,6 +202,6 @@ definition document {
 
 	require.NoError(t, err)
 	require.NotNil(t, devErrs)
-	require.Len(t, devErrs.InputErrors, 1)
-	require.Equal(t, devinterface.DeveloperError_UNKNOWN_OBJECT_TYPE, devErrs.InputErrors[0].Kind)
+	require.Len(t, devErrs.GetInputErrors(), 1)
+	require.Equal(t, devinterface.DeveloperError_UNKNOWN_OBJECT_TYPE, devErrs.GetInputErrors()[0].GetKind())
 }

--- a/pkg/development/development_test.go
+++ b/pkg/development/development_test.go
@@ -137,7 +137,7 @@ definition document {
 	client := v1.NewSchemaServiceClient(conn)
 	resp, err := client.ReadSchema(t.Context(), &v1.ReadSchemaRequest{})
 	require.NoError(t, err)
-	require.Contains(t, resp.SchemaText, "definition document")
+	require.Contains(t, resp.GetSchemaText(), "definition document")
 
 	shutdown()
 }

--- a/pkg/development/parsing_test.go
+++ b/pkg/development/parsing_test.go
@@ -30,8 +30,8 @@ func TestParseAssertionsYAMLInvalid(t *testing.T) {
 	assertions, devErr := ParseAssertionsYAML(invalidYAML)
 	require.Nil(t, assertions)
 	require.NotNil(t, devErr)
-	require.Equal(t, devinterface.DeveloperError_ASSERTION, devErr.Source)
-	require.Equal(t, devinterface.DeveloperError_PARSE_ERROR, devErr.Kind)
+	require.Equal(t, devinterface.DeveloperError_ASSERTION, devErr.GetSource())
+	require.Equal(t, devinterface.DeveloperError_PARSE_ERROR, devErr.GetKind())
 }
 
 func TestParseAssertionsYAMLWithInvalidRelationship(t *testing.T) {
@@ -42,8 +42,8 @@ func TestParseAssertionsYAMLWithInvalidRelationship(t *testing.T) {
 	assertions, devErr := ParseAssertionsYAML(invalidRelYAML)
 	require.Nil(t, assertions)
 	require.NotNil(t, devErr)
-	require.Equal(t, devinterface.DeveloperError_ASSERTION, devErr.Source)
-	require.Equal(t, devinterface.DeveloperError_PARSE_ERROR, devErr.Kind)
+	require.Equal(t, devinterface.DeveloperError_ASSERTION, devErr.GetSource())
+	require.Equal(t, devinterface.DeveloperError_PARSE_ERROR, devErr.GetKind())
 }
 
 func TestParseExpectedRelationsYAMLValid(t *testing.T) {
@@ -64,8 +64,8 @@ func TestParseExpectedRelationsYAMLInvalid(t *testing.T) {
 	expectedRels, devErr := ParseExpectedRelationsYAML(invalidYAML)
 	require.Nil(t, expectedRels)
 	require.NotNil(t, devErr)
-	require.Equal(t, devinterface.DeveloperError_VALIDATION_YAML, devErr.Source)
-	require.Equal(t, devinterface.DeveloperError_PARSE_ERROR, devErr.Kind)
+	require.Equal(t, devinterface.DeveloperError_VALIDATION_YAML, devErr.GetSource())
+	require.Equal(t, devinterface.DeveloperError_PARSE_ERROR, devErr.GetKind())
 }
 
 func TestConvertError(t *testing.T) {
@@ -77,10 +77,10 @@ func TestConvertError(t *testing.T) {
 	err := &testError{message: "test error"}
 	devErr = convertError(devinterface.DeveloperError_ASSERTION, err)
 	require.NotNil(t, devErr)
-	require.Equal(t, "test error", devErr.Message)
-	require.Equal(t, devinterface.DeveloperError_ASSERTION, devErr.Source)
-	require.Equal(t, devinterface.DeveloperError_PARSE_ERROR, devErr.Kind)
-	require.Equal(t, uint32(0), devErr.Line)
+	require.Equal(t, "test error", devErr.GetMessage())
+	require.Equal(t, devinterface.DeveloperError_ASSERTION, devErr.GetSource())
+	require.Equal(t, devinterface.DeveloperError_PARSE_ERROR, devErr.GetKind())
+	require.Equal(t, uint32(0), devErr.GetLine())
 }
 
 func TestConvertSourceError(t *testing.T) {
@@ -93,12 +93,12 @@ func TestConvertSourceError(t *testing.T) {
 
 	devErr := convertSourceError(devinterface.DeveloperError_VALIDATION_YAML, sourceErr)
 	require.NotNil(t, devErr)
-	require.Equal(t, "source error", devErr.Message)
-	require.Equal(t, devinterface.DeveloperError_VALIDATION_YAML, devErr.Source)
-	require.Equal(t, devinterface.DeveloperError_PARSE_ERROR, devErr.Kind)
-	require.Equal(t, uint32(5), devErr.Line)
-	require.Equal(t, uint32(10), devErr.Column)
-	require.Equal(t, "some source code", devErr.Context)
+	require.Equal(t, "source error", devErr.GetMessage())
+	require.Equal(t, devinterface.DeveloperError_VALIDATION_YAML, devErr.GetSource())
+	require.Equal(t, devinterface.DeveloperError_PARSE_ERROR, devErr.GetKind())
+	require.Equal(t, uint32(5), devErr.GetLine())
+	require.Equal(t, uint32(10), devErr.GetColumn())
+	require.Equal(t, "some source code", devErr.GetContext())
 }
 
 // Helper type for testing

--- a/pkg/development/schema_test.go
+++ b/pkg/development/schema_test.go
@@ -32,10 +32,10 @@ func TestCompileSchemaInvalidSyntax(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, compiled)
 	require.NotNil(t, devErr)
-	require.Equal(t, devinterface.DeveloperError_SCHEMA, devErr.Source)
-	require.Equal(t, devinterface.DeveloperError_SCHEMA_ISSUE, devErr.Kind)
-	require.Positive(t, devErr.Line)
-	require.Positive(t, devErr.Column)
+	require.Equal(t, devinterface.DeveloperError_SCHEMA, devErr.GetSource())
+	require.Equal(t, devinterface.DeveloperError_SCHEMA_ISSUE, devErr.GetKind())
+	require.Positive(t, devErr.GetLine())
+	require.Positive(t, devErr.GetColumn())
 }
 
 func TestCompileSchemaUndefinedRelation(t *testing.T) {
@@ -107,7 +107,7 @@ definition document {
 	require.NoError(t, err)
 	require.Nil(t, compiled)
 	require.NotNil(t, devErr)
-	require.Equal(t, devinterface.DeveloperError_SCHEMA, devErr.Source)
-	require.Equal(t, devinterface.DeveloperError_SCHEMA_ISSUE, devErr.Kind)
-	require.Contains(t, devErr.Message, "unknown_type")
+	require.Equal(t, devinterface.DeveloperError_SCHEMA, devErr.GetSource())
+	require.Equal(t, devinterface.DeveloperError_SCHEMA_ISSUE, devErr.GetKind())
+	require.Contains(t, devErr.GetMessage(), "unknown_type")
 }

--- a/pkg/development/validation.go
+++ b/pkg/development/validation.go
@@ -45,7 +45,7 @@ func RunValidation(devContext *DevContext, validation *blocks.ParsedExpectedRela
 		}
 
 		// Add the ONR and its expansion to the membership set.
-		foundSubjects, _, aerr := membershipSet.AddExpansion(onrKey.ObjectAndRelation, er.TreeNode)
+		foundSubjects, _, aerr := membershipSet.AddExpansion(onrKey.ObjectAndRelation, er.GetTreeNode())
 		if aerr != nil {
 			devErr, wireErr := DistinguishGraphError(devContext, aerr, devinterface.DeveloperError_VALIDATION_YAML, 0, 0, onrKey.ObjectRelationString)
 			if wireErr != nil {

--- a/pkg/development/validation_test.go
+++ b/pkg/development/validation_test.go
@@ -63,8 +63,8 @@ definition document {
 	ms, devErrors, err := RunValidation(devCtx, validation)
 	require.NoError(t, err)
 	require.Len(t, devErrors, 1)
-	require.Equal(t, devinterface.DeveloperError_MISSING_EXPECTED_RELATIONSHIP, devErrors[0].Kind)
-	require.Contains(t, devErrors[0].Message, "missing expected subject")
+	require.Equal(t, devinterface.DeveloperError_MISSING_EXPECTED_RELATIONSHIP, devErrors[0].GetKind())
+	require.Contains(t, devErrors[0].GetMessage(), "missing expected subject")
 	require.NotNil(t, ms)
 }
 

--- a/pkg/development/warningdefs.go
+++ b/pkg/development/warningdefs.go
@@ -19,20 +19,20 @@ var lintRelationReferencesParentType = relationCheck{
 		def *schema.Definition,
 	) (*devinterface.DeveloperWarning, error) {
 		parentDef := def.Namespace()
-		if strings.HasSuffix(relation.Name, parentDef.Name) {
-			if def.IsPermission(relation.Name) {
+		if strings.HasSuffix(relation.GetName(), parentDef.GetName()) {
+			if def.IsPermission(relation.GetName()) {
 				return warningForMetadata(
 					"relation-name-references-parent",
-					fmt.Sprintf("Permission %q references parent type %q in its name; it is recommended to drop the suffix", relation.Name, parentDef.Name),
-					relation.Name,
+					fmt.Sprintf("Permission %q references parent type %q in its name; it is recommended to drop the suffix", relation.GetName(), parentDef.GetName()),
+					relation.GetName(),
 					relation,
 				), nil
 			}
 
 			return warningForMetadata(
 				"relation-name-references-parent",
-				fmt.Sprintf("Relation %q references parent type %q in its name; it is recommended to drop the suffix", relation.Name, parentDef.Name),
-				relation.Name,
+				fmt.Sprintf("Relation %q references parent type %q in its name; it is recommended to drop the suffix", relation.GetName(), parentDef.GetName()),
+				relation.GetName(),
 				relation,
 			), nil
 		}
@@ -50,7 +50,7 @@ var lintPermissionReferencingItself = computedUsersetCheck{
 		def *schema.Definition,
 	) (*devinterface.DeveloperWarning, error) {
 		parentRelation := ctx.Value(relationKey).(*corev1.Relation)
-		permName := parentRelation.Name
+		permName := parentRelation.GetName()
 		if computedUserset.GetRelation() == permName {
 			return warningForPosition(
 				"permission-references-itself",
@@ -79,14 +79,14 @@ var lintArrowReferencingUnreachable = ttuCheck{
 			return nil, nil
 		}
 
-		allowedSubjectTypes, err := def.AllowedSubjectRelations(referencedRelation.Name)
+		allowedSubjectTypes, err := def.AllowedSubjectRelations(referencedRelation.GetName())
 		if err != nil {
 			return nil, err
 		}
 
 		wasFound := false
 		for _, subjectType := range allowedSubjectTypes {
-			nts, err := def.TypeSystem().GetDefinition(ctx, subjectType.Namespace)
+			nts, err := def.TypeSystem().GetDefinition(ctx, subjectType.GetNamespace())
 			if err != nil {
 				return nil, err
 			}
@@ -108,7 +108,7 @@ var lintArrowReferencingUnreachable = ttuCheck{
 				fmt.Sprintf(
 					"Arrow `%s` under permission %q references relation/permission %q that does not exist on any subject types of relation %q",
 					arrowString,
-					parentRelation.Name,
+					parentRelation.GetName(),
 					ttu.GetComputedUserset().GetRelation(),
 					ttu.GetTupleset().GetRelation(),
 				),
@@ -136,7 +136,7 @@ var lintArrowOverSubRelation = ttuCheck{
 			return nil, nil
 		}
 
-		allowedSubjectTypes, err := def.AllowedSubjectRelations(referencedRelation.Name)
+		allowedSubjectTypes, err := def.AllowedSubjectRelations(referencedRelation.GetName())
 		if err != nil {
 			return nil, err
 		}
@@ -153,10 +153,10 @@ var lintArrowOverSubRelation = ttuCheck{
 					fmt.Sprintf(
 						"Arrow `%s` under permission %q references relation %q that has relation %q on subject %q: *the subject relation will be ignored for the arrow*",
 						arrowString,
-						parentRelation.Name,
+						parentRelation.GetName(),
 						ttu.GetTupleset().GetRelation(),
 						subjectType.GetRelation(),
-						subjectType.Namespace,
+						subjectType.GetNamespace(),
 					),
 					arrowString,
 					sourcePosition,
@@ -185,7 +185,7 @@ var lintArrowReferencingRelation = ttuCheck{
 
 		// For each subject type of the referenced relation, check if the referenced permission
 		// is, in fact, a relation.
-		allowedSubjectTypes, err := def.AllowedSubjectRelations(referencedRelation.Name)
+		allowedSubjectTypes, err := def.AllowedSubjectRelations(referencedRelation.GetName())
 		if err != nil {
 			return nil, err
 		}
@@ -197,11 +197,11 @@ var lintArrowReferencingRelation = ttuCheck{
 
 		for _, subjectType := range allowedSubjectTypes {
 			// Skip for arrow referencing relations in the same namespace.
-			if subjectType.Namespace == def.Namespace().Name {
+			if subjectType.GetNamespace() == def.Namespace().GetName() {
 				continue
 			}
 
-			nts, err := def.TypeSystem().GetDefinition(ctx, subjectType.Namespace)
+			nts, err := def.TypeSystem().GetDefinition(ctx, subjectType.GetNamespace())
 			if err != nil {
 				return nil, err
 			}
@@ -211,15 +211,15 @@ var lintArrowReferencingRelation = ttuCheck{
 				continue
 			}
 
-			if !nts.IsPermission(targetRelation.Name) {
+			if !nts.IsPermission(targetRelation.GetName()) {
 				return warningForPosition(
 					"arrow-references-relation",
 					fmt.Sprintf(
 						"Arrow `%s` under permission %q references relation %q on definition %q; it is recommended to point to a permission",
 						arrowString,
-						parentRelation.Name,
-						targetRelation.Name,
-						subjectType.Namespace,
+						parentRelation.GetName(),
+						targetRelation.GetName(),
+						subjectType.GetNamespace(),
 					),
 					arrowString,
 					sourcePosition,

--- a/pkg/development/warnings_misc_test.go
+++ b/pkg/development/warnings_misc_test.go
@@ -13,10 +13,10 @@ import (
 func TestWarningForPositionNilSourcePosition(t *testing.T) {
 	warning := warningForPosition("test-warning", "test message", "source code", nil)
 	require.NotNil(t, warning)
-	require.Equal(t, "test message", warning.Message) // No warning name appended when nil source position
-	require.Equal(t, "source code", warning.SourceCode)
-	require.Equal(t, uint32(0), warning.Line)
-	require.Equal(t, uint32(0), warning.Column)
+	require.Equal(t, "test message", warning.GetMessage()) // No warning name appended when nil source position
+	require.Equal(t, "source code", warning.GetSourceCode())
+	require.Equal(t, uint32(0), warning.GetLine())
+	require.Equal(t, uint32(0), warning.GetColumn())
 }
 
 func TestWarningForPositionWithSourcePosition(t *testing.T) {
@@ -27,10 +27,10 @@ func TestWarningForPositionWithSourcePosition(t *testing.T) {
 
 	warning := warningForPosition("test-warning", "test message", "source code", sourcePos)
 	require.NotNil(t, warning)
-	require.Equal(t, "test message (test-warning)", warning.Message) // Warning name appended
-	require.Equal(t, "source code", warning.SourceCode)
-	require.Equal(t, uint32(5), warning.Line)    // 1-indexed
-	require.Equal(t, uint32(10), warning.Column) // 1-indexed
+	require.Equal(t, "test message (test-warning)", warning.GetMessage()) // Warning name appended
+	require.Equal(t, "source code", warning.GetSourceCode())
+	require.Equal(t, uint32(5), warning.GetLine())    // 1-indexed
+	require.Equal(t, uint32(10), warning.GetColumn()) // 1-indexed
 }
 
 func TestWarningForMetadata(t *testing.T) {
@@ -49,10 +49,10 @@ func TestWarningForMetadata(t *testing.T) {
 
 	warning := warningForMetadata("metadata-warning", "metadata message", "source", relation)
 	require.NotNil(t, warning)
-	require.Equal(t, "metadata message (metadata-warning)", warning.Message)
-	require.Equal(t, "source", warning.SourceCode)
-	require.Equal(t, uint32(3), warning.Line)   // 1-indexed
-	require.Equal(t, uint32(8), warning.Column) // 1-indexed
+	require.Equal(t, "metadata message (metadata-warning)", warning.GetMessage())
+	require.Equal(t, "source", warning.GetSourceCode())
+	require.Equal(t, uint32(3), warning.GetLine())   // 1-indexed
+	require.Equal(t, uint32(8), warning.GetColumn()) // 1-indexed
 }
 
 func TestShouldSkipCheckWithoutMetadata(t *testing.T) {
@@ -185,10 +185,10 @@ func TestWarningForPositionWithCastingErrors(t *testing.T) {
 
 	warning := warningForPosition("cast-error", "test message", "source code", sourcePos)
 	require.NotNil(t, warning)
-	require.Equal(t, "test message (cast-error)", warning.Message)
-	require.Equal(t, "source code", warning.SourceCode)
-	require.Equal(t, uint32(1), warning.Line)   // Should be 1 due to zero fallback + 1
-	require.Equal(t, uint32(1), warning.Column) // Should be 1 due to zero fallback + 1
+	require.Equal(t, "test message (cast-error)", warning.GetMessage())
+	require.Equal(t, "source code", warning.GetSourceCode())
+	require.Equal(t, uint32(1), warning.GetLine())   // Should be 1 due to zero fallback + 1
+	require.Equal(t, uint32(1), warning.GetColumn()) // Should be 1 due to zero fallback + 1
 }
 
 func TestWrappedFunctionedTTUUnknownFunction(t *testing.T) {

--- a/pkg/diff/caveats/diff.go
+++ b/pkg/diff/caveats/diff.go
@@ -96,19 +96,19 @@ func DiffCaveats(existing *core.CaveatDefinition, updated *core.CaveatDefinition
 		}, nil
 	}
 
-	deltas := make([]Delta, 0, len(existing.ParameterTypes)+len(updated.ParameterTypes))
+	deltas := make([]Delta, 0, len(existing.GetParameterTypes())+len(updated.GetParameterTypes()))
 
 	// Check the caveats's comments.
-	existingComments := nspkg.GetComments(existing.Metadata)
-	updatedComments := nspkg.GetComments(updated.Metadata)
+	existingComments := nspkg.GetComments(existing.GetMetadata())
+	updatedComments := nspkg.GetComments(updated.GetMetadata())
 	if !slices.Equal(existingComments, updatedComments) {
 		deltas = append(deltas, Delta{
 			Type: CaveatCommentsChanged,
 		})
 	}
 
-	existingParameterNames := mapz.NewSet(slices.Collect(maps.Keys(existing.ParameterTypes))...)
-	updatedParameterNames := mapz.NewSet(slices.Collect(maps.Keys(updated.ParameterTypes))...)
+	existingParameterNames := mapz.NewSet(slices.Collect(maps.Keys(existing.GetParameterTypes()))...)
+	updatedParameterNames := mapz.NewSet(slices.Collect(maps.Keys(updated.GetParameterTypes()))...)
 
 	for _, removed := range existingParameterNames.Subtract(updatedParameterNames).AsSlice() {
 		deltas = append(deltas, Delta{
@@ -125,8 +125,8 @@ func DiffCaveats(existing *core.CaveatDefinition, updated *core.CaveatDefinition
 	}
 
 	for _, shared := range existingParameterNames.Intersect(updatedParameterNames).AsSlice() {
-		existingParamType := existing.ParameterTypes[shared]
-		updatedParamType := updated.ParameterTypes[shared]
+		existingParamType := existing.GetParameterTypes()[shared]
+		updatedParamType := updated.GetParameterTypes()[shared]
 
 		existingType, err := caveattypes.DecodeParameterType(caveatTypeSet, existingParamType)
 		if err != nil {
@@ -149,7 +149,7 @@ func DiffCaveats(existing *core.CaveatDefinition, updated *core.CaveatDefinition
 		}
 	}
 
-	if !bytes.Equal(existing.SerializedExpression, updated.SerializedExpression) {
+	if !bytes.Equal(existing.GetSerializedExpression(), updated.GetSerializedExpression()) {
 		deltas = append(deltas, Delta{
 			Type: CaveatExpressionChanged,
 		})

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -20,7 +20,7 @@ type DiffableSchema struct {
 
 func (ds *DiffableSchema) GetNamespace(namespaceName string) (*core.NamespaceDefinition, bool) {
 	for _, ns := range ds.ObjectDefinitions {
-		if ns.Name == namespaceName {
+		if ns.GetName() == namespaceName {
 			return ns, true
 		}
 	}
@@ -34,8 +34,8 @@ func (ds *DiffableSchema) GetRelation(nsName string, relationName string) (*core
 		return nil, false
 	}
 
-	for _, relation := range ns.Relation {
-		if relation.Name == relationName {
+	for _, relation := range ns.GetRelation() {
+		if relation.GetName() == relationName {
 			return relation, true
 		}
 	}
@@ -45,7 +45,7 @@ func (ds *DiffableSchema) GetRelation(nsName string, relationName string) (*core
 
 func (ds *DiffableSchema) GetCaveat(caveatName string) (*core.CaveatDefinition, bool) {
 	for _, caveat := range ds.CaveatDefinitions {
-		if caveat.Name == caveatName {
+		if caveat.GetName() == caveatName {
 			return caveat, true
 		}
 	}
@@ -87,29 +87,29 @@ func DiffSchemas(existing DiffableSchema, comparison DiffableSchema, caveatTypeS
 	existingNamespacesByName := make(map[string]*core.NamespaceDefinition, len(existing.ObjectDefinitions))
 	existingNamespaceNames := mapz.NewSet[string]()
 	for _, nsDef := range existing.ObjectDefinitions {
-		existingNamespacesByName[nsDef.Name] = nsDef
-		existingNamespaceNames.Add(nsDef.Name)
+		existingNamespacesByName[nsDef.GetName()] = nsDef
+		existingNamespaceNames.Add(nsDef.GetName())
 	}
 
 	existingCaveatsByName := make(map[string]*core.CaveatDefinition, len(existing.CaveatDefinitions))
 	existingCaveatsByNames := mapz.NewSet[string]()
 	for _, caveatDef := range existing.CaveatDefinitions {
-		existingCaveatsByName[caveatDef.Name] = caveatDef
-		existingCaveatsByNames.Add(caveatDef.Name)
+		existingCaveatsByName[caveatDef.GetName()] = caveatDef
+		existingCaveatsByNames.Add(caveatDef.GetName())
 	}
 
 	comparisonNamespacesByName := make(map[string]*core.NamespaceDefinition, len(comparison.ObjectDefinitions))
 	comparisonNamespaceNames := mapz.NewSet[string]()
 	for _, nsDef := range comparison.ObjectDefinitions {
-		comparisonNamespacesByName[nsDef.Name] = nsDef
-		comparisonNamespaceNames.Add(nsDef.Name)
+		comparisonNamespacesByName[nsDef.GetName()] = nsDef
+		comparisonNamespaceNames.Add(nsDef.GetName())
 	}
 
 	comparisonCaveatsByName := make(map[string]*core.CaveatDefinition, len(comparison.CaveatDefinitions))
 	comparisonCaveatsByNames := mapz.NewSet[string]()
 	for _, caveatDef := range comparison.CaveatDefinitions {
-		comparisonCaveatsByName[caveatDef.Name] = caveatDef
-		comparisonCaveatsByNames.Add(caveatDef.Name)
+		comparisonCaveatsByName[caveatDef.GetName()] = caveatDef
+		comparisonCaveatsByNames.Add(caveatDef.GetName())
 	}
 
 	changedNamespaces := make(map[string]namespace.Diff, 0)

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -202,17 +202,17 @@ func TestDiffableSchema(t *testing.T) {
 				func(t *testing.T, ds *DiffableSchema) {
 					ns, ok := ds.GetNamespace("user")
 					require.True(t, ok)
-					require.Equal(t, "user", ns.Name)
+					require.Equal(t, "user", ns.GetName())
 				},
 				func(t *testing.T, ds *DiffableSchema) {
 					ns, ok := ds.GetNamespace("resource")
 					require.True(t, ok)
-					require.Equal(t, "resource", ns.Name)
+					require.Equal(t, "resource", ns.GetName())
 				},
 				func(t *testing.T, ds *DiffableSchema) {
 					caveat, ok := ds.GetCaveat("someCaveat")
 					require.True(t, ok)
-					require.Equal(t, "someCaveat", caveat.Name)
+					require.Equal(t, "someCaveat", caveat.GetName())
 				},
 				func(t *testing.T, ds *DiffableSchema) {
 					_, ok := ds.GetRelation("user", "owner")

--- a/pkg/diff/namespace/diff.go
+++ b/pkg/diff/namespace/diff.go
@@ -121,8 +121,8 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 	deltas := []Delta{}
 
 	// Check the namespace's comments.
-	existingComments := nspkg.GetComments(existing.Metadata)
-	updatedComments := nspkg.GetComments(updated.Metadata)
+	existingComments := nspkg.GetComments(existing.GetMetadata())
+	updatedComments := nspkg.GetComments(updated.GetMetadata())
 	if !slices.Equal(existingComments, updatedComments) {
 		deltas = append(deltas, Delta{
 			Type: NamespaceCommentsChanged,
@@ -142,33 +142,33 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 	updatedPerms := map[string]*core.Relation{}
 	updatedPermNames := mapz.NewSet[string]()
 
-	for _, relation := range existing.Relation {
-		_, ok := existingRels[relation.Name]
+	for _, relation := range existing.GetRelation() {
+		_, ok := existingRels[relation.GetName()]
 		if ok {
-			return nil, nsinternal.NewDuplicateRelationError(existing.Name, relation.Name)
+			return nil, nsinternal.NewDuplicateRelationError(existing.GetName(), relation.GetName())
 		}
 
 		if isPermission(relation) {
-			existingPerms[relation.Name] = relation
-			existingPermNames.Add(relation.Name)
+			existingPerms[relation.GetName()] = relation
+			existingPermNames.Add(relation.GetName())
 		} else {
-			existingRels[relation.Name] = relation
-			existingRelNames.Add(relation.Name)
+			existingRels[relation.GetName()] = relation
+			existingRelNames.Add(relation.GetName())
 		}
 	}
 
-	for _, relation := range updated.Relation {
-		_, ok := updatedRels[relation.Name]
+	for _, relation := range updated.GetRelation() {
+		_, ok := updatedRels[relation.GetName()]
 		if ok {
-			return nil, nsinternal.NewDuplicateRelationError(updated.Name, relation.Name)
+			return nil, nsinternal.NewDuplicateRelationError(updated.GetName(), relation.GetName())
 		}
 
 		if isPermission(relation) {
-			updatedPerms[relation.Name] = relation
-			updatedPermNames.Add(relation.Name)
+			updatedPerms[relation.GetName()] = relation
+			updatedPermNames.Add(relation.GetName())
 		} else {
-			updatedRels[relation.Name] = relation
-			updatedRelNames.Add(relation.Name)
+			updatedRels[relation.GetName()] = relation
+			updatedRelNames.Add(relation.GetName())
 		}
 	}
 
@@ -209,7 +209,7 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 		updatedPerm := updatedPerms[shared]
 
 		// Compare implementations.
-		if areDifferentExpressions(existingPerm.UsersetRewrite, updatedPerm.UsersetRewrite) {
+		if areDifferentExpressions(existingPerm.GetUsersetRewrite(), updatedPerm.GetUsersetRewrite()) {
 			deltas = append(deltas, Delta{
 				Type:         ChangedPermissionImpl,
 				RelationName: shared,
@@ -217,8 +217,8 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 		}
 
 		// Compare comments.
-		existingComments := nspkg.GetComments(existingPerm.Metadata)
-		updatedComments := nspkg.GetComments(updatedPerm.Metadata)
+		existingComments := nspkg.GetComments(existingPerm.GetMetadata())
+		updatedComments := nspkg.GetComments(updatedPerm.GetMetadata())
 		if !slices.Equal(existingComments, updatedComments) {
 			deltas = append(deltas, Delta{
 				Type:         ChangedPermissionComment,
@@ -233,7 +233,7 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 		updatedRel := updatedRels[shared]
 
 		// Compare implementations (legacy).
-		if areDifferentExpressions(existingRel.UsersetRewrite, updatedRel.UsersetRewrite) {
+		if areDifferentExpressions(existingRel.GetUsersetRewrite(), updatedRel.GetUsersetRewrite()) {
 			deltas = append(deltas, Delta{
 				Type:         LegacyChangedRelationImpl,
 				RelationName: shared,
@@ -241,8 +241,8 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 		}
 
 		// Compare comments.
-		existingComments := nspkg.GetComments(existingRel.Metadata)
-		updatedComments := nspkg.GetComments(updatedRel.Metadata)
+		existingComments := nspkg.GetComments(existingRel.GetMetadata())
+		updatedComments := nspkg.GetComments(updatedRel.GetMetadata())
 		if !slices.Equal(existingComments, updatedComments) {
 			deltas = append(deltas, Delta{
 				Type:         ChangedRelationComment,
@@ -251,12 +251,12 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 		}
 
 		// Compare type information.
-		existingTypeInfo := existingRel.TypeInformation
+		existingTypeInfo := existingRel.GetTypeInformation()
 		if existingTypeInfo == nil {
 			existingTypeInfo = &core.TypeInformation{}
 		}
 
-		updatedTypeInfo := updatedRel.TypeInformation
+		updatedTypeInfo := updatedRel.GetTypeInformation()
 		if updatedTypeInfo == nil {
 			updatedTypeInfo = &core.TypeInformation{}
 		}
@@ -265,13 +265,13 @@ func DiffNamespaces(existing *core.NamespaceDefinition, updated *core.NamespaceD
 		updatedAllowedRels := mapz.NewSet[string]()
 		allowedRelsBySource := map[string]*core.AllowedRelation{}
 
-		for _, existingAllowed := range existingTypeInfo.AllowedDirectRelations {
+		for _, existingAllowed := range existingTypeInfo.GetAllowedDirectRelations() {
 			source := schema.SourceForAllowedRelation(existingAllowed)
 			allowedRelsBySource[source] = existingAllowed
 			existingAllowedRels.Add(source)
 		}
 
-		for _, updatedAllowed := range updatedTypeInfo.AllowedDirectRelations {
+		for _, updatedAllowed := range updatedTypeInfo.GetAllowedDirectRelations() {
 			source := schema.SourceForAllowedRelation(updatedAllowed)
 			allowedRelsBySource[source] = updatedAllowed
 			updatedAllowedRels.Add(source)

--- a/pkg/diff/namespace/diffexpr_test.go
+++ b/pkg/diff/namespace/diffexpr_test.go
@@ -173,5 +173,5 @@ func parseUsersetRewrite(s string) (*core.UsersetRewrite, error) {
 		return nil, err
 	}
 
-	return compiled.ObjectDefinitions[0].Relation[0].UsersetRewrite, nil
+	return compiled.ObjectDefinitions[0].GetRelation()[0].GetUsersetRewrite(), nil
 }

--- a/pkg/graph/walker.go
+++ b/pkg/graph/walker.go
@@ -17,7 +17,7 @@ func WalkRewrite(rewrite *core.UsersetRewrite, handler WalkHandler) (any, error)
 		return nil, nil
 	}
 
-	switch rw := rewrite.RewriteOperation.(type) {
+	switch rw := rewrite.GetRewriteOperation().(type) {
 	case *core.UsersetRewrite_Union:
 		return walkRewriteChildren(rw.Union, handler)
 	case *core.UsersetRewrite_Intersection:
@@ -33,7 +33,7 @@ func WalkRewrite(rewrite *core.UsersetRewrite, handler WalkHandler) (any, error)
 // the rewrite is nil, returns false.
 func HasThis(rewrite *core.UsersetRewrite) (bool, error) {
 	result, err := WalkRewrite(rewrite, func(childOneof *core.SetOperation_Child) (any, error) {
-		switch childOneof.ChildType.(type) {
+		switch childOneof.GetChildType().(type) {
 		case *core.SetOperation_Child_XThis:
 			return true, nil
 		default:
@@ -44,7 +44,7 @@ func HasThis(rewrite *core.UsersetRewrite) (bool, error) {
 }
 
 func walkRewriteChildren(so *core.SetOperation, handler WalkHandler) (any, error) {
-	for _, childOneof := range so.Child {
+	for _, childOneof := range so.GetChild() {
 		vle, err := handler(childOneof)
 		if err != nil {
 			return nil, err
@@ -54,7 +54,7 @@ func walkRewriteChildren(so *core.SetOperation, handler WalkHandler) (any, error
 			return vle, nil
 		}
 
-		if child, ok := childOneof.ChildType.(*core.SetOperation_Child_UsersetRewrite); ok {
+		if child, ok := childOneof.GetChildType().(*core.SetOperation_Child_UsersetRewrite); ok {
 			rvle, err := WalkRewrite(child.UsersetRewrite, handler)
 			if err != nil {
 				return nil, err

--- a/pkg/middleware/consistency/consistency.go
+++ b/pkg/middleware/consistency/consistency.go
@@ -290,7 +290,7 @@ func pickBestRevision(ctx context.Context, requested *v1.ZedToken, ds datastore.
 		if status == zedtoken.StatusMismatchedDatastoreID {
 			switch option {
 			case TreatMismatchingTokensAsFullConsistency:
-				log.Warn().Str("zedtoken", requested.Token).Msg("ZedToken specified references a different datastore instance and SpiceDB is configured to treat this as a full consistency request")
+				log.Warn().Str("zedtoken", requested.GetToken()).Msg("ZedToken specified references a different datastore instance and SpiceDB is configured to treat this as a full consistency request")
 				headRev, err := ds.HeadRevision(ctx)
 				if err != nil {
 					return datastore.NoRevision, false, err
@@ -299,11 +299,11 @@ func pickBestRevision(ctx context.Context, requested *v1.ZedToken, ds datastore.
 				return headRev, false, nil
 
 			case TreatMismatchingTokensAsMinLatency:
-				log.Warn().Str("zedtoken", requested.Token).Msg("ZedToken specified references a different datastore instance and SpiceDB is configured to treat this as a min latency request")
+				log.Warn().Str("zedtoken", requested.GetToken()).Msg("ZedToken specified references a different datastore instance and SpiceDB is configured to treat this as a min latency request")
 				return databaseRev, false, nil
 
 			case TreatMismatchingTokensAsError:
-				log.Warn().Str("zedtoken", requested.Token).Msg("ZedToken specified references a different datastore instance and SpiceDB is configured to raise an error in this scenario")
+				log.Warn().Str("zedtoken", requested.GetToken()).Msg("ZedToken specified references a different datastore instance and SpiceDB is configured to raise an error in this scenario")
 				return datastore.NoRevision, false, errors.New("ZedToken specified references a different datastore instance and SpiceDB is configured to raise an error in this scenario")
 
 			default:

--- a/pkg/middleware/requestid/requestid_test.go
+++ b/pkg/middleware/requestid/requestid_test.go
@@ -55,7 +55,7 @@ func (t *testServer) PingStream(server testpb.TestService_PingStreamServer) erro
 			return err
 		}
 
-		if err := server.Send(&testpb.PingStreamResponse{Value: req.Value}); err != nil {
+		if err := server.Send(&testpb.PingStreamResponse{Value: req.GetValue()}); err != nil {
 			return err
 		}
 	}
@@ -181,7 +181,7 @@ func (s *requestIDMiddlewareTestSuite) TestBidirectionalStreamingInterceptor_Ret
 	// Receive the echoed message
 	resp, err := stream.Recv()
 	require.NoError(s.T(), err)
-	require.Equal(s.T(), "test", resp.Value)
+	require.Equal(s.T(), "test", resp.GetValue())
 
 	// Close the stream
 	err = stream.CloseSend()

--- a/pkg/namespace/builder.go
+++ b/pkg/namespace/builder.go
@@ -18,7 +18,7 @@ func Namespace(name string, relations ...*core.Relation) *core.NamespaceDefiniti
 // WithComment creates a namespace definition with one or more defined relations.
 func WithComment(name string, comment string, relations ...*core.Relation) *core.NamespaceDefinition {
 	nd := Namespace(name, relations...)
-	nd.Metadata, _ = AddComment(nd.Metadata, comment)
+	nd.Metadata, _ = AddComment(nd.GetMetadata(), comment)
 	return nd
 }
 
@@ -69,7 +69,7 @@ func Relation(name string, rewrite *core.UsersetRewrite, allowedDirectRelations 
 // MustRelationWithComment creates a relation definition with an optional rewrite definition.
 func MustRelationWithComment(name string, comment string, rewrite *core.UsersetRewrite, allowedDirectRelations ...*core.AllowedRelation) *core.Relation {
 	rel := MustRelation(name, rewrite, allowedDirectRelations...)
-	rel.Metadata, _ = AddComment(rel.Metadata, comment)
+	rel.Metadata, _ = AddComment(rel.GetMetadata(), comment)
 	return rel
 }
 
@@ -97,9 +97,9 @@ func AllowedRelationWithCaveat(namespaceName string, relationName string, withCa
 // WithExpiration adds the expiration trait to the allowed relation.
 func WithExpiration(allowedRelation *core.AllowedRelation) *core.AllowedRelation {
 	return &core.AllowedRelation{
-		Namespace:          allowedRelation.Namespace,
-		RelationOrWildcard: allowedRelation.RelationOrWildcard,
-		RequiredCaveat:     allowedRelation.RequiredCaveat,
+		Namespace:          allowedRelation.GetNamespace(),
+		RelationOrWildcard: allowedRelation.GetRelationOrWildcard(),
+		RequiredCaveat:     allowedRelation.GetRequiredCaveat(),
 		RequiredExpiration: &core.ExpirationTrait{},
 	}
 }
@@ -185,7 +185,7 @@ func MustCaveatDefinitionWithComment(env *caveats.Environment, name string, comm
 	if err != nil {
 		panic(err)
 	}
-	cd.Metadata, _ = AddComment(cd.Metadata, comment)
+	cd.Metadata, _ = AddComment(cd.GetMetadata(), comment)
 	return cd
 }
 

--- a/pkg/namespace/metadata_test.go
+++ b/pkg/namespace/metadata_test.go
@@ -48,17 +48,17 @@ func TestMetadata(t *testing.T) {
 	verr := ns.Validate()
 	require.NoError(verr)
 
-	require.Equal([]string{"Hi there"}, GetComments(ns.Metadata))
-	require.Equal([]string{"Hi there"}, GetComments(ns.Relation[0].Metadata))
-	require.Equal(iv1.RelationMetadata_PERMISSION, GetRelationKind(ns.Relation[0]))
+	require.Equal([]string{"Hi there"}, GetComments(ns.GetMetadata()))
+	require.Equal([]string{"Hi there"}, GetComments(ns.GetRelation()[0].GetMetadata()))
+	require.Equal(iv1.RelationMetadata_PERMISSION, GetRelationKind(ns.GetRelation()[0]))
 
-	require.Equal([]string{}, GetComments(ns.Relation[1].Metadata))
+	require.Equal([]string{}, GetComments(ns.GetRelation()[1].GetMetadata()))
 
 	FilterUserDefinedMetadataInPlace(ns)
-	require.Equal([]string{}, GetComments(ns.Metadata))
-	require.Equal([]string{}, GetComments(ns.Relation[0].Metadata))
+	require.Equal([]string{}, GetComments(ns.GetMetadata()))
+	require.Equal([]string{}, GetComments(ns.GetRelation()[0].GetMetadata()))
 
-	require.Equal(iv1.RelationMetadata_PERMISSION, GetRelationKind(ns.Relation[0]))
+	require.Equal(iv1.RelationMetadata_PERMISSION, GetRelationKind(ns.GetRelation()[0]))
 }
 
 func TestTypeAnnotations(t *testing.T) {

--- a/pkg/promutil/promutil.go
+++ b/pkg/promutil/promutil.go
@@ -24,5 +24,9 @@ func MustCounterValue(m prometheus.Metric) float64 {
 	if err := m.Write(&written); err != nil {
 		panic("failed to read Prometheus counter: " + err.Error())
 	}
-	return *written.Counter.Value
+	counter := written.GetCounter()
+	if counter == nil {
+		panic("counter was nil")
+	}
+	return counter.GetValue()
 }

--- a/pkg/promutil/promutil_test.go
+++ b/pkg/promutil/promutil_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMustCounterValue(t *testing.T) {
@@ -13,29 +14,23 @@ func TestMustCounterValue(t *testing.T) {
 	})
 
 	result := MustCounterValue(counter)
-	if result != 0.0 {
-		t.Errorf("Initial counter value should be 0.0, got %v", result)
-	}
+	require.Equal(t, 0.0, result, "Initial counter value should be 0.0")
 
 	counter.Add(15)
 	result = MustCounterValue(counter)
-	if result != 15 {
-		t.Errorf("Counter value should be 15.5 after Add(15.5), got %v", result)
-	}
+	require.Equal(t, 15.0, result, "Counter value should be 15 after Add(15)")
 
 	counter.Inc()
 	result = MustCounterValue(counter)
-	if result != 16 {
-		t.Errorf("Counter value should be 16.5 after Inc(), got %v", result)
-	}
+	require.Equal(t, 16.0, result, "Counter value should be 16 after Inc()")
 }
 
 func TestMustCounterValue_Panics(t *testing.T) {
-	defer func() { _ = recover() }()
 	histogram := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "test",
 		Help: "A test histogram for unit testing",
 	})
-	MustCounterValue(histogram)
-	t.Fatal("did not panic when provided a non-counter")
+	require.Panics(t, func() {
+		MustCounterValue(histogram)
+	})
 }

--- a/pkg/proto/dispatch/v1/00_zerolog.go
+++ b/pkg/proto/dispatch/v1/00_zerolog.go
@@ -8,59 +8,59 @@ import (
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (cr *DispatchCheckRequest) MarshalZerologObject(e *zerolog.Event) {
-	e.Object("metadata", cr.Metadata)
-	e.Str("resource-type", tuple.StringCoreRR(cr.ResourceRelation))
-	e.Str("subject", tuple.StringCoreONR(cr.Subject))
-	e.Array("resource-ids", strArray(cr.ResourceIds))
+	e.Object("metadata", cr.GetMetadata())
+	e.Str("resource-type", tuple.StringCoreRR(cr.GetResourceRelation()))
+	e.Str("subject", tuple.StringCoreONR(cr.GetSubject()))
+	e.Array("resource-ids", strArray(cr.GetResourceIds()))
 }
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (cr *DispatchCheckResponse) MarshalZerologObject(e *zerolog.Event) {
-	e.Object("metadata", cr.Metadata)
+	e.Object("metadata", cr.GetMetadata())
 
 	results := zerolog.Dict()
-	for resourceID, result := range cr.ResultsByResourceId {
-		results.Str(resourceID, ResourceCheckResult_Membership_name[int32(result.Membership)])
+	for resourceID, result := range cr.GetResultsByResourceId() {
+		results.Str(resourceID, ResourceCheckResult_Membership_name[int32(result.GetMembership())])
 	}
 	e.Dict("results", results)
 }
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (er *DispatchExpandRequest) MarshalZerologObject(e *zerolog.Event) {
-	e.Object("metadata", er.Metadata)
-	e.Str("expand", tuple.StringCoreONR(er.ResourceAndRelation))
-	e.Stringer("mode", er.ExpansionMode)
+	e.Object("metadata", er.GetMetadata())
+	e.Str("expand", tuple.StringCoreONR(er.GetResourceAndRelation()))
+	e.Stringer("mode", er.GetExpansionMode())
 }
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (cr *DispatchExpandResponse) MarshalZerologObject(e *zerolog.Event) {
-	e.Object("metadata", cr.Metadata)
+	e.Object("metadata", cr.GetMetadata())
 }
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (lr *DispatchLookupResources2Request) MarshalZerologObject(e *zerolog.Event) {
-	e.Object("metadata", lr.Metadata)
-	e.Str("resource", tuple.StringCoreRR(lr.ResourceRelation))
-	e.Str("subject", tuple.StringCoreRR(lr.SubjectRelation))
-	e.Array("subject-ids", strArray(lr.SubjectIds))
-	e.Interface("context", lr.Context)
+	e.Object("metadata", lr.GetMetadata())
+	e.Str("resource", tuple.StringCoreRR(lr.GetResourceRelation()))
+	e.Str("subject", tuple.StringCoreRR(lr.GetSubjectRelation()))
+	e.Array("subject-ids", strArray(lr.GetSubjectIds()))
+	e.Interface("context", lr.GetContext())
 }
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (lr *DispatchLookupResources3Request) MarshalZerologObject(e *zerolog.Event) {
-	e.Object("metadata", lr.Metadata)
-	e.Str("resource", tuple.StringCoreRR(lr.ResourceRelation))
-	e.Str("subject", tuple.StringCoreRR(lr.SubjectRelation))
-	e.Array("subject-ids", strArray(lr.SubjectIds))
-	e.Interface("context", lr.Context)
+	e.Object("metadata", lr.GetMetadata())
+	e.Str("resource", tuple.StringCoreRR(lr.GetResourceRelation()))
+	e.Str("subject", tuple.StringCoreRR(lr.GetSubjectRelation()))
+	e.Array("subject-ids", strArray(lr.GetSubjectIds()))
+	e.Interface("context", lr.GetContext())
 }
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (ls *DispatchLookupSubjectsRequest) MarshalZerologObject(e *zerolog.Event) {
-	e.Object("metadata", ls.Metadata)
-	e.Str("resource-type", tuple.StringCoreRR(ls.ResourceRelation))
-	e.Str("subject-type", tuple.StringCoreRR(ls.SubjectRelation))
-	e.Array("resource-ids", strArray(ls.ResourceIds))
+	e.Object("metadata", ls.GetMetadata())
+	e.Str("resource-type", tuple.StringCoreRR(ls.GetResourceRelation()))
+	e.Str("subject-type", tuple.StringCoreRR(ls.GetSubjectRelation()))
+	e.Array("resource-ids", strArray(ls.GetResourceIds()))
 }
 
 type strArray []string
@@ -77,17 +77,17 @@ func (cs *DispatchLookupSubjectsResponse) MarshalZerologObject(e *zerolog.Event)
 	if cs == nil {
 		e.Interface("response", nil)
 	} else {
-		e.Object("metadata", cs.Metadata)
+		e.Object("metadata", cs.GetMetadata())
 	}
 }
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (x *ResolverMeta) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("revision", x.AtRevision)
-	e.Uint32("depth", x.DepthRemaining)
+	e.Str("revision", x.GetAtRevision())
+	e.Uint32("depth", x.GetDepthRemaining())
 }
 
 // MarshalZerologObject implements zerolog object marshalling.
 func (cr *ResponseMeta) MarshalZerologObject(e *zerolog.Event) {
-	e.Uint32("count", cr.DispatchCount)
+	e.Uint32("count", cr.GetDispatchCount())
 }

--- a/pkg/proto/dispatch/v1/02_resolvermeta.go
+++ b/pkg/proto/dispatch/v1/02_resolvermeta.go
@@ -16,12 +16,12 @@ func (x *ResolverMeta) RecordTraversal(key string) (possiblyLoop bool, err error
 		return false, spiceerrors.MustBugf("missing key to be recorded in traversal")
 	}
 
-	if x == nil || len(x.TraversalBloom) == 0 {
+	if x == nil || len(x.GetTraversalBloom()) == 0 {
 		return false, status.Error(codes.Internal, errors.New("required traversal bloom filter is missing").Error())
 	}
 
 	bf := &bloom.BloomFilter{}
-	if err := bf.UnmarshalBinary(x.TraversalBloom); err != nil {
+	if err := bf.UnmarshalBinary(x.GetTraversalBloom()); err != nil {
 		return false, status.Error(codes.Internal, fmt.Errorf("unable to unmarshall traversal bloom filter: %w", err).Error())
 	}
 

--- a/pkg/proto/dispatch/v1/02_resolvermeta_test.go
+++ b/pkg/proto/dispatch/v1/02_resolvermeta_test.go
@@ -32,7 +32,7 @@ func TestRecordTraversal(t *testing.T) {
 	require.NoError(t, err)
 
 	bfs := bloom.BloomFilter{}
-	err = bfs.UnmarshalBinary(rm.TraversalBloom)
+	err = bfs.UnmarshalBinary(rm.GetTraversalBloom())
 	require.NoError(t, err)
 	require.True(t, bfs.TestString("test"))
 

--- a/pkg/query/arrow_test.go
+++ b/pkg/query/arrow_test.go
@@ -277,7 +277,7 @@ func TestArrowIteratorCaveatCombination(t *testing.T) {
 		relCaveat := rels[0].Caveat
 		require.NotNil(relCaveat, "Result should have combined caveat")
 		require.NotNil(relCaveat.GetOperation(), "Caveat should be an operation")
-		require.Equal(relCaveat.GetOperation().Op, core.CaveatOperation_AND, "Caveat should be an AND")
+		require.Equal(relCaveat.GetOperation().GetOp(), core.CaveatOperation_AND, "Caveat should be an AND")
 		require.Len(relCaveat.GetOperation().GetChildren(), 2, "Caveat should be an AND of two children")
 	})
 

--- a/pkg/query/caveat.go
+++ b/pkg/query/caveat.go
@@ -57,7 +57,7 @@ func (c *CaveatIterator) runCaveats(ctx *Context, subSeq PathSeq) (PathSeq, erro
 	}
 
 	return func(yield func(Path, error) bool) {
-		ctx.TraceStep(c, "applying caveat '%s' to sub-iterator results", c.caveat.CaveatName)
+		ctx.TraceStep(c, "applying caveat '%s' to sub-iterator results", c.caveat.GetCaveatName())
 
 		processedCount := 0
 		passedCount := 0
@@ -148,7 +148,7 @@ func (c *CaveatIterator) containsExpectedCaveat(expr *core.CaveatExpression) boo
 		return true // No expected caveat, so any expression passes
 	}
 
-	return c.containsCaveatName(expr, c.caveat.CaveatName)
+	return c.containsCaveatName(expr, c.caveat.GetCaveatName())
 }
 
 // containsCaveatName recursively checks if a caveat expression contains a specific caveat name
@@ -159,12 +159,12 @@ func (c *CaveatIterator) containsCaveatName(expr *core.CaveatExpression, expecte
 
 	// Check if this is a leaf caveat
 	if expr.GetCaveat() != nil {
-		return expr.GetCaveat().CaveatName == expectedName
+		return expr.GetCaveat().GetCaveatName() == expectedName
 	}
 
 	// Check if this is an operation with children
 	if expr.GetOperation() != nil {
-		for _, child := range expr.GetOperation().Children {
+		for _, child := range expr.GetOperation().GetChildren() {
 			if c.containsCaveatName(child, expectedName) {
 				return true
 			}
@@ -206,12 +206,12 @@ func (c *CaveatIterator) buildExplainInfo() string {
 	}
 
 	// Build basic caveat information
-	info := "Caveat(" + c.caveat.CaveatName
+	info := "Caveat(" + c.caveat.GetCaveatName()
 
 	// Add context information if available
-	if c.caveat.Context != nil && len(c.caveat.Context.GetFields()) > 0 {
-		contextInfo := make([]string, 0, len(c.caveat.Context.GetFields()))
-		for key := range c.caveat.Context.GetFields() {
+	if c.caveat.GetContext() != nil && len(c.caveat.GetContext().GetFields()) > 0 {
+		contextInfo := make([]string, 0, len(c.caveat.GetContext().GetFields()))
+		for key := range c.caveat.GetContext().GetFields() {
 			contextInfo = append(contextInfo, key)
 		}
 		info += fmt.Sprintf(", context: [%v]", contextInfo)

--- a/pkg/query/context.go
+++ b/pkg/query/context.go
@@ -68,7 +68,7 @@ func (t *TraceLogger) ExitIterator(it Iterator, paths []Path) {
 		if p.Caveat != nil {
 			// Extract caveat name from CaveatExpression
 			if p.Caveat.GetCaveat() != nil {
-				caveatInfo = fmt.Sprintf("[%s]", p.Caveat.GetCaveat().CaveatName)
+				caveatInfo = fmt.Sprintf("[%s]", p.Caveat.GetCaveat().GetCaveatName())
 			} else {
 				caveatInfo = "[complex_caveat]"
 			}

--- a/pkg/query/exclusion_test.go
+++ b/pkg/query/exclusion_test.go
@@ -547,7 +547,7 @@ func TestCombineExclusionCaveats(t *testing.T) {
 		resultCaveat := result.Caveat
 		require.NotNil(resultCaveat, "Result should have a combined caveat")
 		require.NotNil(resultCaveat.GetOperation(), "Caveat should be an operation")
-		require.Equal(resultCaveat.GetOperation().Op, core.CaveatOperation_AND, "Caveat should be an AND")
+		require.Equal(resultCaveat.GetOperation().GetOp(), core.CaveatOperation_AND, "Caveat should be an AND")
 		require.Len(resultCaveat.GetOperation().GetChildren(), 2, "Caveat should be an AND of two children (main_caveat AND NOT excluded_caveat)")
 
 		// Verify the result has the same endpoints as main
@@ -632,7 +632,7 @@ func TestExclusion_CombinedCaveatLogic(t *testing.T) {
 		doc1Caveat := doc1Result.Caveat
 		require.NotNil(doc1Caveat, "doc1 result should have combined caveat")
 		require.NotNil(doc1Caveat.GetOperation(), "Caveat should be an operation")
-		require.Equal(doc1Caveat.GetOperation().Op, core.CaveatOperation_AND, "Caveat should be an AND")
+		require.Equal(doc1Caveat.GetOperation().GetOp(), core.CaveatOperation_AND, "Caveat should be an AND")
 		require.Len(doc1Caveat.GetOperation().GetChildren(), 2, "Caveat should be an AND of two children (caveat1 AND NOT caveat2)")
 
 		// doc2 should have no caveat (original state preserved)

--- a/pkg/query/intersection_arrow_test.go
+++ b/pkg/query/intersection_arrow_test.go
@@ -358,7 +358,7 @@ func TestIntersectionArrowIteratorCaveatCombination(t *testing.T) {
 		pathCaveat := paths[0].Caveat
 		require.NotNil(pathCaveat, "Result should have combined caveat")
 		require.NotNil(pathCaveat.GetOperation(), "Caveat should be an operation")
-		require.Equal(pathCaveat.GetOperation().Op, core.CaveatOperation_AND, "Caveat should be an AND")
+		require.Equal(pathCaveat.GetOperation().GetOp(), core.CaveatOperation_AND, "Caveat should be an AND")
 		require.Len(pathCaveat.GetOperation().GetChildren(), 2, "Caveat should be an AND of two children")
 	})
 
@@ -404,7 +404,7 @@ func TestIntersectionArrowIteratorCaveatCombination(t *testing.T) {
 
 		// Verify caveat preservation
 		require.NotNil(paths[0].Caveat, "Left caveat should be preserved")
-		require.Equal("left_caveat", paths[0].Caveat.GetCaveat().CaveatName)
+		require.Equal("left_caveat", paths[0].Caveat.GetCaveat().GetCaveatName())
 	})
 
 	t.Run("MultiplePaths_CombineCaveats_AND_Logic", func(t *testing.T) {
@@ -496,8 +496,8 @@ func TestIntersectionArrowIteratorCaveatCombination(t *testing.T) {
 		// Verify it's an AND operation
 		caveatOp := paths[0].Caveat.GetOperation()
 		require.NotNil(caveatOp, "Result caveat should be an operation")
-		require.Equal(core.CaveatOperation_AND, caveatOp.Op, "Combined caveat should use AND operation")
-		require.NotEmpty(caveatOp.Children, "Combined caveat should have children")
+		require.Equal(core.CaveatOperation_AND, caveatOp.GetOp(), "Combined caveat should use AND operation")
+		require.NotEmpty(caveatOp.GetChildren(), "Combined caveat should have children")
 	})
 }
 

--- a/pkg/query/intersection_test.go
+++ b/pkg/query/intersection_test.go
@@ -351,7 +351,7 @@ func TestIntersectionIteratorCaveatCombination(t *testing.T) {
 		relCaveat := rels[0].Caveat
 		require.NotNil(relCaveat, "Result should have combined caveat")
 		require.NotNil(relCaveat.GetOperation(), "Caveat should be an operation")
-		require.Equal(relCaveat.GetOperation().Op, core.CaveatOperation_AND, "Caveat should be an AND")
+		require.Equal(relCaveat.GetOperation().GetOp(), core.CaveatOperation_AND, "Caveat should be an AND")
 		require.Len(relCaveat.GetOperation().GetChildren(), 2, "Caveat should be an AND of two children")
 	})
 
@@ -518,7 +518,7 @@ func TestIntersectionIteratorCaveatCombination(t *testing.T) {
 		relCaveat := rels[0].Caveat
 		require.NotNil(relCaveat, "Final result should have combined caveat")
 		require.NotNil(relCaveat.GetOperation(), "Caveat should be an operation")
-		require.Equal(relCaveat.GetOperation().Op, core.CaveatOperation_AND, "Caveat should be an AND")
+		require.Equal(relCaveat.GetOperation().GetOp(), core.CaveatOperation_AND, "Caveat should be an AND")
 		require.Len(relCaveat.GetOperation().GetChildren(), 2, "Caveat should be an AND of two children (caveat1 and caveat2)")
 	})
 }

--- a/pkg/query/optimize_caveat.go
+++ b/pkg/query/optimize_caveat.go
@@ -89,5 +89,5 @@ func relationContainsCaveat(rel *RelationIterator, caveat *core.ContextualizedCa
 	}
 
 	// Check if the relation has this caveat
-	return rel.base.Caveat() == caveat.CaveatName
+	return rel.base.Caveat() == caveat.GetCaveatName()
 }

--- a/pkg/query/simplify_caveat_test.go
+++ b/pkg/query/simplify_caveat_test.go
@@ -178,7 +178,7 @@ func TestSimplifyAndOperation(t *testing.T) {
 
 		// Should only have caveat2 left
 		require.NotNil(simplified.GetCaveat())
-		require.Equal("caveat2", simplified.GetCaveat().CaveatName)
+		require.Equal("caveat2", simplified.GetCaveat().GetCaveatName())
 	})
 
 	t.Run("OneFalse_ReturnsFalse", func(t *testing.T) {
@@ -192,7 +192,7 @@ func TestSimplifyAndOperation(t *testing.T) {
 
 		// Should return the false caveat
 		require.NotNil(simplified.GetCaveat())
-		require.Equal("caveat1", simplified.GetCaveat().CaveatName)
+		require.Equal("caveat1", simplified.GetCaveat().GetCaveatName())
 	})
 }
 
@@ -282,7 +282,7 @@ func TestSimplifyOrOperation(t *testing.T) {
 
 		// Should only have caveat2 left
 		require.NotNil(simplified.GetCaveat())
-		require.Equal("caveat2", simplified.GetCaveat().CaveatName)
+		require.Equal("caveat2", simplified.GetCaveat().GetCaveatName())
 	})
 
 	t.Run("BothFalse_ReturnsExpression", func(t *testing.T) {
@@ -296,7 +296,7 @@ func TestSimplifyOrOperation(t *testing.T) {
 
 		// Should return original expression since all are false
 		require.NotNil(simplified.GetOperation())
-		require.Equal(core.CaveatOperation_OR, simplified.GetOperation().Op)
+		require.Equal(core.CaveatOperation_OR, simplified.GetOperation().GetOp())
 	})
 }
 
@@ -402,7 +402,7 @@ func TestSimplifyNestedOperations(t *testing.T) {
 
 		// Should simplify to just caveat3
 		require.NotNil(simplified.GetCaveat())
-		require.Equal("caveat3", simplified.GetCaveat().CaveatName)
+		require.Equal("caveat3", simplified.GetCaveat().GetCaveatName())
 	})
 }
 
@@ -568,8 +568,8 @@ func TestSimplifyAndWithSameCaveatDifferentContexts(t *testing.T) {
 
 		// Should return the failed caveat (limit=2)
 		require.NotNil(simplified.GetCaveat())
-		require.Equal("write_limit", simplified.GetCaveat().CaveatName)
-		require.Equal(float64(2), simplified.GetCaveat().Context.AsMap()["limit"])
+		require.Equal("write_limit", simplified.GetCaveat().GetCaveatName())
+		require.Equal(float64(2), simplified.GetCaveat().GetContext().AsMap()["limit"])
 	})
 
 	t.Run("Count5_ShouldFailBothBranches", func(t *testing.T) {
@@ -583,8 +583,8 @@ func TestSimplifyAndWithSameCaveatDifferentContexts(t *testing.T) {
 
 		// Should return the first failed caveat (limit=2)
 		require.NotNil(simplified.GetCaveat())
-		require.Equal("write_limit", simplified.GetCaveat().CaveatName)
-		require.Equal(float64(2), simplified.GetCaveat().Context.AsMap()["limit"])
+		require.Equal("write_limit", simplified.GetCaveat().GetCaveatName())
+		require.Equal(float64(2), simplified.GetCaveat().GetContext().AsMap()["limit"])
 	})
 }
 
@@ -1276,10 +1276,10 @@ func TestSimplifyNotConditional(t *testing.T) {
 
 	// Verify the structure: should still be a NOT operation with the child caveat
 	require.NotNil(simplified.GetOperation(), "Result should be an operation")
-	require.Equal(core.CaveatOperation_NOT, simplified.GetOperation().Op, "Should be a NOT operation")
-	require.Len(simplified.GetOperation().Children, 1, "NOT should have one child")
-	require.NotNil(simplified.GetOperation().Children[0].GetCaveat(), "Child should be the original caveat")
-	require.Equal("limit_check", simplified.GetOperation().Children[0].GetCaveat().CaveatName)
+	require.Equal(core.CaveatOperation_NOT, simplified.GetOperation().GetOp(), "Should be a NOT operation")
+	require.Len(simplified.GetOperation().GetChildren(), 1, "NOT should have one child")
+	require.NotNil(simplified.GetOperation().GetChildren()[0].GetCaveat(), "Child should be the original caveat")
+	require.Equal("limit_check", simplified.GetOperation().GetChildren()[0].GetCaveat().GetCaveatName())
 }
 
 func TestSimplifyDeeplyNestedCaveats(t *testing.T) {

--- a/pkg/query/union_test.go
+++ b/pkg/query/union_test.go
@@ -509,7 +509,7 @@ func TestUnionIteratorCaveatCombination(t *testing.T) {
 		relCaveat := rels[0].Caveat
 		require.NotNil(relCaveat, "Result should have combined caveat")
 		require.NotNil(relCaveat.GetOperation(), "Caveat should be an operation")
-		require.Equal(relCaveat.GetOperation().Op, core.CaveatOperation_OR, "Caveat should be an OR")
+		require.Equal(relCaveat.GetOperation().GetOp(), core.CaveatOperation_OR, "Caveat should be an OR")
 		require.Len(relCaveat.GetOperation().GetChildren(), 2, "Caveat should be an OR of two children")
 	})
 
@@ -588,7 +588,7 @@ func TestUnionIteratorCaveatCombination(t *testing.T) {
 			require.NotNil(path.Caveat, "Each path should keep its caveat")
 			// Extract caveat name - simplified check for test
 			if caveatExpr := path.Caveat.GetCaveat(); caveatExpr != nil {
-				caveatNames[i] = caveatExpr.CaveatName
+				caveatNames[i] = caveatExpr.GetCaveatName()
 			}
 		}
 		require.ElementsMatch([]string{"caveat1", "caveat2"}, caveatNames)

--- a/pkg/schema/arrows_test.go
+++ b/pkg/schema/arrows_test.go
@@ -132,17 +132,17 @@ func TestLookupTuplesetArrows(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, resource := range schema.ObjectDefinitions {
-				for _, relation := range resource.Relation {
-					arrows := arrowSet.LookupTuplesetArrows(resource.Name, relation.Name)
+				for _, relation := range resource.GetRelation() {
+					arrows := arrowSet.LookupTuplesetArrows(resource.GetName(), relation.GetName())
 					require.NotNil(t, arrows)
 
-					rel := resource.Name + "#" + relation.Name
+					rel := resource.GetName() + "#" + relation.GetName()
 					expected, ok := tc.expected[rel]
 					require.True(t, ok, "expected %v to be in %v", rel, tc.expected)
 					require.Len(t, arrows, len(expected), rel)
 
 					for _, arrow := range arrows {
-						key := arrow.Arrow.Tupleset.Relation + "->" + arrow.Arrow.ComputedUserset.Relation
+						key := arrow.Arrow.GetTupleset().GetRelation() + "->" + arrow.Arrow.GetComputedUserset().GetRelation()
 						require.Contains(t, expected, key, "expected %v to be in %v", key, expected)
 					}
 				}

--- a/pkg/schema/definition.go
+++ b/pkg/schema/definition.go
@@ -79,16 +79,16 @@ const (
 func NewDefinition(ts *TypeSystem, nsDef *core.NamespaceDefinition) (*Definition, error) {
 	relationMap := make(map[string]*core.Relation, len(nsDef.GetRelation()))
 	for _, relation := range nsDef.GetRelation() {
-		_, existing := relationMap[relation.Name]
+		_, existing := relationMap[relation.GetName()]
 		if existing {
 			return nil, NewTypeWithSourceError(
-				NewDuplicateRelationError(nsDef.Name, relation.Name),
+				NewDuplicateRelationError(nsDef.GetName(), relation.GetName()),
 				relation,
-				relation.Name,
+				relation.GetName(),
 			)
 		}
 
-		relationMap[relation.Name] = relation
+		relationMap[relation.GetName()] = relation
 	}
 
 	return &Definition{
@@ -151,7 +151,7 @@ func (def *Definition) IsPermission(relationName string) bool {
 func (def *Definition) GetAllowedDirectNamespaceSubjectRelations(sourceRelationName string, targetNamespaceName string) (*mapz.Set[string], error) {
 	found, ok := def.relationMap[sourceRelationName]
 	if !ok {
-		return nil, asTypeError(NewRelationNotFoundErr(def.nsDef.Name, sourceRelationName))
+		return nil, asTypeError(NewRelationNotFoundErr(def.nsDef.GetName(), sourceRelationName))
 	}
 
 	typeInfo := found.GetTypeInformation()
@@ -175,7 +175,7 @@ func (def *Definition) GetAllowedDirectNamespaceSubjectRelations(sourceRelationN
 func (def *Definition) IsAllowedDirectNamespace(sourceRelationName string, targetNamespaceName string) (AllowedDefinitionOption, error) {
 	found, ok := def.relationMap[sourceRelationName]
 	if !ok {
-		return UnknownIfAllowedDefinition, asTypeError(NewRelationNotFoundErr(def.nsDef.Name, sourceRelationName))
+		return UnknownIfAllowedDefinition, asTypeError(NewRelationNotFoundErr(def.nsDef.GetName(), sourceRelationName))
 	}
 
 	typeInfo := found.GetTypeInformation()
@@ -197,7 +197,7 @@ func (def *Definition) IsAllowedDirectNamespace(sourceRelationName string, targe
 func (def *Definition) IsAllowedPublicNamespace(sourceRelationName string, targetNamespaceName string) (AllowedPublicSubject, error) {
 	found, ok := def.relationMap[sourceRelationName]
 	if !ok {
-		return UnknownIfPublicAllowed, asTypeError(NewRelationNotFoundErr(def.nsDef.Name, sourceRelationName))
+		return UnknownIfPublicAllowed, asTypeError(NewRelationNotFoundErr(def.nsDef.GetName(), sourceRelationName))
 	}
 
 	typeInfo := found.GetTypeInformation()
@@ -220,7 +220,7 @@ func (def *Definition) IsAllowedPublicNamespace(sourceRelationName string, targe
 func (def *Definition) IsAllowedDirectRelation(sourceRelationName string, targetNamespaceName string, targetRelationName string) (AllowedDirectRelation, error) {
 	found, ok := def.relationMap[sourceRelationName]
 	if !ok {
-		return UnknownIfRelationAllowed, asTypeError(NewRelationNotFoundErr(def.nsDef.Name, sourceRelationName))
+		return UnknownIfRelationAllowed, asTypeError(NewRelationNotFoundErr(def.nsDef.GetName(), sourceRelationName))
 	}
 
 	typeInfo := found.GetTypeInformation()
@@ -242,7 +242,7 @@ func (def *Definition) IsAllowedDirectRelation(sourceRelationName string, target
 func (def *Definition) HasAllowedRelation(sourceRelationName string, toCheck *core.AllowedRelation) (AllowedRelationOption, error) {
 	found, ok := def.relationMap[sourceRelationName]
 	if !ok {
-		return UnknownIfAllowed, asTypeError(NewRelationNotFoundErr(def.nsDef.Name, sourceRelationName))
+		return UnknownIfAllowed, asTypeError(NewRelationNotFoundErr(def.nsDef.GetName(), sourceRelationName))
 	}
 
 	typeInfo := found.GetTypeInformation()
@@ -265,7 +265,7 @@ func (def *Definition) HasAllowedRelation(sourceRelationName string, toCheck *co
 func (def *Definition) AllowedDirectRelationsAndWildcards(sourceRelationName string) ([]*core.AllowedRelation, error) {
 	found, ok := def.relationMap[sourceRelationName]
 	if !ok {
-		return []*core.AllowedRelation{}, asTypeError(NewRelationNotFoundErr(def.nsDef.Name, sourceRelationName))
+		return []*core.AllowedRelation{}, asTypeError(NewRelationNotFoundErr(def.nsDef.GetName(), sourceRelationName))
 	}
 
 	typeInfo := found.GetTypeInformation()
@@ -322,7 +322,7 @@ func SourceForAllowedRelation(allowedRelation *core.AllowedRelation) string {
 	if hasTraits {
 		caveatAndTraitsStr = " with "
 		if hasCaveat {
-			caveatAndTraitsStr += allowedRelation.RequiredCaveat.CaveatName
+			caveatAndTraitsStr += allowedRelation.GetRequiredCaveat().GetCaveatName()
 		}
 
 		if hasCaveat && hasExpirationTrait {
@@ -335,14 +335,14 @@ func SourceForAllowedRelation(allowedRelation *core.AllowedRelation) string {
 	}
 
 	if allowedRelation.GetPublicWildcard() != nil {
-		return tuple.JoinObjectRef(allowedRelation.Namespace, "*") + caveatAndTraitsStr
+		return tuple.JoinObjectRef(allowedRelation.GetNamespace(), "*") + caveatAndTraitsStr
 	}
 
 	if rel := allowedRelation.GetRelation(); rel != tuple.Ellipsis {
-		return tuple.JoinRelRef(allowedRelation.Namespace, rel) + caveatAndTraitsStr
+		return tuple.JoinRelRef(allowedRelation.GetNamespace(), rel) + caveatAndTraitsStr
 	}
 
-	return allowedRelation.Namespace + caveatAndTraitsStr
+	return allowedRelation.GetNamespace() + caveatAndTraitsStr
 }
 
 // RelationDoesNotAllowCaveatsOrTraitsForSubject returns true if and only if it can be conclusively determined that
@@ -377,7 +377,7 @@ func (t Traits) union(other Traits) Traits {
 func (def *Definition) PossibleTraitsForSubject(relationName string, subjectTypeName string) (Traits, error) {
 	relation, ok := def.relationMap[relationName]
 	if !ok {
-		return Traits{}, NewRelationNotFoundErr(def.nsDef.Name, relationName)
+		return Traits{}, NewRelationNotFoundErr(def.nsDef.GetName(), relationName)
 	}
 
 	typeInfo := relation.GetTypeInformation()
@@ -393,7 +393,7 @@ func (def *Definition) PossibleTraitsForSubject(relationName string, subjectType
 	for _, allowedRelation := range typeInfo.GetAllowedDirectRelations() {
 		if allowedRelation.GetNamespace() == subjectTypeName {
 			foundSubjectType = true
-			if allowedRelation.GetRequiredCaveat() != nil && allowedRelation.GetRequiredCaveat().CaveatName != "" {
+			if allowedRelation.GetRequiredCaveat() != nil && allowedRelation.GetRequiredCaveat().GetCaveatName() != "" {
 				foundTraits.AllowsCaveats = true
 			}
 			if allowedRelation.GetRequiredExpiration() != nil {
@@ -417,7 +417,7 @@ func (def *Definition) PossibleTraitsForSubject(relationName string, subjectType
 func (def *Definition) PossibleTraitsForAnySubject(relationName string) (Traits, error) {
 	relation, ok := def.relationMap[relationName]
 	if !ok {
-		return Traits{}, NewRelationNotFoundErr(def.nsDef.Name, relationName)
+		return Traits{}, NewRelationNotFoundErr(def.nsDef.GetName(), relationName)
 	}
 
 	typeInfo := relation.GetTypeInformation()
@@ -430,7 +430,7 @@ func (def *Definition) PossibleTraitsForAnySubject(relationName string) (Traits,
 
 	foundTraits := Traits{}
 	for _, allowedRelation := range typeInfo.GetAllowedDirectRelations() {
-		if allowedRelation.GetRequiredCaveat() != nil && allowedRelation.GetRequiredCaveat().CaveatName != "" {
+		if allowedRelation.GetRequiredCaveat() != nil && allowedRelation.GetRequiredCaveat().GetCaveatName() != "" {
 			foundTraits.AllowsCaveats = true
 		}
 		if allowedRelation.GetRequiredExpiration() != nil {

--- a/pkg/schema/definition_test.go
+++ b/pkg/schema/definition_test.go
@@ -1530,13 +1530,13 @@ func TestTypeSystemAccessors(t *testing.T) {
 
 				require.Equal(vts.Namespace(), nsDef)
 
-				tester, ok := tc.namespaces[nsDef.Name]
+				tester, ok := tc.namespaces[nsDef.GetName()]
 				if ok {
 					tester := tester
 					vts := vts
-					t.Run(nsDef.Name, func(t *testing.T) {
-						for _, relation := range nsDef.Relation {
-							require.True(vts.IsPermission(relation.Name) || vts.HasTypeInformation(relation.Name))
+					t.Run(nsDef.GetName(), func(t *testing.T) {
+						for _, relation := range nsDef.GetRelation() {
+							require.True(vts.IsPermission(relation.GetName()) || vts.HasTypeInformation(relation.GetName()))
 						}
 
 						tester(t, vts)

--- a/pkg/schema/errors.go
+++ b/pkg/schema/errors.go
@@ -423,8 +423,8 @@ func NewTypeWithSourceError(wrapped error, withSource nspkg.WithSourcePosition, 
 		return asTypeError(spiceerrors.NewWithSourceError(
 			wrapped,
 			sourceCodeString,
-			sourcePosition.ZeroIndexedLineNumber+1, // +1 to make 1-indexed
-			sourcePosition.ZeroIndexedColumnPosition+1, // +1 to make 1-indexed
+			sourcePosition.GetZeroIndexedLineNumber()+1,     // +1 to make 1-indexed
+			sourcePosition.GetZeroIndexedColumnPosition()+1, // +1 to make 1-indexed
 		))
 	}
 

--- a/pkg/schema/full_reachability_test.go
+++ b/pkg/schema/full_reachability_test.go
@@ -364,9 +364,9 @@ func TestRelationsReferencing(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, resource := range schema.ObjectDefinitions {
-				for _, relation := range resource.Relation {
-					references := graph.RelationsReferencing(resource.Name, relation.Name)
-					rel := resource.Name + "#" + relation.Name
+				for _, relation := range resource.GetRelation() {
+					references := graph.RelationsReferencing(resource.GetName(), relation.GetName())
+					rel := resource.GetName() + "#" + relation.GetName()
 					expectedRelations, ok := tc.expected[rel]
 					require.True(t, ok, "expected %v to be in %v", rel, tc.expected)
 					require.Len(t, references, len(expectedRelations), "found rel: %s => expected: %v | found %v", rel, expectedRelations, references)
@@ -381,8 +381,8 @@ func TestRelationsReferencing(t *testing.T) {
 
 func containsRelation(references []RelationReferenceInfo, relation expectedRelation) bool {
 	for _, reference := range references {
-		if reference.Relation.Namespace == relation.Namespace &&
-			reference.Relation.Relation == relation.Relation &&
+		if reference.Relation.GetNamespace() == relation.Namespace &&
+			reference.Relation.GetRelation() == relation.Relation &&
 			reference.Type == relation.Type {
 			return true
 		}

--- a/pkg/schema/reachabilitygraph_test.go
+++ b/pkg/schema/reachabilitygraph_test.go
@@ -1267,10 +1267,10 @@ func TestReachabilityGraph(t *testing.T) {
 				})
 				ts := NewTypeSystem(resolver)
 
-				vdef, terr := ts.GetValidatedDefinition(ctx, nsDef.Name)
+				vdef, terr := ts.GetValidatedDefinition(ctx, nsDef.GetName())
 				require.NoError(terr)
 
-				if nsDef.Name == tc.resourceType.Namespace {
+				if nsDef.GetName() == tc.resourceType.GetNamespace() {
 					rdef = vdef
 				}
 			}
@@ -1299,7 +1299,7 @@ func verifyEntrypoints(require *require.Assertions, foundEntrypoints []Reachabil
 	for _, entrypoint := range foundEntrypoints {
 		foundRelations = append(foundRelations, tuple.StringCoreRR(entrypoint.ContainingRelationOrPermission()))
 		if isDirect, ok := isDirectMap[tuple.StringCoreRR(entrypoint.ContainingRelationOrPermission())]; ok {
-			require.Equal(isDirect, entrypoint.IsDirectResult(), "found mismatch for whether a direct result for entrypoint for %s", entrypoint.parentRelation.Relation)
+			require.Equal(isDirect, entrypoint.IsDirectResult(), "found mismatch for whether a direct result for entrypoint for %s", entrypoint.parentRelation.GetRelation())
 		}
 	}
 

--- a/pkg/schema/resolver.go
+++ b/pkg/schema/resolver.go
@@ -67,7 +67,7 @@ type DatastoreResolver struct {
 func (r *DatastoreResolver) LookupDefinition(ctx context.Context, name string) (*core.NamespaceDefinition, bool, error) {
 	if len(r.predefined.Definitions) > 0 {
 		for _, def := range r.predefined.Definitions {
-			if def.Name == name {
+			if def.GetName() == name {
 				return def, false, nil
 			}
 		}

--- a/pkg/schema/type_check.go
+++ b/pkg/schema/type_check.go
@@ -52,10 +52,10 @@ func (ts *TypeSystem) getTypesForRelationInternal(ctx context.Context, defName s
 		// Supress the error that it couldn't find the relation, as if a relation is missing in a definition, it's already a noop in dispatch.
 		return nil, nil
 	}
-	if rel.TypeInformation != nil {
-		return ts.getTypesForInfo(ctx, rel.TypeInformation, seen, nonTerminals)
-	} else if rel.UsersetRewrite != nil {
-		return ts.getTypesForRewrite(ctx, defName, rel.UsersetRewrite, seen, nonTerminals)
+	if rel.GetTypeInformation() != nil {
+		return ts.getTypesForInfo(ctx, rel.GetTypeInformation(), seen, nonTerminals)
+	} else if rel.GetUsersetRewrite() != nil {
+		return ts.getTypesForRewrite(ctx, defName, rel.GetUsersetRewrite(), seen, nonTerminals)
 	}
 	return nil, asTypeError(NewMissingAllowedRelationsErr(defName, relationName))
 }
@@ -96,7 +96,7 @@ func (ts *TypeSystem) getIntermediateRelationTypes(ctx context.Context, defName 
 		return nil, asTypeError(NewRelationNotFoundErr(defName, relName))
 	}
 	out := mapz.NewSet[string]()
-	for _, dr := range rel.TypeInformation.GetAllowedDirectRelations() {
+	for _, dr := range rel.GetTypeInformation().GetAllowedDirectRelations() {
 		out.Add(dr.GetNamespace())
 	}
 	return out, nil

--- a/pkg/schema/type_check_test.go
+++ b/pkg/schema/type_check_test.go
@@ -215,11 +215,11 @@ func TestTypecheckingJustTypes(t *testing.T) {
 			res := ResolverForCompiledSchema(*schema)
 			ts := NewTypeSystem(res)
 			for _, resource := range schema.ObjectDefinitions {
-				for _, relation := range resource.Relation {
-					types, err := ts.GetRecursiveTerminalTypesForRelation(t.Context(), resource.Name, relation.Name)
+				for _, relation := range resource.GetRelation() {
+					types, err := ts.GetRecursiveTerminalTypesForRelation(t.Context(), resource.GetName(), relation.GetName())
 					require.NoError(t, err)
 
-					rel := resource.Name + "#" + relation.Name
+					rel := resource.GetName() + "#" + relation.GetName()
 					expected, ok := tc.expected[rel]
 					require.True(t, ok, "expected %v to be in %v", rel, tc.expected)
 					require.Len(t, types, len(expected), rel)
@@ -398,11 +398,11 @@ func TestTypecheckingWithSubrelations(t *testing.T) {
 			res := ResolverForCompiledSchema(*schema)
 			ts := NewTypeSystem(res)
 			for _, resource := range schema.ObjectDefinitions {
-				for _, relation := range resource.Relation {
-					types, err := ts.GetFullRecursiveSubjectTypesForRelation(t.Context(), resource.Name, relation.Name)
+				for _, relation := range resource.GetRelation() {
+					types, err := ts.GetFullRecursiveSubjectTypesForRelation(t.Context(), resource.GetName(), relation.GetName())
 					require.NoError(t, err)
 
-					rel := resource.Name + "#" + relation.Name
+					rel := resource.GetName() + "#" + relation.GetName()
 					expected, ok := tc.expected[rel]
 					require.True(t, ok, "expected %v to be in %v", rel, tc.expected)
 					require.Len(t, types, len(expected), rel)
@@ -508,7 +508,7 @@ func TestTypeAnnotationsValidation(t *testing.T) {
 
 			var foundError error
 			for _, resource := range schema.ObjectDefinitions {
-				def, err := ts.GetDefinition(t.Context(), resource.Name)
+				def, err := ts.GetDefinition(t.Context(), resource.GetName())
 				if err != nil {
 					foundError = err
 					break

--- a/pkg/schema/v2/flatten_test.go
+++ b/pkg/schema/v2/flatten_test.go
@@ -298,13 +298,13 @@ definition folder {
 			// Step 6: Generate schema string
 			// Sort definitions by name for deterministic output
 			sort.Slice(defs, func(i, j int) bool {
-				return defs[i].Name < defs[j].Name
+				return defs[i].GetName() < defs[j].GetName()
 			})
 
 			// Sort relations within each definition for deterministic output
 			for _, def := range defs {
-				sort.Slice(def.Relation, func(i, j int) bool {
-					return def.Relation[i].Name < def.Relation[j].Name
+				sort.Slice(def.GetRelation(), func(i, j int) bool {
+					return def.GetRelation()[i].GetName() < def.GetRelation()[j].GetName()
 				})
 			}
 
@@ -337,12 +337,12 @@ definition folder {
 
 			// Sort expected definitions and relations the same way
 			sort.Slice(expectedCompiled.ObjectDefinitions, func(i, j int) bool {
-				return expectedCompiled.ObjectDefinitions[i].Name < expectedCompiled.ObjectDefinitions[j].Name
+				return expectedCompiled.ObjectDefinitions[i].GetName() < expectedCompiled.ObjectDefinitions[j].GetName()
 			})
 
 			for _, def := range expectedCompiled.ObjectDefinitions {
-				sort.Slice(def.Relation, func(i, j int) bool {
-					return def.Relation[i].Name < def.Relation[j].Name
+				sort.Slice(def.GetRelation(), func(i, j int) bool {
+					return def.GetRelation()[i].GetName() < def.GetRelation()[j].GetName()
 				})
 			}
 
@@ -645,13 +645,13 @@ definition user {}`,
 			// Step 6: Generate schema string
 			// Sort definitions by name for deterministic output
 			sort.Slice(defs, func(i, j int) bool {
-				return defs[i].Name < defs[j].Name
+				return defs[i].GetName() < defs[j].GetName()
 			})
 
 			// Sort relations within each definition for deterministic output
 			for _, def := range defs {
-				sort.Slice(def.Relation, func(i, j int) bool {
-					return def.Relation[i].Name < def.Relation[j].Name
+				sort.Slice(def.GetRelation(), func(i, j int) bool {
+					return def.GetRelation()[i].GetName() < def.GetRelation()[j].GetName()
 				})
 			}
 
@@ -684,12 +684,12 @@ definition user {}`,
 
 			// Sort expected definitions and relations the same way
 			sort.Slice(expectedCompiled.ObjectDefinitions, func(i, j int) bool {
-				return expectedCompiled.ObjectDefinitions[i].Name < expectedCompiled.ObjectDefinitions[j].Name
+				return expectedCompiled.ObjectDefinitions[i].GetName() < expectedCompiled.ObjectDefinitions[j].GetName()
 			})
 
 			for _, def := range expectedCompiled.ObjectDefinitions {
-				sort.Slice(def.Relation, func(i, j int) bool {
-					return def.Relation[i].Name < def.Relation[j].Name
+				sort.Slice(def.GetRelation(), func(i, j int) bool {
+					return def.GetRelation()[i].GetName() < def.GetRelation()[j].GetName()
 				})
 			}
 
@@ -1087,13 +1087,13 @@ definition user {}
 			// Step 6: Generate schema string
 			// Sort definitions by name for deterministic output
 			sort.Slice(defs, func(i, j int) bool {
-				return defs[i].Name < defs[j].Name
+				return defs[i].GetName() < defs[j].GetName()
 			})
 
 			// Sort relations within each definition for deterministic output
 			for _, def := range defs {
-				sort.Slice(def.Relation, func(i, j int) bool {
-					return def.Relation[i].Name < def.Relation[j].Name
+				sort.Slice(def.GetRelation(), func(i, j int) bool {
+					return def.GetRelation()[i].GetName() < def.GetRelation()[j].GetName()
 				})
 			}
 
@@ -1126,12 +1126,12 @@ definition user {}
 
 			// Sort expected definitions and relations the same way
 			sort.Slice(expectedCompiled.ObjectDefinitions, func(i, j int) bool {
-				return expectedCompiled.ObjectDefinitions[i].Name < expectedCompiled.ObjectDefinitions[j].Name
+				return expectedCompiled.ObjectDefinitions[i].GetName() < expectedCompiled.ObjectDefinitions[j].GetName()
 			})
 
 			for _, def := range expectedCompiled.ObjectDefinitions {
-				sort.Slice(def.Relation, func(i, j int) bool {
-					return def.Relation[i].Name < def.Relation[j].Name
+				sort.Slice(def.GetRelation(), func(i, j int) bool {
+					return def.GetRelation()[i].GetName() < def.GetRelation()[j].GetName()
 				})
 			}
 

--- a/pkg/schema/v2/resolved_test.go
+++ b/pkg/schema/v2/resolved_test.go
@@ -683,7 +683,7 @@ definition user {}`
 	// Find the document definition
 	var docDef *core.NamespaceDefinition
 	for _, def := range defs {
-		if def.Name == "document" {
+		if def.GetName() == "document" {
 			docDef = def
 			break
 		}
@@ -692,8 +692,8 @@ definition user {}`
 
 	// Verify the permission exists
 	var viewPerm *core.Relation
-	for _, rel := range docDef.Relation {
-		if rel.Name == "view" {
+	for _, rel := range docDef.GetRelation() {
+		if rel.GetName() == "view" {
 			viewPerm = rel
 			break
 		}
@@ -701,6 +701,6 @@ definition user {}`
 	require.NotNil(t, viewPerm)
 
 	// The UsersetRewrite should contain a FunctionedTupleToUserset
-	require.NotNil(t, viewPerm.UsersetRewrite)
-	require.NotNil(t, viewPerm.UsersetRewrite.RewriteOperation)
+	require.NotNil(t, viewPerm.GetUsersetRewrite())
+	require.NotNil(t, viewPerm.GetUsersetRewrite().GetRewriteOperation())
 }

--- a/pkg/schema/v2/schema_conversion_test.go
+++ b/pkg/schema/v2/schema_conversion_test.go
@@ -311,14 +311,14 @@ func TestSchemaConversionFromCompiler(t *testing.T) {
 
 			// Check that each compiled definition maps to a v2 definition
 			for _, compiledDef := range compiled.ObjectDefinitions {
-				v2Def, exists := v2Schema.Definitions()[compiledDef.Name]
-				require.True(t, exists, "Compiled definition %s should exist in v2 schema", compiledDef.Name)
-				require.Equal(t, compiledDef.Name, v2Def.Name())
+				v2Def, exists := v2Schema.Definitions()[compiledDef.GetName()]
+				require.True(t, exists, "Compiled definition %s should exist in v2 schema", compiledDef.GetName())
+				require.Equal(t, compiledDef.GetName(), v2Def.Name())
 
 				// Count relations and permissions from compiled schema
 				compiledRelations := 0
 				compiledPermissions := 0
-				for _, relation := range compiledDef.Relation {
+				for _, relation := range compiledDef.GetRelation() {
 					if relation.GetTypeInformation() != nil {
 						compiledRelations++
 					}
@@ -333,10 +333,10 @@ func TestSchemaConversionFromCompiler(t *testing.T) {
 
 			// Check that each compiled caveat maps to a v2 caveat
 			for _, compiledCaveat := range compiled.CaveatDefinitions {
-				v2Caveat, exists := v2Schema.Caveats()[compiledCaveat.Name]
-				require.True(t, exists, "Compiled caveat %s should exist in v2 schema", compiledCaveat.Name)
-				require.Equal(t, compiledCaveat.Name, v2Caveat.Name())
-				require.Equal(t, string(compiledCaveat.SerializedExpression), v2Caveat.Expression())
+				v2Caveat, exists := v2Schema.Caveats()[compiledCaveat.GetName()]
+				require.True(t, exists, "Compiled caveat %s should exist in v2 schema", compiledCaveat.GetName())
+				require.Equal(t, compiledCaveat.GetName(), v2Caveat.Name())
+				require.Equal(t, string(compiledCaveat.GetSerializedExpression()), v2Caveat.Expression())
 			}
 		})
 	}

--- a/pkg/schemadsl/compiler/compiler_test.go
+++ b/pkg/schemadsl/compiler/compiler_test.go
@@ -1081,22 +1081,22 @@ func TestCompile(t *testing.T) {
 					if caveatDef, ok := def.(*core.CaveatDefinition); ok {
 						expectedCaveatDef, ok := expectedDef.(*core.CaveatDefinition)
 						require.True(ok, "definition is not a caveat def")
-						require.Equal(expectedCaveatDef.Name, caveatDef.Name)
-						require.Len(caveatDef.ParameterTypes, len(expectedCaveatDef.ParameterTypes))
+						require.Equal(expectedCaveatDef.GetName(), caveatDef.GetName())
+						require.Len(caveatDef.GetParameterTypes(), len(expectedCaveatDef.GetParameterTypes()))
 
-						for expectedParamName, expectedParam := range expectedCaveatDef.ParameterTypes {
-							foundParam, ok := caveatDef.ParameterTypes[expectedParamName]
+						for expectedParamName, expectedParam := range expectedCaveatDef.GetParameterTypes() {
+							foundParam, ok := caveatDef.GetParameterTypes()[expectedParamName]
 							require.True(ok, "missing parameter %s", expectedParamName)
 							testutil.RequireProtoEqual(t, expectedParam, foundParam, "mismatch type for parameter %s", expectedParamName)
 						}
 
-						parameterTypes, err := caveattypes.DecodeParameterTypes(caveattypes.Default.TypeSet, caveatDef.ParameterTypes)
+						parameterTypes, err := caveattypes.DecodeParameterTypes(caveattypes.Default.TypeSet, caveatDef.GetParameterTypes())
 						require.NoError(err)
 
-						expectedDecoded, err := caveats.DeserializeCaveatWithDefaultTypeSet(expectedCaveatDef.SerializedExpression, parameterTypes)
+						expectedDecoded, err := caveats.DeserializeCaveatWithDefaultTypeSet(expectedCaveatDef.GetSerializedExpression(), parameterTypes)
 						require.NoError(err)
 
-						foundDecoded, err := caveats.DeserializeCaveatWithDefaultTypeSet(caveatDef.SerializedExpression, parameterTypes)
+						foundDecoded, err := caveats.DeserializeCaveatWithDefaultTypeSet(caveatDef.GetSerializedExpression(), parameterTypes)
 						require.NoError(err)
 
 						expectedExprString, err := expectedDecoded.ExprString()

--- a/pkg/schemadsl/compiler/translator.go
+++ b/pkg/schemadsl/compiler/translator.go
@@ -191,7 +191,7 @@ func translateCaveatDefinition(tctx *translationContext, defNode *dslNode) (*cor
 		return nil, err
 	}
 
-	def.Metadata = addComments(def.Metadata, defNode)
+	def.Metadata = addComments(def.GetMetadata(), defNode)
 	def.SourcePosition = getSourcePosition(defNode, tctx.mapper)
 	return def, nil
 }
@@ -247,7 +247,7 @@ func translateObjectDefinition(tctx *translationContext, defNode *dslNode) (*cor
 
 	if len(relationsAndPermissions) == 0 {
 		ns := namespace.Namespace(nspath)
-		ns.Metadata = addComments(ns.Metadata, defNode)
+		ns.Metadata = addComments(ns.GetMetadata(), defNode)
 		ns.SourcePosition = getSourcePosition(defNode, tctx.mapper)
 
 		if !tctx.skipValidate {
@@ -260,7 +260,7 @@ func translateObjectDefinition(tctx *translationContext, defNode *dslNode) (*cor
 	}
 
 	ns := namespace.Namespace(nspath, relationsAndPermissions...)
-	ns.Metadata = addComments(ns.Metadata, defNode)
+	ns.Metadata = addComments(ns.GetMetadata(), defNode)
 	ns.SourcePosition = getSourcePosition(defNode, tctx.mapper)
 
 	if !tctx.skipValidate {
@@ -331,7 +331,7 @@ func translateRelationOrPermission(tctx *translationContext, relOrPermNode *dslN
 		if err != nil {
 			return nil, err
 		}
-		rel.Metadata = addComments(rel.Metadata, relOrPermNode)
+		rel.Metadata = addComments(rel.GetMetadata(), relOrPermNode)
 		rel.SourcePosition = getSourcePosition(relOrPermNode, tctx.mapper)
 		return rel, err
 
@@ -340,7 +340,7 @@ func translateRelationOrPermission(tctx *translationContext, relOrPermNode *dslN
 		if err != nil {
 			return nil, err
 		}
-		rel.Metadata = addComments(rel.Metadata, relOrPermNode)
+		rel.Metadata = addComments(rel.GetMetadata(), relOrPermNode)
 		rel.SourcePosition = getSourcePosition(relOrPermNode, tctx.mapper)
 		return rel, err
 
@@ -490,8 +490,8 @@ func collapseOps(op *core.SetOperation_Child, handler func(rewrite *core.Userset
 		return []*core.SetOperation_Child{op}
 	}
 
-	collapsed := make([]*core.SetOperation_Child, 0, len(operation.Child))
-	for _, child := range operation.Child {
+	collapsed := make([]*core.SetOperation_Child, 0, len(operation.GetChild()))
+	for _, child := range operation.GetChild() {
 		collapsed = append(collapsed, collapseOps(child, handler)...)
 	}
 	return collapsed

--- a/pkg/schemadsl/compiler/type_annotations_integration_test.go
+++ b/pkg/schemadsl/compiler/type_annotations_integration_test.go
@@ -81,9 +81,9 @@ definition document {
 			// Find the document definition and the expected permission
 			var foundPermission *core.Relation
 			for _, ns := range compiled.ObjectDefinitions {
-				if ns.Name == "document" {
-					for _, rel := range ns.Relation {
-						if rel.Name == tt.expectedPermission {
+				if ns.GetName() == "document" {
+					for _, rel := range ns.GetRelation() {
+						if rel.GetName() == tt.expectedPermission {
 							foundPermission = rel
 							break
 						}
@@ -97,14 +97,14 @@ definition document {
 			if !tt.shouldContainMetadata {
 				// For permissions without type annotations, PERMISSION metadata should still exist (created by namespace.Relation)
 				// but type annotations should be empty
-				require.NotNil(t, foundPermission.Metadata, "All permissions should have metadata")
+				require.NotNil(t, foundPermission.GetMetadata(), "All permissions should have metadata")
 
 				// Find the PERMISSION RelationMetadata
 				var foundMetadata *implv1.RelationMetadata
-				for _, metadataAny := range foundPermission.Metadata.MetadataMessage {
+				for _, metadataAny := range foundPermission.GetMetadata().GetMetadataMessage() {
 					var relationMetadata implv1.RelationMetadata
 					if err := metadataAny.UnmarshalTo(&relationMetadata); err == nil {
-						if relationMetadata.Kind == implv1.RelationMetadata_PERMISSION {
+						if relationMetadata.GetKind() == implv1.RelationMetadata_PERMISSION {
 							foundMetadata = &relationMetadata
 							break
 						}
@@ -112,8 +112,8 @@ definition document {
 				}
 
 				require.NotNil(t, foundMetadata, "Should have PERMISSION RelationMetadata")
-				if foundMetadata.TypeAnnotations != nil {
-					require.Empty(t, foundMetadata.TypeAnnotations.Types, "Type annotations should be empty for permission without type annotations")
+				if foundMetadata.GetTypeAnnotations() != nil {
+					require.Empty(t, foundMetadata.GetTypeAnnotations().GetTypes(), "Type annotations should be empty for permission without type annotations")
 				}
 
 				// Test the helper function for retrieving type annotations
@@ -123,15 +123,15 @@ definition document {
 			}
 
 			// For permissions with type annotations, verify metadata exists
-			require.NotNil(t, foundPermission.Metadata, "Metadata should not be nil for permission with type annotations")
-			require.NotEmpty(t, foundPermission.Metadata.MetadataMessage, "MetadataMessage should not be empty")
+			require.NotNil(t, foundPermission.GetMetadata(), "Metadata should not be nil for permission with type annotations")
+			require.NotEmpty(t, foundPermission.GetMetadata().GetMetadataMessage(), "MetadataMessage should not be empty")
 
 			// Find the RelationMetadata with PERMISSION kind
 			var foundMetadata *implv1.RelationMetadata
-			for _, metadataAny := range foundPermission.Metadata.MetadataMessage {
+			for _, metadataAny := range foundPermission.GetMetadata().GetMetadataMessage() {
 				var relationMetadata implv1.RelationMetadata
 				if err := metadataAny.UnmarshalTo(&relationMetadata); err == nil {
-					if relationMetadata.Kind == implv1.RelationMetadata_PERMISSION {
+					if relationMetadata.GetKind() == implv1.RelationMetadata_PERMISSION {
 						foundMetadata = &relationMetadata
 						break
 					}
@@ -139,9 +139,9 @@ definition document {
 			}
 
 			require.NotNil(t, foundMetadata, "Should have PERMISSION RelationMetadata")
-			require.Equal(t, implv1.RelationMetadata_PERMISSION, foundMetadata.Kind)
-			require.NotNil(t, foundMetadata.TypeAnnotations, "TypeAnnotations should not be nil")
-			require.Equal(t, tt.expectedAnnotations, foundMetadata.TypeAnnotations.Types)
+			require.Equal(t, implv1.RelationMetadata_PERMISSION, foundMetadata.GetKind())
+			require.NotNil(t, foundMetadata.GetTypeAnnotations(), "TypeAnnotations should not be nil")
+			require.Equal(t, tt.expectedAnnotations, foundMetadata.GetTypeAnnotations().GetTypes())
 
 			// Test the helper function for retrieving type annotations
 			retrievedAnnotations := namespace.GetTypeAnnotations(foundPermission)

--- a/pkg/spiceerrors/testutil.go
+++ b/pkg/spiceerrors/testutil.go
@@ -23,6 +23,6 @@ func RequireReason(t testing.TB, reason v1.ErrorReason, err error, expectedMetad
 	require.Equal(t, v1.ErrorReason_name[int32(reason)], info.GetReason())
 
 	for _, expectedKey := range expectedMetadataKeys {
-		require.Contains(t, info.Metadata, expectedKey)
+		require.Contains(t, info.GetMetadata(), expectedKey)
 	}
 }

--- a/pkg/testutil/proto_test.go
+++ b/pkg/testutil/proto_test.go
@@ -222,7 +222,7 @@ func TestAreProtoSlicesEqual(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := AreProtoSlicesEqual(tc.first, tc.second, func(first, second *core.ObjectAndRelation) int {
-				return strings.Compare(first.ObjectId, second.ObjectId)
+				return strings.Compare(first.GetObjectId(), second.GetObjectId())
 			}, "something went wrong")
 			require.Equal(t, tc.expectedEqual, err == nil)
 		})
@@ -268,7 +268,7 @@ func TestRequireProtoSlicesEqual(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			RequireProtoSlicesEqual(t, tc.first, tc.second, func(first *core.ObjectAndRelation, second *core.ObjectAndRelation) int {
-				return strings.Compare(first.ObjectId, second.ObjectId)
+				return strings.Compare(first.GetObjectId(), second.GetObjectId())
 			}, "something went wrong")
 		})
 	}

--- a/pkg/tuple/comparison.go
+++ b/pkg/tuple/comparison.go
@@ -44,5 +44,5 @@ func caveatEqual(lhs, rhs *core.ContextualizedCaveat) bool {
 		return false
 	}
 
-	return lhs.CaveatName == rhs.CaveatName && proto.Equal(lhs.Context, rhs.Context)
+	return lhs.GetCaveatName() == rhs.GetCaveatName() && proto.Equal(lhs.GetContext(), rhs.GetContext())
 }

--- a/pkg/tuple/core.go
+++ b/pkg/tuple/core.go
@@ -22,11 +22,11 @@ func ONRStringToCore(ns, oid, rel string) *core.ObjectAndRelation {
 
 // CoreRelationToStringWithoutCaveatOrExpiration creates a string from a core.RelationTuple without stringifying the caveat.
 func CoreRelationToStringWithoutCaveatOrExpiration(rel *core.RelationTuple) string {
-	if rel.Subject.Relation == Ellipsis {
-		return rel.ResourceAndRelation.Namespace + ":" + rel.ResourceAndRelation.ObjectId + "@" + rel.Subject.Namespace + ":" + rel.Subject.ObjectId
+	if rel.GetSubject().GetRelation() == Ellipsis {
+		return rel.GetResourceAndRelation().GetNamespace() + ":" + rel.GetResourceAndRelation().GetObjectId() + "@" + rel.GetSubject().GetNamespace() + ":" + rel.GetSubject().GetObjectId()
 	}
 
-	return rel.ResourceAndRelation.Namespace + ":" + rel.ResourceAndRelation.ObjectId + "@" + rel.Subject.Namespace + ":" + rel.Subject.ObjectId + "#" + rel.ResourceAndRelation.Relation
+	return rel.GetResourceAndRelation().GetNamespace() + ":" + rel.GetResourceAndRelation().GetObjectId() + "@" + rel.GetSubject().GetNamespace() + ":" + rel.GetSubject().GetObjectId() + "#" + rel.GetResourceAndRelation().GetRelation()
 }
 
 // CoreRelationToString creates a string from a core.RelationTuple.
@@ -58,25 +58,25 @@ func FromCoreRelationTuple(rt *core.RelationTuple) Relationship {
 	}, "relation tuple must be valid")
 
 	var expiration *time.Time
-	if rt.OptionalExpirationTime != nil {
-		t := rt.OptionalExpirationTime.AsTime()
+	if rt.GetOptionalExpirationTime() != nil {
+		t := rt.GetOptionalExpirationTime().AsTime()
 		expiration = &t
 	}
 
 	return Relationship{
 		RelationshipReference: RelationshipReference{
 			Resource: ObjectAndRelation{
-				ObjectType: rt.ResourceAndRelation.Namespace,
-				ObjectID:   rt.ResourceAndRelation.ObjectId,
-				Relation:   rt.ResourceAndRelation.Relation,
+				ObjectType: rt.GetResourceAndRelation().GetNamespace(),
+				ObjectID:   rt.GetResourceAndRelation().GetObjectId(),
+				Relation:   rt.GetResourceAndRelation().GetRelation(),
 			},
 			Subject: ObjectAndRelation{
-				ObjectType: rt.Subject.Namespace,
-				ObjectID:   rt.Subject.ObjectId,
-				Relation:   rt.Subject.Relation,
+				ObjectType: rt.GetSubject().GetNamespace(),
+				ObjectID:   rt.GetSubject().GetObjectId(),
+				Relation:   rt.GetSubject().GetRelation(),
 			},
 		},
-		OptionalCaveat:     rt.Caveat,
+		OptionalCaveat:     rt.GetCaveat(),
 		OptionalExpiration: expiration,
 	}
 }
@@ -88,9 +88,9 @@ func FromCoreObjectAndRelation(oar *core.ObjectAndRelation) ObjectAndRelation {
 	}, "object and relation must be valid")
 
 	return ObjectAndRelation{
-		ObjectType: oar.Namespace,
-		ObjectID:   oar.ObjectId,
-		Relation:   oar.Relation,
+		ObjectType: oar.GetNamespace(),
+		ObjectID:   oar.GetObjectId(),
+		Relation:   oar.GetRelation(),
 	}
 }
 
@@ -126,7 +126,7 @@ func FromCoreRelationReference(rr *core.RelationReference) RelationReference {
 	}, "relation reference must be valid")
 
 	return RelationReference{
-		ObjectType: rr.Namespace,
-		Relation:   rr.Relation,
+		ObjectType: rr.GetNamespace(),
+		Relation:   rr.GetRelation(),
 	}
 }

--- a/pkg/tuple/hashing.go
+++ b/pkg/tuple/hashing.go
@@ -29,13 +29,13 @@ func CanonicalBytes(rel Relationship) ([]byte, error) {
 	sb.WriteString("#")
 	sb.WriteString(rel.Subject.Relation)
 
-	if rel.OptionalCaveat != nil && rel.OptionalCaveat.CaveatName != "" {
+	if rel.OptionalCaveat != nil && rel.OptionalCaveat.GetCaveatName() != "" {
 		sb.WriteString(" with ")
-		sb.WriteString(rel.OptionalCaveat.CaveatName)
+		sb.WriteString(rel.OptionalCaveat.GetCaveatName())
 
-		if rel.OptionalCaveat.Context != nil && len(rel.OptionalCaveat.Context.Fields) > 0 {
+		if rel.OptionalCaveat.GetContext() != nil && len(rel.OptionalCaveat.GetContext().GetFields()) > 0 {
 			sb.WriteString(":")
-			if err := writeCanonicalContext(&sb, rel.OptionalCaveat.Context); err != nil {
+			if err := writeCanonicalContext(&sb, rel.OptionalCaveat.GetContext()); err != nil {
 				return nil, err
 			}
 		}
@@ -52,13 +52,13 @@ func CanonicalBytes(rel Relationship) ([]byte, error) {
 
 func writeCanonicalContext(sb *bytes.Buffer, context *structpb.Struct) error {
 	sb.WriteString("{")
-	for i, key := range sortedContextKeys(context.Fields) {
+	for i, key := range sortedContextKeys(context.GetFields()) {
 		if i > 0 {
 			sb.WriteString(",")
 		}
 		sb.WriteString(key)
 		sb.WriteString(":")
-		if err := writeCanonicalContextValue(sb, context.Fields[key]); err != nil {
+		if err := writeCanonicalContextValue(sb, context.GetFields()[key]); err != nil {
 			return err
 		}
 	}
@@ -67,7 +67,7 @@ func writeCanonicalContext(sb *bytes.Buffer, context *structpb.Struct) error {
 }
 
 func writeCanonicalContextValue(sb *bytes.Buffer, value *structpb.Value) error {
-	switch value.Kind.(type) {
+	switch value.GetKind().(type) {
 	case *structpb.Value_NullValue:
 		sb.WriteString("null")
 	case *structpb.Value_NumberValue:
@@ -82,7 +82,7 @@ func writeCanonicalContextValue(sb *bytes.Buffer, value *structpb.Value) error {
 		}
 	case *structpb.Value_ListValue:
 		sb.WriteString("[")
-		for i, elem := range value.GetListValue().Values {
+		for i, elem := range value.GetListValue().GetValues() {
 			if i > 0 {
 				sb.WriteString(",")
 			}
@@ -92,7 +92,7 @@ func writeCanonicalContextValue(sb *bytes.Buffer, value *structpb.Value) error {
 		}
 		sb.WriteString("]")
 	default:
-		return spiceerrors.MustBugf("unknown structpb.Value type: %T", value.Kind)
+		return spiceerrors.MustBugf("unknown structpb.Value type: %T", value.GetKind())
 	}
 
 	return nil

--- a/pkg/tuple/parsing_test.go
+++ b/pkg/tuple/parsing_test.go
@@ -64,7 +64,7 @@ func cv1rel(resType, resID, relation, subType, subID, subRel, caveatName string,
 		panic(err)
 	}
 
-	if len(context.Fields) == 0 {
+	if len(context.GetFields()) == 0 {
 		context = nil
 	}
 
@@ -94,7 +94,7 @@ func ecv1rel(resType, resID, relation, subType, subID, subRel string, expiration
 		panic(err)
 	}
 
-	if len(context.Fields) == 0 {
+	if len(context.GetFields()) == 0 {
 		context = nil
 	}
 
@@ -678,8 +678,8 @@ func TestValidate(t *testing.T) {
 		t.Run("validate/"+tc.input, func(t *testing.T) {
 			parsed, err := ParseV1Rel(tc.input)
 			if err == nil {
-				require.NoError(t, ValidateResourceID(parsed.Resource.ObjectId))
-				require.NoError(t, ValidateSubjectID(parsed.Subject.Object.ObjectId))
+				require.NoError(t, ValidateResourceID(parsed.GetResource().GetObjectId()))
+				require.NoError(t, ValidateSubjectID(parsed.GetSubject().GetObject().GetObjectId()))
 			}
 		})
 	}

--- a/pkg/tuple/strings.go
+++ b/pkg/tuple/strings.go
@@ -44,7 +44,7 @@ func StringCoreRR(rr *core.RelationReference) string {
 		return ""
 	}
 
-	return JoinRelRef(rr.Namespace, rr.Relation)
+	return JoinRelRef(rr.GetNamespace(), rr.GetRelation())
 }
 
 // StringCoreONR converts a core ONR object to a string.
@@ -53,7 +53,7 @@ func StringCoreONR(onr *core.ObjectAndRelation) string {
 		return ""
 	}
 
-	return StringONRStrings(onr.Namespace, onr.ObjectId, onr.Relation)
+	return StringONRStrings(onr.GetNamespace(), onr.GetObjectId(), onr.GetRelation())
 }
 
 // StringONRStrings converts ONR strings to a string.
@@ -126,11 +126,11 @@ func MustStringCaveat(caveat *core.ContextualizedCaveat) string {
 
 // StringCaveat converts a contextualized caveat to a string. If the caveat is nil or empty, returns empty string.
 func StringCaveat(caveat *core.ContextualizedCaveat) (string, error) {
-	if caveat == nil || caveat.CaveatName == "" {
+	if caveat == nil || caveat.GetCaveatName() == "" {
 		return "", nil
 	}
 
-	contextString, err := StringCaveatContext(caveat.Context)
+	contextString, err := StringCaveatContext(caveat.GetContext())
 	if err != nil {
 		return "", err
 	}
@@ -139,12 +139,12 @@ func StringCaveat(caveat *core.ContextualizedCaveat) (string, error) {
 		contextString = ":" + contextString
 	}
 
-	return "[" + caveat.CaveatName + contextString + "]", nil
+	return "[" + caveat.GetCaveatName() + contextString + "]", nil
 }
 
 // StringCaveatContext converts the context of a caveat to a string. If the context is nil or empty, returns an empty string.
 func StringCaveatContext(context *structpb.Struct) (string, error) {
-	if context == nil || len(context.Fields) == 0 {
+	if context == nil || len(context.GetFields()) == 0 {
 		return "", nil
 	}
 

--- a/pkg/tuple/v1_test.go
+++ b/pkg/tuple/v1_test.go
@@ -30,7 +30,7 @@ func TestStringObjectRef(t *testing.T) {
 	}
 	for _, tt := range table {
 		require.Equal(t, tt.expected, V1StringObjectRef(tt.ref))
-		require.Equal(t, tt.expected, V1StringSubjectRef(subRef(tt.ref.ObjectType, tt.ref.ObjectId, "")))
+		require.Equal(t, tt.expected, V1StringSubjectRef(subRef(tt.ref.GetObjectType(), tt.ref.GetObjectId(), "")))
 	}
 }
 

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -191,7 +191,7 @@ func PopulateFromFilesContents(ctx context.Context, ds datastore.Datastore, cave
 			}
 
 			if err := rwt.WriteNamespaces(ctx, objectDef); err != nil {
-				return fmt.Errorf("error when loading object definition %s: %w", objectDef.Name, err)
+				return fmt.Errorf("error when loading object definition %s: %w", objectDef.GetName(), err)
 			}
 		}
 


### PR DESCRIPTION
Fixes #2633 
Part of #2579 

## Description
If you have a deeply nested proto object, calling `a.GetSet().GetOf().GetGetters()` is safer than referencing `some.Chain.Of.Properties`, because the first will return `nil` if there's a nil in the chain, where the second will panic. `protogetter` lints for this and should help address #2579.

## Changes
* Add protogetter linter
* Run fixes
## Testing
Review. See that tests pass.