### PR TITLE
feat: Add a builder pattern to the schema v2 library and fix how caveats are converted

### DIFF
--- a/pkg/schema/v2/builder.go
+++ b/pkg/schema/v2/builder.go
@@ -1,0 +1,709 @@
+package schema
+
+import "github.com/authzed/spicedb/pkg/tuple"
+
+// Common caveat parameter type constants for use with CaveatBuilder.
+const (
+	CaveatTypeInt        = "int"
+	CaveatTypeBool       = "bool"
+	CaveatTypeString     = "string"
+	CaveatTypeBytes      = "bytes"
+	CaveatTypeDouble     = "double"
+	CaveatTypeUInt       = "uint"
+	CaveatTypeDuration   = "duration"
+	CaveatTypeTimestamp  = "timestamp"
+	CaveatTypeIPAddress  = "ipaddress"
+	CaveatTypeList       = "list"
+	CaveatTypeMap        = "map"
+	CaveatTypeAny        = "any"
+	CaveatTypeListString = "list<string>"
+	CaveatTypeListInt    = "list<int>"
+	CaveatTypeMapAny     = "map<any>"
+)
+
+// SchemaBuilder provides a fluent API for constructing schemas programmatically.
+// It maintains parent-child relationships automatically and provides method chaining.
+//
+// Example usage:
+//
+//	schema := NewSchemaBuilder().
+//		AddDefinition("user").
+//			Done().
+//		AddDefinition("document").
+//			AddRelation("owner").
+//				AllowedDirectRelation("user").
+//				Done().
+//			AddRelation("viewer").
+//				AllowedDirectRelation("user").
+//				AllowedRelation("group", "member").
+//				Done().
+//			AddPermission("view").
+//				UnionExpr().
+//					Add(RelRef("owner")).
+//					Add(RelRef("viewer")).
+//					Done().
+//				Done().
+//			Done().
+//		AddCaveat("has_access").
+//			Expression("resource == 42").
+//			Parameter("resource", CaveatTypeInt).
+//			Done().
+//		Build()
+type SchemaBuilder struct {
+	schema *Schema
+}
+
+// NewSchemaBuilder creates a new builder for constructing schemas.
+func NewSchemaBuilder() *SchemaBuilder {
+	return &SchemaBuilder{
+		schema: &Schema{
+			definitions: make(map[string]*Definition),
+			caveats:     make(map[string]*Caveat),
+		},
+	}
+}
+
+// AddDefinition adds or modifies a definition in the schema by name.
+// Returns a DefinitionBuilder for fluent configuration.
+func (sb *SchemaBuilder) AddDefinition(name string) *DefinitionBuilder {
+	def, exists := sb.schema.definitions[name]
+	if !exists {
+		def = &Definition{
+			parent:      sb.schema,
+			name:        name,
+			relations:   make(map[string]*Relation),
+			permissions: make(map[string]*Permission),
+		}
+		sb.schema.definitions[name] = def
+	}
+	return &DefinitionBuilder{
+		schemaBuilder: sb,
+		definition:    def,
+	}
+}
+
+// Definition accepts a DefinitionBuilder and integrates it into the schema.
+// Returns the SchemaBuilder for continued chaining.
+func (sb *SchemaBuilder) Definition(db *DefinitionBuilder) *SchemaBuilder {
+	if db != nil && db.definition != nil {
+		// Update the parent reference
+		db.definition.parent = sb.schema
+		db.schemaBuilder = sb
+		// Add or update the definition in the schema
+		sb.schema.definitions[db.definition.name] = db.definition
+	}
+	return sb
+}
+
+// AddCaveat adds or modifies a caveat in the schema by name.
+// Returns a CaveatBuilder for fluent configuration.
+func (sb *SchemaBuilder) AddCaveat(name string) *CaveatBuilder {
+	caveat, exists := sb.schema.caveats[name]
+	if !exists {
+		caveat = &Caveat{
+			parent:     sb.schema,
+			name:       name,
+			parameters: []CaveatParameter{},
+		}
+		sb.schema.caveats[name] = caveat
+	}
+	return &CaveatBuilder{
+		schemaBuilder: sb,
+		caveat:        caveat,
+	}
+}
+
+// Caveat accepts a CaveatBuilder and integrates it into the schema.
+// Returns the SchemaBuilder for continued chaining.
+func (sb *SchemaBuilder) Caveat(cb *CaveatBuilder) *SchemaBuilder {
+	if cb != nil && cb.caveat != nil {
+		// Update the parent reference
+		cb.caveat.parent = sb.schema
+		cb.schemaBuilder = sb
+		// Add or update the caveat in the schema
+		sb.schema.caveats[cb.caveat.name] = cb.caveat
+	}
+	return sb
+}
+
+// Build finalizes and returns the constructed schema.
+func (sb *SchemaBuilder) Build() *Schema {
+	return sb.schema
+}
+
+// DefinitionBuilder provides a fluent API for constructing object definitions.
+type DefinitionBuilder struct {
+	schemaBuilder *SchemaBuilder
+	definition    *Definition
+}
+
+// AddRelation adds or modifies a relation in the definition by name.
+// Returns a RelationBuilder for fluent configuration.
+func (db *DefinitionBuilder) AddRelation(name string) *RelationBuilder {
+	relation, exists := db.definition.relations[name]
+	if !exists {
+		relation = &Relation{
+			parent:        db.definition,
+			name:          name,
+			baseRelations: []*BaseRelation{},
+		}
+		db.definition.relations[name] = relation
+	}
+	return &RelationBuilder{
+		definitionBuilder: db,
+		relation:          relation,
+	}
+}
+
+// Relation accepts a RelationBuilder and integrates it into the definition.
+// Returns the DefinitionBuilder for continued chaining.
+func (db *DefinitionBuilder) Relation(rb *RelationBuilder) *DefinitionBuilder {
+	if rb != nil && rb.relation != nil {
+		// Update the parent reference
+		rb.relation.parent = db.definition
+		rb.definitionBuilder = db
+		// Add or update the relation in the definition
+		db.definition.relations[rb.relation.name] = rb.relation
+	}
+	return db
+}
+
+// AddPermission adds or modifies a permission in the definition by name.
+// Returns a PermissionBuilder for fluent configuration.
+func (db *DefinitionBuilder) AddPermission(name string) *PermissionBuilder {
+	permission, exists := db.definition.permissions[name]
+	if !exists {
+		permission = &Permission{
+			parent:    db.definition,
+			name:      name,
+			synthetic: false,
+		}
+		db.definition.permissions[name] = permission
+	}
+	return &PermissionBuilder{
+		definitionBuilder: db,
+		permission:        permission,
+	}
+}
+
+// Permission accepts a PermissionBuilder and integrates it into the definition.
+// Returns the DefinitionBuilder for continued chaining.
+func (db *DefinitionBuilder) Permission(pb *PermissionBuilder) *DefinitionBuilder {
+	if pb != nil && pb.permission != nil {
+		// Update the parent reference
+		pb.permission.parent = db.definition
+		pb.definitionBuilder = db
+		// Add or update the permission in the definition
+		db.definition.permissions[pb.permission.name] = pb.permission
+	}
+	return db
+}
+
+// Done completes the definition and returns to the schema builder.
+func (db *DefinitionBuilder) Done() *SchemaBuilder {
+	return db.schemaBuilder
+}
+
+// RelationBuilder provides a fluent API for constructing relations.
+type RelationBuilder struct {
+	definitionBuilder *DefinitionBuilder
+	relation          *Relation
+}
+
+// AllowedDirectRelation adds a direct subject type to the relation.
+// This allows subjects of the specified type to be directly assigned to this relation.
+func (rb *RelationBuilder) AllowedDirectRelation(subjectType string) *RelationBuilder {
+	baseRel := &BaseRelation{
+		parent:      rb.relation,
+		subjectType: subjectType,
+		subrelation: tuple.Ellipsis,
+	}
+	rb.relation.baseRelations = append(rb.relation.baseRelations, baseRel)
+	return rb
+}
+
+// AllowedRelation adds a base relation (allowed subject type with subrelation) to the relation.
+// subrelation specifies a specific relation/permission on the subject type.
+func (rb *RelationBuilder) AllowedRelation(subjectType, subrelation string) *RelationBuilder {
+	baseRel := &BaseRelation{
+		parent:      rb.relation,
+		subjectType: subjectType,
+		subrelation: subrelation,
+	}
+	rb.relation.baseRelations = append(rb.relation.baseRelations, baseRel)
+	return rb
+}
+
+// AllowedDirectRelationWithCaveat adds a direct subject type with a caveat.
+func (rb *RelationBuilder) AllowedDirectRelationWithCaveat(subjectType, caveat string) *RelationBuilder {
+	baseRel := &BaseRelation{
+		parent:      rb.relation,
+		subjectType: subjectType,
+		subrelation: tuple.Ellipsis,
+		caveat:      caveat,
+	}
+	rb.relation.baseRelations = append(rb.relation.baseRelations, baseRel)
+	return rb
+}
+
+// AllowedRelationWithCaveat adds a base relation with a caveat.
+func (rb *RelationBuilder) AllowedRelationWithCaveat(subjectType, subrelation, caveat string) *RelationBuilder {
+	baseRel := &BaseRelation{
+		parent:      rb.relation,
+		subjectType: subjectType,
+		subrelation: subrelation,
+		caveat:      caveat,
+	}
+	rb.relation.baseRelations = append(rb.relation.baseRelations, baseRel)
+	return rb
+}
+
+// AllowedDirectRelationWithExpiration adds a direct subject type with expiration support.
+func (rb *RelationBuilder) AllowedDirectRelationWithExpiration(subjectType string) *RelationBuilder {
+	baseRel := &BaseRelation{
+		parent:      rb.relation,
+		subjectType: subjectType,
+		subrelation: tuple.Ellipsis,
+		expiration:  true,
+	}
+	rb.relation.baseRelations = append(rb.relation.baseRelations, baseRel)
+	return rb
+}
+
+// AllowedRelationWithExpiration adds a base relation with expiration support.
+func (rb *RelationBuilder) AllowedRelationWithExpiration(subjectType, subrelation string) *RelationBuilder {
+	baseRel := &BaseRelation{
+		parent:      rb.relation,
+		subjectType: subjectType,
+		subrelation: subrelation,
+		expiration:  true,
+	}
+	rb.relation.baseRelations = append(rb.relation.baseRelations, baseRel)
+	return rb
+}
+
+// AllowedDirectRelationWithFeatures adds a direct subject type with full feature control.
+func (rb *RelationBuilder) AllowedDirectRelationWithFeatures(subjectType, caveat string, expiration bool) *RelationBuilder {
+	baseRel := &BaseRelation{
+		parent:      rb.relation,
+		subjectType: subjectType,
+		subrelation: tuple.Ellipsis,
+		caveat:      caveat,
+		expiration:  expiration,
+	}
+	rb.relation.baseRelations = append(rb.relation.baseRelations, baseRel)
+	return rb
+}
+
+// AllowedRelationWithFeatures adds a base relation with full feature control.
+func (rb *RelationBuilder) AllowedRelationWithFeatures(subjectType, subrelation, caveat string, expiration bool) *RelationBuilder {
+	baseRel := &BaseRelation{
+		parent:      rb.relation,
+		subjectType: subjectType,
+		subrelation: subrelation,
+		caveat:      caveat,
+		expiration:  expiration,
+	}
+	rb.relation.baseRelations = append(rb.relation.baseRelations, baseRel)
+	return rb
+}
+
+// AllowedWildcard adds a wildcard base relation.
+func (rb *RelationBuilder) AllowedWildcard(subjectType string) *RelationBuilder {
+	baseRel := &BaseRelation{
+		parent:      rb.relation,
+		subjectType: subjectType,
+		wildcard:    true,
+	}
+	rb.relation.baseRelations = append(rb.relation.baseRelations, baseRel)
+	return rb
+}
+
+// AllowedWildcardWithCaveat adds a wildcard base relation with a caveat.
+func (rb *RelationBuilder) AllowedWildcardWithCaveat(subjectType, caveat string) *RelationBuilder {
+	baseRel := &BaseRelation{
+		parent:      rb.relation,
+		subjectType: subjectType,
+		wildcard:    true,
+		caveat:      caveat,
+	}
+	rb.relation.baseRelations = append(rb.relation.baseRelations, baseRel)
+	return rb
+}
+
+// Alias sets this relation as an alias to another relation.
+func (rb *RelationBuilder) Alias(aliasingRelation string) *RelationBuilder {
+	rb.relation.aliasingRelation = aliasingRelation
+	return rb
+}
+
+// Done completes the relation and returns to the definition builder.
+func (rb *RelationBuilder) Done() *DefinitionBuilder {
+	return rb.definitionBuilder
+}
+
+// PermissionBuilder provides a fluent API for constructing permissions.
+type PermissionBuilder struct {
+	definitionBuilder *DefinitionBuilder
+	permission        *Permission
+}
+
+// Operation sets the permission's operation directly.
+func (pb *PermissionBuilder) Operation(op Operation) *PermissionBuilder {
+	pb.permission.operation = op
+	return pb
+}
+
+// RelationRef creates a simple relation reference operation (e.g., "viewer").
+func (pb *PermissionBuilder) RelationRef(relationName string) *PermissionBuilder {
+	pb.permission.operation = &RelationReference{
+		relationName: relationName,
+	}
+	return pb
+}
+
+// Arrow creates an arrow reference operation (e.g., "owner->edit").
+func (pb *PermissionBuilder) Arrow(relationName, permissionName string) *PermissionBuilder {
+	pb.permission.operation = &ArrowReference{
+		left:  relationName,
+		right: permissionName,
+	}
+	return pb
+}
+
+// IntersectionArrow creates an intersection arrow operation (e.g., "relation.all(permission)").
+func (pb *PermissionBuilder) IntersectionArrow(relation string, computedRelationName string) *PermissionBuilder {
+	pb.permission.operation = &FunctionedArrowReference{
+		left:     relation,
+		right:    computedRelationName,
+		function: FunctionTypeAll,
+	}
+	return pb
+}
+
+// Union creates a union (OR) operation from multiple operations.
+func (pb *PermissionBuilder) Union(operations ...Operation) *PermissionBuilder {
+	pb.permission.operation = &UnionOperation{
+		children: operations,
+	}
+	return pb
+}
+
+// UnionExpr starts building a union expression incrementally.
+func (pb *PermissionBuilder) UnionExpr() *UnionExprBuilder {
+	return &UnionExprBuilder{
+		permissionBuilder: pb,
+		children:          []Operation{},
+	}
+}
+
+// Intersection creates an intersection (AND) operation from multiple operations.
+func (pb *PermissionBuilder) Intersection(operations ...Operation) *PermissionBuilder {
+	pb.permission.operation = &IntersectionOperation{
+		children: operations,
+	}
+	return pb
+}
+
+// IntersectionExpr starts building an intersection expression incrementally.
+func (pb *PermissionBuilder) IntersectionExpr() *IntersectionExprBuilder {
+	return &IntersectionExprBuilder{
+		permissionBuilder: pb,
+		children:          []Operation{},
+	}
+}
+
+// Exclusion creates an exclusion (subtraction) operation.
+func (pb *PermissionBuilder) Exclusion(base, excluded Operation) *PermissionBuilder {
+	pb.permission.operation = &ExclusionOperation{
+		left:  base,
+		right: excluded,
+	}
+	return pb
+}
+
+// ExclusionExpr starts building an exclusion expression incrementally.
+func (pb *PermissionBuilder) ExclusionExpr() *ExclusionExprBuilder {
+	return &ExclusionExprBuilder{
+		permissionBuilder: pb,
+	}
+}
+
+// Done completes the permission and returns to the definition builder.
+func (pb *PermissionBuilder) Done() *DefinitionBuilder {
+	return pb.definitionBuilder
+}
+
+// UnionExprBuilder allows building union operations incrementally.
+type UnionExprBuilder struct {
+	permissionBuilder *PermissionBuilder
+	children          []Operation
+}
+
+// Add adds an operation to the union.
+func (ub *UnionExprBuilder) Add(op Operation) *UnionExprBuilder {
+	ub.children = append(ub.children, op)
+	return ub
+}
+
+// AddRelationRef adds a relation reference to the union.
+func (ub *UnionExprBuilder) AddRelationRef(relationName string) *UnionExprBuilder {
+	ub.children = append(ub.children, &RelationReference{
+		relationName: relationName,
+	})
+	return ub
+}
+
+// AddArrow adds an arrow reference to the union.
+func (ub *UnionExprBuilder) AddArrow(relationName, permissionName string) *UnionExprBuilder {
+	ub.children = append(ub.children, &ArrowReference{
+		left:  relationName,
+		right: permissionName,
+	})
+	return ub
+}
+
+// Done completes the union expression and returns to the permission builder.
+func (ub *UnionExprBuilder) Done() *PermissionBuilder {
+	ub.permissionBuilder.permission.operation = &UnionOperation{
+		children: ub.children,
+	}
+	return ub.permissionBuilder
+}
+
+// IntersectionExprBuilder allows building intersection operations incrementally.
+type IntersectionExprBuilder struct {
+	permissionBuilder *PermissionBuilder
+	children          []Operation
+}
+
+// Add adds an operation to the intersection.
+func (ib *IntersectionExprBuilder) Add(op Operation) *IntersectionExprBuilder {
+	ib.children = append(ib.children, op)
+	return ib
+}
+
+// AddRelationRef adds a relation reference to the intersection.
+func (ib *IntersectionExprBuilder) AddRelationRef(relationName string) *IntersectionExprBuilder {
+	ib.children = append(ib.children, &RelationReference{
+		relationName: relationName,
+	})
+	return ib
+}
+
+// AddArrow adds an arrow reference to the intersection.
+func (ib *IntersectionExprBuilder) AddArrow(relationName, permissionName string) *IntersectionExprBuilder {
+	ib.children = append(ib.children, &ArrowReference{
+		left:  relationName,
+		right: permissionName,
+	})
+	return ib
+}
+
+// Done completes the intersection expression and returns to the permission builder.
+func (ib *IntersectionExprBuilder) Done() *PermissionBuilder {
+	ib.permissionBuilder.permission.operation = &IntersectionOperation{
+		children: ib.children,
+	}
+	return ib.permissionBuilder
+}
+
+// ExclusionExprBuilder allows building exclusion operations incrementally.
+type ExclusionExprBuilder struct {
+	permissionBuilder *PermissionBuilder
+	base              Operation
+	excluded          Operation
+}
+
+// Base sets the base operation for the exclusion.
+func (eb *ExclusionExprBuilder) Base(op Operation) *ExclusionExprBuilder {
+	eb.base = op
+	return eb
+}
+
+// BaseRelationRef sets the base as a relation reference.
+func (eb *ExclusionExprBuilder) BaseRelationRef(relationName string) *ExclusionExprBuilder {
+	eb.base = &RelationReference{
+		relationName: relationName,
+	}
+	return eb
+}
+
+// BaseArrow sets the base as an arrow reference.
+func (eb *ExclusionExprBuilder) BaseArrow(relationName, permissionName string) *ExclusionExprBuilder {
+	eb.base = &ArrowReference{
+		left:  relationName,
+		right: permissionName,
+	}
+	return eb
+}
+
+// Exclude sets the operation to exclude from the base.
+func (eb *ExclusionExprBuilder) Exclude(op Operation) *ExclusionExprBuilder {
+	eb.excluded = op
+	return eb
+}
+
+// ExcludeRelationRef sets the excluded operation as a relation reference.
+func (eb *ExclusionExprBuilder) ExcludeRelationRef(relationName string) *ExclusionExprBuilder {
+	eb.excluded = &RelationReference{
+		relationName: relationName,
+	}
+	return eb
+}
+
+// ExcludeArrow sets the excluded operation as an arrow reference.
+func (eb *ExclusionExprBuilder) ExcludeArrow(relationName, permissionName string) *ExclusionExprBuilder {
+	eb.excluded = &ArrowReference{
+		left:  relationName,
+		right: permissionName,
+	}
+	return eb
+}
+
+// Done completes the exclusion expression and returns to the permission builder.
+func (eb *ExclusionExprBuilder) Done() *PermissionBuilder {
+	eb.permissionBuilder.permission.operation = &ExclusionOperation{
+		left:  eb.base,
+		right: eb.excluded,
+	}
+	return eb.permissionBuilder
+}
+
+// CaveatBuilder provides a fluent API for constructing caveats.
+type CaveatBuilder struct {
+	schemaBuilder *SchemaBuilder
+	caveat        *Caveat
+}
+
+// Expression sets the caveat's expression.
+func (cb *CaveatBuilder) Expression(expr string) *CaveatBuilder {
+	cb.caveat.expression = expr
+	return cb
+}
+
+// Parameter adds a parameter with name and type to the caveat.
+func (cb *CaveatBuilder) Parameter(paramName, paramType string) *CaveatBuilder {
+	cb.caveat.parameters = append(cb.caveat.parameters, CaveatParameter{
+		name: paramName,
+		typ:  paramType,
+	})
+	return cb
+}
+
+// ParameterMap adds multiple parameters from a map of name to type.
+// This is useful when you have many parameters to add at once.
+func (cb *CaveatBuilder) ParameterMap(params map[string]string) *CaveatBuilder {
+	for name, typ := range params {
+		cb.caveat.parameters = append(cb.caveat.parameters, CaveatParameter{
+			name: name,
+			typ:  typ,
+		})
+	}
+	return cb
+}
+
+// Done completes the caveat and returns to the schema builder.
+func (cb *CaveatBuilder) Done() *SchemaBuilder {
+	return cb.schemaBuilder
+}
+
+// Helper functions for creating operations inline
+
+// RelRef creates a RelationReference operation for use in permission builders.
+func RelRef(relationName string) Operation {
+	return &RelationReference{
+		relationName: relationName,
+	}
+}
+
+// ArrowRef creates an ArrowReference operation for use in permission builders.
+func ArrowRef(relationName, permissionName string) Operation {
+	return &ArrowReference{
+		left:  relationName,
+		right: permissionName,
+	}
+}
+
+// IntersectionArrowRef creates an intersection arrow operation for use in permission builders.
+func IntersectionArrowRef(relation string, computedRelationName string) Operation {
+	return &FunctionedArrowReference{
+		left:     relation,
+		right:    computedRelationName,
+		function: FunctionTypeAll,
+	}
+}
+
+// Union creates a UnionOperation for use in permission builders.
+func Union(operations ...Operation) Operation {
+	return &UnionOperation{
+		children: operations,
+	}
+}
+
+// Intersection creates an IntersectionOperation for use in permission builders.
+func Intersection(operations ...Operation) Operation {
+	return &IntersectionOperation{
+		children: operations,
+	}
+}
+
+// Exclusion creates an ExclusionOperation for use in permission builders.
+func Exclusion(base, excluded Operation) Operation {
+	return &ExclusionOperation{
+		left:  base,
+		right: excluded,
+	}
+}
+
+// Standalone constructor functions for building schema elements
+
+// NewDefinition creates a new DefinitionBuilder for constructing a definition.
+// This is used with SchemaBuilder.Definition() to add definitions using the builder pattern.
+func NewDefinition(name string) *DefinitionBuilder {
+	def := &Definition{
+		name:        name,
+		relations:   make(map[string]*Relation),
+		permissions: make(map[string]*Permission),
+	}
+	return &DefinitionBuilder{
+		definition: def,
+	}
+}
+
+// NewRelation creates a new RelationBuilder for constructing a relation.
+// This is used with DefinitionBuilder.Relation() to add relations using the builder pattern.
+func NewRelation(name string) *RelationBuilder {
+	rel := &Relation{
+		name:          name,
+		baseRelations: []*BaseRelation{},
+	}
+	return &RelationBuilder{
+		relation: rel,
+	}
+}
+
+// NewPermission creates a new PermissionBuilder for constructing a permission with an operation.
+// This is used with DefinitionBuilder.Permission() to add permissions using the builder pattern.
+func NewPermission(name string, operation Operation) *PermissionBuilder {
+	perm := &Permission{
+		name:      name,
+		operation: operation,
+		synthetic: false,
+	}
+	return &PermissionBuilder{
+		permission: perm,
+	}
+}
+
+// NewCaveat creates a new CaveatBuilder for constructing a caveat.
+// This is used with SchemaBuilder.Caveat() to add caveats using the builder pattern.
+func NewCaveat(name string) *CaveatBuilder {
+	cav := &Caveat{
+		name:       name,
+		parameters: []CaveatParameter{},
+	}
+	return &CaveatBuilder{
+		caveat: cav,
+	}
+}

