### PR TITLE
ci: fix when benchmarks run for Main

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -412,8 +412,10 @@ jobs:
     runs-on: "depot-ubuntu-24.04-8"
     timeout-minutes: 30
     needs: "paths-filter"
+    # Benchmarks on Main are ran through a different workflow
     if: |
-      needs.paths-filter.outputs.codechange == 'true'
+      needs.paths-filter.outputs.codechange == 'true' &&
+      github.ref_name != 'main'
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         with:


### PR DESCRIPTION
Follow-up of https://github.com/authzed/spicedb/pull/2610

This should fix https://github.com/authzed/spicedb/actions/runs/18886519158/job/53903216146
<img width="1802" height="276" alt="image" src="https://github.com/user-attachments/assets/bd35df4c-1fe5-4196-8b8e-b35cb2d1f97d" />
