### PR TITLE
fix: follow up to pr #2694 for spanner watch

### DIFF
--- a/internal/datastore/spanner/watch.go
+++ b/internal/datastore/spanner/watch.go
@@ -174,7 +174,7 @@ func (sd *spannerDatastore) watch(
 	}
 	defer reader.Close()
 
-	metadataForTransactionTag := xsync.Map[string, TransactionMetadata]{}
+	metadataForTransactionTag := xsync.NewMap[string, TransactionMetadata]()
 
 	addMetadataForTransactionTag := func(ctx context.Context, tracked *common.Changes[revisions.TimestampRevision, int64], revision revisions.TimestampRevision, transactionTag string) error {
 		if metadata, ok := metadataForTransactionTag.Load(transactionTag); ok {


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

Follow-up to https://github.com/authzed/spicedb/pull/2694



## Testing

This code panics

```go
package main

import (
	"fmt"

	"github.com/puzpuzpuz/xsync/v4"
)

type TransactionMetadata map[string]any

func main() {
	mymap := xsync.Map[string, TransactionMetadata]{}

	val, ok := mymap.Load("key")
	if !ok {
		fmt.Println("key not found")
	}

	fmt.Println("val:", val)
}

```

with

```shell
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x1008e9808]

goroutine 1 [running]:
github.com/puzpuzpuz/xsync/v4.(*Map[...]).Load(0x1008854a4?, {0x1008e9dda?, 0x3})
	/Users/miparnisari/go/pkg/mod/github.com/puzpuzpuz/xsync/v4@v4.2.0/map.go:266 +0x38
```

but this one doesn't:

```go
package main

import (
	"fmt"

	"github.com/puzpuzpuz/xsync/v4"
)

type TransactionMetadata map[string]any

func main() {
	mymap := xsync.NewMap[string, TransactionMetadata]()

	val, ok := mymap.Load("key")
	if !ok {
		fmt.Println("key not found")
	}

	fmt.Println("val:", val)
}
```

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->