### PR TITLE
fix: change crdb ready check to measure idle conns

### DIFF
--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -413,6 +413,12 @@ func wrapError(err error) error {
 	return err
 }
 
+// ReadyState provides an indication of whether the datastore is ready to receive traffic.
+// It ensures that migrations have been run and that revisions look correct, and then checks
+// the number of available idle connections in the connection pool.
+// We use idle connections instead of total connections because we want all connetions
+// to be ready to receive traffic, and total connections counts connections in the constructing
+// state, which cannot receive traffic.
 func (cds *crdbDatastore) ReadyState(ctx context.Context) (datastore.ReadyState, error) {
 	currentRevision, err := migrations.NewCRDBDriver(cds.dburl)
 	if err != nil {
@@ -429,6 +435,12 @@ func (cds *crdbDatastore) ReadyState(ctx context.Context) (datastore.ReadyState,
 		return state, nil
 	}
 
+	// Wait only until the minimum number of connections is available before
+	// reporting the datastore as ready.
+	// NOTE: we do this manually here because new connections to CockroachDB are
+	// added relatively slowly, and pgxpool doesn't seem to contain logic that
+	// waits for a pool to be filled before the pool is treated as available/
+	// ready.
 	readMin := cds.readPool.MinConns()
 	if readMin > 0 {
 		readMin--
@@ -437,21 +449,21 @@ func (cds *crdbDatastore) ReadyState(ctx context.Context) (datastore.ReadyState,
 	if writeMin > 0 {
 		writeMin--
 	}
-	writeTotal, err := safecast.Convert[uint32](cds.writePool.Stat().TotalConns())
+	writeIdle, err := safecast.Convert[uint32](cds.writePool.Stat().IdleConns())
 	if err != nil {
 		return datastore.ReadyState{}, spiceerrors.MustBugf("could not cast writeTotal to uint32: %v", err)
 	}
-	readTotal, err := safecast.Convert[uint32](cds.readPool.Stat().TotalConns())
+	readIdle, err := safecast.Convert[uint32](cds.readPool.Stat().IdleConns())
 	if err != nil {
 		return datastore.ReadyState{}, spiceerrors.MustBugf("could not cast readTotal to uint32: %v", err)
 	}
-	if writeTotal < writeMin || readTotal < readMin {
+	if writeIdle < writeMin || readIdle < readMin {
 		return datastore.ReadyState{
 			Message: fmt.Sprintf(
 				"spicedb does not have the required minimum connection count to the datastore. Read: %d/%d, Write: %d/%d",
-				readTotal,
+				readIdle,
 				readMin,
-				writeTotal,
+				writeIdle,
 				writeMin,
 			),
 			IsReady: false,

--- a/pkg/datastore/test/relationships.go
+++ b/pkg/datastore/test/relationships.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ccoveille/go-safecast/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
@@ -43,21 +44,21 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 	for _, numRels := range testCases {
 		numRels := numRels
 		t.Run(strconv.Itoa(numRels), func(t *testing.T) {
-			require := require.New(t)
-
 			ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
-			require.NoError(err)
+			require.NoError(t, err)
 			defer ds.Close()
 
 			ctx := t.Context()
 
-			ok, err := ds.ReadyState(ctx)
-			require.NoError(err)
-			require.True(ok.IsReady, "datastore not ready: %s", ok.Message)
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				r, err := ds.ReadyState(ctx)
+				require.NoError(c, err)
+				require.True(c, r.IsReady, "datastore not ready: %s", r.Message)
+			}, 3*time.Second, 50*time.Millisecond)
 
-			setupDatastore(ds, require)
+			setupDatastore(ds, require.New(t))
 
-			tRequire := testfixtures.RelationshipChecker{Require: require, DS: ds}
+			tRequire := testfixtures.RelationshipChecker{Require: require.New(t), DS: ds}
 
 			var testRels []tuple.Relationship
 			for i := 0; i < numRels; i++ {
@@ -69,7 +70,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 			}
 
 			lastRevision, err := common.WriteRelationships(ctx, ds, tuple.UpdateOperationCreate, testRels...)
-			require.NoError(err)
+			require.NoError(t, err)
 
 			for _, toCheck := range testRels {
 				tRequire.RelationshipExists(ctx, toCheck, lastRevision)
@@ -77,7 +78,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 
 			// Write a duplicate relationship to make sure the datastore rejects it
 			_, err = common.WriteRelationships(ctx, ds, tuple.UpdateOperationCreate, testRels...)
-			require.Error(err)
+			require.Error(t, err)
 
 			dsReader := ds.SnapshotReader(lastRevision)
 			for _, relToFind := range testRels {
@@ -88,14 +89,14 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 					OptionalResourceType: relToFind.Resource.ObjectType,
 					OptionalResourceIds:  []string{relToFind.Resource.ObjectID},
 				}, options.WithQueryShape(queryshape.Varying))
-				require.NoError(err)
+				require.NoError(t, err)
 				tRequire.VerifyIteratorResults(iter, relToFind)
 
 				// Check without a resource type.
 				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
 					OptionalResourceIds: []string{relToFind.Resource.ObjectID},
 				}, options.WithQueryShape(queryshape.Varying))
-				require.NoError(err)
+				require.NoError(t, err)
 				tRequire.VerifyIteratorResults(iter, relToFind)
 
 				iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
@@ -103,7 +104,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 					OptionalResourceIds:      []string{relToFind.Resource.ObjectID},
 					OptionalResourceRelation: relToFind.Resource.Relation,
 				}, options.WithQueryShape(queryshape.AllSubjectsForResources))
-				require.NoError(err)
+				require.NoError(t, err)
 				tRequire.VerifyIteratorResults(iter, relToFind)
 
 				iter, err = dsReader.ReverseQueryRelationships(
@@ -115,7 +116,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 					}),
 					options.WithQueryShapeForReverse(queryshape.Varying),
 				)
-				require.NoError(err)
+				require.NoError(t, err)
 				tRequire.VerifyIteratorResults(iter, relToFind)
 
 				iter, err = dsReader.ReverseQueryRelationships(
@@ -128,7 +129,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 					options.WithLimitForReverse(options.LimitOne),
 					options.WithQueryShapeForReverse(queryshape.Varying),
 				)
-				require.NoError(err)
+				require.NoError(t, err)
 				tRequire.VerifyIteratorResults(iter, relToFind)
 
 				// Check that we fail to find the relationship with the wrong filters
@@ -137,7 +138,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 					OptionalResourceIds:      []string{relToFind.Resource.ObjectID},
 					OptionalResourceRelation: "fake",
 				}, options.WithQueryShape(queryshape.Varying))
