### PR TITLE
fix: fix riscv nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,7 +3,7 @@ name: "Devel (nightly) Release"
 on: # yamllint disable-line rule:truthy
   push:
     branches:
-      - "main"
+      - "*"
 permissions:
   contents: "read"
 jobs:

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 ---
 version: 2
 builds:
@@ -133,7 +134,7 @@ kos:
       - "quay.io/authzed/spicedb-git"
       - "ghcr.io/authzed/spicedb-git"
       - "authzed/spicedb-git"
-    base_image: "docker.io/busybox"
+    base_image: "riscv64/busybox"
     platforms:
       - "linux/riscv64"
     tags:

--- a/.goreleaser.windows.yml
+++ b/.goreleaser.windows.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 ---
 version: 2
 git:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 ---
 version: 2
 git:


### PR DESCRIPTION
Followon to #2601 

## Description
We added support for riscv in #2601, but it broke nightly builds. I found a place where the values meaningfully differed; I also added the correct schema for a yaml LSP to each of the files.

## Changes
* Fix `base_image` key
* Add schema to all files
## Testing
Review. Merge and then check nightly builds.