### PR TITLE
chore: unflake sleeper tests using synctest

### DIFF
--- a/internal/dispatch/remote/cluster_test.go
+++ b/internal/dispatch/remote/cluster_test.go
@@ -953,6 +953,7 @@ func TestCheckUsesMaximumDelayByDefaultForPrimary(t *testing.T) {
 }
 
 func connectionForDispatching(t *testing.T, svc v1.DispatchServiceServer) *grpc.ClientConn {
+	t.Helper()
 	listener := bufconn.Listen(humanize.MiByte)
 	s := grpc.NewServer()
 


### PR DESCRIPTION
## Description
These are a prime candidate for synctest - all of the logic is based around sleeping and waiting. This makes these tests deterministic and (relatively) instantaneous.

## Changes
* Use `synctest` to make these tests deterministic
## Testing
Review.