### PR TITLE
test: create mage target to run e2e tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -326,6 +326,10 @@ jobs:
     name: "E2E"
     runs-on: "depot-ubuntu-24.04-8"
     needs: "paths-filter"
+    strategy:
+      fail-fast: false
+      matrix:
+        crdbversion: ["22.1.5"] # TODO update to 25.x when we figure out how to override the clock
     if: |
       needs.paths-filter.outputs.codechange == 'true'
     steps:
@@ -334,20 +338,8 @@ jobs:
         with:
           go-version-file: "e2e/go.mod"
           cache-dependency-path: "e2e/go.sum"
-      - name: "Install cockroachdb and chaosd"
-        if: "steps.cache-binaries.outputs.cache-hit != 'true'"
-        working-directory: "e2e/newenemy"
-        run: |
-          curl https://binaries.cockroachdb.com/cockroach-v22.1.5.linux-amd64.tgz | tar -xz && mv cockroach-v22.1.5.linux-amd64/cockroach ./cockroach
-          curl -fsSL https://mirrors.chaos-mesh.org/chaosd-v1.1.1-linux-amd64.tar.gz | tar -xz && mv chaosd-v1.1.1-linux-amd64/chaosd ./chaosd
-      - name: "Build SpiceDB"
-        run: |
-          go get -d ./...
-          go build -o ./e2e/newenemy/spicedb ./cmd/spicedb/...
       - name: "Run e2e"
-        working-directory: "e2e/newenemy"
-        run: |
-          go test -v -timeout 11m ./...
+        run: "go run mage.go test:e2e ${{ matrix.crdbversion }}"
       - uses: "actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4" # v5.0.0
         if: "always()"
         # this upload step is really flaky, don't fail the job if it fails

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ manpages/
 .vscode/settings.json
 .env.local
 coverage*.txt
+.idea/
+.claude/
+e2e/newenemy/spicedb
+e2e/newenemy/cockroach
+e2e/newenemy/chaosd

--- a/e2e/spice/spicedb.go
+++ b/e2e/spice/spicedb.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net"
 	"strconv"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -195,15 +194,10 @@ func (c *Cluster) Connect(ctx context.Context, out io.Writer) error {
 
 // MigrateHead migrates a Datastore to the latest revision defined in spicedb
 func MigrateHead(ctx context.Context, out io.Writer, datastore, uri string) error {
-	for i := 0; i < 5; i++ {
-		if err := e2e.Run(ctx, out, out,
-			"./spicedb",
-			"migrate", "head", "--datastore-engine="+datastore,
-			"--datastore-conn-uri="+uri,
-		); err == nil {
-			return nil
-		}
-		time.Sleep(1 * time.Second)
-	}
-	return fmt.Errorf("failed to migrate spicedb")
+	return e2e.Run(ctx, out, out,
+		"./spicedb",
+		"datastore", "migrate", "head",
+		"--datastore-engine="+datastore,
+		"--datastore-conn-uri="+uri,
+	)
 }

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 )
@@ -32,4 +34,11 @@ func (Build) Testimage() error {
 	mg.Deps(checkDocker)
 	return sh.RunWithV(map[string]string{"DOCKER_BUILDKIT": "1"}, "docker",
 		"build", "-t", "authzed/spicedb:ci", ".")
+}
+
+// E2e Build the new enemy tests
+func (Build) E2e() error {
+	err1 := sh.Run("go", "get", "./...")
+	err2 := sh.Run("go", "build", "-o", "./e2e/newenemy/spicedb", "./cmd/spicedb")
+	return errors.Join(err1, err2)
 }


### PR DESCRIPTION
# Description

Followup of https://github.com/authzed/spicedb/pull/2665

- create mage targets
- prevent `TestNoNewEnemy/protected_from_data_newenemy_with_standard_overlap` from flaking out because the `-timeout=10m` is too short

## Testing

@tstirrat15 could you test the mage target on your machine?