### PR TITLE
chore: fix new govet issues

### DIFF
--- a/cmd/spicedb/migrate_integration_test.go
+++ b/cmd/spicedb/migrate_integration_test.go
@@ -1,5 +1,4 @@
 //go:build docker && image
-// +build docker,image
 
 package main
 

--- a/cmd/spicedb/restgateway_integration_test.go
+++ b/cmd/spicedb/restgateway_integration_test.go
@@ -1,5 +1,4 @@
 //go:build docker && image
-// +build docker,image
 
 package main
 

--- a/cmd/spicedb/schemawatch_integration_test.go
+++ b/cmd/spicedb/schemawatch_integration_test.go
@@ -1,5 +1,4 @@
 //go:build docker && image
-// +build docker,image
 
 package main
 

--- a/cmd/spicedb/serve_integration_test.go
+++ b/cmd/spicedb/serve_integration_test.go
@@ -1,5 +1,4 @@
 //go:build docker && image
-// +build docker,image
 
 package main
 

--- a/cmd/spicedb/servetesting_integration_test.go
+++ b/cmd/spicedb/servetesting_integration_test.go
@@ -1,5 +1,4 @@
 //go:build docker && image
-// +build docker,image
 
 package main
 

--- a/cmd/spicedb/servetesting_race_test.go
+++ b/cmd/spicedb/servetesting_race_test.go
@@ -1,5 +1,4 @@
 //go:build docker && image
-// +build docker,image
 
 package main
 