--- a/pkg/schema/v2/builder_example_test.go
+++ b/pkg/schema/v2/builder_example_test.go
@@ -1,0 +1,503 @@
+package schema_test
+
+import (
+	"fmt"
+	"strings"
+
+	schema "github.com/authzed/spicedb/pkg/schema/v2"
+	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
+	"github.com/authzed/spicedb/pkg/schemadsl/generator"
+)
+
+func toSchemaDefinitions[T compiler.SchemaDefinition](items []T) []compiler.SchemaDefinition {
+	result := make([]compiler.SchemaDefinition, len(items))
+	for i, item := range items {
+		result[i] = item
+	}
+	return result
+}
+
+// ExampleSchemaBuilder demonstrates basic schema creation using the builder pattern.
+func ExampleSchemaBuilder() {
+	s := schema.NewSchemaBuilder().
+		AddDefinition("user").
+		Done().
+		AddDefinition("document").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		Union(
+			schema.RelRef("owner"),
+			schema.RelRef("viewer"),
+		).
+		Done().
+		Done().
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_incrementalUnion demonstrates building a union permission incrementally.
+func ExampleSchemaBuilder_incrementalUnion() {
+	s := schema.NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("editor").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		UnionExpr().
+		AddRelationRef("owner").
+		AddRelationRef("editor").
+		AddRelationRef("viewer").
+		Done().
+		Done().
+		Done().
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_withArrow demonstrates using arrow references for hierarchical permissions.
+func ExampleSchemaBuilder_withArrow() {
+	s := schema.NewSchemaBuilder().
+		AddDefinition("folder").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		RelationRef("owner").
+		Done().
+		Done().
+		AddDefinition("document").
+		AddRelation("parent").
+		AllowedDirectRelation("folder").
+		Done().
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		UnionExpr().
+		AddRelationRef("owner").
+		AddArrow("parent", "view").
+		Done().
+		Done().
+		Done().
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_withCaveat demonstrates using caveats with relations.
+func ExampleSchemaBuilder_withCaveat() {
+	s := schema.NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("conditional_viewer").
+		AllowedDirectRelationWithCaveat("user", "valid_ip").
+		Done().
+		Done().
+		AddCaveat("valid_ip").
+		Expression("request.ip_address in allowed_ranges").
+		Parameter("allowed_ranges", "list<string>").
+		Parameter("request", "map<any>").
+		Done().
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_withCaveatTypes demonstrates using type constants and ParameterMap for caveats.
+func ExampleSchemaBuilder_withCaveatTypes() {
+	s := schema.NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("viewer").
+		AllowedDirectRelationWithCaveat("user", "ip_and_time_check").
+		Done().
+		Done().
+		AddCaveat("ip_and_time_check").
+		Expression("request.ip in allowed_ips && current_time < expiration").
+		Parameter("allowed_ips", schema.CaveatTypeListString).
+		Parameter("expiration", schema.CaveatTypeTimestamp).
+		Parameter("current_time", schema.CaveatTypeTimestamp).
+		Done().
+		AddCaveat("role_check").
+		Expression("user_roles.contains(required_role) && is_active").
+		ParameterMap(map[string]string{
+			"user_roles":    schema.CaveatTypeListString,
+			"required_role": schema.CaveatTypeString,
+			"is_active":     schema.CaveatTypeBool,
+		}).
+		Done().
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_withExclusion demonstrates using exclusion (subtraction) in permissions.
+func ExampleSchemaBuilder_withExclusion() {
+	s := schema.NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("banned").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		ExclusionExpr().
+		BaseRelationRef("viewer").
+		ExcludeRelationRef("banned").
+		Done().
+		Done().
+		Done().
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_withIntersection demonstrates using intersection (AND) in permissions.
+func ExampleSchemaBuilder_withIntersection() {
+	s := schema.NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("approved").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("admin_edit").
+		IntersectionExpr().
+		AddRelationRef("owner").
+		AddRelationRef("approved").
+		Done().
+		Done().
+		Done().
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_withWildcard demonstrates using wildcard relations.
+func ExampleSchemaBuilder_withWildcard() {
+	s := schema.NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("public_viewer").
+		AllowedWildcard("user").
+		Done().
+		Done().
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_complex demonstrates a complex schema with multiple features.
+func ExampleSchemaBuilder_complex() {
+	s := schema.NewSchemaBuilder().
+		AddDefinition("user").
+		Done().
+		AddDefinition("group").
+		AddRelation("member").
+		AllowedDirectRelation("user").
+		AllowedRelation("group", "member").
+		Done().
+		Done().
+		AddDefinition("folder").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		AllowedRelation("group", "member").
+		Done().
+		AddPermission("view").
+		UnionExpr().
+		AddRelationRef("owner").
+		AddRelationRef("viewer").
+		Done().
+		Done().
+		AddPermission("edit").
+		RelationRef("owner").
+		Done().
+		Done().
+		AddDefinition("document").
+		AddRelation("parent").
+		AllowedDirectRelation("folder").
+		Done().
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		AllowedRelation("group", "member").
+		Done().
+		AddRelation("banned").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		ExclusionExpr().
+		Base(
+			schema.Union(
+				schema.RelRef("owner"),
+				schema.RelRef("viewer"),
+				schema.ArrowRef("parent", "view"),
+			),
+		).
+		ExcludeRelationRef("banned").
+		Done().
+		Done().
+		AddPermission("edit").
+		IntersectionExpr().
+		AddRelationRef("owner").
+		AddArrow("parent", "edit").
+		Done().
+		Done().
+		Done().
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_constructorPattern demonstrates the new constructor-based builder pattern.
+func ExampleSchemaBuilder_constructorPattern() {
+	s := schema.NewSchemaBuilder().
+		Definition(
+			schema.NewDefinition("user"),
+		).
+		Definition(
+			schema.NewDefinition("document").
+				Relation(schema.NewRelation("owner").AllowedDirectRelation("user")).
+				Relation(schema.NewRelation("editor").AllowedDirectRelation("user")).
+				Relation(schema.NewRelation("viewer").AllowedDirectRelation("user")).
+				Permission(
+					schema.NewPermission("view", schema.Union(
+						schema.RelRef("owner"),
+						schema.RelRef("editor"),
+						schema.RelRef("viewer"),
+					)),
+				),
+		).
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_constructorWithIntersection demonstrates using intersection with the constructor pattern.
+func ExampleSchemaBuilder_constructorWithIntersection() {
+	s := schema.NewSchemaBuilder().
+		Definition(
+			schema.NewDefinition("document").
+				Relation(schema.NewRelation("owner").AllowedDirectRelation("user")).
+				Relation(schema.NewRelation("approved").AllowedDirectRelation("user")).
+				Permission(
+					schema.NewPermission("admin_edit", schema.Intersection(
+						schema.RelRef("owner"),
+						schema.RelRef("approved"),
+					)),
+				),
+		).
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_constructorWithExclusion demonstrates using exclusion (subtraction) with the constructor pattern.
+func ExampleSchemaBuilder_constructorWithExclusion() {
+	s := schema.NewSchemaBuilder().
+		Definition(
+			schema.NewDefinition("document").
+				Relation(schema.NewRelation("viewer").AllowedDirectRelation("user")).
+				Relation(schema.NewRelation("banned").AllowedDirectRelation("user")).
+				Permission(
+					schema.NewPermission("view", schema.Exclusion(
+						schema.RelRef("viewer"),
+						schema.RelRef("banned"),
+					)),
+				),
+		).
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_constructorWithArrow demonstrates using arrow references for hierarchical permissions.
+func ExampleSchemaBuilder_constructorWithArrow() {
+	s := schema.NewSchemaBuilder().
+		Definition(
+			schema.NewDefinition("folder").
+				Relation(schema.NewRelation("owner").AllowedDirectRelation("user")).
+				Permission(schema.NewPermission("view", schema.RelRef("owner"))),
+		).
+		Definition(
+			schema.NewDefinition("document").
+				Relation(schema.NewRelation("parent").AllowedDirectRelation("folder")).
+				Relation(schema.NewRelation("owner").AllowedDirectRelation("user")).
+				Permission(
+					schema.NewPermission("view", schema.Union(
+						schema.RelRef("owner"),
+						schema.ArrowRef("parent", "view"),
+					)),
+				),
+		).
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_constructorWithIntersectionArrow demonstrates using intersection arrow (all) operations.
+func ExampleSchemaBuilder_constructorWithIntersectionArrow() {
+	s := schema.NewSchemaBuilder().
+		Definition(
+			schema.NewDefinition("folder").
+				Relation(schema.NewRelation("viewer").AllowedDirectRelation("user")),
+		).
+		Definition(
+			schema.NewDefinition("document").
+				Relation(schema.NewRelation("parent").AllowedDirectRelation("folder")).
+				Permission(
+					schema.NewPermission("all_parents_can_view", schema.IntersectionArrowRef("parent", "viewer")),
+				),
+		).
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_constructorWithCaveat demonstrates using caveats with the constructor pattern.
+func ExampleSchemaBuilder_constructorWithCaveat() {
+	s := schema.NewSchemaBuilder().
+		Definition(
+			schema.NewDefinition("document").
+				Relation(
+					schema.NewRelation("conditional_viewer").
+						AllowedDirectRelationWithCaveat("user", "valid_ip"),
+				),
+		).
+		Caveat(
+			schema.NewCaveat("valid_ip").
+				Expression("request.ip_address in allowed_ranges").
+				Parameter("allowed_ranges", schema.CaveatTypeListString).
+				Parameter("request", schema.CaveatTypeMapAny),
+		).
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_constructorComplexNested demonstrates complex nested operations with the constructor pattern.
+func ExampleSchemaBuilder_constructorComplexNested() {
+	s := schema.NewSchemaBuilder().
+		Definition(schema.NewDefinition("user")).
+		Definition(
+			schema.NewDefinition("group").
+				Relation(schema.NewRelation("member").AllowedDirectRelation("user")),
+		).
+		Definition(
+			schema.NewDefinition("folder").
+				Relation(schema.NewRelation("owner").AllowedDirectRelation("user")).
+				Relation(
+					schema.NewRelation("viewer").
+						AllowedDirectRelation("user").
+						AllowedRelation("group", "member"),
+				).
+				Permission(
+					schema.NewPermission("view", schema.Union(
+						schema.RelRef("owner"),
+						schema.RelRef("viewer"),
+					)),
+				),
+		).
+		Definition(
+			schema.NewDefinition("document").
+				Relation(schema.NewRelation("parent").AllowedDirectRelation("folder")).
+				Relation(schema.NewRelation("owner").AllowedDirectRelation("user")).
+				Relation(schema.NewRelation("banned").AllowedDirectRelation("user")).
+				Permission(
+					schema.NewPermission("view", schema.Exclusion(
+						schema.Union(
+							schema.RelRef("owner"),
+							schema.ArrowRef("parent", "view"),
+						),
+						schema.RelRef("banned"),
+					)),
+				).
+				Permission(
+					schema.NewPermission("edit", schema.Intersection(
+						schema.Union(
+							schema.RelRef("owner"),
+							schema.ArrowRef("parent", "view"),
+						),
+						schema.Exclusion(
+							schema.RelRef("owner"),
+							schema.RelRef("banned"),
+						),
+					)),
+				),
+		).
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}
+
+// ExampleSchemaBuilder_withIntersectionArrow demonstrates using intersection arrow (all) operation.
+func ExampleSchemaBuilder_withIntersectionArrow() {
+	s := schema.NewSchemaBuilder().
+		AddDefinition("folder").
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		Done().
+		Done().
+		AddDefinition("document").
+		AddRelation("parent").
+		AllowedDirectRelation("folder").
+		Done().
+		AddPermission("all_parents_can_view").
+		IntersectionArrow("parent", "viewer").
+		Done().
+		Done().
+		Build()
+
+	defs, caveats, _ := s.ToDefinitions()
+	schemaText, _, _ := generator.GenerateSchema(append(toSchemaDefinitions(defs), toSchemaDefinitions(caveats)...))
+	fmt.Println(strings.TrimSpace(schemaText))
+}

--- a/pkg/schema/v2/builder_test.go
+++ b/pkg/schema/v2/builder_test.go
@@ -1,0 +1,975 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/tuple"
+)
+
+func TestSchemaBuilderBasic(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("user").
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	require.Len(t, schema.definitions, 1)
+	require.Contains(t, schema.definitions, "user")
+
+	userDef := schema.definitions["user"]
+	require.Equal(t, "user", userDef.name)
+	require.Equal(t, schema, userDef.parent)
+	require.Empty(t, userDef.relations)
+	require.Empty(t, userDef.permissions)
+}
+
+func TestSchemaBuilderWithRelations(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		AllowedRelation("group", "member").
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	require.NotNil(t, docDef)
+
+	// Check owner relation
+	ownerRel := docDef.relations["owner"]
+	require.NotNil(t, ownerRel)
+	require.Equal(t, "owner", ownerRel.name)
+	require.Equal(t, docDef, ownerRel.parent)
+	require.Len(t, ownerRel.baseRelations, 1)
+	require.Equal(t, "user", ownerRel.baseRelations[0].subjectType)
+	require.Equal(t, tuple.Ellipsis, ownerRel.baseRelations[0].subrelation)
+
+	// Check viewer relation
+	viewerRel := docDef.relations["viewer"]
+	require.NotNil(t, viewerRel)
+	require.Len(t, viewerRel.baseRelations, 2)
+	require.Equal(t, "user", viewerRel.baseRelations[0].subjectType)
+	require.Equal(t, tuple.Ellipsis, viewerRel.baseRelations[0].subrelation)
+	require.Equal(t, "group", viewerRel.baseRelations[1].subjectType)
+	require.Equal(t, "member", viewerRel.baseRelations[1].subrelation)
+}
+
+func TestSchemaBuilderWithCaveats(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("viewer").
+		AllowedDirectRelationWithCaveat("user", "valid_ip").
+		Done().
+		Done().
+		AddCaveat("valid_ip").
+		Expression("request.ip_address in allowed_ips").
+		Parameter("allowed_ips", "list<string>").
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+
+	// Check caveat
+	caveat := schema.caveats["valid_ip"]
+	require.NotNil(t, caveat)
+	require.Equal(t, "valid_ip", caveat.name)
+	require.Equal(t, "request.ip_address in allowed_ips", caveat.expression)
+	require.Len(t, caveat.parameters, 1)
+	require.Equal(t, "allowed_ips", caveat.parameters[0].name)
+	require.Equal(t, "list<string>", caveat.parameters[0].typ)
+	require.Equal(t, schema, caveat.parent)
+
+	// Check relation with caveat
+	docDef := schema.definitions["document"]
+	viewerRel := docDef.relations["viewer"]
+	require.NotNil(t, viewerRel)
+	require.Len(t, viewerRel.baseRelations, 1)
+	require.Equal(t, "user", viewerRel.baseRelations[0].subjectType)
+	require.Equal(t, "valid_ip", viewerRel.baseRelations[0].caveat)
+}
+
+func TestSchemaBuilderWithExpiration(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("temporary_viewer").
+		AllowedDirectRelationWithExpiration("user").
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	tempViewerRel := docDef.relations["temporary_viewer"]
+	require.NotNil(t, tempViewerRel)
+	require.Len(t, tempViewerRel.baseRelations, 1)
+	require.True(t, tempViewerRel.baseRelations[0].expiration)
+}
+
+func TestSchemaBuilderWithWildcard(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("public_viewer").
+		AllowedWildcard("user").
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	publicViewerRel := docDef.relations["public_viewer"]
+	require.NotNil(t, publicViewerRel)
+	require.Len(t, publicViewerRel.baseRelations, 1)
+	require.True(t, publicViewerRel.baseRelations[0].wildcard)
+	require.Equal(t, "user", publicViewerRel.baseRelations[0].subjectType)
+}
+
+func TestSchemaBuilderWithAlias(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("reader").
+		Alias("viewer").
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	readerRel := docDef.relations["reader"]
+	require.NotNil(t, readerRel)
+	require.Equal(t, "viewer", readerRel.aliasingRelation)
+}
+
+func TestSchemaBuilderWithPermissionRelationRef(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		RelationRef("viewer").
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+	require.Equal(t, "view", viewPerm.name)
+	require.Equal(t, docDef, viewPerm.parent)
+
+	relRef, ok := viewPerm.operation.(*RelationReference)
+	require.True(t, ok)
+	require.Equal(t, "viewer", relRef.RelationName())
+}
+
+func TestSchemaBuilderWithPermissionArrow(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("parent").
+		AllowedDirectRelation("folder").
+		Done().
+		AddPermission("view").
+		Arrow("parent", "view").
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+
+	arrowRef, ok := viewPerm.operation.(*ArrowReference)
+	require.True(t, ok)
+	require.Equal(t, "parent", arrowRef.Left())
+	require.Equal(t, "view", arrowRef.Right())
+}
+
+func TestSchemaBuilderWithPermissionUnion(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		Union(
+			RelRef("owner"),
+			RelRef("viewer"),
+		).
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+
+	unionOp, ok := viewPerm.operation.(*UnionOperation)
+	require.True(t, ok)
+	require.Len(t, unionOp.Children(), 2)
+
+	relRef1, ok := unionOp.Children()[0].(*RelationReference)
+	require.True(t, ok)
+	require.Equal(t, "owner", relRef1.RelationName())
+
+	relRef2, ok := unionOp.Children()[1].(*RelationReference)
+	require.True(t, ok)
+	require.Equal(t, "viewer", relRef2.RelationName())
+}
+
+func TestSchemaBuilderWithPermissionUnionExpr(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("editor").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		UnionExpr().
+		AddRelationRef("owner").
+		AddRelationRef("viewer").
+		AddRelationRef("editor").
+		Done().
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+
+	unionOp, ok := viewPerm.operation.(*UnionOperation)
+	require.True(t, ok)
+	require.Len(t, unionOp.Children(), 3)
+}
+
+func TestSchemaBuilderWithPermissionIntersection(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("approved").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("admin_edit").
+		Intersection(
+			RelRef("owner"),
+			RelRef("approved"),
+		).
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	adminEditPerm := docDef.permissions["admin_edit"]
+	require.NotNil(t, adminEditPerm)
+
+	intersectionOp, ok := adminEditPerm.operation.(*IntersectionOperation)
+	require.True(t, ok)
+	require.Len(t, intersectionOp.Children(), 2)
+}
+
+func TestSchemaBuilderWithPermissionIntersectionExpr(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("approved").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("admin_edit").
+		IntersectionExpr().
+		AddRelationRef("owner").
+		AddRelationRef("approved").
+		Done().
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	adminEditPerm := docDef.permissions["admin_edit"]
+	require.NotNil(t, adminEditPerm)
+
+	intersectionOp, ok := adminEditPerm.operation.(*IntersectionOperation)
+	require.True(t, ok)
+	require.Len(t, intersectionOp.Children(), 2)
+}
+
+func TestSchemaBuilderWithPermissionExclusion(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("banned").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		Exclusion(
+			RelRef("viewer"),
+			RelRef("banned"),
+		).
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+
+	exclusionOp, ok := viewPerm.operation.(*ExclusionOperation)
+	require.True(t, ok)
+	require.NotNil(t, exclusionOp.Left())
+	require.NotNil(t, exclusionOp.Right())
+
+	baseRef, ok := exclusionOp.Left().(*RelationReference)
+	require.True(t, ok)
+	require.Equal(t, "viewer", baseRef.RelationName())
+
+	excludedRef, ok := exclusionOp.Right().(*RelationReference)
+	require.True(t, ok)
+	require.Equal(t, "banned", excludedRef.RelationName())
+}
+
+func TestSchemaBuilderWithPermissionExclusionExpr(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("banned").
+		AllowedDirectRelation("user").
+		Done().
+		AddPermission("view").
+		ExclusionExpr().
+		BaseRelationRef("viewer").
+		ExcludeRelationRef("banned").
+		Done().
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+
+	exclusionOp, ok := viewPerm.operation.(*ExclusionOperation)
+	require.True(t, ok)
+	require.NotNil(t, exclusionOp.Left())
+	require.NotNil(t, exclusionOp.Right())
+}
+
+func TestSchemaBuilderWithIntersectionArrow(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("parent").
+		AllowedDirectRelation("folder").
+		Done().
+		AddPermission("view").
+		IntersectionArrow("parent", "viewer").
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+
+	funcOp, ok := viewPerm.operation.(*FunctionedArrowReference)
+	require.True(t, ok)
+	require.Equal(t, FunctionTypeAll, funcOp.Function())
+	require.Equal(t, "parent", funcOp.Left())
+	require.Equal(t, "viewer", funcOp.Right())
+}
+
+func TestSchemaBuilderComplexExample(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("user").
+		Done().
+		AddDefinition("group").
+		AddRelation("member").
+		AllowedDirectRelation("user").
+		AllowedRelation("group", "member").
+		Done().
+		Done().
+		AddDefinition("folder").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		AllowedRelation("group", "member").
+		Done().
+		AddPermission("view").
+		UnionExpr().
+		AddRelationRef("owner").
+		AddRelationRef("viewer").
+		Done().
+		Done().
+		Done().
+		AddDefinition("document").
+		AddRelation("parent").
+		AllowedDirectRelation("folder").
+		Done().
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		AllowedRelation("group", "member").
+		Done().
+		AddPermission("view").
+		UnionExpr().
+		AddRelationRef("owner").
+		AddRelationRef("viewer").
+		AddArrow("parent", "view").
+		Done().
+		Done().
+		AddPermission("edit").
+		RelationRef("owner").
+		Done().
+		Done().
+		AddCaveat("valid_ip").
+		Expression("request.ip_address in allowed_ranges").
+		Parameter("allowed_ranges", "list<string>").
+		Parameter("request", "map<any>").
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	require.Len(t, schema.definitions, 4)
+	require.Len(t, schema.caveats, 1)
+
+	// Verify document definition
+	docDef := schema.definitions["document"]
+	require.NotNil(t, docDef)
+	require.Len(t, docDef.relations, 3)
+	require.Len(t, docDef.permissions, 2)
+
+	// Verify view permission
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+	unionOp, ok := viewPerm.operation.(*UnionOperation)
+	require.True(t, ok)
+	require.Len(t, unionOp.Children(), 3)
+
+	// Verify arrow is part of union
+	arrowRef, ok := unionOp.Children()[2].(*ArrowReference)
+	require.True(t, ok)
+	require.Equal(t, "parent", arrowRef.Left())
+	require.Equal(t, "view", arrowRef.Right())
+}
+
+func TestSchemaBuilderModifyExisting(t *testing.T) {
+	builder := NewSchemaBuilder()
+
+	// Add initial definition
+	builder.AddDefinition("document").
+		AddRelation("owner").
+		AllowedDirectRelation("user").
+		Done().
+		Done()
+
+	// Modify the same definition
+	builder.AddDefinition("document").
+		AddRelation("viewer").
+		AllowedDirectRelation("user").
+		Done().
+		Done()
+
+	schema := builder.Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	require.NotNil(t, docDef)
+	require.Len(t, docDef.relations, 2)
+	require.Contains(t, docDef.relations, "owner")
+	require.Contains(t, docDef.relations, "viewer")
+}
+
+func TestSchemaBuilderWithAllFeatures(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddDefinition("document").
+		AddRelation("viewer").
+		AllowedDirectRelationWithFeatures("user", "valid_ip", true).
+		Done().
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	viewerRel := docDef.relations["viewer"]
+	require.NotNil(t, viewerRel)
+	require.Len(t, viewerRel.baseRelations, 1)
+
+	baseRel := viewerRel.baseRelations[0]
+	require.Equal(t, "user", baseRel.subjectType)
+	require.Equal(t, tuple.Ellipsis, baseRel.subrelation)
+	require.Equal(t, "valid_ip", baseRel.caveat)
+	require.True(t, baseRel.expiration)
+}
+
+func TestSchemaBuilderWithCaveatParameterMap(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddCaveat("complex_caveat").
+		Expression("param1 == param2 && param3").
+		ParameterMap(map[string]string{
+			"param1": CaveatTypeString,
+			"param2": CaveatTypeString,
+			"param3": CaveatTypeBool,
+		}).
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	caveat := schema.caveats["complex_caveat"]
+	require.NotNil(t, caveat)
+	require.Len(t, caveat.parameters, 3)
+
+	// Check that all parameters are present
+	paramMap := make(map[string]string)
+	for _, param := range caveat.parameters {
+		paramMap[param.name] = param.typ
+	}
+	require.Equal(t, CaveatTypeString, paramMap["param1"])
+	require.Equal(t, CaveatTypeString, paramMap["param2"])
+	require.Equal(t, CaveatTypeBool, paramMap["param3"])
+}
+
+func TestSchemaBuilderWithMixedCaveatParameters(t *testing.T) {
+	schema := NewSchemaBuilder().
+		AddCaveat("mixed_caveat").
+		Expression("count > threshold && allowed").
+		Parameter("count", CaveatTypeInt).
+		ParameterMap(map[string]string{
+			"threshold": CaveatTypeInt,
+			"allowed":   CaveatTypeBool,
+		}).
+		Done().
+		Build()
+
+	require.NotNil(t, schema)
+	caveat := schema.caveats["mixed_caveat"]
+	require.NotNil(t, caveat)
+	require.Len(t, caveat.parameters, 3)
+
+	// Check that all parameters are present in the right order
+	require.Equal(t, "count", caveat.parameters[0].name)
+	require.Equal(t, CaveatTypeInt, caveat.parameters[0].typ)
+
+	// The map parameters might be in any order
+	paramMap := make(map[string]string)
+	for _, param := range caveat.parameters {
+		paramMap[param.name] = param.typ
+	}
+	require.Equal(t, CaveatTypeInt, paramMap["count"])
+	require.Equal(t, CaveatTypeInt, paramMap["threshold"])
+	require.Equal(t, CaveatTypeBool, paramMap["allowed"])
+}
+
+func TestSchemaBuilderWithConstructorPattern(t *testing.T) {
+	// Test the new constructor pattern with NewDefinition(), NewRelation(), NewPermission()
+	schema := NewSchemaBuilder().
+		Definition(
+			NewDefinition("document").
+				Relation(
+					NewRelation("owner").AllowedDirectRelation("user"),
+				).
+				Relation(
+					NewRelation("editor").AllowedDirectRelation("user"),
+				).
+				Relation(
+					NewRelation("viewer").AllowedDirectRelation("user"),
+				).
+				Permission(
+					NewPermission("view", Union(
+						RelRef("owner"),
+						RelRef("editor"),
+						RelRef("viewer"),
+					)),
+				),
+		).
+		Definition(
+			NewDefinition("user").
+				Relation(
+					NewRelation("friend").AllowedDirectRelation("user"),
+				),
+		).
+		Build()
+
+	require.NotNil(t, schema)
+	require.Len(t, schema.definitions, 2)
+
+	// Verify document definition
+	docDef := schema.definitions["document"]
+	require.NotNil(t, docDef)
+	require.Equal(t, "document", docDef.name)
+	require.Len(t, docDef.relations, 3)
+	require.Len(t, docDef.permissions, 1)
+
+	// Verify relations
+	require.Contains(t, docDef.relations, "owner")
+	require.Contains(t, docDef.relations, "editor")
+	require.Contains(t, docDef.relations, "viewer")
+
+	ownerRel := docDef.relations["owner"]
+	require.Len(t, ownerRel.baseRelations, 1)
+	require.Equal(t, "user", ownerRel.baseRelations[0].subjectType)
+
+	// Verify permission
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+	require.Equal(t, "view", viewPerm.name)
+
+	unionOp, ok := viewPerm.operation.(*UnionOperation)
+	require.True(t, ok)
+	require.Len(t, unionOp.Children(), 3)
+
+	// Verify user definition
+	userDef := schema.definitions["user"]
+	require.NotNil(t, userDef)
+	require.Equal(t, "user", userDef.name)
+	require.Len(t, userDef.relations, 1)
+
+	friendRel := userDef.relations["friend"]
+	require.NotNil(t, friendRel)
+	require.Equal(t, "friend", friendRel.name)
+	require.Len(t, friendRel.baseRelations, 1)
+	require.Equal(t, "user", friendRel.baseRelations[0].subjectType)
+}
+
+func TestSchemaBuilderConstructorWithIntersection(t *testing.T) {
+	// Test constructor pattern with intersection operations
+	schema := NewSchemaBuilder().
+		Definition(
+			NewDefinition("document").
+				Relation(NewRelation("owner").AllowedDirectRelation("user")).
+				Relation(NewRelation("approved").AllowedDirectRelation("user")).
+				Permission(
+					NewPermission("admin_edit", Intersection(
+						RelRef("owner"),
+						RelRef("approved"),
+					)),
+				),
+		).
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	require.NotNil(t, docDef)
+
+	// Verify permission with intersection
+	adminEditPerm := docDef.permissions["admin_edit"]
+	require.NotNil(t, adminEditPerm)
+	intersectionOp, ok := adminEditPerm.operation.(*IntersectionOperation)
+	require.True(t, ok)
+	require.Len(t, intersectionOp.Children(), 2)
+}
+
+func TestSchemaBuilderConstructorWithExclusion(t *testing.T) {
+	// Test constructor pattern with exclusion operations
+	schema := NewSchemaBuilder().
+		Definition(
+			NewDefinition("document").
+				Relation(NewRelation("viewer").AllowedDirectRelation("user")).
+				Relation(NewRelation("banned").AllowedDirectRelation("user")).
+				Permission(
+					NewPermission("view", Exclusion(
+						RelRef("viewer"),
+						RelRef("banned"),
+					)),
+				),
+		).
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	require.NotNil(t, docDef)
+
+	// Verify permission with exclusion
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+	exclusionOp, ok := viewPerm.operation.(*ExclusionOperation)
+	require.True(t, ok)
+	require.NotNil(t, exclusionOp.Left())
+	require.NotNil(t, exclusionOp.Right())
+
+	baseRef, ok := exclusionOp.Left().(*RelationReference)
+	require.True(t, ok)
+	require.Equal(t, "viewer", baseRef.RelationName())
+
+	excludedRef, ok := exclusionOp.Right().(*RelationReference)
+	require.True(t, ok)
+	require.Equal(t, "banned", excludedRef.RelationName())
+}
+
+func TestSchemaBuilderConstructorWithArrow(t *testing.T) {
+	// Test constructor pattern with arrow references
+	schema := NewSchemaBuilder().
+		Definition(
+			NewDefinition("folder").
+				Relation(NewRelation("owner").AllowedDirectRelation("user")).
+				Permission(NewPermission("view", RelRef("owner"))),
+		).
+		Definition(
+			NewDefinition("document").
+				Relation(NewRelation("parent").AllowedDirectRelation("folder")).
+				Relation(NewRelation("owner").AllowedDirectRelation("user")).
+				Permission(
+					NewPermission("view", Union(
+						RelRef("owner"),
+						ArrowRef("parent", "view"),
+					)),
+				),
+		).
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	require.NotNil(t, docDef)
+
+	// Verify permission with arrow
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+	unionOp, ok := viewPerm.operation.(*UnionOperation)
+	require.True(t, ok)
+	require.Len(t, unionOp.Children(), 2)
+
+	arrowRef, ok := unionOp.Children()[1].(*ArrowReference)
+	require.True(t, ok)
+	require.Equal(t, "parent", arrowRef.Left())
+	require.Equal(t, "view", arrowRef.Right())
+}
+
+func TestSchemaBuilderConstructorWithIntersectionArrow(t *testing.T) {
+	// Test constructor pattern with intersection arrow (all) operations
+	schema := NewSchemaBuilder().
+		Definition(
+			NewDefinition("folder").
+				Relation(NewRelation("viewer").AllowedDirectRelation("user")),
+		).
+		Definition(
+			NewDefinition("document").
+				Relation(NewRelation("parent").AllowedDirectRelation("folder")).
+				Permission(
+					NewPermission("all_parents_can_view", IntersectionArrowRef("parent", "viewer")),
+				),
+		).
+		Build()
+
+	require.NotNil(t, schema)
+	docDef := schema.definitions["document"]
+	require.NotNil(t, docDef)
+
+	// Verify permission with intersection arrow
+	viewPerm := docDef.permissions["all_parents_can_view"]
+	require.NotNil(t, viewPerm)
+	funcOp, ok := viewPerm.operation.(*FunctionedArrowReference)
+	require.True(t, ok)
+	require.Equal(t, FunctionTypeAll, funcOp.Function())
+	require.Equal(t, "parent", funcOp.Left())
+	require.Equal(t, "viewer", funcOp.Right())
+}
+
+func TestSchemaBuilderConstructorWithCaveat(t *testing.T) {
+	// Test constructor pattern with caveats
+	schema := NewSchemaBuilder().
+		Definition(
+			NewDefinition("document").
+				Relation(
+					NewRelation("conditional_viewer").
+						AllowedDirectRelationWithCaveat("user", "valid_ip"),
+				),
+		).
+		Caveat(
+			NewCaveat("valid_ip").
+				Expression("request.ip_address in allowed_ranges").
+				Parameter("allowed_ranges", CaveatTypeListString).
+				Parameter("request", CaveatTypeMapAny),
+		).
+		Build()
+
+	require.NotNil(t, schema)
+
+	// Verify caveat
+	caveat := schema.caveats["valid_ip"]
+	require.NotNil(t, caveat)
+	require.Equal(t, "valid_ip", caveat.name)
+	require.Equal(t, "request.ip_address in allowed_ranges", caveat.expression)
+	require.Len(t, caveat.parameters, 2)
+
+	// Verify relation with caveat
+	docDef := schema.definitions["document"]
+	require.NotNil(t, docDef)
+	conditionalViewerRel := docDef.relations["conditional_viewer"]
+	require.NotNil(t, conditionalViewerRel)
+	require.Len(t, conditionalViewerRel.baseRelations, 1)
+	require.Equal(t, "user", conditionalViewerRel.baseRelations[0].subjectType)
+	require.Equal(t, "valid_ip", conditionalViewerRel.baseRelations[0].caveat)
+}
+
+func TestSchemaBuilderConstructorComplexNested(t *testing.T) {
+	// Test constructor pattern with complex nested operations
+	schema := NewSchemaBuilder().
+		Definition(
+			NewDefinition("user"),
+		).
+		Definition(
+			NewDefinition("group").
+				Relation(NewRelation("member").AllowedDirectRelation("user")),
+		).
+		Definition(
+			NewDefinition("folder").
+				Relation(NewRelation("owner").AllowedDirectRelation("user")).
+				Relation(
+					NewRelation("editor").
+						AllowedDirectRelation("user").
+						AllowedRelation("group", "member"),
+				).
+				Relation(
+					NewRelation("viewer").
+						AllowedDirectRelation("user").
+						AllowedRelation("group", "member"),
+				).
+				Permission(
+					NewPermission("view", Union(
+						RelRef("owner"),
+						RelRef("editor"),
+						RelRef("viewer"),
+					)),
+				).
+				Permission(
+					NewPermission("edit", Union(
+						RelRef("owner"),
+						RelRef("editor"),
+					)),
+				),
+		).
+		Definition(
+			NewDefinition("document").
+				Relation(NewRelation("parent").AllowedDirectRelation("folder")).
+				Relation(NewRelation("owner").AllowedDirectRelation("user")).
+				Relation(NewRelation("banned").AllowedDirectRelation("user")).
+				Permission(
+					NewPermission("view", Exclusion(
+						Union(
+							RelRef("owner"),
+							ArrowRef("parent", "view"),
+						),
+						RelRef("banned"),
+					)),
+				).
+				Permission(
+					NewPermission("edit", Intersection(
+						Union(
+							RelRef("owner"),
+							ArrowRef("parent", "edit"),
+						),
+						Exclusion(
+							RelRef("owner"),
+							RelRef("banned"),
+						),
+					)),
+				),
+		).
+		Build()
+
+	require.NotNil(t, schema)
+	require.Len(t, schema.definitions, 4)
+
+	// Verify document definition
+	docDef := schema.definitions["document"]
+	require.NotNil(t, docDef)
+	require.Len(t, docDef.relations, 3)
+	require.Len(t, docDef.permissions, 2)
+
+	// Verify complex view permission (exclusion of union)
+	viewPerm := docDef.permissions["view"]
+	require.NotNil(t, viewPerm)
+	exclusionOp, ok := viewPerm.operation.(*ExclusionOperation)
+	require.True(t, ok)
+
+	unionBase, ok := exclusionOp.Left().(*UnionOperation)
+	require.True(t, ok)
+	require.Len(t, unionBase.Children(), 2)
+
+	// Verify complex edit permission (intersection of union and exclusion)
+	editPerm := docDef.permissions["edit"]
+	require.NotNil(t, editPerm)
+	intersectionOp, ok := editPerm.operation.(*IntersectionOperation)
+	require.True(t, ok)
+	require.Len(t, intersectionOp.Children(), 2)
+}
+
+func TestSchemaBuilderHelperFunctions(t *testing.T) {
+	// Test RelRef
+	relRef := RelRef("viewer")
+	require.NotNil(t, relRef)
+	relRefTyped, ok := relRef.(*RelationReference)
+	require.True(t, ok)
+	require.Equal(t, "viewer", relRefTyped.RelationName())
+
+	// Test ArrowRef
+	arrowRef := ArrowRef("parent", "view")
+	require.NotNil(t, arrowRef)
+	arrowRefTyped, ok := arrowRef.(*ArrowReference)
+	require.True(t, ok)
+	require.Equal(t, "parent", arrowRefTyped.Left())
+	require.Equal(t, "view", arrowRefTyped.Right())
+
+	// Test Union
+	unionOp := Union(RelRef("owner"), RelRef("viewer"))
+	require.NotNil(t, unionOp)
+	unionOpTyped, ok := unionOp.(*UnionOperation)
+	require.True(t, ok)
+	require.Len(t, unionOpTyped.Children(), 2)
+
+	// Test Intersection
+	intersectionOp := Intersection(RelRef("owner"), RelRef("approved"))
+	require.NotNil(t, intersectionOp)
+	intersectionOpTyped, ok := intersectionOp.(*IntersectionOperation)
+	require.True(t, ok)
+	require.Len(t, intersectionOpTyped.Children(), 2)
+
+	// Test Exclusion
+	exclusionOp := Exclusion(RelRef("viewer"), RelRef("banned"))
+	require.NotNil(t, exclusionOp)
+	exclusionOpTyped, ok := exclusionOp.(*ExclusionOperation)
+	require.True(t, ok)
+	require.NotNil(t, exclusionOpTyped.Left())
+	require.NotNil(t, exclusionOpTyped.Right())
+
+	// Test IntersectionArrowRef
+	intersectionArrowOp := IntersectionArrowRef("parent", "viewer")
+	require.NotNil(t, intersectionArrowOp)
+	funcOpTyped, ok := intersectionArrowOp.(*FunctionedArrowReference)
+	require.True(t, ok)
+	require.Equal(t, FunctionTypeAll, funcOpTyped.Function())
+	require.Equal(t, "parent", funcOpTyped.Left())
+	require.Equal(t, "viewer", funcOpTyped.Right())
+}

--- a/pkg/schema/v2/clone_test.go
+++ b/pkg/schema/v2/clone_test.go
@@ -73,9 +73,11 @@ func TestCloneSchema_WithCaveats(t *testing.T) {
 		definitions: make(map[string]*Definition),
 		caveats: map[string]*Caveat{
 			"is_admin": {
-				name:           "is_admin",
-				expression:     "admin == true",
-				parameterTypes: []string{"admin"},
+				name:       "is_admin",
+				expression: "admin == true",
+				parameters: []CaveatParameter{
+					{name: "admin", typ: "bool"},
+				},
 			},
 		},
 	}
@@ -96,11 +98,14 @@ func TestCloneSchema_WithCaveats(t *testing.T) {
 	// Check that values are preserved
 	require.Equal(t, "is_admin", cloned.caveats["is_admin"].name)
 	require.Equal(t, "admin == true", cloned.caveats["is_admin"].expression)
-	require.Equal(t, []string{"admin"}, cloned.caveats["is_admin"].parameterTypes)
+	require.Len(t, cloned.caveats["is_admin"].parameters, 1)
+	require.Equal(t, "admin", cloned.caveats["is_admin"].parameters[0].name)
+	require.Equal(t, "bool", cloned.caveats["is_admin"].parameters[0].typ)
 
-	// Check that parameter types slice is a new slice by verifying mutations don't affect original
-	cloned.caveats["is_admin"].parameterTypes[0] = "modified"
-	require.Equal(t, "admin", original.caveats["is_admin"].parameterTypes[0])
+	// Check that parameters slice is a new slice by verifying mutations don't affect original
+	cloned.caveats["is_admin"].parameters[0] = CaveatParameter{name: "modified", typ: "string"}
+	require.Equal(t, "admin", original.caveats["is_admin"].parameters[0].name)
+	require.Equal(t, "bool", original.caveats["is_admin"].parameters[0].typ)
 }
 
 func TestCloneSchema_WithRelations(t *testing.T) {
@@ -303,9 +308,11 @@ func TestCloneSchema_CompleteSchema(t *testing.T) {
 	perm1.parent = def1
 
 	caveat1 := &Caveat{
-		name:           "is_admin",
-		expression:     "admin == true",
-		parameterTypes: []string{"admin"},
+		name:       "is_admin",
+		expression: "admin == true",
+		parameters: []CaveatParameter{
+			{name: "admin", typ: "bool"},
+		},
 	}
 
 	original := &Schema{

--- a/pkg/schema/v2/convert.go
+++ b/pkg/schema/v2/convert.go
@@ -38,13 +38,16 @@ func convertDefinition(def *corev1.NamespaceDefinition) (*Definition, error) {
 
 func convertCaveat(def *corev1.CaveatDefinition) (*Caveat, error) {
 	out := &Caveat{
-		name:           def.GetName(),
-		expression:     string(def.GetSerializedExpression()),
-		parameterTypes: make([]string, 0, len(def.GetParameterTypes())),
+		name:       def.GetName(),
+		expression: string(def.GetSerializedExpression()),
+		parameters: make([]CaveatParameter, 0, len(def.GetParameterTypes())),
 	}
 
-	for paramName := range def.GetParameterTypes() {
-		out.parameterTypes = append(out.parameterTypes, paramName)
+	for paramName, paramType := range def.GetParameterTypes() {
+		out.parameters = append(out.parameters, CaveatParameter{
+			name: paramName,
+			typ:  paramType.GetTypeName(),
+		})
 	}
 
 	return out, nil

--- a/pkg/schema/v2/convert_test.go
+++ b/pkg/schema/v2/convert_test.go
@@ -490,7 +490,7 @@ func TestConvertCaveatEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "test_caveat", result.Name())
 		require.Equal(t, "test expression", result.Expression())
-		require.Empty(t, result.ParameterTypes())
+		require.Empty(t, result.Parameters())
 	})
 
 	t.Run("caveat with multiple parameter types", func(t *testing.T) {
@@ -509,10 +509,16 @@ func TestConvertCaveatEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "complex_caveat", result.Name())
 		require.Equal(t, "complex expression", result.Expression())
-		require.Len(t, result.ParameterTypes(), 3)
-		require.Contains(t, result.ParameterTypes(), "param1")
-		require.Contains(t, result.ParameterTypes(), "param2")
-		require.Contains(t, result.ParameterTypes(), "param3")
+		require.Len(t, result.Parameters(), 3)
+
+		// Check that all parameters are present
+		paramMap := make(map[string]string)
+		for _, param := range result.Parameters() {
+			paramMap[param.Name()] = param.Type()
+		}
+		require.Equal(t, "string", paramMap["param1"])
+		require.Equal(t, "int", paramMap["param2"])
+		require.Equal(t, "bool", paramMap["param3"])
 	})
 }
 

--- a/pkg/schema/v2/flatten_test.go
+++ b/pkg/schema/v2/flatten_test.go
@@ -291,7 +291,7 @@ definition folder {
 			require.NotNil(t, flattened)
 
 			// Step 5: Convert back to corev1
-			defs, caveats, err := flattened.ResolvedSchema().Schema().ToNamespaceDefinition("test")
+			defs, caveats, err := flattened.ResolvedSchema().Schema().ToDefinitions()
 			require.NoError(t, err)
 			require.NotNil(t, defs)
 
@@ -638,7 +638,7 @@ definition user {}`,
 			require.NotNil(t, flattened)
 
 			// Step 5: Convert back to corev1
-			defs, caveats, err := flattened.ResolvedSchema().Schema().ToNamespaceDefinition("test")
+			defs, caveats, err := flattened.ResolvedSchema().Schema().ToDefinitions()
 			require.NoError(t, err)
 			require.NotNil(t, defs)
 
@@ -991,7 +991,7 @@ definition user {}`,
 			require.NotNil(t, flattened)
 
 			// Step 5: Convert back to corev1
-			defs, caveats, err := flattened.ResolvedSchema().Schema().ToNamespaceDefinition("test")
+			defs, caveats, err := flattened.ResolvedSchema().Schema().ToDefinitions()
 			require.NoError(t, err)
 			require.NotNil(t, defs)
 

--- a/pkg/schema/v2/resolved_test.go
+++ b/pkg/schema/v2/resolved_test.go
@@ -642,7 +642,7 @@ definition user {}`,
 	}
 }
 
-func TestToNamespaceDefinition_FunctionedArrowReference(t *testing.T) {
+func TestToDefinitions_FunctionedArrowReference(t *testing.T) {
 	schemaString := `definition document {
 	relation parent: folder
 	permission view = parent.any(viewer)
@@ -672,7 +672,7 @@ definition user {}`
 	require.NotNil(t, resolved)
 
 	// Step 4: Convert back to namespace definition
-	defs, caveats, err := resolved.Schema().ToNamespaceDefinition("test")
+	defs, caveats, err := resolved.Schema().ToDefinitions()
 	require.NoError(t, err)
 	require.NotNil(t, defs)
 	require.Empty(t, caveats)

--- a/pkg/schema/v2/schema.go
+++ b/pkg/schema/v2/schema.go
@@ -113,12 +113,28 @@ func (d *Definition) cloneWithParent(parentSchema *Schema) *Definition {
 
 var _ schemaUnitWithParent[*Definition, *Schema] = &Definition{}
 
+// CaveatParameter represents a single parameter in a caveat with its name and type.
+type CaveatParameter struct {
+	name string
+	typ  string
+}
+
+// Name returns the name of the parameter.
+func (cp *CaveatParameter) Name() string {
+	return cp.name
+}
+
+// Type returns the type of the parameter.
+func (cp *CaveatParameter) Type() string {
+	return cp.typ
+}
+
 // Caveat is a single, top-level caveat definition and it's internal expresion.
 type Caveat struct {
-	parent         *Schema
-	name           string
-	expression     string
-	parameterTypes []string
+	parent     *Schema
+	name       string
+	expression string
+	parameters []CaveatParameter
 }
 
 // Parent returns the parent schema.
@@ -136,9 +152,9 @@ func (c *Caveat) Expression() string {
 	return c.expression
 }
 
-// ParameterTypes returns the parameter types of the caveat.
-func (c *Caveat) ParameterTypes() []string {
-	return c.parameterTypes
+// Parameters returns the parameters of the caveat.
+func (c *Caveat) Parameters() []CaveatParameter {
+	return c.parameters
 }
 
 // cloneWithParent creates a deep copy of the Caveat with the specified parent.
@@ -147,14 +163,14 @@ func (c *Caveat) cloneWithParent(parentSchema *Schema) *Caveat {
 		return nil
 	}
 
-	parameterTypes := make([]string, len(c.parameterTypes))
-	copy(parameterTypes, c.parameterTypes)
+	parameters := make([]CaveatParameter, len(c.parameters))
+	copy(parameters, c.parameters)
 
 	return &Caveat{
-		parent:         parentSchema,
-		name:           c.name,
-		expression:     c.expression,
-		parameterTypes: parameterTypes,
+		parent:     parentSchema,
+		name:       c.name,
+		expression: c.expression,
+		parameters: parameters,
 	}
 }
 

--- a/pkg/schema/v2/tocorev1.go
+++ b/pkg/schema/v2/tocorev1.go
@@ -7,9 +7,9 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
-// ToNamespaceDefinition converts a Schema to a core.NamespaceDefinition.
+// ToDefinitions converts a Schema to the full set of namespace and caveat definitions.
 // This is useful for converting schemas back to the protobuf format for serialization.
-func (s *Schema) ToNamespaceDefinition(name string) ([]*core.NamespaceDefinition, []*core.CaveatDefinition, error) {
+func (s *Schema) ToDefinitions() ([]*core.NamespaceDefinition, []*core.CaveatDefinition, error) {
 	if s == nil {
 		return nil, nil, errors.New("cannot convert nil schema")
 	}


### PR DESCRIPTION
## Description

Adds a builder pattern for the schema v2 lib.

Example with Done:

```go
	s := schema.NewSchemaBuilder().
		AddDefinition("document").
		AddRelation("owner").
		AllowedDirectRelation("user").
		Done().
		AddRelation("editor").
		AllowedDirectRelation("user").
		Done().
		AddRelation("viewer").
		AllowedDirectRelation("user").
		Done().
		AddPermission("view").
		UnionExpr().
		AddRelationRef("owner").
		AddRelationRef("editor").
		AddRelationRef("viewer").
		Done().
		Done().
		Done().
		Build()
```

Example with constructors:

```go
	s := schema.NewSchemaBuilder().
		Definition(
			schema.NewDefinition("user"),
		).
		Definition(
			schema.NewDefinition("document").
				Relation(schema.NewRelation("owner").AllowedDirectRelation("user")).
				Relation(schema.NewRelation("editor").AllowedDirectRelation("user")).
				Relation(schema.NewRelation("viewer").AllowedDirectRelation("user")).
				Permission(
					schema.NewPermission("view", schema.Union(
						schema.RelRef("owner"),
						schema.RelRef("editor"),
						schema.RelRef("viewer"),
					)),
				),
		).
		Build()
```

## Testing

Local unit tests
