### PR TITLE
fix: schema/relationship generator does not conform to regex 

### DIFF
--- a/pkg/schema/v2/testing/generator.go
+++ b/pkg/schema/v2/testing/generator.go
@@ -22,10 +22,14 @@ type RelationshipGenerator struct {
 	subjectTypeNames  []string
 }
 
+// See parsing.go for reference regexes. max length is 64. We subtract 4 due to "o_" and first and last character
+// expressed in the regex first and last segments.
+const objectExpr = "[a-z0-9_][a-z0-9_]{0,59}[a-z0-9]+"
+
 // GenerateRelationships generates an infinite sequence of relationships for the schema.
 // Relationships are randomly generated but valid according to the schema.
 func (rg *RelationshipGenerator) GenerateRelationships(t *rapid.T) iter.Seq[tuple.Relationship] {
-	rapidObjectString := rapid.StringMatching("o_\\w\\w\\w+")
+	rapidObjectString := rapid.StringMatching("o_" + objectExpr)
 
 	return func(yield func(tuple.Relationship) bool) {
 		for {
@@ -76,9 +80,9 @@ func (rg *RelationshipGenerator) GenerateRelationships(t *rapid.T) iter.Seq[tupl
 func CheckWithSchema(t *testing.T, handler func(t *rapid.T, schema *schema.Schema, relationshipGenerator RelationshipGenerator)) {
 	t.Helper()
 	rapid.Check(t, func(t *rapid.T) {
-		rapidRelationString := rapid.StringMatching("r_\\w\\w\\w+")
-		rapidPermissionString := rapid.StringMatching("p_\\w\\w\\w+")
-		rapidDefinitionString := rapid.StringMatching("d_\\w\\w\\w+")
+		rapidRelationString := rapid.StringMatching("r_" + objectExpr)
+		rapidPermissionString := rapid.StringMatching("p_" + objectExpr)
+		rapidDefinitionString := rapid.StringMatching("d_" + objectExpr)
 
 		builder := schema.NewSchemaBuilder()
 

--- a/pkg/schema/v2/testing/generator_test.go
+++ b/pkg/schema/v2/testing/generator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/authzed/spicedb/pkg/schema/v2"
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/schemadsl/generator"
+	"github.com/authzed/spicedb/pkg/tuple"
 )
 
 func TestExampleRunWithSchemaForTesting(t *testing.T) {
@@ -35,6 +36,22 @@ func TestExampleRunWithSchemaForTesting(t *testing.T) {
 			t.Logf("Generated relationship: %s\n", relationship.String())
 			counter++
 			if counter >= 5 {
+				break
+			}
+		}
+	})
+}
+
+func TestGenerateRelationshipsConformsToRegex(t *testing.T) {
+	CheckWithSchema(t, func(t *rapid.T, schema *schema.Schema, relGenerator RelationshipGenerator) {
+		require.NotNil(t, schema)
+
+		counter := 0
+		total := 1000
+		for relationship := range relGenerator.GenerateRelationships(t) {
+			_ = tuple.MustParse(relationship.String())
+			counter++
+			if counter >= total {
 				break
 			}
 		}


### PR DESCRIPTION
## Description

The Schema/Relationship Generator in the `schema/v2/testing` package does not conform to the regular expression defined for namespaces, object types, object IDs and relations. 

## Testing

A test was added that generates 1K relationships and parses it using the reference regular expression