--- a/go.mod
+++ b/go.mod
@@ -211,6 +211,7 @@ require (
 	github.com/butuzov/mirror v1.3.0 // indirect
 	github.com/catenacyber/perfsprint v0.9.1 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.4 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/charithe/durationcheck v0.0.10 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect

--- a/go.sum
+++ b/go.sum
@@ -1534,6 +1534,8 @@ github.com/ccoveille/go-safecast v1.6.1 h1:Nb9WMDR8PqhnKCVs2sCB+OqhohwO5qaXtCviZ
 github.com/ccoveille/go-safecast v1.6.1/go.mod h1:QqwNjxQ7DAqY0C721OIO9InMk9zCwcsO7tnRuHytad8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=

--- a/internal/datastore/common/relationships.go
+++ b/internal/datastore/common/relationships.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -71,14 +72,16 @@ func runExplainIfNecessary[R Rows](ctx context.Context, builder RelationshipsQue
 	}
 
 	err = tx.QueryFunc(ctx, func(ctx context.Context, rows R) error {
-		explainString := ""
+		var explainBuilder strings.Builder
 		for rows.Next() {
 			var explain string
 			if err := rows.Scan(&explain); err != nil {
 				return fmt.Errorf(errUnableToQueryRels, fmt.Errorf("scan err: %w", err))
 			}
-			explainString += explain + "\n"
+			explainBuilder.WriteString(explain + "\n")
 		}
+
+		explainString := explainBuilder.String()
 		if explainString == "" {
 			return errors.New("received empty explain")
 		}

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -1,5 +1,4 @@
 //go:build ci && docker
-// +build ci,docker
 
 package crdb
 

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -1,5 +1,4 @@
 //go:build ci && docker
-// +build ci,docker
 
 package mysql
 

--- a/internal/datastore/mysql/migrations/migrations_test.go
+++ b/internal/datastore/mysql/migrations/migrations_test.go
@@ -1,5 +1,4 @@
 //go:build ci
-// +build ci
 
 package migrations
 

--- a/internal/datastore/postgres/pgbouncer_test.go
+++ b/internal/datastore/postgres/pgbouncer_test.go
@@ -1,5 +1,4 @@
 //go:build ci && docker && pgbouncer
-// +build ci,docker,pgbouncer
 
 package postgres
 

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -1,5 +1,4 @@
 //go:build ci && docker
-// +build ci,docker
 
 package postgres
 

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -1,5 +1,4 @@
 //go:build ci && docker && postgres
-// +build ci,docker,postgres
 
 package postgres
 

--- a/internal/datastore/postgres/testutil.go
+++ b/internal/datastore/postgres/testutil.go
@@ -1,5 +1,4 @@
 //go:build ci && docker
-// +build ci,docker
 
 package postgres
 
@@ -25,15 +24,16 @@ func getExplanation(ctx context.Context, querier pgxcommon.Querier, sql string, 
 		return "", err
 	}
 
-	explanation := ""
+	var explanation strings.Builder
 	for explainRows.Next() {
-		explanation += string(explainRows.RawValues()[0]) + "\n"
+		explanation.Write(explainRows.RawValues()[0])
+		explanation.WriteString("\n")
 	}
 	explainRows.Close()
 	if err := explainRows.Err(); err != nil {
 		return "", err
 	}
-	return explanation, nil
+	return explanation.String(), nil
 }
 
 type withQueryInterceptor struct {

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -1,5 +1,4 @@
 //go:build ci && docker
-// +build ci,docker
 
 package spanner
 

--- a/internal/dispatch/keys/hasher_ristretto.go
+++ b/internal/dispatch/keys/hasher_ristretto.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package keys
 

--- a/internal/dispatch/keys/hasher_wasm.go
+++ b/internal/dispatch/keys/hasher_wasm.go
@@ -1,5 +1,4 @@
 //go:build wasm
-// +build wasm
 
 package keys
 

--- a/internal/services/integrationtesting/benchmark_test.go
+++ b/internal/services/integrationtesting/benchmark_test.go
@@ -1,5 +1,4 @@
 //go:build !skipintegrationtests
-// +build !skipintegrationtests
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/cert_test.go
+++ b/internal/services/integrationtesting/cert_test.go
@@ -1,5 +1,4 @@
 //go:build !skipintegrationtests
-// +build !skipintegrationtests
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/consistency_datastore_test.go
+++ b/internal/services/integrationtesting/consistency_datastore_test.go
@@ -1,5 +1,4 @@
 //go:build ci && docker && datastoreconsistency
-// +build ci,docker,datastoreconsistency
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -1,5 +1,4 @@
 //go:build !skipintegrationtests
-// +build !skipintegrationtests
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/dispatch_test.go
+++ b/internal/services/integrationtesting/dispatch_test.go
@@ -1,5 +1,4 @@
 //go:build ci && docker && !skipintegrationtests
-// +build ci,docker,!skipintegrationtests
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/healthcheck_test.go
+++ b/internal/services/integrationtesting/healthcheck_test.go
@@ -1,5 +1,4 @@
 //go:build ci && docker && !skipintegrationtests
-// +build ci,docker,!skipintegrationtests
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/ops_test.go
+++ b/internal/services/integrationtesting/ops_test.go
@@ -1,5 +1,4 @@
 //go:build !skipintegrationtests
-// +build !skipintegrationtests
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/perf_test.go
+++ b/internal/services/integrationtesting/perf_test.go
@@ -1,5 +1,4 @@
 //go:build ci && docker && !skipintegrationtests
-// +build ci,docker,!skipintegrationtests
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/query_plan_consistency_test.go
+++ b/internal/services/integrationtesting/query_plan_consistency_test.go
@@ -1,5 +1,4 @@
 //go:build !skipintegrationtests
-// +build !skipintegrationtests
 
 package integrationtesting_test
 

--- a/internal/services/steelthreadtesting/definitions.go
+++ b/internal/services/steelthreadtesting/definitions.go
@@ -1,5 +1,4 @@
 //go:build steelthread
-// +build steelthread
 
 package steelthreadtesting
 

--- a/internal/services/steelthreadtesting/operations.go
+++ b/internal/services/steelthreadtesting/operations.go
@@ -1,5 +1,4 @@
 //go:build steelthread
-// +build steelthread
 
 package steelthreadtesting
 

--- a/internal/services/steelthreadtesting/steelthread_test.go
+++ b/internal/services/steelthreadtesting/steelthread_test.go
@@ -1,5 +1,4 @@
 //go:build steelthread && docker && image
-// +build steelthread,docker,image
 
 package steelthreadtesting
 

--- a/internal/services/v1/hash_nonwasm.go
+++ b/internal/services/v1/hash_nonwasm.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package v1
 

--- a/pkg/cache/cache_otter.go
+++ b/pkg/cache/cache_otter.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package cache
 

--- a/pkg/cache/cache_ristretto.go
+++ b/pkg/cache/cache_ristretto.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package cache
 

--- a/pkg/cache/cache_theine.go
+++ b/pkg/cache/cache_theine.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package cache
 

--- a/pkg/cache/standard.go
+++ b/pkg/cache/standard.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package cache
 

--- a/pkg/composableschemadsl/compiler/development.go
+++ b/pkg/composableschemadsl/compiler/development.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"strings"
+
 	"github.com/authzed/spicedb/pkg/composableschemadsl/dslshape"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/input"
 )
@@ -46,11 +48,11 @@ func (nc *NodeChain) FindNodeOfType(nodeType dslshape.NodeType) DSLNode {
 }
 
 func (nc *NodeChain) String() string {
-	var out string
+	var builder strings.Builder
 	for _, node := range nc.nodes {
-		out += node.GetType().String() + " "
+		builder.WriteString(node.GetType().String() + " ")
 	}
-	return out
+	return builder.String()
 }
 
 // PositionToAstNodeChain returns the AST node, and its parents (if any), found at the given position in the source, if any.

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -73,25 +73,25 @@ func (rc RevisionChanges) DebugString() string {
 		return "[checkpoint]"
 	}
 
-	debugString := ""
+	var debugString strings.Builder
 
 	for _, relChange := range rc.RelationshipChanges {
-		debugString += relChange.DebugString() + "\n"
+		debugString.WriteString(relChange.DebugString() + "\n")
 	}
 
 	for _, def := range rc.ChangedDefinitions {
-		debugString += fmt.Sprintf("Definition: %T:%s\n", def, def.GetName())
+		debugString.WriteString(fmt.Sprintf("Definition: %T:%s\n", def, def.GetName()))
 	}
 
 	for _, ns := range rc.DeletedNamespaces {
-		debugString += fmt.Sprintf("DeletedNamespace: %s\n", ns)
+		debugString.WriteString(fmt.Sprintf("DeletedNamespace: %s\n", ns))
 	}
 
 	for _, caveat := range rc.DeletedCaveats {
-		debugString += fmt.Sprintf("DeletedCaveat: %s\n", caveat)
+		debugString.WriteString(fmt.Sprintf("DeletedCaveat: %s\n", caveat))
 	}
 
-	return debugString
+	return debugString.String()
 }
 
 func (rc RevisionChanges) MarshalZerologObject(e *zerolog.Event) {

--- a/pkg/schemadsl/compiler/development.go
+++ b/pkg/schemadsl/compiler/development.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"strings"
+
 	"github.com/authzed/spicedb/pkg/schemadsl/dslshape"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
 )
@@ -46,11 +48,11 @@ func (nc *NodeChain) FindNodeOfType(nodeType dslshape.NodeType) DSLNode {
 }
 
 func (nc *NodeChain) String() string {
-	var out string
+	var out strings.Builder
 	for _, node := range nc.nodes {
-		out += node.GetType().String() + " "
+		out.WriteString(node.GetType().String() + " ")
 	}
-	return out
+	return out.String()
 }
 
 // PositionToAstNodeChain returns the AST node, and its parents (if any), found at the given position in the source, if any.

--- a/pkg/spiceerrors/assert_off.go
+++ b/pkg/spiceerrors/assert_off.go
@@ -1,5 +1,4 @@
 //go:build !ci
-// +build !ci
 
 package spiceerrors
 

--- a/pkg/spiceerrors/assert_on.go
+++ b/pkg/spiceerrors/assert_on.go
@@ -1,5 +1,4 @@
 //go:build ci
-// +build ci
 
 package spiceerrors
 

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ccoveille/go-safecast"
 
@@ -66,7 +67,7 @@ func PopulateFromFiles(ctx context.Context, ds datastore.Datastore, caveatTypeSe
 // PopulateFromFilesContents populates the given datastore with the namespaces and tuples found in
 // the validation file(s) contents specified.
 func PopulateFromFilesContents(ctx context.Context, ds datastore.Datastore, caveatTypeSet *caveattypes.TypeSet, filesContents map[string][]byte) (*PopulatedValidationFile, datastore.Revision, error) {
-	var schemaStr string
+	var schemaBuilder strings.Builder
 	var objectDefs []*core.NamespaceDefinition
 	var caveatDefs []*core.CaveatDefinition
 	var rels []tuple.Relationship
@@ -143,7 +144,7 @@ func PopulateFromFilesContents(ctx context.Context, ds datastore.Datastore, cave
 		if compiled != nil {
 			defs := compiled.ObjectDefinitions
 			if len(defs) > 0 {
-				schemaStr += parsed.Schema.Schema + "\n\n"
+				schemaBuilder.WriteString(parsed.Schema.Schema + "\n\n")
 			}
 
 			log.Ctx(ctx).Info().Str("filePath", filePath).
@@ -220,7 +221,7 @@ func PopulateFromFilesContents(ctx context.Context, ds datastore.Datastore, cave
 		return nil, nil, err
 	}
 
-	return &PopulatedValidationFile{schemaStr, objectDefs, caveatDefs, rels, files}, revision, err
+	return &PopulatedValidationFile{schemaBuilder.String(), objectDefs, caveatDefs, rels, files}, revision, err
 }
 
 // CompileSchema takes an InputSchema and returns the compiled schema, or else an error.


### PR DESCRIPTION
## Description
Part of getting linting sorted. These came with the most recent version of golangci-lint.

## Changes
* Autofix `buildtag: +build line is no longer needed (govet)`
* Fix `concat-loop: string concatenation in a loop (perfsprint)`
## Testing
Review. See that tests pass.