### PR TITLE
test: fix flaky TestExecuteRepair

### DIFF
--- a/internal/datastore/common/gc.go
+++ b/internal/datastore/common/gc.go
@@ -71,7 +71,7 @@ func RegisterGCMetrics() ([]prometheus.Collector, error) {
 	}
 	for _, metric := range collectors {
 		if err := prometheus.Register(metric); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to register GC metric: %w", err)
 		}
 	}
 

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -85,6 +85,9 @@ func TestCRDBDatastoreWithoutIntegrity(t *testing.T) {
 				WithAcquireTimeout(5*time.Second),
 			)
 			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = ds.Close()
+			})
 			return indexcheck.WrapWithIndexCheckingDatastoreProxyIfApplicable(ds)
 		})
 
@@ -116,9 +119,11 @@ func createDatastoreTest(b testdatastore.RunningEngineForTest, tf datastoreTestF
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 			ds, err := NewCRDBDatastore(ctx, uri, options...)
 			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = ds.Close()
+			})
 			return ds
 		})
-		defer ds.Close()
 
 		tf(t, ds)
 	}
@@ -208,6 +213,9 @@ func TestCRDBDatastoreWithIntegrity(t *testing.T) { //nolint:tparallel
 				WithAcquireTimeout(5*time.Second),
 			)
 			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = ds.Close()
+			})
 
 			wrapped, err := proxy.NewRelationshipIntegrityProxy(ds, defaultKeyForTesting, nil)
 			require.NoError(t, err)
@@ -232,6 +240,9 @@ func TestCRDBDatastoreWithIntegrity(t *testing.T) { //nolint:tparallel
 				WithAcquireTimeout(5*time.Second),
 			)
 			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = ds.Close()
+			})
 			return ds
 		})
 
@@ -303,6 +314,9 @@ func TestWatchFeatureDetection(t *testing.T) {
 
 			ds, err := NewCRDBDatastore(ctx, connStrings[unprivileged], WithAcquireTimeout(5*time.Second))
 			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = ds.Close()
+			})
 
 			features, err := ds.Features(ctx)
 			require.NoError(t, err)

--- a/internal/datastore/mysql/connection.go
+++ b/internal/datastore/mysql/connection.go
@@ -68,17 +68,20 @@ func instrumentConnector(c driver.Connector, replicaIndex string) (driver.Connec
 		}, []string{"success"})
 	)
 
+	var collectors []prometheus.Collector
+
 	err := prometheus.Register(connectHistogram)
 	if err != nil {
-		return nil, nil, err
+		return nil, collectors, err
 	}
 
+	collectors = append(collectors, connectHistogram)
 	err = prometheus.Register(connectCount)
 	if err != nil {
-		return nil, nil, err
+		return nil, collectors, err
 	}
 
-	collectors := []prometheus.Collector{connectCount, connectHistogram}
+	collectors = append(collectors, connectCount)
 
 	return &instrumentedConnector{
 		conn:             c,

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -177,6 +177,9 @@ func newMySQLDatastore(ctx context.Context, uri string, replicaIndex int, option
 
 	db, collectors, err := registerAndReturnPrometheusCollectors(replicaIndex, isPrimary, connector, config.enablePrometheusStats)
 	if err != nil {
+		for _, collector := range collectors {
+			_ = prometheus.Unregister(collector)
+		}
 		return nil, err
 	}
 
@@ -690,7 +693,7 @@ func registerAndReturnPrometheusCollectors(replicaIndex int, isPrimary bool, con
 
 	connector, collectors, err := instrumentConnector(connector, strconv.Itoa(replicaIndex))
 	if err != nil {
-		return nil, nil, err
+		return nil, collectors, err
 	}
 
 	dbName := "spicedb"
@@ -701,14 +704,14 @@ func registerAndReturnPrometheusCollectors(replicaIndex int, isPrimary bool, con
 	db := sql.OpenDB(connector)
 	collector := sqlstats.NewStatsCollector(dbName, db)
 	if err := prometheus.Register(collector); err != nil {
-		return nil, nil, err
+		return nil, collectors, err
 	}
 	collectors = append(collectors, collector)
 
 	if isPrimary {
 		gcMetrics, err := common.RegisterGCMetrics()
 		if err != nil {
-			return nil, nil, err
+			return nil, collectors, err
 		}
 		collectors = append(collectors, gcMetrics...)
 	}

--- a/internal/testserver/datastore/config/config.go
+++ b/internal/testserver/datastore/config/config.go
@@ -24,6 +24,9 @@ func DatastoreConfigInitFunc(t testing.TB, options ...dsconfig.ConfigOption) tes
 				dsconfig.WithURI(uri),
 			)...)
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			ds.Close()
+		})
 		return ds
 	}
 }

