### PR TITLE
fix: set missing fields in postgresRevision.MarshalBinary

### DIFF
--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -1215,7 +1215,7 @@ func ConcurrentRevisionWatchTest(t *testing.T, ds datastore.Datastore) {
 	require.Eventually(func() bool {
 		seenWatchRevisionsLock.Lock()
 		defer seenWatchRevisionsLock.Unlock()
-		return len(seenWatchRevisions) == 3 && seenWatchRevisions[len(seenWatchRevisions)-1].String() == afterRev.String()
+		return len(seenWatchRevisions) == 3 && seenWatchRevisions[len(seenWatchRevisions)-1].Equal(afterRev)
 	}, 2*time.Second, 5*time.Millisecond)
 }
 

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -404,9 +404,11 @@ func (pr postgresRevision) MarshalBinary() ([]byte, error) {
 		return nil, spiceerrors.MustBugf("could not safely cast snapshot xmax to int64: %v", err)
 	}
 	protoRevision := implv1.PostgresRevision{
-		Xmin:         pr.snapshot.xmin,
-		RelativeXmax: relativeXmax - xminInt,
-		RelativeXips: relativeXips,
+		Xmin:              pr.snapshot.xmin,
+		RelativeXmax:      relativeXmax - xminInt,
+		RelativeXips:      relativeXips,
+		OptionalTxid:      pr.optionalTxID.Uint64,
+		OptionalTimestamp: pr.optionalNanosTimestamp,
 	}
 
 	return protoRevision.MarshalVT()

--- a/internal/datastore/postgres/revisions_test.go
+++ b/internal/datastore/postgres/revisions_test.go
@@ -57,18 +57,22 @@ func TestRevisionSerDe(t *testing.T) {
 	}
 
 	testCases := []struct {
-		snapshot    pgSnapshot
-		expectedStr string
+		snapshot       pgSnapshot
+		expectedStr    string
+		optionalTxID   uint64
+		optionalNanoTS uint64
 	}{
-		{snap(0, 0), ""},
-		{snap(0, 5, 1), "EAUaAQE="},
-		{snap(1, 1), "CAE="},
-		{snap(1, 3, 1), "CAEQAhoBAA=="},
-		{snap(1, 2, 1), "CAEQARoBAA=="},
-		{snap(2, 2), "CAI="},
-		{snap(123, 123), "CHs="},
-		{snap(100, 150, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110), "CGQQMhoKAQIDBAUGBwgJCg=="},
-		{snap(maxSizeList[0], maxSizeList[len(maxSizeList)-1], maxSizeList...), "COv/////////fxATGhQAAQIDBAUGBwgJCgsMDQ4PEBESEw=="},
+		{snapshot: snap(0, 0), expectedStr: ""},
+		{snapshot: snap(0, 5, 1), expectedStr: "EAUaAQE="},
+		{snapshot: snap(1, 1), expectedStr: "CAE="},
+		{snapshot: snap(1, 3, 1), expectedStr: "CAEQAhoBAA=="},
+		{snapshot: snap(1, 2, 1), expectedStr: "CAEQARoBAA=="},
+		{snapshot: snap(2, 2), expectedStr: "CAI="},
+		{snapshot: snap(123, 123), expectedStr: "CHs="},
+		{snapshot: snap(100, 150, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110), expectedStr: "CGQQMhoKAQIDBAUGBwgJCg=="},
+		{snapshot: snap(maxSizeList[0], maxSizeList[len(maxSizeList)-1], maxSizeList...), expectedStr: "COv/////////fxATGhQAAQIDBAUGBwgJCgsMDQ4PEBESEw=="},
+		{snapshot: snap(1, 1), expectedStr: "CAEgASi4o46CjtKKvBg=", optionalTxID: 1, optionalNanoTS: 1763206055841731000},
+		{snapshot: snap(1, 3, 1), expectedStr: "CAEQAhoBACAKKIitk9OQ5Iq8GA==", optionalTxID: 10, optionalNanoTS: 1763206675023845000},
 	}
 
 	for _, tc := range testCases {
@@ -76,7 +80,11 @@ func TestRevisionSerDe(t *testing.T) {
 		t.Run(tc.snapshot.String(), func(t *testing.T) {
 			require := require.New(t)
 
-			rev := postgresRevision{snapshot: tc.snapshot}
+			rev := postgresRevision{
+				snapshot:               tc.snapshot,
+				optionalTxID:           xid8{Uint64: tc.optionalTxID, Valid: tc.optionalTxID > 0},
+				optionalNanosTimestamp: tc.optionalNanoTS,
+			}
 			serialized := rev.String()
 			require.Equal(tc.expectedStr, serialized)
 


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

This change sets `OptionalTxid` and `OptionalTimestamp` when marshalling a postgres revision to `probuf`.

<!--
Why do we need this PR? Any implementation details worth mentioning here?
-->

## Testing

Add test case to `TestRevisionSerDe`.