### PR TITLE
fix (migrate): Improve UX of error msg

### DIFF
--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -42,7 +43,6 @@ func NewMigrateCommand(programName string) *cobra.Command {
 		Long:    fmt.Sprintf("Executes datastore schema migrations for the datastore.\nThe special value \"%s\" can be used to migrate to the latest revision.", color.YellowString(migrate.Head)),
 		PreRunE: server.DefaultPreRunE(programName),
 		RunE:    termination.PublishError(migrateRun),
-		Args:    cobra.ExactArgs(1),
 	}
 }
 
@@ -51,6 +51,10 @@ func migrateRun(cmd *cobra.Command, args []string) error {
 	dbURL := cobrautil.MustGetStringExpanded(cmd, "datastore-conn-uri")
 	timeout := cobrautil.MustGetDuration(cmd, "migration-timeout")
 	migrationBatachSize := cobrautil.MustGetUint64(cmd, "migration-backfill-batch-size")
+
+	if len(args) != 1 {
+		return errors.New("missing required argument: 'revision'")
+	}
 
 	switch datastoreEngine {
 	case "cockroachdb":


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

closes: #2744 

## Description

Improve UX of error msg

before: 
accepts 1 arg(s), received 0

after:
missing required argument: 'revision'

<!--
Why do we need this PR? Any implementation details worth mentioning here?
-->

## Testing

<!--
How did you test this and how can reviewers test this?
-->

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->