-				require.NoError(err)
+				require.NoError(t, err)
 				tRequire.VerifyIteratorResults(iter)
 
 				incorrectUserset := relSubject.WithRelation("fake")
@@ -151,7 +152,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 					}),
 					options.WithQueryShapeForReverse(queryshape.Varying),
 				)
-				require.NoError(err)
+				require.NoError(t, err)
 				tRequire.VerifyIteratorResults(iter)
 			}
 
@@ -159,7 +160,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 			iter, err := dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
 				OptionalResourceType: testResourceNamespace,
 			}, options.WithQueryShape(queryshape.Varying))
-			require.NoError(err)
+			require.NoError(t, err)
 			tRequire.VerifyIteratorResults(iter, testRels...)
 
 			// Filter it down to a single relationship with a userset
@@ -172,14 +173,14 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 					},
 				},
 			}, options.WithQueryShape(queryshape.Varying))
-			require.NoError(err)
+			require.NoError(t, err)
 			tRequire.VerifyIteratorResults(iter, testRels[0])
 
 			// Check for larger reverse queries.
 			iter, err = dsReader.ReverseQueryRelationships(ctx, datastore.SubjectsFilter{
 				SubjectType: testUserNamespace,
 			}, options.WithQueryShapeForReverse(queryshape.Varying))
-			require.NoError(err)
+			require.NoError(t, err)
 			tRequire.VerifyIteratorResults(iter, testRels...)
 
 			// Check limit.
