### PR TITLE
chore: reduce t.Parallel() fanout

### DIFF
--- a/internal/services/integrationtesting/consistency_datastore_test.go
+++ b/internal/services/integrationtesting/consistency_datastore_test.go
@@ -36,13 +36,12 @@ func TestConsistencyPerDatastore(t *testing.T) { //nolint:tparallel
 	}
 
 	for _, engineID := range datastore.Engines {
-		for _, filePath := range consistencyTestFiles {
-			t.Run(engineID+"/"+path.Base(filePath), func(t *testing.T) {
-				// FIXME errors arise if spanner is run in parallel
-				if engineID != "spanner" {
-					t.Parallel()
-				}
-
+		t.Run(engineID, func(t *testing.T) {
+			// FIXME errors arise if spanner is run in parallel
+			if engineID != "spanner" {
+				t.Parallel()
+			}
+			for _, filePath := range consistencyTestFiles {
 				rde := testdatastore.RunDatastoreEngine(t, engineID)
 				baseds := rde.NewDatastore(t, config.DatastoreConfigInitFunc(t,
 					dsconfig.WithWatchBufferLength(0),
@@ -74,12 +73,11 @@ func TestConsistencyPerDatastore(t *testing.T) { //nolint:tparallel
 						dispatcher:       dispatcher,
 					}
 
-					t.Run(tester.Name(), func(t *testing.T) {
-						t.Parallel()
+					t.Run(path.Base(filePath)+"/"+tester.Name(), func(t *testing.T) {
 						runAssertions(t, vctx)
 					})
 				}
-			})
-		}
+			}
+		})
 	}
 }

--- a/internal/services/integrationtesting/query_plan_consistency_test.go
+++ b/internal/services/integrationtesting/query_plan_consistency_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/authzed/spicedb/pkg/validationfile/blocks"
 )
 
-func TestQueryPlanConsistency(t *testing.T) {
+func TestQueryPlanConsistency(t *testing.T) { // nolint:tparallel
 	t.Parallel()
 	consistencyTestFiles, err := consistencytestutil.ListTestConfigs()
 	require.NoError(t, err)
@@ -30,7 +30,6 @@ func TestQueryPlanConsistency(t *testing.T) {
 		filePath := filePath
 
 		t.Run(filepath.Base(filePath), func(t *testing.T) {
-			t.Parallel()
 			runQueryPlanConsistencyForFile(t, filePath)
 		})
 	}


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

Reorders and removes some overly-aggressive uses of `t.Parallel()` to improve CI

## Testing

Run `go run mage.go test:integrationCover` like CI
Local timing before change: 419.87s
Local timing after change: 437.459s

## References
https://github.com/authzed/spicedb/actions/runs/19870343724/job/56944204925
<!--
GitHub Issue, Discord or Slack threads, etc.
-->