### PR TITLE
chore: change nil references to be their own object type in schema v2

### DIFF
--- a/pkg/query/build_tree.go
+++ b/pkg/query/build_tree.go
@@ -153,10 +153,10 @@ func (b *iteratorBuilder) buildIteratorFromOperation(p *schema.Permission, op sc
 		}
 		return b.buildArrowIterators(rel, perm.Right())
 
+	case *schema.NilReference:
+		return NewEmptyFixedIterator(), nil
+
 	case *schema.RelationReference:
-		if perm.RelationName() == "_nil" {
-			return NewEmptyFixedIterator(), nil
-		}
 		return b.buildIteratorFromSchemaInternal(p.Parent().Name(), perm.RelationName(), true)
 
 	case *schema.UnionOperation:

--- a/pkg/schema/v2/convert.go
+++ b/pkg/schema/v2/convert.go
@@ -240,9 +240,7 @@ func convertChild(child *corev1.SetOperation_Child) (Operation, error) {
 			function: functionType,
 		}, nil
 	case *corev1.SetOperation_Child_XNil:
-		return &RelationReference{
-			relationName: "_nil",
-		}, nil
+		return &NilReference{}, nil
 	default:
 		return nil, fmt.Errorf("unknown child type: %#v", child.GetChildType())
 	}

