### PR TITLE
test: disable revision heartbeat in PG revision tests

### DIFF
--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -364,7 +364,7 @@ func newPostgresDatastore(
 
 	datastore.SetOptimizedRevisionFunc(datastore.optimizedRevisionFunc)
 
-	// Start a goroutine for garbage collection.
+	// Start a goroutine for garbage collection and the revision heartbeat.
 	if isPrimary {
 		datastore.workerGroup, datastore.workerCtx = errgroup.WithContext(datastore.workerCtx)
 		if config.revisionHeartbeatEnabled {

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -895,6 +895,7 @@ func QuantizedRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest) {
 					GCWindow(24*time.Hour),
 					WatchBufferLength(1),
 					FollowerReadDelay(tc.followerReadDelay),
+					WithRevisionHeartbeat(false),
 				)
 				require.NoError(err)
 
@@ -972,6 +973,7 @@ func OverlappingRevisionTest(t *testing.T, b testdatastore.RunningEngineForTest)
 					GCWindow(24*time.Hour),
 					WatchBufferLength(1),
 					FollowerReadDelay(tc.followerReadDelay),
+					WithRevisionHeartbeat(false),
 				)
 				require.NoError(err)
 


### PR DESCRIPTION
They may be interfering with the expected revisions and therefore causing flakiness
