### PR TITLE
fix: do not warn if requestid middleware errors due to ErrIllegalHeaderWrite

### DIFF
--- a/pkg/middleware/serverversion/serverversion.go
+++ b/pkg/middleware/serverversion/serverversion.go
@@ -37,7 +37,7 @@ func (r *HandleServerVersion) ServerReporter(ctx context.Context, _ interceptors
 				err = responsemeta.SetResponseTrailerMetadata(ctx, map[responsemeta.ResponseMetadataTrailerKey]string{
 					responsemeta.ResponseMetadataTrailerKey(responsemeta.ServerVersion): version,
 				})
-				// if context is cancelled, the stream will be closed, and gRPC will return ErrIllegalHeaderWrite
+				// if context is cancelled, the stream will be closed, and gRPC will return ErrIllegalHeaderWrite (which is private)
 				// this prevents logging unnecessary error messages
 				if err := ctx.Err(); err != nil {
 					return interceptors.NoopReporter{}, ctx


### PR DESCRIPTION
## Description

Sometimes, we are seeing this:

```

{"level":"warn","error":"rpc error: code = Internal desc = transport: SendHeader called multiple times","time":"2025-10-27T18:15:17Z","message":"requestid: could not report metadata"} |  
```

This is noisy, because `Internal` triggers our 5xx alarms.

## Changes

- Fix `requestid` middleware
- Minor refactor to `usagemetric` middleware (no functional changes)

## References

Similar PR with a similar change was sent in https://github.com/authzed/spicedb/pull/986