### PR TITLE
chore: update Docker to fix CVE-2025-54410

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,9 @@ replace github.com/influxdata/tdigest => github.com/hdrodz/tdigest v0.0.0-202304
 // FIXME undo this
 replace github.com/ecordell/optgen => github.com/ecordell/optgen v0.0.10-0.20230609182709-018141bf9698
 
+// See https://github.com/ory/dockertest/issues/614 and https://pkg.go.dev/vuln/GO-2025-3829
+replace github.com/docker/docker => github.com/docker/docker v28.0.0+incompatible
+
 require (
 	buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.36.6-20250320161912-af2aab87b1b3.1
 	cloud.google.com/go/spanner v1.85.0

--- a/go.sum
+++ b/go.sum
@@ -1625,8 +1625,8 @@ github.com/dlmiddlecote/sqlstats v1.0.2 h1:gSU11YN23D/iY50A2zVYwgXgy072khatTsIW6
 github.com/dlmiddlecote/sqlstats v1.0.2/go.mod h1:0CWaIh/Th+z2aI6Q9Jpfg/o21zmGxWhbByHgQSCUQvY=
 github.com/docker/cli v27.4.1+incompatible h1:VzPiUlRJ/xh+otB75gva3r05isHMo5wXDfPRi5/b4hI=
 github.com/docker/cli v27.4.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/docker v27.1.1+incompatible h1:hO/M4MtV36kzKldqnA37IWhebRA+LnqqcqDja6kVaKY=
-github.com/docker/docker v27.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.0.0+incompatible h1:Olh0KS820sJ7nPsBKChVhk5pzqcwDR15fumfAd/p9hM=
+github.com/docker/docker v28.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=


### PR DESCRIPTION
https://pkg.go.dev/vuln/GO-2025-3829

failure seen in https://github.com/authzed/spicedb/pull/2610

```
=== Symbol Results ===

Vulnerability #1: GO-2025-3829
    Moby firewalld reload removes bridge network isolation in
    github.com/docker/docker
  More info: https://pkg.go.dev/vuln/GO-2025-3829
  Module: github.com/docker/docker
    Found in: github.com/docker/docker@v27.1.1+incompatible
    Fixed in: github.com/docker/docker@v28.0.0+incompatible
    Example traces found:
Error:       #1: internal/testserver/datastore/crdb.go:12:2: datastore.init calls docker.init, which eventually calls blkiodev.init
Error:       #2: internal/testserver/datastore/crdb.go:12:2: datastore.init calls docker.init, which eventually calls container.init
Error:       #3: internal/testserver/datastore/crdb.go:12:2: datastore.init calls docker.init, which eventually calls filters.init
Error:       #4: internal/testserver/datastore/crdb.go:12:2: datastore.init calls docker.init, which eventually calls mount.init
Error:       #5: internal/testserver/datastore/crdb.go:12:2: datastore.init calls docker.init, which eventually calls multierror.init
Error:       #6: internal/testserver/datastore/crdb.go:12:2: datastore.init calls docker.init, which eventually calls network.init
Error:       #7: internal/testserver/datastore/crdb.go:12:2: datastore.init calls docker.init, which eventually calls runtime.init
Error:       #8: internal/testserver/datastore/crdb.go:12:2: datastore.init calls docker.init, which eventually calls strslice.init
Error:       #9: internal/testserver/datastore/crdb.go:12:2: datastore.init calls docker.init, which eventually calls swarm.init
Error:       #10: internal/testserver/datastore/crdb.go:12:2: datastore.init calls docker.init, which eventually calls versions.init
```