### PR TITLE
fix(metrics): inverted values for pgxpool_max_conns{read} and pgxpool…

### DIFF
--- a/internal/datastore/common/gc_test.go
+++ b/internal/datastore/common/gc_test.go
@@ -225,8 +225,6 @@ func TestGCFailureBackoff(t *testing.T) {
 	// we should see failures at 100s, 200s, 400s, 800s
 	// but depending on jitter this could end up being squished down such that we get 5 failures.
 	// Experimentally, we see 5 most often and 4 sometimes, so asserting greater than 3 works here.
-	fmt.Println("failures")
-	fmt.Println(*(mf.GetMetric()[0].Counter.Value))
 	require.Greater(t, *(mf.GetMetric()[0].Counter.Value), 3.0, "did not see expected number of backoffs")
 }
 

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -650,7 +650,7 @@ func (cds *crdbDatastore) registerPrometheusCollectors(enablePrometheusStats boo
 		return nil
 	}
 
-	readCollector := pgxpoolprometheus.NewCollector(cds.writePool, map[string]string{
+	readCollector := pgxpoolprometheus.NewCollector(cds.readPool, map[string]string{
 		"db_name":    "spicedb",
 		"pool_usage": "read",
 	})
@@ -660,7 +660,7 @@ func (cds *crdbDatastore) registerPrometheusCollectors(enablePrometheusStats boo
 	}
 	cds.collectors = append(cds.collectors, readCollector)
 
-	writeCollector := pgxpoolprometheus.NewCollector(cds.readPool, map[string]string{
+	writeCollector := pgxpoolprometheus.NewCollector(cds.writePool, map[string]string{
 		"db_name":    "spicedb",
 		"pool_usage": "write",
 	})


### PR DESCRIPTION
…_max_conns{write}

In https://github.com/authzed/spicedb/pull/2707 I accidentally introduced a bug: max_conns for `read` and for `write` are inverted.