### PR TITLE
ci: update test matrix for CRDB

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -260,7 +260,7 @@ jobs:
       fail-fast: false
       matrix:
         datastore: ["crdb"]
-        crdbversion: ["24.3.6", "25.1.0", "25.2.0"]
+        crdbversion: ["25.2.0", "25.3.0"]
     steps:
       - uses: "actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493" # v4.2.2
         if: |
@@ -295,7 +295,7 @@ jobs:
       fail-fast: false
       matrix:
         datastore: ["crdb"]
-        crdbversion: ["24.3.6", "25.1.0", "25.2.0"]
+        crdbversion: ["25.2.0", "25.3.0"]
     steps:
       - uses: "actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493" # v4.2.2
         if: |


### PR DESCRIPTION
https://endoflife.date/cockroachdb

24.3 ends maintenance support in 2 weeks.