### PR TITLE
fix(generator): do not generate duplicated relations/perms

### DIFF
--- a/pkg/schema/v2/testing/generator.go
+++ b/pkg/schema/v2/testing/generator.go
@@ -87,7 +87,7 @@ func CheckWithSchema(t *testing.T, handler func(t *rapid.T, schema *schema.Schem
 		builder := schema.NewSchemaBuilder()
 
 		// Generate between 1 and 3 types to represent subjects.
-		subjectTypeNames := rapid.SliceOfN(rapidDefinitionString, 1, 3).Draw(t, "subjectTypeNames")
+		subjectTypeNames := rapid.SliceOfNDistinct(rapidDefinitionString, 1, 3, rapid.ID[string]).Draw(t, "subjectTypeNames")
 		subjectTypeRelationMap := map[string]string{}
 		for _, subjectTypeName := range subjectTypeNames {
 			builder = builder.AddDefinition(subjectTypeName).Done()
@@ -108,17 +108,17 @@ func CheckWithSchema(t *testing.T, handler func(t *rapid.T, schema *schema.Schem
 		}
 
 		// Generate between 1 and 3 types to represent resources.
-		resourceTypeNames := rapid.SliceOfN(rapidDefinitionString, 1, 3).Draw(t, "resourceTypeNames")
+		resourceTypeNames := rapid.SliceOfNDistinct(rapidDefinitionString, 1, 3, rapid.ID[string]).Draw(t, "resourceTypeNames")
 		for _, resourceTypeName := range resourceTypeNames {
 			resourceBuilder := builder.AddDefinition(resourceTypeName)
 
 			// Generate between 3 and 5 relations per resource.
-			relationNames := rapid.SliceOfN(rapidRelationString, 3, 5).Draw(t, resourceTypeName+"-relationNames")
+			relationNames := rapid.SliceOfNDistinct(rapidRelationString, 3, 5, rapid.ID[string]).Draw(t, resourceTypeName+"-relationNames")
 			for _, relationName := range relationNames {
 				relationBuilder := resourceBuilder.AddRelation(relationName)
 
 				// Link the relation to between 1 and 3 subject types.
-				subjectTypeNames := rapid.SliceOfN(rapid.SampledFrom(subjectTypeNames), 1, 3).Draw(t, resourceTypeName+"-"+relationName+"-subjectTypeNames")
+				subjectTypeNames := rapid.SliceOfNDistinct(rapid.SampledFrom(subjectTypeNames), 1, 3, rapid.ID[string]).Draw(t, resourceTypeName+"-"+relationName+"-subjectTypeNames")
 				addedSubjectTypeNames := mapz.NewSet[string]()
 				for _, subjectTypeName := range subjectTypeNames {
 					if !addedSubjectTypeNames.Add(subjectTypeName) {
@@ -138,7 +138,7 @@ func CheckWithSchema(t *testing.T, handler func(t *rapid.T, schema *schema.Schem
 
 			// Generate between 1 and 5 permissions per resource.
 			subjectRelationNames := slices.Collect(maps.Values(subjectTypeRelationMap))
-			permissionNames := rapid.SliceOfN(rapidPermissionString, 1, 5).Draw(t, resourceTypeName+"-permissionNames")
+			permissionNames := rapid.SliceOfNDistinct(rapidPermissionString, 1, 5, rapid.ID[string]).Draw(t, resourceTypeName+"-permissionNames")
 			for _, permissionName := range permissionNames {
 				permBuilder := resourceBuilder.AddPermission(permissionName)
 				op := mustGenerateOperation(t, relationNames, subjectRelationNames, 3, "")

--- a/pkg/schema/v2/testing/generator_test.go
+++ b/pkg/schema/v2/testing/generator_test.go
@@ -21,9 +21,11 @@ func TestExampleRunWithSchemaForTesting(t *testing.T) {
 
 		definitions := make([]compiler.SchemaDefinition, 0, len(typeDefs)+len(caveatDefs))
 		for _, td := range typeDefs {
+			require.NoError(t, td.Validate())
 			definitions = append(definitions, td)
 		}
 		for _, cd := range caveatDefs {
+			require.NoError(t, cd.Validate())
 			definitions = append(definitions, cd)
 		}
 


### PR DESCRIPTION
## Description

The generator was drawing from rapid's pool without uniqueness guarantee. This led to invalid schemas.


## Testing

Updated the test to call `Validate`

## References
