### PR TITLE
test: remove timeouts in flaky tests

### DIFF
--- a/cmd/spicedb/restgateway_integration_test.go
+++ b/cmd/spicedb/restgateway_integration_test.go
@@ -26,7 +26,6 @@ func TestRESTGateway(t *testing.T) {
 		false,
 	)
 	require.NoError(err)
-	defer tester.cleanup()
 
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%s", tester.HTTPPort))
 	require.NoError(err)

--- a/cmd/spicedb/schemawatch_integration_test.go
+++ b/cmd/spicedb/schemawatch_integration_test.go
@@ -67,12 +67,12 @@ func TestSchemaWatch(t *testing.T) {
 				}
 			})
 			require.NoError(t, err)
-
-			waitCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			defer cancel()
+			t.Cleanup(func() {
+				_ = pool.Purge(migrateResource)
+			})
 
 			// Ensure the command completed successfully.
-			status, err := pool.Client.WaitContainerWithContext(migrateResource.Container.ID, waitCtx)
+			status, err := pool.Client.WaitContainerWithContext(migrateResource.Container.ID, t.Context())
 			require.NoError(t, err)
 			require.Equal(t, 0, status)
 

--- a/cmd/spicedb/servetesting_race_test.go
+++ b/cmd/spicedb/servetesting_race_test.go
@@ -38,7 +38,6 @@ func TestCheckPermissionOnTesterNoFlakes(t *testing.T) {
 		true,
 	)
 	require.NoError(t, err)
-	defer tester.cleanup()
 
 	for i := 0; i < 1000; i++ {
 		conn, err := grpc.NewClient(fmt.Sprintf("localhost:%s", tester.port),

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -163,7 +163,7 @@ func datastoreTest(ctx context.Context, datastore string, env map[string]string,
 	mergedTags := append([]string{"ci", "docker"}, tags...)
 	tagString := strings.Join(mergedTags, ",")
 	mg.Deps(checkDocker)
-	args := []string{"-tags", tagString, "-timeout", "15m"}
+	args := []string{"-tags", tagString}
 	args = append(args, coverageFlags...)
 	return goDirTestWithEnv(ctx, ".", fmt.Sprintf("./internal/datastore/%s/...", datastore), env, args...)
 }
@@ -225,7 +225,6 @@ func consistencyTest(ctx context.Context, datastore string, env map[string]strin
 	mg.Deps(checkDocker)
 	args := []string{
 		"-tags", "ci,docker,datastoreconsistency",
-		"-timeout", "10m",
 		"-run", fmt.Sprintf("TestConsistencyPerDatastore/%s", datastore),
 	}
 	args = append(args, coverageFlags...)

--- a/magefiles/util.go
+++ b/magefiles/util.go
@@ -17,12 +17,12 @@ import (
 
 var coverageFlags = []string{"-coverpkg=./...", "-covermode=atomic", "-coverprofile=coverage.txt"}
 
-// run go test in the root
+// goDirTest runs go test in the root with a timeout
 func goTest(ctx context.Context, path string, args ...string) error {
 	return goDirTest(ctx, ".", path, args...)
 }
 
-// run go test in a directory
+// goDirTest runs go test in a directory with a timeout
 func goDirTest(ctx context.Context, dir string, path string, args ...string) error {
 	testArgs, err := testWithArgs(ctx, args...)
 	if err != nil {
@@ -31,6 +31,7 @@ func goDirTest(ctx context.Context, dir string, path string, args ...string) err
 	return RunSh(goCmdForTests(), WithV(), WithDir(dir), WithArgs(testArgs...))(path)
 }
 
+// goDirTestWithEnv runs go test in a directory with a timeout and environment variables
 func goDirTestWithEnv(ctx context.Context, dir string, path string, env map[string]string, args ...string) error {
 	testArgs, err := testWithArgs(ctx, args...)
 	if err != nil {
@@ -39,12 +40,14 @@ func goDirTestWithEnv(ctx context.Context, dir string, path string, env map[stri
 	return RunSh(goCmdForTests(), WithV(), WithDir(dir), WithEnv(env), WithArgs(testArgs...))(path)
 }
 
+// testWithArgs includes -race and -timeout=20m.
 func testWithArgs(ctx context.Context, args ...string) ([]string, error) {
 	testArgs := append([]string{
 		"test",
 		"-failfast",
 		"-count=1",
 		"-race",
+		"-timeout=20m",
 	}, args...)
 
 	return testArgs, nil


### PR DESCRIPTION
- Remove timeouts in `TestMigrate/cockroachdb`
- Remove timeouts in  `TestSchemaWatch/cockroachdb`
- Adds a default `-timeout=20m` to all tests