### PR TITLE
perf: have DeleteNamespaces skip rel deletes when invoked from WriteSchema

### DIFF
--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -809,7 +809,7 @@ func StreamingWatchTest(t *testing.T, rawDS datastore.Datastore) {
 		})
 		require.NoError(err)
 
-		err = rwt.DeleteNamespaces(ctx, "resource2")
+		err = rwt.DeleteNamespaces(ctx, []string{"resource2"}, datastore.DeleteNamespacesAndRelationships)
 		require.NoError(err)
 
 		err = rwt.DeleteCaveats(ctx, []string{"somecaveat2"})

--- a/internal/datastore/crdb/readwrite.go
+++ b/internal/datastore/crdb/readwrite.go
@@ -508,12 +508,16 @@ func (rwt *crdbReadWriteTXN) WriteNamespaces(ctx context.Context, newConfigs ...
 	return nil
 }
 
-func (rwt *crdbReadWriteTXN) DeleteNamespaces(ctx context.Context, nsNames ...string) error {
+func (rwt *crdbReadWriteTXN) DeleteNamespaces(ctx context.Context, nsNames []string, delOption datastore.DeleteNamespacesRelationshipsOption) error {
+	if len(nsNames) == 0 {
+		return nil
+	}
+
 	rwt.hasNonExpiredDeletionChange = true
 
 	querier := pgxcommon.QuerierFuncsFor(rwt.tx)
 	// For each namespace, check they exist and collect predicates for the
-	// "WHERE" clause to delete the namespaces and associated tuples.
+	// "WHERE" clause to delete the namespaces and (if requested) associated tuples.
 	nsClauses := make([]sq.Sqlizer, 0, len(nsNames))
 	tplClauses := make([]sq.Sqlizer, 0, len(nsNames))
 	for _, nsName := range nsNames {
@@ -541,18 +545,20 @@ func (rwt *crdbReadWriteTXN) DeleteNamespaces(ctx context.Context, nsNames ...st
 		return fmt.Errorf(errUnableToDeleteConfig, err)
 	}
 
-	deleteTupleSQL, deleteTupleArgs, err := rwt.queryDeleteTuples(nil).Where(sq.Or(tplClauses)).ToSql()
-	if err != nil {
-		return fmt.Errorf(errUnableToDeleteConfig, err)
-	}
+	if delOption == datastore.DeleteNamespacesAndRelationships {
+		deleteTupleSQL, deleteTupleArgs, err := rwt.queryDeleteTuples(nil).Where(sq.Or(tplClauses)).ToSql()
+		if err != nil {
+			return fmt.Errorf(errUnableToDeleteConfig, err)
+		}
 
-	modified, err := rwt.tx.Exec(ctx, deleteTupleSQL, deleteTupleArgs...)
-	if err != nil {
-		return fmt.Errorf(errUnableToDeleteConfig, err)
-	}
+		modified, err := rwt.tx.Exec(ctx, deleteTupleSQL, deleteTupleArgs...)
+		if err != nil {
+			return fmt.Errorf(errUnableToDeleteConfig, err)
+		}
 
-	numRowsDeleted := modified.RowsAffected()
-	rwt.relCountChange -= numRowsDeleted
+		numRowsDeleted := modified.RowsAffected()
+		rwt.relCountChange -= numRowsDeleted
+	}
 
 	return nil
 }

--- a/internal/datastore/proxy/indexcheck/fakedatastore_test.go
+++ b/internal/datastore/proxy/indexcheck/fakedatastore_test.go
@@ -207,7 +207,7 @@ func (f *fakeRWT) WriteNamespaces(ctx context.Context, newConfigs ...*corev1.Nam
 	return nil
 }
 
-func (f *fakeRWT) DeleteNamespaces(ctx context.Context, nsNames ...string) error {
+func (f *fakeRWT) DeleteNamespaces(ctx context.Context, nsNames []string, delOption datastore.DeleteNamespacesRelationshipsOption) error {
 	return nil
 }
 

--- a/internal/datastore/proxy/indexcheck/indexcheck.go
+++ b/internal/datastore/proxy/indexcheck/indexcheck.go
@@ -214,8 +214,8 @@ func (rwt *indexcheckingRWT) WriteNamespaces(ctx context.Context, newConfigs ...
 	return rwt.delegate.WriteNamespaces(ctx, newConfigs...)
 }
 
-func (rwt *indexcheckingRWT) DeleteNamespaces(ctx context.Context, nsNames ...string) error {
-	return rwt.delegate.DeleteNamespaces(ctx, nsNames...)
+func (rwt *indexcheckingRWT) DeleteNamespaces(ctx context.Context, nsNames []string, delOption datastore.DeleteNamespacesRelationshipsOption) error {
+	return rwt.delegate.DeleteNamespaces(ctx, nsNames, delOption)
 }
 
 func (rwt *indexcheckingRWT) DeleteRelationships(ctx context.Context, filter *v1.RelationshipFilter, options ...options.DeleteOptionsOption) (uint64, bool, error) {

--- a/internal/datastore/proxy/indexcheck/indexcheck_test.go
+++ b/internal/datastore/proxy/indexcheck/indexcheck_test.go
@@ -275,7 +275,7 @@ func TestIndexCheckingRWT(t *testing.T) {
 		})
 
 		t.Run("DeleteNamespaces", func(t *testing.T) {
-			err := indexRWT.DeleteNamespaces(ctx, "test")
+			err := indexRWT.DeleteNamespaces(ctx, []string{"test"}, datastore.DeleteNamespacesAndRelationships)
 			require.NoError(t, err)
 		})
 

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -357,13 +357,13 @@ func (rwt *observableRWT) WriteNamespaces(ctx context.Context, newConfigs ...*co
 	return rwt.delegate.WriteNamespaces(ctx, newConfigs...)
 }
 
-func (rwt *observableRWT) DeleteNamespaces(ctx context.Context, nsNames ...string) error {
+func (rwt *observableRWT) DeleteNamespaces(ctx context.Context, nsNames []string, delOption datastore.DeleteNamespacesRelationshipsOption) error {
 	ctx, closer := observe(ctx, "DeleteNamespaces", "", trace.WithAttributes(
 		attribute.StringSlice(otelconv.AttrDatastoreNames, nsNames),
 	))
 	defer closer()
 
-	return rwt.delegate.DeleteNamespaces(ctx, nsNames...)
+	return rwt.delegate.DeleteNamespaces(ctx, nsNames, delOption)
 }
 
 func (rwt *observableRWT) DeleteRelationships(ctx context.Context, filter *v1.RelationshipFilter, options ...options.DeleteOptionsOption) (uint64, bool, error) {

--- a/internal/datastore/proxy/proxy_test/mock.go
+++ b/internal/datastore/proxy/proxy_test/mock.go
@@ -294,11 +294,12 @@ func (dm *MockReadWriteTransaction) WriteNamespaces(_ context.Context, newConfig
 	return args.Error(0)
 }
 
-func (dm *MockReadWriteTransaction) DeleteNamespaces(_ context.Context, nsNames ...string) error {
-	xs := make([]any, 0, len(nsNames))
+func (dm *MockReadWriteTransaction) DeleteNamespaces(_ context.Context, nsNames []string, delOption datastore.DeleteNamespacesRelationshipsOption) error {
+	xs := make([]any, 0, len(nsNames)+1)
 	for _, nsName := range nsNames {
 		xs = append(xs, nsName)
 	}
+	xs = append(xs, delOption)
 
 	args := dm.Called(xs...)
 	return args.Error(0)

--- a/internal/datastore/proxy/readonly_test.go
+++ b/internal/datastore/proxy/readonly_test.go
@@ -34,7 +34,7 @@ func TestRWOperationErrors(t *testing.T) {
 	ctx := t.Context()
 
 	rev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-		return rwt.DeleteNamespaces(ctx, "fake")
+		return rwt.DeleteNamespaces(ctx, []string{"fake"}, datastore.DeleteNamespacesAndRelationships)
 	})
 	require.ErrorAs(err, &datastore.ReadOnlyError{})
 	require.Equal(datastore.NoRevision, rev)

--- a/internal/services/shared/schema.go
+++ b/internal/services/shared/schema.go
@@ -205,9 +205,10 @@ func ApplySchemaChangesOverExisting(
 	}
 
 	if !validated.additiveOnly {
-		// Delete the removed namespaces.
+		// Delete the removed namespaces. Note that we don't need to delete relationships here,
+		// as that is handled by the ensureNoRelationshipsExistWithResourceType call above.
 		if removedObjectDefNames.Len() > 0 {
-			if err := rwt.DeleteNamespaces(ctx, removedObjectDefNames.AsSlice()...); err != nil {
+			if err := rwt.DeleteNamespaces(ctx, removedObjectDefNames.AsSlice(), datastore.DeleteNamespacesOnly); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/testfixtures/validating.go
+++ b/internal/testfixtures/validating.go
@@ -215,8 +215,8 @@ func (vrwt validatingReadWriteTransaction) WriteNamespaces(ctx context.Context, 
 	return vrwt.delegate.WriteNamespaces(ctx, newConfigs...)
 }
 
-func (vrwt validatingReadWriteTransaction) DeleteNamespaces(ctx context.Context, nsNames ...string) error {
-	return vrwt.delegate.DeleteNamespaces(ctx, nsNames...)
+func (vrwt validatingReadWriteTransaction) DeleteNamespaces(ctx context.Context, nsNames []string, delOption datastore.DeleteNamespacesRelationshipsOption) error {
+	return vrwt.delegate.DeleteNamespaces(ctx, nsNames, delOption)
 }
 
 func (vrwt validatingReadWriteTransaction) WriteRelationships(ctx context.Context, mutations []tuple.RelationshipUpdate) error {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -544,6 +544,19 @@ type Reader interface {
 	LookupNamespacesWithNames(ctx context.Context, nsNames []string) ([]RevisionedNamespace, error)
 }
 
+// DeleteNamespacesRelationshipsOption is an option for deleting namespaces and their relationships.
+type DeleteNamespacesRelationshipsOption int
+
+const (
+	// DeleteNamespacesOnly indicates that only namespaces should be deleted.
+	// It is therefore the caller's responsibility to delete any relationships in those namespaces.
+	DeleteNamespacesOnly DeleteNamespacesRelationshipsOption = iota
+
+	// DeleteNamespacesAndRelationships indicates that namespaces and all relationships
+	// in those namespaces should be deleted.
+	DeleteNamespacesAndRelationships
+)
+
 type ReadWriteTransaction interface {
 	Reader
 	CaveatStorer
@@ -563,8 +576,8 @@ type ReadWriteTransaction interface {
 	// WriteNamespaces takes proto namespace definitions and persists them.
 	WriteNamespaces(ctx context.Context, newConfigs ...*core.NamespaceDefinition) error
 
-	// DeleteNamespaces deletes namespaces including associated relationships.
-	DeleteNamespaces(ctx context.Context, nsNames ...string) error
+	// DeleteNamespaces deletes namespaces.
+	DeleteNamespaces(ctx context.Context, nsNames []string, delOption DeleteNamespacesRelationshipsOption) error
 
 	// BulkLoad takes a relationship source iterator, and writes all of the
 	// relationships to the backing datastore in an optimized fashion. This

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -116,6 +116,7 @@ func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories, 
 	t.Run("TestNamespaceNotFound", runner(tester, NamespaceNotFoundTest))
 	t.Run("TestNamespaceWrite", runner(tester, NamespaceWriteTest))
 	t.Run("TestNamespaceDelete", runner(tester, NamespaceDeleteTest))
+	t.Run("TestNamespaceDeleteNoRelationships", runner(tester, NamespaceDeleteNoRelationshipsTest))
 	t.Run("TestNamespaceMultiDelete", runner(tester, NamespaceMultiDeleteTest))
 	t.Run("TestEmptyNamespaceDelete", runner(tester, EmptyNamespaceDeleteTest))
 	t.Run("TestStableNamespaceReadWrite", runner(tester, StableNamespaceReadWriteTest))

--- a/pkg/datastore/test/watch.go
+++ b/pkg/datastore/test/watch.go
@@ -635,7 +635,7 @@ func WatchSchemaTest(t *testing.T, tester DatastoreTester) {
 	// Removed
 	// Delete some namespaces and caveats.
 	_, err = ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-		err := rwt.DeleteNamespaces(ctx, "somenewnamespace")
+		err := rwt.DeleteNamespaces(ctx, []string{"somenewnamespace"}, datastore.DeleteNamespacesAndRelationships)
 		if err != nil {
 			return err
 		}
@@ -713,7 +713,7 @@ func WatchAllTest(t *testing.T, tester DatastoreTester) {
 
 	// Delete some namespaces and caveats.
 	_, err = ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-		err := rwt.DeleteNamespaces(ctx, "somenewnamespace")
+		err := rwt.DeleteNamespaces(ctx, []string{"somenewnamespace"}, datastore.DeleteNamespacesAndRelationships)
 		if err != nil {
 			return err
 		}

--- a/pkg/datastore/util.go
+++ b/pkg/datastore/util.go
@@ -53,7 +53,7 @@ func DeleteAllData(ctx context.Context, ds Datastore) error {
 		}
 
 		// Delete all namespaces.
-		if err := rwt.DeleteNamespaces(ctx, namespaceNames...); err != nil {
+		if err := rwt.DeleteNamespaces(ctx, namespaceNames, DeleteNamespacesAndRelationships); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
WriteSchema is already validating that there are no relationships for the namespace, within the same txn, so the delete call is superfluous and adding (in some cases significant) overhead
