### PR TITLE
ci: fix when benchmarks run

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -423,7 +423,8 @@ jobs:
     # Benchmarks on Main are ran through a different workflow
     if: |
       needs.paths-filter.outputs.codechange == 'true' &&
-      github.base_ref != 'main'
+      github.event_name == 'pull_request' &&
+      github.base_ref == 'main'
     steps:
       - uses: "actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493" # v4.2.2
         with:


### PR DESCRIPTION
I don't want these to trigger on every push to `main`:

<img width="716" height="120" alt="image" src="https://github.com/user-attachments/assets/7877d110-2e2e-4ac4-85d6-2173b4537967" />