@@ -188,7 +189,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 				iter, err := dsReader.ReverseQueryRelationships(ctx, datastore.SubjectsFilter{
 					SubjectType: testUserNamespace,
 				}, options.WithLimitForReverse(&limit), options.WithQueryShapeForReverse(queryshape.Varying))
-				require.NoError(err)
+				require.NoError(t, err)
 
 				tRequire.VerifyIteratorCount(iter, len(testRels)-1)
 			}
@@ -197,14 +198,14 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 			iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
 				OptionalResourceType: testRels[0].Resource.ObjectType,
 			}, options.WithQueryShape(queryshape.Varying))
-			require.NoError(err)
+			require.NoError(t, err)
 			tRequire.VerifyIteratorResults(iter, testRels...)
 
 			iter, err = dsReader.QueryRelationships(ctx, datastore.RelationshipsFilter{
 				OptionalResourceType:     testRels[0].Resource.ObjectType,
 				OptionalResourceRelation: testRels[0].Resource.Relation,
 			}, options.WithQueryShape(queryshape.Varying))
-			require.NoError(err)
+			require.NoError(t, err)
 			tRequire.VerifyIteratorResults(iter, testRels...)
 
 			// Try some bad queries
@@ -212,16 +213,16 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 				OptionalResourceType: testRels[0].Resource.ObjectType,
 				OptionalResourceIds:  []string{"fakeobectid"},
 			}, options.WithQueryShape(queryshape.Varying))
-			require.NoError(err)
+			require.NoError(t, err)
 			tRequire.VerifyIteratorResults(iter)
 
 			// Delete the first relationship.
 			deletedAt, err := common.WriteRelationships(ctx, ds, tuple.UpdateOperationDelete, testRels[0])
-			require.NoError(err)
+			require.NoError(t, err)
 
 			// Delete it AGAIN (idempotent delete) and make sure there's no error
 			_, err = common.WriteRelationships(ctx, ds, tuple.UpdateOperationDelete, testRels[0])
-			require.NoError(err)
+			require.NoError(t, err)
 
 			// Verify it can still be read at the old revision
 			tRequire.RelationshipExists(ctx, testRels[0], lastRevision)
@@ -235,12 +236,12 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 				},
 				options.WithQueryShape(queryshape.FindResourceOfType),
 			)
-			require.NoError(err)
+			require.NoError(t, err)
 			tRequire.VerifyIteratorResults(alreadyDeletedIter, testRels[1:]...)
 
 			// Write it back
 			returnedAt, err := common.WriteRelationships(ctx, ds, tuple.UpdateOperationCreate, testRels[0])
-			require.NoError(err)
+			require.NoError(t, err)
 			tRequire.RelationshipExists(ctx, testRels[0], returnedAt)
 
 			// Delete with DeleteRelationship
@@ -248,10 +249,10 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 				_, _, err := rwt.DeleteRelationships(ctx, &v1.RelationshipFilter{
 					ResourceType: testResourceNamespace,
 				})
-				require.NoError(err)
+				require.NoError(t, err)
 				return err
 			})
-			require.NoError(err)
+			require.NoError(t, err)
 			tRequire.NoRelationshipExists(ctx, testRels[0], deletedAt)
 		})
 	}


### PR DESCRIPTION
Fixes #2765 

## Description
We've seen cases in deployments where a SpiceDB rollout backed by CRDB will have many `ResourceExhausted` errors caused by a write request being  being unable to acquire a write pool connection within the timeout. This was surprising because we wait until the pool is filled to the number of minimum connections before a pod starts accepting traffic.

We noticed that we were counting `TotalConns`, which according to the docs is the sum of `ConstructingConns`, `IdleConns`, and `AcquiredConns`. When the system is starting up and new connections are being established, all (or most) of the connections would be in a constructing state, at which point they're not able to accept traffic.

Changing this to check for `IdleConns` should mean that we're waiting until the number of connections ready to accept traffic is above our minimum threshold, which should mitigate this issue.

## Changes
* Add docstring
* Check `IdleConns` instead of `TotalConns`
## Testing
Review.