--- a/pkg/cmd/datastore.go
+++ b/pkg/cmd/datastore.go
@@ -77,7 +77,12 @@ func executeGC(ctx context.Context, cfg *datastore.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create datastore: %w", err)
 	}
-	defer ds.Close()
+	defer func() {
+		err = ds.Close()
+		if err != nil {
+			log.Error().Err(err).Msg("failed to close datastore")
+		}
+	}()
 
 	gcds := dspkg.UnwrapAs[common.GarbageCollectableDatastore](ds)
 	if gcds == nil {
@@ -121,7 +126,12 @@ func executeRepair(cfg *datastore.Config, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create datastore: %w", err)
 	}
-	defer ds.Close()
+	defer func() {
+		err = ds.Close()
+		if err != nil {
+			log.Error().Err(err).Msg("failed to close datastore")
+		}
+	}()
 
 	repairable := dspkg.UnwrapAs[dspkg.RepairableDatastore](ds)
 	if repairable == nil {

--- a/pkg/cmd/datastore/datastore_test.go
+++ b/pkg/cmd/datastore/datastore_test.go
@@ -23,6 +23,9 @@ func TestLoadDatastoreFromFileContents(t *testing.T) {
 		SetBootstrapFileContents(map[string][]byte{"test": []byte("schema: definition user{}")}),
 		WithEngine(MemoryEngine))
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		ds.Close()
+	})
 
 	revision, err := ds.HeadRevision(ctx)
 	require.NoError(t, err)
@@ -44,6 +47,9 @@ func TestLoadDatastoreFromFile(t *testing.T) {
 		SetBootstrapFiles([]string{file.Name()}),
 		WithEngine(MemoryEngine))
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		ds.Close()
+	})
 
 	revision, err := ds.HeadRevision(ctx)
 	require.NoError(t, err)

--- a/pkg/cmd/server/middleware_test.go
+++ b/pkg/cmd/server/middleware_test.go
@@ -367,6 +367,9 @@ func TestMiddlewareOrdering(t *testing.T) {
 		datastore.WithRequestHedgingEnabled(false),
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		ds.Close()
+	})
 
 	c := ConfigWithOptions(
 		&Config{},
@@ -447,6 +450,7 @@ func TestIncorrectOrderAssertionFails(t *testing.T) {
 		ds.Close()
 	})
 	require.NoError(t, err)
+
 	noopUnary := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		return nil, nil
 	}

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -96,6 +96,9 @@ func TestOTelReporting(t *testing.T) {
 		datastore.WithRequestHedgingEnabled(false),
 	)
 	require.NoError(t, err, "unable to start memdb datastore")
+	t.Cleanup(func() {
+		ds.Close()
+	})
 
 	configOpts := []ConfigOption{
 		WithGRPCServer(util.GRPCServerConfig{
@@ -167,6 +170,9 @@ func TestDisableHealthCheckTracing(t *testing.T) {
 		datastore.WithRequestHedgingEnabled(false),
 	)
 	require.NoError(t, err, "unable to start memdb datastore")
+	t.Cleanup(func() {
+		ds.Close()
+	})
 
 	configOpts := []ConfigOption{
 		WithGRPCServer(util.GRPCServerConfig{
@@ -287,6 +293,9 @@ func TestRetryPolicy(t *testing.T) {
 		datastore.WithRequestHedgingEnabled(false),
 	)
 	require.NoError(t, err, "unable to start memdb datastore")
+	t.Cleanup(func() {
+		ds.Close()
+	})
 
 	var interceptor countingInterceptor
 	configOpts := []ConfigOption{


### PR DESCRIPTION
Should prevent this

```
--- FAIL: TestExecuteRepair (0.00s)
    --- FAIL: TestExecuteRepair/cockroachdb_does_not_support_repair (13.51s)
        datastore_test.go:89: 
            	Error Trace:	/home/runner/work/spicedb/spicedb/pkg/cmd/datastore_test.go:89
            	Error:      	Error "failed to create datastore: duplicate metrics collector registration attempted" does not contain "datastore of type 'cockroachdb' does not support the repair operation"
            	Test:       	TestExecuteRepair/cockroachdb_does_not_support_repair
FAIL
coverage: 3.8% of statements in ./...

```