### PR TITLE
chore: unflake cursored parallel iterators test by refactoring iterator logic

### DIFF
--- a/internal/taskrunner/preloadedtaskrunner.go
+++ b/internal/taskrunner/preloadedtaskrunner.go
@@ -54,15 +54,21 @@ func (tr *PreloadedTaskRunner) Start() {
 	}
 }
 
-// StartAndWait starts running the tasks in the task runner and waits for them to complete.
-func (tr *PreloadedTaskRunner) StartAndWait() error {
-	tr.Start()
+// Wait calls .Wait() on the underlying waitgroup, allowing for e.g.
+// cleanup of existing tasks to happen.
+func (tr *PreloadedTaskRunner) Wait() error {
 	tr.wg.Wait()
 
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
 
 	return tr.err
+}
+
+// StartAndWait starts running the tasks in the task runner and waits for them to complete.
+func (tr *PreloadedTaskRunner) StartAndWait() error {
+	tr.Start()
+	return tr.Wait()
 }
 
 func (tr *PreloadedTaskRunner) spawnIfAvailable() {


### PR DESCRIPTION
## Description
This is a flake that we were seeing relatively frequently: https://github.com/authzed/spicedb/actions/runs/19578836216/job/56071339937?pr=2691

The issue was that the test [expected that the error iterator would produce a result before the error](https://github.com/authzed/spicedb/blob/b55a9f65aaacba19ec0b3eb004529a0d0bca4530/internal/cursorediterator/blocks_test.go#L397-L400), but the code was effectively racing the result and the error between a pair of channels that held results and errors.

This refactors it so that the `item` that's passed through the channel holds the error as well, so we're no longer racing channels.

## Changes
* Refactor `CursoredParallelIterators` to remove `errChannels`
## Testing
Review. See that tests pass and no longer flake.