--- a/pkg/schema/v2/convert_test.go
+++ b/pkg/schema/v2/convert_test.go
@@ -458,9 +458,9 @@ func TestConvertChildEdgeCases(t *testing.T) {
 		result, err := convertChild(child)
 		require.NoError(t, err)
 
-		relRef, ok := result.(*RelationReference)
+		nilRef, ok := result.(*NilReference)
 		require.True(t, ok)
-		require.Equal(t, "_nil", relRef.RelationName())
+		require.NotNil(t, nilRef)
 	})
 
 	t.Run("unknown child type", func(t *testing.T) {

--- a/pkg/schema/v2/flatten.go
+++ b/pkg/schema/v2/flatten.go
@@ -161,6 +161,10 @@ func flattenOperation(op Operation, def *Definition, baseName string, options Fl
 		// They will be extracted when they appear as children of operations if FlattenArrows is enabled
 		return o, nil, nil
 
+	case *NilReference:
+		// Nil reference is a leaf node, no flattening needed
+		return o, nil, nil
+
 	case *UnionOperation:
 		// Flatten children first
 		flattenedChildren := make([]Operation, len(o.children))
@@ -429,6 +433,8 @@ func buildVarMapRecursive(op Operation, varMap map[string]int) {
 	case *ExclusionOperation:
 		buildVarMapRecursive(o.left, varMap)
 		buildVarMapRecursive(o.right, varMap)
+	case *NilReference:
+		// NilReference has no variables to add to the map
 	}
 }
 
@@ -536,6 +542,10 @@ func operationToBdd(op Operation, bdd *rudd.BDD, varMap map[string]int) (rudd.No
 		// We need to negate the right node
 		notRight := bdd.Not(rightNode)
 		return bdd.And(leftNode, notRight), nil
+
+	case *NilReference:
+		// NilReference represents an empty set, so return the BDD false node
+		return bdd.False(), nil
 
 	default:
 		return nil, fmt.Errorf("unknown operation type: %T", op)

--- a/pkg/schema/v2/flatten_test.go
+++ b/pkg/schema/v2/flatten_test.go
@@ -960,6 +960,23 @@ definition folder {
 
 definition user {}`,
 		},
+		{
+			name: "union with nil",
+			schemaString: `definition document {
+	relation viewer: user
+	permission view = viewer + nil
+}
+
+definition user {}`,
+			flattenNonUnionOperations: true,
+			flattenArrows:             true,
+			expectedString: `definition document {
+	relation viewer: user
+	permission view = viewer + nil
+}
+
+definition user {}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/schema/v2/operations.go
+++ b/pkg/schema/v2/operations.go
@@ -47,6 +47,20 @@ func (r *RelationReference) clone() Operation {
 
 var _ schemaUnit[Operation] = &RelationReference{}
 
+// NilReference is a specialized Operation that represents a nil/empty operation.
+// Unlike RelationReference, it is not replaced during resolution.
+type NilReference struct{}
+
+// clone creates a copy of the NilReference.
+func (n *NilReference) clone() Operation {
+	if n == nil {
+		return nil
+	}
+	return &NilReference{}
+}
+
+var _ schemaUnit[Operation] = &NilReference{}
+
 // ArrowReference is an Operation that represents `permission foo = Left->Right`.
 type ArrowReference struct {
 	// left is the relation on the resource.
@@ -340,6 +354,7 @@ func (f *FunctionedArrowReference) clone() Operation {
 
 // We close the enum by implementing the private method.
 func (r *RelationReference) isOperation()                {}
+func (n *NilReference) isOperation()                     {}
 func (a *ArrowReference) isOperation()                   {}
 func (u *UnionOperation) isOperation()                   {}
 func (i *IntersectionOperation) isOperation()            {}
@@ -351,6 +366,7 @@ func (a *ResolvedFunctionedArrowReference) isOperation() {}
 
 var (
 	_ Operation = (*RelationReference)(nil)
+	_ Operation = (*NilReference)(nil)
 	_ Operation = (*ArrowReference)(nil)
 	_ Operation = (*UnionOperation)(nil)
 	_ Operation = (*IntersectionOperation)(nil)

--- a/pkg/schema/v2/resolved.go
+++ b/pkg/schema/v2/resolved.go
@@ -147,6 +147,10 @@ func resolveOperation(op Operation, def *Definition) (Operation, error) {
 		// Already resolved, just return it
 		return o, nil
 
+	case *NilReference:
+		// NilReference is not replaced during resolution
+		return o, nil
+
 	default:
 		return nil, fmt.Errorf("unknown operation type: %T", op)
 	}

--- a/pkg/schema/v2/tocorev1.go
+++ b/pkg/schema/v2/tocorev1.go
@@ -292,6 +292,19 @@ func operationToUsersetRewrite(op Operation) (*core.UsersetRewrite, error) {
 			},
 		}, nil
 
+	case *NilReference:
+		return &core.UsersetRewrite{
+			RewriteOperation: &core.UsersetRewrite_Union{
+				Union: &core.SetOperation{
+					Child: []*core.SetOperation_Child{
+						{
+							ChildType: &core.SetOperation_Child_XNil{},
+						},
+					},
+				},
+			},
+		}, nil
+
 	default:
 		return nil, fmt.Errorf("unknown operation type: %T", op)
 	}
@@ -403,6 +416,11 @@ func operationToChild(op Operation) (*core.SetOperation_Child, error) {
 			ChildType: &core.SetOperation_Child_UsersetRewrite{
 				UsersetRewrite: rewrite,
 			},
+		}, nil
+
+	case *NilReference:
+		return &core.SetOperation_Child{
+			ChildType: &core.SetOperation_Child_XNil{},
 		}, nil
 
 	default:

--- a/pkg/schema/v2/walk.go
+++ b/pkg/schema/v2/walk.go
@@ -51,6 +51,12 @@ type RelationReferenceVisitor[T any] interface {
 	VisitRelationReference(rr *RelationReference, value T) (T, error)
 }
 
+// NilReferenceVisitor is called when visiting a NilReference.
+// Returns the value to pass to subsequent visits, and error to halt immediately.
+type NilReferenceVisitor[T any] interface {
+	VisitNilReference(nr *NilReference, value T) (T, error)
+}
+
 // ArrowReferenceVisitor is called when visiting an ArrowReference.
 // Returns the value to pass to subsequent visits, and error to halt immediately.
 type ArrowReferenceVisitor[T any] interface {
@@ -284,6 +290,15 @@ func WalkOperation[T any](op Operation, v Visitor[T], value T) (T, error) {
 	case *RelationReference:
 		if rrv, ok := v.(RelationReferenceVisitor[T]); ok {
 			newValue, err := rrv.VisitRelationReference(o, currentValue)
+			if err != nil {
+				return currentValue, err
+			}
+			currentValue = newValue
+		}
+
+	case *NilReference:
+		if nrv, ok := v.(NilReferenceVisitor[T]); ok {
+			newValue, err := nrv.VisitNilReference(o, currentValue)
 			if err != nil {
 				return currentValue, err
 			}


### PR DESCRIPTION
This is necessary to make resolution easier and to not use a magic string for nil

## Testing

Unit tests
