### PR TITLE
ci: revert #2601

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 ---
 version: 2
 builds:

--- a/.goreleaser.windows.yml
+++ b/.goreleaser.windows.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 ---
 version: 2
 git:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 ---
 version: 2
 git:
@@ -181,25 +181,19 @@ docker_manifests:
 
   # Quay (debug)
   - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
-    image_templates:
-      [*amd_debug_image_quay, *arm_debug_image_quay]
+    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
   - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
-    image_templates:
-      [*amd_debug_image_quay, *arm_debug_image_quay]
+    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
   # GitHub Registry
   - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
-    image_templates:
-      [*amd_debug_image_gh, *arm_debug_image_gh]
+    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
   - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
-    image_templates:
-      [*amd_debug_image_gh, *arm_debug_image_gh]
+    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
   # Docker Hub
   - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
-    image_templates:
-      [*amd_debug_image_dh, *arm_debug_image_dh]
+    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
   - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
-    image_templates:
-      [*amd_debug_image_dh, *arm_debug_image_dh]
+    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
## Description
When I went to debug why nightly builds were failing (https://github.com/authzed/spicedb/pull/2601#issuecomment-3422773103), I realized that `docker.io/busybox` doesn't have a `riscv64` image, and there aren't chainguard static images for `riscv64` either. There is a `riscv64/busybox` image, but I don't know that I want to use that as the primary image for SpiceDB, since we use the chainguard images for security reasons.

I'll reopen the associated issue. We also might be able to introduce a debug image with `riscv64/busybox` in the meantime; it'll be more clear to prospective users that it's in an experimental state and they can use it at their own risk.

## Changes
* Revert #2601 
* Add the correct schemas to the goreleaser files
## Testing
Review.