### PR TITLE
test: refactor GC and GC tests to be more reliable using synctest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/bits-and-blooms/bloom/v3 v3.7.1
 	github.com/caio/go-tdigest/v4 v4.1.0
 	github.com/ccoveille/go-safecast/v2 v2.0.0
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cloudspannerecosystem/spanner-change-streams-tail v0.3.1
 	github.com/creasty/defaults v1.8.0
@@ -213,6 +213,7 @@ require (
 	github.com/butuzov/mirror v1.3.0 // indirect
 	github.com/catenacyber/perfsprint v0.10.0 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.4 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/charithe/durationcheck v0.0.11 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect

--- a/go.sum
+++ b/go.sum
@@ -803,6 +803,8 @@ github.com/ccoveille/go-safecast/v2 v2.0.0 h1:+5eyITXAUj3wMjad6cRVJKGnC7vDS55zk0
 github.com/ccoveille/go-safecast/v2 v2.0.0/go.mod h1:JIYA4CAR33blIDuE6fSwCp2sz1oOBahXnvmdBhOAABs=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=

--- a/internal/services/health/health.go
+++ b/internal/services/health/health.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/authzed/grpcutil"
@@ -64,7 +64,6 @@ func (hm *healthManager) Checker(ctx context.Context) func() error {
 	return func() error {
 		// Run immediately for the initial check
 		backoffInterval := backoff.NewExponentialBackOff()
-		backoffInterval.MaxElapsedTime = 0
 
 		ticker := time.After(0)
 

--- a/internal/telemetry/reporter.go
+++ b/internal/telemetry/reporter.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	prompb "buf.build/gen/go/prometheus/prometheus/protocolbuffers/go"
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
@@ -176,7 +176,6 @@ func RemoteReporter(
 		backoffInterval := backoff.NewExponentialBackOff()
 		backoffInterval.InitialInterval = interval
 		backoffInterval.MaxInterval = MaxElapsedTimeBetweenReports
-		backoffInterval.MaxElapsedTime = 0
 
 		// Must reset the backoff object after changing parameters
 		backoffInterval.Reset()

--- a/pkg/cmd/datastore_test.go
+++ b/pkg/cmd/datastore_test.go
@@ -36,7 +36,7 @@ func TestExecuteGC(t *testing.T) {
 			t.Parallel()
 
 			cfg := tt.cfgBuilder(t)
-			err := executeGC(cfg)
+			err := executeGC(t.Context(), cfg)
 			require.ErrorContains(t, err, tt.expectedError)
 		})
 	}

--- a/pkg/datastore/test/revisions.go
+++ b/pkg/datastore/test/revisions.go
@@ -20,6 +20,7 @@ import (
 
 // RevisionQuantizationTest tests whether or not the requirements for revisions hold
 // for a particular datastore.
+// TODO: rewrite using synctest
 func RevisionQuantizationTest(t *testing.T, tester DatastoreTester) {
 	testCases := []struct {
 		quantizationRange        time.Duration
@@ -95,6 +96,7 @@ func RevisionSerializationTest(t *testing.T, tester DatastoreTester) {
 
 // GCProcessRunTest tests whether the custom GC process runs for the datastore.
 // For datastores that do not have custom GC processes, will no-op.
+// TODO: rewrite using synctest
 func GCProcessRunTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 	gcWindow := 300 * time.Millisecond
@@ -139,6 +141,7 @@ func GCProcessRunTest(t *testing.T, tester DatastoreTester) {
 
 // RevisionGCTest makes sure revision GC takes place, revisions out-side of the GC window
 // are invalid, and revisions inside the GC window are valid.
+// TODO: rewrite using synctest if possible
 func RevisionGCTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 	gcWindow := 300 * time.Millisecond
@@ -179,7 +182,7 @@ func RevisionGCTest(t *testing.T, tester DatastoreTester) {
 	if ok {
 		// Run garbage collection.
 		gcable.ResetGCCompleted()
-		err := common.RunGarbageCollection(gcable, gcWindow, 10*time.Second)
+		err := common.RunGarbageCollection(ctx, gcable, gcWindow)
 		require.NoError(err)
 		require.True(gcable.HasGCRun(), "GC was never run as expected")
 	}


### PR DESCRIPTION
Parting out #2455

## Description
Part of getting the `testifyrequire` linter enabled.

## TODO
- [x] Address this comment: https://github.com/authzed/spicedb/pull/2455#discussion_r2303544841

## Changes
Will annotate.

## Testing
Review