### PR TITLE
fix: properly rewrite errors for watch api, part 2

### DIFF
--- a/internal/services/shared/errors.go
+++ b/internal/services/shared/errors.go
@@ -177,6 +177,9 @@ func rewriteError(ctx context.Context, err error, config *ConfigForErrors) error
 		return status.Errorf(codes.Canceled, "watch canceled by user: %s", err)
 	case errors.As(err, &datastore.WatchDisconnectedError{}):
 		return status.Errorf(codes.ResourceExhausted, "watch disconnected: %s", err)
+	case errors.As(err, &datastore.WatchRetryableError{}):
+		// Unavailable is safe to retry
+		return status.Error(codes.Unavailable, err.Error())
 	case errors.As(err, &datastore.CounterAlreadyRegisteredError{}):
 		return spiceerrors.WithCodeAndReason(err, codes.FailedPrecondition, v1.ErrorReason_ERROR_REASON_COUNTER_ALREADY_REGISTERED)
 	case errors.As(err, &datastore.CounterNotRegisteredError{}):

--- a/internal/services/shared/errors_test.go
+++ b/internal/services/shared/errors_test.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -115,6 +116,13 @@ func TestRewriteError(t *testing.T) {
 			config:           nil,
 			expectedCode:     codes.FailedPrecondition,
 			expectedContains: "watch is currently disabled: it was disabled",
+		},
+		{
+			name:             "watch retryable",
+			inputError:       datastore.NewWatchTemporaryErr(errors.New("server is shutting down")),
+			config:           nil,
+			expectedCode:     codes.Unavailable,
+			expectedContains: "watch has failed with a temporary condition: server is shutting down. Please retry",
 		},
 		{
 			name:             "counter already registered",

--- a/pkg/datastore/errors.go
+++ b/pkg/datastore/errors.go
@@ -136,7 +136,7 @@ func NewWatchDisabledErr(reason string) error {
 // a temporary condition and clients may consider retrying by calling watch again (vs a fatal error).
 func NewWatchTemporaryErr(wrapped error) error {
 	return WatchRetryableError{
-		error: fmt.Errorf("watch has failed with a temporary condition: %w. please retry the watch", wrapped),
+		error: fmt.Errorf("watch has failed with a temporary condition: %w. Please retry", wrapped),
 	}
 }
 


### PR DESCRIPTION
This is a continuation of https://github.com/authzed/spicedb/pull/2640