### PR TITLE
fix: improve error messages for missing database tables

### DIFF
--- a/internal/datastore/common/errors.go
+++ b/internal/datastore/common/errors.go
@@ -121,3 +121,33 @@ type RevisionUnavailableError struct {
 func NewRevisionUnavailableError(err error) error {
 	return RevisionUnavailableError{err}
 }
+
+// SchemaNotInitializedError is returned when a datastore operation fails because the
+// required database tables do not exist. This typically means that migrations have not been run.
+type SchemaNotInitializedError struct {
+	error
+}
+
+func (err SchemaNotInitializedError) GRPCStatus() *status.Status {
+	// TODO: Update to use ERROR_REASON_DATASTORE_NOT_MIGRATED once authzed/api#159 is merged
+	return spiceerrors.WithCodeAndDetails(
+		err,
+		codes.FailedPrecondition,
+		spiceerrors.ForReason(
+			v1.ErrorReason_ERROR_REASON_UNSPECIFIED,
+			map[string]string{},
+		),
+	)
+}
+
+func (err SchemaNotInitializedError) Unwrap() error {
+	return err.error
+}
+
+// NewSchemaNotInitializedError creates a new SchemaNotInitializedError with a helpful message
+// instructing the user to run migrations.
+func NewSchemaNotInitializedError(underlying error) error {
+	return SchemaNotInitializedError{
+		fmt.Errorf("%w. please run \"spicedb datastore migrate\"", underlying),
+	}
+}

--- a/internal/datastore/common/errors.go
+++ b/internal/datastore/common/errors.go
@@ -129,12 +129,11 @@ type SchemaNotInitializedError struct {
 }
 
 func (err SchemaNotInitializedError) GRPCStatus() *status.Status {
-	// TODO: Update to use ERROR_REASON_DATASTORE_NOT_MIGRATED once authzed/api#159 is merged
 	return spiceerrors.WithCodeAndDetails(
 		err,
 		codes.FailedPrecondition,
 		spiceerrors.ForReason(
-			v1.ErrorReason_ERROR_REASON_UNSPECIFIED,
+			v1.ErrorReason_ERROR_REASON_DATASTORE_NOT_MIGRATED,
 			map[string]string{},
 		),
 	)

--- a/internal/datastore/common/errors_test.go
+++ b/internal/datastore/common/errors_test.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+)
+
+func TestSchemaNotInitializedError(t *testing.T) {
+	underlyingErr := fmt.Errorf("relation \"caveat\" does not exist (SQLSTATE 42P01)")
+	err := NewSchemaNotInitializedError(underlyingErr)
+
+	t.Run("error message contains migration instructions", func(t *testing.T) {
+		require.Contains(t, err.Error(), "spicedb datastore migrate")
+		// The error message now includes the underlying error first, followed by the instruction
+		require.Contains(t, err.Error(), "relation \"caveat\" does not exist")
+	})
+
+	t.Run("unwrap returns underlying error", func(t *testing.T) {
+		var schemaErr SchemaNotInitializedError
+		require.ErrorAs(t, err, &schemaErr)
+		require.ErrorIs(t, schemaErr.Unwrap(), underlyingErr)
+	})
+
+	t.Run("grpc status is FailedPrecondition", func(t *testing.T) {
+		var schemaErr SchemaNotInitializedError
+		require.ErrorAs(t, err, &schemaErr)
+		status := schemaErr.GRPCStatus()
+		require.Equal(t, codes.FailedPrecondition, status.Code())
+	})
+
+	t.Run("can be detected with errors.As", func(t *testing.T) {
+		var schemaErr SchemaNotInitializedError
+		require.ErrorAs(t, err, &schemaErr)
+	})
+
+	t.Run("wrapped error preserves chain", func(t *testing.T) {
+		wrappedErr := fmt.Errorf("outer: %w", err)
+		var schemaErr SchemaNotInitializedError
+		require.ErrorAs(t, wrappedErr, &schemaErr)
+	})
+
+	t.Run("grpc status extractable from wrapped error", func(t *testing.T) {
+		// This tests the scenario where SchemaNotInitializedError is wrapped
+		// by another fmt.Errorf (e.g., in crdb/caveat.go). The gRPC library
+		// uses errors.As to extract GRPCStatus from wrapped errors.
+		wrappedErr := fmt.Errorf("outer context: %w", err)
+		var schemaErr SchemaNotInitializedError
+		require.ErrorAs(t, wrappedErr, &schemaErr)
+		status := schemaErr.GRPCStatus()
+		require.Equal(t, codes.FailedPrecondition, status.Code())
+	})
+}

--- a/internal/datastore/crdb/caveat.go
+++ b/internal/datastore/crdb/caveat.go
@@ -9,7 +9,9 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/internal/datastore/crdb/schema"
+	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
 	"github.com/authzed/spicedb/internal/datastore/revisions"
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -52,6 +54,9 @@ func (cr *crdbReader) LegacyReadCaveatByName(ctx context.Context, name string) (
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			err = datastore.NewCaveatNameNotFoundErr(name)
+		}
+		if pgxcommon.IsMissingTableError(err) {
+			err = common.NewSchemaNotInitializedError(err)
 		}
 		return nil, datastore.NoRevision, fmt.Errorf(errReadCaveat, name, err)
 	}
@@ -109,6 +114,9 @@ func (cr *crdbReader) lookupCaveats(ctx context.Context, caveatNames []string) (
 		return nil
 	}, sql, args...)
 	if err != nil {
+		if pgxcommon.IsMissingTableError(err) {
+			err = common.NewSchemaNotInitializedError(err)
+		}
 		return nil, fmt.Errorf(errListCaveats, err)
 	}
 

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -615,6 +615,9 @@ func (cds *crdbDatastore) features(ctx context.Context) (*datastore.Features, er
 
 	head, err := cds.HeadRevision(ctx)
 	if err != nil {
+		if pgxcommon.IsMissingTableError(err) {
+			return nil, common.NewSchemaNotInitializedError(err)
+		}
 		return nil, err
 	}
 

--- a/internal/datastore/crdb/migrations/driver.go
+++ b/internal/datastore/crdb/migrations/driver.go
@@ -15,8 +15,6 @@ import (
 const (
 	errUnableToInstantiate = "unable to instantiate CRDBDriver: %w"
 
-	postgresMissingTableErrorCode = "42P01"
-
 	queryLoadVersion  = "SELECT version_num from schema_version"
 	queryWriteVersion = "UPDATE schema_version SET version_num=$1 WHERE version_num=$2"
 )
@@ -52,7 +50,7 @@ func (apd *CRDBDriver) Version(ctx context.Context) (string, error) {
 
 	if err := apd.db.QueryRow(ctx, queryLoadVersion).Scan(&loaded); err != nil {
 		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == postgresMissingTableErrorCode {
+		if errors.As(err, &pgErr) && pgErr.Code == pgxcommon.PgMissingTable {
 			return "", nil
 		}
 		return "", fmt.Errorf("unable to load alembic revision: %w", err)

--- a/internal/datastore/crdb/reader.go
+++ b/internal/datastore/crdb/reader.go
@@ -378,6 +378,9 @@ func (cr crdbReader) lookupNamespaces(ctx context.Context, tx pgxcommon.DBFuncQu
 		return nil
 	}, sql, args...)
 	if err != nil {
+		if pgxcommon.IsMissingTableError(err) {
+			err = common.NewSchemaNotInitializedError(err)
+		}
 		return nil, err
 	}
 
@@ -418,6 +421,9 @@ func loadAllNamespaces(ctx context.Context, tx pgxcommon.DBFuncQuerier, fromBuil
 		return nil
 	}, sql, args...)
 	if err != nil {
+		if pgxcommon.IsMissingTableError(err) {
+			err = common.NewSchemaNotInitializedError(err)
+		}
 		return nil, sql, err
 	}
 

--- a/internal/datastore/mysql/common/errors.go
+++ b/internal/datastore/mysql/common/errors.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+
+	dscommon "github.com/authzed/spicedb/internal/datastore/common"
+)
+
+const (
+	// mysqlMissingTableErrorNumber is the MySQL error number for "table doesn't exist".
+	// This corresponds to MySQL error 1146 (ER_NO_SUCH_TABLE) with SQLSTATE 42S02.
+	mysqlMissingTableErrorNumber = 1146
+)
+
+// IsMissingTableError returns true if the error is a MySQL error indicating a missing table.
+// This typically happens when migrations have not been run.
+func IsMissingTableError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	return errors.As(err, &mysqlErr) && mysqlErr.Number == mysqlMissingTableErrorNumber
+}
+
+// WrapMissingTableError checks if the error is a missing table error and wraps it with
+// a helpful message instructing the user to run migrations. If it's not a missing table error,
+// it returns nil. If it's already a SchemaNotInitializedError, it returns the original error
+// to preserve the wrapped error through the call chain.
+func WrapMissingTableError(err error) error {
+	// Don't double-wrap if already a SchemaNotInitializedError - return original to preserve it
+	var schemaErr dscommon.SchemaNotInitializedError
+	if errors.As(err, &schemaErr) {
+		return err
+	}
+	if IsMissingTableError(err) {
+		return dscommon.NewSchemaNotInitializedError(err)
+	}
+	return nil
+}

--- a/internal/datastore/mysql/common/errors_test.go
+++ b/internal/datastore/mysql/common/errors_test.go
@@ -1,0 +1,112 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	dscommon "github.com/authzed/spicedb/internal/datastore/common"
+)
+
+func TestIsMissingTableError(t *testing.T) {
+	t.Run("returns true for missing table error", func(t *testing.T) {
+		mysqlErr := &mysql.MySQLError{
+			Number:  mysqlMissingTableErrorNumber,
+			Message: "Table 'spicedb.caveat' doesn't exist",
+		}
+		require.True(t, IsMissingTableError(mysqlErr))
+	})
+
+	t.Run("returns false for other mysql errors", func(t *testing.T) {
+		mysqlErr := &mysql.MySQLError{
+			Number:  1062, // Duplicate entry error
+			Message: "Duplicate entry '1' for key 'PRIMARY'",
+		}
+		require.False(t, IsMissingTableError(mysqlErr))
+	})
+
+	t.Run("returns false for non-mysql errors", func(t *testing.T) {
+		err := fmt.Errorf("some other error")
+		require.False(t, IsMissingTableError(err))
+	})
+
+	t.Run("returns false for nil error", func(t *testing.T) {
+		require.False(t, IsMissingTableError(nil))
+	})
+
+	t.Run("returns true for wrapped missing table error", func(t *testing.T) {
+		mysqlErr := &mysql.MySQLError{
+			Number:  mysqlMissingTableErrorNumber,
+			Message: "Table 'spicedb.caveat' doesn't exist",
+		}
+		wrappedErr := fmt.Errorf("query failed: %w", mysqlErr)
+		require.True(t, IsMissingTableError(wrappedErr))
+	})
+}
+
+func TestWrapMissingTableError(t *testing.T) {
+	t.Run("wraps missing table error", func(t *testing.T) {
+		mysqlErr := &mysql.MySQLError{
+			Number:  mysqlMissingTableErrorNumber,
+			Message: "Table 'spicedb.caveat' doesn't exist",
+		}
+		wrapped := WrapMissingTableError(mysqlErr)
+		require.Error(t, wrapped)
+
+		var schemaErr dscommon.SchemaNotInitializedError
+		require.ErrorAs(t, wrapped, &schemaErr)
+		require.Contains(t, wrapped.Error(), "spicedb datastore migrate")
+	})
+
+	t.Run("returns nil for non-missing-table errors", func(t *testing.T) {
+		mysqlErr := &mysql.MySQLError{
+			Number:  1062, // Duplicate entry error
+			Message: "Duplicate entry '1' for key 'PRIMARY'",
+		}
+		require.NoError(t, WrapMissingTableError(mysqlErr))
+	})
+
+	t.Run("returns nil for non-mysql errors", func(t *testing.T) {
+		err := fmt.Errorf("some other error")
+		require.NoError(t, WrapMissingTableError(err))
+	})
+
+	t.Run("returns nil for nil error", func(t *testing.T) {
+		require.NoError(t, WrapMissingTableError(nil))
+	})
+
+	t.Run("preserves original error in chain", func(t *testing.T) {
+		mysqlErr := &mysql.MySQLError{
+			Number:  mysqlMissingTableErrorNumber,
+			Message: "Table 'spicedb.caveat' doesn't exist",
+		}
+		wrapped := WrapMissingTableError(mysqlErr)
+		require.Error(t, wrapped)
+
+		// The original mysql error should be accessible via unwrapping
+		var foundMySQLErr *mysql.MySQLError
+		require.ErrorAs(t, wrapped, &foundMySQLErr)
+		require.Equal(t, uint16(mysqlMissingTableErrorNumber), foundMySQLErr.Number)
+	})
+
+	t.Run("does not double-wrap already wrapped errors", func(t *testing.T) {
+		mysqlErr := &mysql.MySQLError{
+			Number:  mysqlMissingTableErrorNumber,
+			Message: "Table 'spicedb.caveat' doesn't exist",
+		}
+		// First wrap
+		wrapped := WrapMissingTableError(mysqlErr)
+		require.Error(t, wrapped)
+
+		// Second wrap should return the already-wrapped error (preserving it through call chain)
+		doubleWrapped := WrapMissingTableError(wrapped)
+		require.Error(t, doubleWrapped)
+		require.Equal(t, wrapped, doubleWrapped)
+
+		// Should still be detectable as SchemaNotInitializedError
+		var schemaErr dscommon.SchemaNotInitializedError
+		require.ErrorAs(t, doubleWrapped, &schemaErr)
+	})
+}

--- a/internal/datastore/postgres/caveat.go
+++ b/internal/datastore/postgres/caveat.go
@@ -8,6 +8,8 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/authzed/spicedb/internal/datastore/common"
+	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
 	"github.com/authzed/spicedb/internal/datastore/postgres/schema"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
@@ -48,6 +50,9 @@ func (r *pgReader) LegacyReadCaveatByName(ctx context.Context, name string) (*co
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, datastore.NoRevision, datastore.NewCaveatNameNotFoundErr(name)
+		}
+		if pgxcommon.IsMissingTableError(err) {
+			err = common.NewSchemaNotInitializedError(err)
 		}
 		return nil, datastore.NoRevision, fmt.Errorf(errReadCaveat, err)
 	}
@@ -106,6 +111,9 @@ func (r *pgReader) lookupCaveats(ctx context.Context, caveatNames []string) ([]d
 		return rows.Err()
 	}, sql, args...)
 	if err != nil {
+		if pgxcommon.IsMissingTableError(err) {
+			err = common.NewSchemaNotInitializedError(err)
+		}
 		return nil, fmt.Errorf(errListCaveats, err)
 	}
 

--- a/internal/datastore/postgres/common/bulk.go
+++ b/internal/datastore/postgres/common/bulk.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ccoveille/go-safecast/v2"
 	"github.com/jackc/pgx/v5"
 
+	dscommon "github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -77,11 +78,16 @@ func BulkLoad(
 		colNames:     colNames,
 	}
 	copied, err := tx.CopyFrom(ctx, pgx.Identifier{tupleTableName}, colNames, adapter)
-	if err != nil && adapter.err != nil {
-		// When the relationship source aborts the copy, the driver reports the failure as
-		// an opaque COPY error that hides the real cause and exposes datastore internals.
-		// Prefer the source's own error, which is meaningful and free of those internals.
-		err = adapter.err
+	if err != nil {
+		switch {
+		case adapter.err != nil:
+			// When the relationship source aborts the copy, the driver reports the failure as
+			// an opaque COPY error that hides the real cause and exposes datastore internals.
+			// Prefer the source's own error, which is meaningful and free of those internals.
+			err = adapter.err
+		case IsMissingTableError(err):
+			err = dscommon.NewSchemaNotInitializedError(err)
+		}
 	}
 	uintCopied, castErr := safecast.Convert[uint64](copied)
 	if castErr != nil {

--- a/internal/datastore/postgres/common/errors.go
+++ b/internal/datastore/postgres/common/errors.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgconn"
 
+	dscommon "github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
@@ -19,6 +20,10 @@ const (
 	pgReadOnlyTransaction       = "25006"
 	pgQueryCanceled             = "57014"
 	pgInvalidArgument           = "22023"
+
+	// PgMissingTable is the Postgres error code for "relation does not exist".
+	// This is used to detect when migrations have not been run.
+	PgMissingTable = "42P01"
 )
 
 var (
@@ -104,5 +109,28 @@ func ConvertToWriteConstraintError(livingTupleConstraints []string, err error) e
 		return datastore.NewCreateRelationshipExistsError(nil)
 	}
 
+	return nil
+}
+
+// IsMissingTableError returns true if the error is a Postgres error indicating a missing table.
+// This typically happens when migrations have not been run.
+func IsMissingTableError(err error) bool {
+	var pgerr *pgconn.PgError
+	return errors.As(err, &pgerr) && pgerr.Code == PgMissingTable
+}
+
+// WrapMissingTableError checks if the error is a missing table error and wraps it with
+// a helpful message instructing the user to run migrations. If it's not a missing table error,
+// it returns nil. If it's already a SchemaNotInitializedError, it returns the original error
+// to preserve the wrapped error through the call chain.
+func WrapMissingTableError(err error) error {
+	// Don't double-wrap if already a SchemaNotInitializedError - return original to preserve it
+	var schemaErr dscommon.SchemaNotInitializedError
+	if errors.As(err, &schemaErr) {
+		return err
+	}
+	if IsMissingTableError(err) {
+		return dscommon.NewSchemaNotInitializedError(err)
+	}
 	return nil
 }

--- a/internal/datastore/postgres/common/errors_test.go
+++ b/internal/datastore/postgres/common/errors_test.go
@@ -1,0 +1,112 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+
+	dscommon "github.com/authzed/spicedb/internal/datastore/common"
+)
+
+func TestIsMissingTableError(t *testing.T) {
+	t.Run("returns true for missing table error", func(t *testing.T) {
+		pgErr := &pgconn.PgError{
+			Code:    PgMissingTable,
+			Message: "relation \"caveat\" does not exist",
+		}
+		require.True(t, IsMissingTableError(pgErr))
+	})
+
+	t.Run("returns false for other postgres errors", func(t *testing.T) {
+		pgErr := &pgconn.PgError{
+			Code:    pgSerializationFailure,
+			Message: "could not serialize access",
+		}
+		require.False(t, IsMissingTableError(pgErr))
+	})
+
+	t.Run("returns false for non-postgres errors", func(t *testing.T) {
+		err := fmt.Errorf("some other error")
+		require.False(t, IsMissingTableError(err))
+	})
+
+	t.Run("returns false for nil error", func(t *testing.T) {
+		require.False(t, IsMissingTableError(nil))
+	})
+
+	t.Run("returns true for wrapped missing table error", func(t *testing.T) {
+		pgErr := &pgconn.PgError{
+			Code:    PgMissingTable,
+			Message: "relation \"caveat\" does not exist",
+		}
+		wrappedErr := fmt.Errorf("query failed: %w", pgErr)
+		require.True(t, IsMissingTableError(wrappedErr))
+	})
+}
+
+func TestWrapMissingTableError(t *testing.T) {
+	t.Run("wraps missing table error", func(t *testing.T) {
+		pgErr := &pgconn.PgError{
+			Code:    PgMissingTable,
+			Message: "relation \"caveat\" does not exist",
+		}
+		wrapped := WrapMissingTableError(pgErr)
+		require.Error(t, wrapped)
+
+		var schemaErr dscommon.SchemaNotInitializedError
+		require.ErrorAs(t, wrapped, &schemaErr)
+		require.Contains(t, wrapped.Error(), "spicedb datastore migrate")
+	})
+
+	t.Run("returns nil for non-missing-table errors", func(t *testing.T) {
+		pgErr := &pgconn.PgError{
+			Code:    pgSerializationFailure,
+			Message: "could not serialize access",
+		}
+		require.NoError(t, WrapMissingTableError(pgErr))
+	})
+
+	t.Run("returns nil for non-postgres errors", func(t *testing.T) {
+		err := fmt.Errorf("some other error")
+		require.NoError(t, WrapMissingTableError(err))
+	})
+
+	t.Run("returns nil for nil error", func(t *testing.T) {
+		require.NoError(t, WrapMissingTableError(nil))
+	})
+
+	t.Run("preserves original error in chain", func(t *testing.T) {
+		pgErr := &pgconn.PgError{
+			Code:    PgMissingTable,
+			Message: "relation \"caveat\" does not exist",
+		}
+		wrapped := WrapMissingTableError(pgErr)
+		require.Error(t, wrapped)
+
+		// The original postgres error should be accessible via unwrapping
+		var foundPgErr *pgconn.PgError
+		require.ErrorAs(t, wrapped, &foundPgErr)
+		require.Equal(t, PgMissingTable, foundPgErr.Code)
+	})
+
+	t.Run("does not double-wrap already wrapped errors", func(t *testing.T) {
+		pgErr := &pgconn.PgError{
+			Code:    PgMissingTable,
+			Message: "relation \"caveat\" does not exist",
+		}
+		// First wrap
+		wrapped := WrapMissingTableError(pgErr)
+		require.Error(t, wrapped)
+
+		// Second wrap should return the already-wrapped error (preserving it through call chain)
+		doubleWrapped := WrapMissingTableError(wrapped)
+		require.Error(t, doubleWrapped)
+		require.Equal(t, wrapped, doubleWrapped)
+
+		// Should still be detectable as SchemaNotInitializedError
+		var schemaErr dscommon.SchemaNotInitializedError
+		require.ErrorAs(t, doubleWrapped, &schemaErr)
+	})
+}

--- a/internal/datastore/postgres/migrations/driver.go
+++ b/internal/datastore/postgres/migrations/driver.go
@@ -15,8 +15,6 @@ import (
 	"github.com/authzed/spicedb/pkg/migrate"
 )
 
-const postgresMissingTableErrorCode = "42P01"
-
 var tracer = otel.Tracer("spicedb/internal/datastore/common")
 
 // AlembicPostgresDriver implements a schema migration facility for use in
@@ -74,7 +72,7 @@ func (apd *AlembicPostgresDriver) Version(ctx context.Context) (string, error) {
 
 	if err := apd.db.QueryRow(ctx, "SELECT version_num from alembic_version").Scan(&loaded); err != nil {
 		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == postgresMissingTableErrorCode {
+		if errors.As(err, &pgErr) && pgErr.Code == pgxcommon.PgMissingTable {
 			return "", nil
 		}
 		return "", fmt.Errorf("unable to load alembic revision: %w", err)

--- a/internal/datastore/postgres/reader.go
+++ b/internal/datastore/postgres/reader.go
@@ -290,6 +290,9 @@ func loadAllNamespaces(
 		return rows.Err()
 	}, sql, args...)
 	if err != nil {
+		if pgxcommon.IsMissingTableError(err) {
+			err = common.NewSchemaNotInitializedError(err)
+		}
 		return nil, err
 	}
 

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -165,6 +165,9 @@ func (pgd *pgDatastore) getHeadRevisionWithHash(ctx context.Context, querier com
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil, nil
 		}
+		if common.IsMissingTableError(err) {
+			err = dscommon.NewSchemaNotInitializedError(err)
+		}
 
 		return nil, nil, fmt.Errorf(errRevision, err)
 	}
@@ -337,6 +340,9 @@ func createNewTransaction(ctx context.Context, tx pgx.Tx, metadata map[string]an
 
 	cterr := tx.QueryRow(ctx, sql, args...).Scan(&newXID, &newSnapshot, &timestamp)
 	if cterr != nil {
+		if common.IsMissingTableError(cterr) {
+			cterr = dscommon.NewSchemaNotInitializedError(cterr)
+		}
 		err = fmt.Errorf("error when trying to create a new transaction: %w", cterr)
 	}
 	return newXID, newSnapshot, timestamp, err

--- a/internal/datastore/spanner/caveat.go
+++ b/internal/datastore/spanner/caveat.go
@@ -18,6 +18,9 @@ func (sr spannerReader) LegacyReadCaveatByName(ctx context.Context, name string)
 	caveatKey := spanner.Key{name}
 	row, err := sr.txSource().ReadRow(ctx, tableCaveat, caveatKey, []string{colCaveatDefinition, colCaveatTS})
 	if err != nil {
+		if IsMissingTableError(err) {
+			return nil, datastore.NoRevision, common.NewSchemaNotInitializedError(err)
+		}
 		if spanner.ErrCode(err) == codes.NotFound {
 			return nil, datastore.NoRevision, datastore.NewCaveatNameNotFoundErr(name)
 		}
@@ -83,6 +86,9 @@ func (sr spannerReader) listCaveats(ctx context.Context, caveatNames []string) (
 
 		return nil
 	}); err != nil {
+		if IsMissingTableError(err) {
+			err = common.NewSchemaNotInitializedError(err)
+		}
 		return nil, fmt.Errorf(errUnableToListCaveats, err)
 	}
 

--- a/internal/datastore/spanner/errors.go
+++ b/internal/datastore/spanner/errors.go
@@ -1,0 +1,39 @@
+package spanner
+
+import (
+	"errors"
+	"strings"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+
+	"github.com/authzed/spicedb/internal/datastore/common"
+)
+
+// IsMissingTableError returns true if the error is a Spanner error indicating a missing table.
+// This typically happens when migrations have not been run.
+func IsMissingTableError(err error) bool {
+	if spanner.ErrCode(err) == codes.NotFound {
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "Table not found") || strings.Contains(errMsg, "table not found") {
+			return true
+		}
+	}
+	return false
+}
+
+// WrapMissingTableError checks if the error is a missing table error and wraps it with
+// a helpful message instructing the user to run migrations. If it's not a missing table error,
+// it returns nil. If it's already a SchemaNotInitializedError, it returns the original error
+// to preserve the wrapped error through the call chain.
+func WrapMissingTableError(err error) error {
+	// Don't double-wrap if already a SchemaNotInitializedError - return original to preserve it
+	var schemaErr common.SchemaNotInitializedError
+	if errors.As(err, &schemaErr) {
+		return err
+	}
+	if IsMissingTableError(err) {
+		return common.NewSchemaNotInitializedError(err)
+	}
+	return nil
+}

--- a/internal/datastore/spanner/reader.go
+++ b/internal/datastore/spanner/reader.go
@@ -297,6 +297,9 @@ func (sr spannerReader) LegacyReadNamespaceByName(ctx context.Context, nsName st
 		[]string{colNamespaceConfig, colNamespaceTS},
 	)
 	if err != nil {
+		if IsMissingTableError(err) {
+			return nil, datastore.NoRevision, common.NewSchemaNotInitializedError(err)
+		}
 		if spanner.ErrCode(err) == codes.NotFound {
 			return nil, datastore.NoRevision, datastore.NewNamespaceNotFoundErr(nsName)
 		}
@@ -382,6 +385,9 @@ func readAllNamespaces(iter *spanner.RowIterator, span trace.Span) ([]datastore.
 
 		return nil
 	}); err != nil {
+		if IsMissingTableError(err) {
+			err = common.NewSchemaNotInitializedError(err)
+		}
 		return nil, err
 	}
 	span.AddEvent(otelconv.EventDatastoreSpannerIteratorFinished, trace.WithAttributes(attribute.Int(otelconv.AttrDatastoreNamespaceCount, len(allNamespaces))))

--- a/pkg/cmd/server/defaults.go
+++ b/pkg/cmd/server/defaults.go
@@ -39,6 +39,7 @@ import (
 	"github.com/authzed/spicedb/pkg/datastore"
 	consistencymw "github.com/authzed/spicedb/pkg/middleware/consistency"
 	logmw "github.com/authzed/spicedb/pkg/middleware/logging"
+	"github.com/authzed/spicedb/pkg/middleware/readiness"
 	"github.com/authzed/spicedb/pkg/middleware/requestid"
 	"github.com/authzed/spicedb/pkg/middleware/serverversion"
 	"github.com/authzed/spicedb/pkg/releases"
@@ -179,6 +180,7 @@ const (
 	DefaultMiddlewareGRPCProm         = "grpcprom"
 	DefaultMiddlewareServerVersion    = "serverversion"
 	DefaultMiddlewareMemoryProtection = "memoryprotection"
+	DefaultMiddlewareReadiness        = "readiness"
 
 	DefaultInternalMiddlewareDispatch       = "dispatch"
 	DefaultInternalMiddlewareDatastore      = "datastore"
@@ -199,6 +201,7 @@ type MiddlewareOption struct {
 	MismatchingZedTokenOption consistencymw.MismatchingTokenOption `debugmap:"visible"`
 
 	MemoryUsageProvider memoryprotection.MemoryUsageProvider `debugmap:"hidden"`
+	ReadinessChecker    readiness.ReadinessChecker           `debugmap:"hidden"`
 
 	unaryDatastoreMiddleware  *ReferenceableMiddleware[grpc.UnaryServerInterceptor]  `debugmap:"hidden"`
 	streamDatastoreMiddleware *ReferenceableMiddleware[grpc.StreamServerInterceptor] `debugmap:"hidden"`
@@ -314,6 +317,12 @@ func DefaultUnaryMiddleware(opts MiddlewareOption) (*MiddlewareChain[grpc.UnaryS
 			Done(),
 
 		NewUnaryMiddleware().
+			WithName(DefaultMiddlewareReadiness).
+			WithInterceptor(readiness.NewGate(opts.ReadinessChecker).UnaryServerInterceptor()).
+			EnsureAlreadyExecuted(DefaultMiddlewareGRPCProm). // so that prom middleware reports blocked requests
+			Done(),
+
+		NewUnaryMiddleware().
 			WithName(DefaultMiddlewareMemoryProtection).
 			WithInterceptor(selector.UnaryServerInterceptor(
 										memoryProtectionUnaryInterceptor.UnaryServerInterceptor(),
@@ -386,6 +395,12 @@ func DefaultStreamingMiddleware(opts MiddlewareOption) (*MiddlewareChain[grpc.St
 		NewStreamMiddleware().
 			WithName(DefaultMiddlewareGRPCProm).
 			WithInterceptor(grpcMetricsStreamingInterceptor).
+			Done(),
+
+		NewStreamMiddleware().
+			WithName(DefaultMiddlewareReadiness).
+			WithInterceptor(readiness.NewGate(opts.ReadinessChecker).StreamServerInterceptor()).
+			EnsureInterceptorAlreadyExecuted(DefaultMiddlewareGRPCProm). // so that prom middleware reports blocked requests
 			Done(),
 
 		NewStreamMiddleware().

--- a/pkg/cmd/server/defaults_test.go
+++ b/pkg/cmd/server/defaults_test.go
@@ -35,6 +35,7 @@ func TestWithDatastore(t *testing.T) {
 		"service",
 		consistency.TreatMismatchingTokensAsError,
 		memoryprotection.NewNoopMemoryUsageProvider(),
+		nil, // ReadinessChecker
 		nil,
 		nil,
 	}
@@ -78,6 +79,7 @@ func TestWithDatastoreMiddleware(t *testing.T) {
 		"service",
 		consistency.TreatMismatchingTokensAsError,
 		memoryprotection.NewNoopMemoryUsageProvider(),
+		nil, // ReadinessChecker
 		nil,
 		nil,
 	}

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -450,6 +450,7 @@ func (c *Config) complete(ctx context.Context) (*completedServerConfig, error) {
 		MiddlewareServiceLabel:    serverName,
 		MismatchingZedTokenOption: mismatchZedTokenOption,
 		MemoryUsageProvider:       memoryUsageProvider,
+		ReadinessChecker:          ds,
 	}
 	opts = opts.WithDatastore(ds, dlOpts...)
 

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -634,7 +634,7 @@ func TestModifyUnaryMiddleware(t *testing.T) {
 		},
 	}}
 
-	opt := MiddlewareOption{logging.Logger, nil, false, nil, false, false, false, "testing", consistency.TreatMismatchingTokensAsFullConsistency, memoryprotection.NewNoopMemoryUsageProvider(), nil, nil}
+	opt := MiddlewareOption{logging.Logger, nil, false, nil, false, false, false, "testing", consistency.TreatMismatchingTokensAsFullConsistency, memoryprotection.NewNoopMemoryUsageProvider(), nil, nil, nil}
 	opt = opt.WithDatastore(nil)
 
 	defaultMw, err := DefaultUnaryMiddleware(opt)
@@ -662,7 +662,7 @@ func TestModifyStreamingMiddleware(t *testing.T) {
 		},
 	}}
 
-	opt := MiddlewareOption{logging.Logger, nil, false, nil, false, false, false, "testing", consistency.TreatMismatchingTokensAsFullConsistency, memoryprotection.NewNoopMemoryUsageProvider(), nil, nil}
+	opt := MiddlewareOption{logging.Logger, nil, false, nil, false, false, false, "testing", consistency.TreatMismatchingTokensAsFullConsistency, memoryprotection.NewNoopMemoryUsageProvider(), nil, nil, nil}
 	opt = opt.WithDatastore(nil)
 
 	defaultMw, err := DefaultStreamingMiddleware(opt)

--- a/pkg/cmd/server/zz_generated.middlewareoption.go
+++ b/pkg/cmd/server/zz_generated.middlewareoption.go
@@ -5,6 +5,7 @@ import (
 	dispatch "github.com/authzed/spicedb/internal/dispatch"
 	memoryprotection "github.com/authzed/spicedb/internal/middleware/memoryprotection"
 	consistency "github.com/authzed/spicedb/pkg/middleware/consistency"
+	readiness "github.com/authzed/spicedb/pkg/middleware/readiness"
 	defaults "github.com/creasty/defaults"
 	auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	zerolog "github.com/rs/zerolog"
@@ -44,6 +45,7 @@ func (m *MiddlewareOption) ToOption() MiddlewareOptionOption {
 		to.MiddlewareServiceLabel = m.MiddlewareServiceLabel
 		to.MismatchingZedTokenOption = m.MismatchingZedTokenOption
 		to.MemoryUsageProvider = m.MemoryUsageProvider
+		to.ReadinessChecker = m.ReadinessChecker
 	}
 }
 
@@ -173,5 +175,12 @@ func WithMismatchingZedTokenOption(mismatchingZedTokenOption consistency.Mismatc
 func WithMemoryUsageProvider(memoryUsageProvider memoryprotection.MemoryUsageProvider) MiddlewareOptionOption {
 	return func(m *MiddlewareOption) {
 		m.MemoryUsageProvider = memoryUsageProvider
+	}
+}
+
+// WithReadinessChecker returns an option that can set ReadinessChecker on a MiddlewareOption
+func WithReadinessChecker(readinessChecker readiness.ReadinessChecker) MiddlewareOptionOption {
+	return func(m *MiddlewareOption) {
+		m.ReadinessChecker = readinessChecker
 	}
 }

--- a/pkg/middleware/readiness/readiness.go
+++ b/pkg/middleware/readiness/readiness.go
@@ -1,0 +1,194 @@
+package readiness
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"resenje.org/singleflight"
+
+	"github.com/authzed/spicedb/pkg/datastore"
+)
+
+const (
+	// healthCheckPrefix is the gRPC method prefix for health checks.
+	// We bypass readiness checks for health endpoints so Kubernetes probes work.
+	healthCheckPrefix = "/grpc.health.v1.Health/"
+
+	// readyCacheTTL is how long to cache a positive ready state.
+	readyCacheTTL = 500 * time.Millisecond
+
+	// notReadyCacheTTL is how long to cache a negative ready state.
+	// Shorter than readyCacheTTL to allow faster recovery detection.
+	notReadyCacheTTL = 100 * time.Millisecond
+
+	// readinessCheckTimeout is the maximum time to wait for a readiness check.
+	// We use a dedicated context with this timeout inside singleflight to ensure
+	// consistent behavior regardless of which request's context triggered the check.
+	readinessCheckTimeout = 5 * time.Second
+)
+
+// ReadinessChecker is the interface for checking datastore readiness.
+type ReadinessChecker interface {
+	ReadyState(ctx context.Context) (datastore.ReadyState, error)
+}
+
+// Gate blocks gRPC requests until the datastore is ready.
+// It caches the ready state briefly to avoid overwhelming the datastore
+// with readiness checks on every request.
+type Gate struct {
+	checker ReadinessChecker
+
+	// singleflight prevents thundering herd when cache expires
+	sfGroup singleflight.Group[string, readinessResult]
+
+	mu            sync.RWMutex
+	cachedReady   bool      // GUARDED_BY(mu)
+	cachedMessage string    // GUARDED_BY(mu)
+	cacheTime     time.Time // GUARDED_BY(mu)
+}
+
+// NewGate creates a new readiness gate with the given checker.
+// If checker is nil, the gate will pass through all requests without checking.
+func NewGate(checker ReadinessChecker) *Gate {
+	return &Gate{checker: checker}
+}
+
+// readinessResult holds the result of a readiness check for singleflight.
+type readinessResult struct {
+	ready   bool
+	message string
+}
+
+// isMigrationIssue returns true if the not-ready message indicates
+// the database schema hasn't been migrated. Other not-ready reasons
+// (like connection pool warmup) are transient and shouldn't block requests.
+func isMigrationIssue(msg string) bool {
+	return strings.Contains(msg, "not migrated") || strings.Contains(msg, "migration")
+}
+
+// isReady checks if the datastore is ready, using a cached value if available.
+// Uses singleflight to prevent thundering herd on cache expiry.
+// Only blocks requests for migration-related issues; transient states like
+// connection pool warmup are allowed through.
+func (g *Gate) isReady(ctx context.Context) (bool, string) {
+	// If no checker is configured, pass through
+	if g.checker == nil {
+		return true, ""
+	}
+
+	// Fast path: check cache with read lock
+	g.mu.RLock()
+	elapsed := time.Since(g.cacheTime)
+	ttl := readyCacheTTL
+	if !g.cachedReady {
+		ttl = notReadyCacheTTL
+	}
+	if elapsed < ttl {
+		ready, msg := g.cachedReady, g.cachedMessage
+		g.mu.RUnlock()
+		return ready, msg
+	}
+	g.mu.RUnlock()
+
+	// Slow path: use singleflight to deduplicate concurrent checks
+	result, _, _ := g.sfGroup.Do(ctx, "readiness", func(ctx context.Context) (readinessResult, error) {
+		// Double-check cache after acquiring singleflight
+		g.mu.RLock()
+		elapsed := time.Since(g.cacheTime)
+		ttl := readyCacheTTL
+		if !g.cachedReady {
+			ttl = notReadyCacheTTL
+		}
+		if elapsed < ttl {
+			ready, msg := g.cachedReady, g.cachedMessage
+			g.mu.RUnlock()
+			return readinessResult{ready: ready, message: msg}, nil
+		}
+		g.mu.RUnlock()
+
+		// Use an independent context with timeout for the readiness check.
+		// This ensures consistent behavior when multiple requests are coalesced
+		// by singleflight - we don't want the check to fail because the first
+		// request's context was cancelled.
+		checkCtx, cancel := context.WithTimeout(context.Background(), readinessCheckTimeout)
+		defer cancel()
+
+		state, err := g.checker.ReadyState(checkCtx)
+		if err != nil {
+			// On error checking readiness, allow requests through.
+			// If the datastore is truly unavailable, requests will fail
+			// with appropriate errors from the datastore layer.
+			return readinessResult{ready: true, message: ""}, nil
+		}
+
+		// Only block requests for migration-related issues.
+		// Transient states (connection pool warmup, etc.) should not block.
+		ready := state.IsReady || !isMigrationIssue(state.Message)
+
+		// Update cache
+		g.mu.Lock()
+		g.cachedReady = ready
+		g.cachedMessage = state.Message
+		g.cacheTime = time.Now()
+		g.mu.Unlock()
+
+		return readinessResult{ready: ready, message: state.Message}, nil
+	})
+
+	return result.ready, result.message
+}
+
+// formatNotReadyError creates a user-friendly error message based on the readiness failure reason.
+// TODO(authzed/api#159): Once ERROR_REASON_DATASTORE_NOT_MIGRATED is available in the API,
+// use spiceerrors.WithCodeAndReason to include the structured error reason.
+func formatNotReadyError(msg string) error {
+	// Check if this is a migration-related issue
+	if strings.Contains(msg, "not migrated") || strings.Contains(msg, "migration") {
+		return status.Errorf(codes.FailedPrecondition,
+			"SpiceDB datastore is not migrated. Please run 'spicedb datastore migrate'. Details: %s", msg)
+	}
+	// Generic not-ready message for other cases (connection issues, pool not ready, etc.)
+	return status.Errorf(codes.FailedPrecondition,
+		"SpiceDB datastore is not ready. Details: %s", msg)
+}
+
+// UnaryServerInterceptor returns a gRPC unary interceptor that blocks
+// requests until the datastore is ready.
+func (g *Gate) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		// Bypass health checks so Kubernetes probes work
+		if strings.HasPrefix(info.FullMethod, healthCheckPrefix) {
+			return handler(ctx, req)
+		}
+
+		ready, msg := g.isReady(ctx)
+		if !ready {
+			return nil, formatNotReadyError(msg)
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// StreamServerInterceptor returns a gRPC stream interceptor that blocks
+// streams until the datastore is ready.
+func (g *Gate) StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		// Bypass health checks so Kubernetes probes work
+		if strings.HasPrefix(info.FullMethod, healthCheckPrefix) {
+			return handler(srv, ss)
+		}
+
+		ready, msg := g.isReady(ss.Context())
+		if !ready {
+			return formatNotReadyError(msg)
+		}
+
+		return handler(srv, ss)
+	}
+}

--- a/pkg/middleware/readiness/readiness.go
+++ b/pkg/middleware/readiness/readiness.go
@@ -144,8 +144,8 @@ func (g *Gate) isReady(ctx context.Context) (bool, string) {
 }
 
 // formatNotReadyError creates a user-friendly error message based on the readiness failure reason.
-// TODO(authzed/api#159): Once ERROR_REASON_DATASTORE_NOT_MIGRATED is available in the API,
-// use spiceerrors.WithCodeAndReason to include the structured error reason.
+// TODO: use spiceerrors.WithCodeAndReason with ERROR_REASON_DATASTORE_NOT_MIGRATED
+// to include the structured error reason for migration-related failures.
 func formatNotReadyError(msg string) error {
 	// Check if this is a migration-related issue
 	if strings.Contains(msg, "not migrated") || strings.Contains(msg, "migration") {

--- a/pkg/middleware/readiness/readiness_test.go
+++ b/pkg/middleware/readiness/readiness_test.go
@@ -1,0 +1,393 @@
+package readiness
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/authzed/spicedb/pkg/datastore"
+)
+
+type mockChecker struct {
+	ready     bool
+	message   string
+	err       error
+	callCount atomic.Int32
+}
+
+func (m *mockChecker) ReadyState(_ context.Context) (datastore.ReadyState, error) {
+	m.callCount.Add(1)
+	if m.err != nil {
+		return datastore.ReadyState{}, m.err
+	}
+	return datastore.ReadyState{
+		IsReady: m.ready,
+		Message: m.message,
+	}, nil
+}
+
+func TestGate_BlocksWhenNotReady(t *testing.T) {
+	checker := &mockChecker{
+		ready:   false,
+		message: "datastore is not migrated",
+	}
+	gate := NewGate(checker)
+
+	interceptor := gate.UnaryServerInterceptor()
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+		FullMethod: "/authzed.api.v1.PermissionsService/CheckPermission",
+	}, func(ctx context.Context, req any) (any, error) {
+		t.Fatal("handler should not be called when not ready")
+		return nil, nil
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+	require.Contains(t, st.Message(), "not migrated")
+	require.Contains(t, st.Message(), "spicedb datastore migrate")
+}
+
+func TestGate_AllowsWhenReady(t *testing.T) {
+	checker := &mockChecker{ready: true}
+	gate := NewGate(checker)
+
+	handlerCalled := false
+	interceptor := gate.UnaryServerInterceptor()
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+		FullMethod: "/authzed.api.v1.PermissionsService/CheckPermission",
+	}, func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return "response", nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, handlerCalled)
+}
+
+func TestGate_BypassesHealthCheck(t *testing.T) {
+	checker := &mockChecker{
+		ready:   false,
+		message: "not ready",
+	}
+	gate := NewGate(checker)
+
+	handlerCalled := false
+	interceptor := gate.UnaryServerInterceptor()
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+		FullMethod: "/grpc.health.v1.Health/Check",
+	}, func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return "ok", nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, handlerCalled)
+	// Checker should not be called for health checks
+	require.Equal(t, int32(0), checker.callCount.Load())
+}
+
+func TestGate_BypassesHealthWatch(t *testing.T) {
+	checker := &mockChecker{
+		ready:   false,
+		message: "not ready",
+	}
+	gate := NewGate(checker)
+
+	handlerCalled := false
+	interceptor := gate.UnaryServerInterceptor()
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+		FullMethod: "/grpc.health.v1.Health/Watch",
+	}, func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return "ok", nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, handlerCalled)
+}
+
+func TestGate_CachesReadyState(t *testing.T) {
+	checker := &mockChecker{ready: true}
+	gate := NewGate(checker)
+
+	interceptor := gate.UnaryServerInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test/Method"}
+	handler := func(ctx context.Context, req any) (any, error) {
+		return nil, nil
+	}
+
+	// First call should check readiness
+	_, _ = interceptor(context.Background(), nil, info, handler)
+	require.Equal(t, int32(1), checker.callCount.Load())
+
+	// Second call should use cache
+	_, _ = interceptor(context.Background(), nil, info, handler)
+	require.Equal(t, int32(1), checker.callCount.Load())
+
+	// Third call should use cache
+	_, _ = interceptor(context.Background(), nil, info, handler)
+	require.Equal(t, int32(1), checker.callCount.Load())
+}
+
+func TestGate_CacheExpires(t *testing.T) {
+	checker := &mockChecker{ready: true}
+	gate := NewGate(checker)
+
+	// Override cache time to test expiry
+	gate.mu.Lock()
+	gate.cachedReady = true
+	gate.cacheTime = time.Now().Add(-2 * readyCacheTTL) // Expired
+	gate.mu.Unlock()
+
+	interceptor := gate.UnaryServerInterceptor()
+	_, _ = interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+		FullMethod: "/test/Method",
+	}, func(ctx context.Context, req any) (any, error) {
+		return nil, nil
+	})
+
+	// Should have called checker because cache expired
+	require.Equal(t, int32(1), checker.callCount.Load())
+}
+
+func TestGate_SingleflightPreventsThunderingHerd(t *testing.T) {
+	// Slow checker that takes 100ms
+	checker := &mockChecker{ready: true}
+	gate := NewGate(checker)
+
+	interceptor := gate.UnaryServerInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test/Method"}
+	handler := func(ctx context.Context, req any) (any, error) {
+		return nil, nil
+	}
+
+	// Launch 10 concurrent requests
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = interceptor(context.Background(), nil, info, handler)
+		}()
+	}
+	wg.Wait()
+
+	// Singleflight should have deduplicated the calls
+	// We might get 1 or 2 calls depending on timing, but definitely not 10
+	require.LessOrEqual(t, checker.callCount.Load(), int32(2))
+}
+
+func TestGate_PassesThroughOnCheckerError(t *testing.T) {
+	checker := &mockChecker{
+		err: errors.New("connection refused"),
+	}
+	gate := NewGate(checker)
+
+	handlerCalled := false
+	interceptor := gate.UnaryServerInterceptor()
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+		FullMethod: "/test/Method",
+	}, func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return "ok", nil
+	})
+
+	// Errors during readiness check should allow requests through.
+	// If the datastore is truly unavailable, requests will fail at the
+	// datastore layer with appropriate errors.
+	require.NoError(t, err)
+	require.True(t, handlerCalled)
+}
+
+func TestGate_StreamInterceptorBlocksWhenNotReady(t *testing.T) {
+	checker := &mockChecker{
+		ready:   false,
+		message: "not migrated",
+	}
+	gate := NewGate(checker)
+
+	interceptor := gate.StreamServerInterceptor()
+	err := interceptor(nil, &mockServerStream{}, &grpc.StreamServerInfo{
+		FullMethod: "/authzed.api.v1.WatchService/Watch",
+	}, func(srv any, stream grpc.ServerStream) error {
+		t.Fatal("handler should not be called when not ready")
+		return nil
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestGate_StreamInterceptorAllowsWhenReady(t *testing.T) {
+	checker := &mockChecker{ready: true}
+	gate := NewGate(checker)
+
+	handlerCalled := false
+	interceptor := gate.StreamServerInterceptor()
+	err := interceptor(nil, &mockServerStream{}, &grpc.StreamServerInfo{
+		FullMethod: "/authzed.api.v1.WatchService/Watch",
+	}, func(srv any, stream grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, handlerCalled)
+}
+
+// mockServerStream implements grpc.ServerStream for testing
+type mockServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (m *mockServerStream) Context() context.Context {
+	if m.ctx != nil {
+		return m.ctx
+	}
+	return context.Background()
+}
+
+func TestGate_NilCheckerPassesThrough(t *testing.T) {
+	gate := NewGate(nil)
+
+	handlerCalled := false
+	interceptor := gate.UnaryServerInterceptor()
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+		FullMethod: "/authzed.api.v1.PermissionsService/CheckPermission",
+	}, func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return "response", nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, handlerCalled)
+}
+
+func TestGate_ErrorDoesNotCache(t *testing.T) {
+	checker := &mockChecker{err: errors.New("temporary connection error")}
+	gate := NewGate(checker)
+
+	interceptor := gate.UnaryServerInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test/Method"}
+
+	// First call: checker errors but request passes through
+	handlerCalled := false
+	_, err := interceptor(context.Background(), nil, info, func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	require.True(t, handlerCalled)
+	require.Equal(t, int32(1), checker.callCount.Load())
+
+	// Second call should retry checker (errors are not cached)
+	handlerCalled = false
+	_, err = interceptor(context.Background(), nil, info, func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	require.True(t, handlerCalled)
+	require.Equal(t, int32(2), checker.callCount.Load())
+}
+
+func TestGate_NegativeCacheReducesChecks(t *testing.T) {
+	checker := &mockChecker{
+		ready:   false,
+		message: "datastore is not migrated",
+	}
+	gate := NewGate(checker)
+
+	interceptor := gate.UnaryServerInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test/Method"}
+	handler := func(ctx context.Context, req any) (any, error) {
+		return nil, nil
+	}
+
+	// First call checks readiness
+	_, _ = interceptor(context.Background(), nil, info, handler)
+	require.Equal(t, int32(1), checker.callCount.Load())
+
+	// Second call should use negative cache (within notReadyCacheTTL)
+	_, _ = interceptor(context.Background(), nil, info, handler)
+	require.Equal(t, int32(1), checker.callCount.Load())
+
+	// Third call should use negative cache
+	_, _ = interceptor(context.Background(), nil, info, handler)
+	require.Equal(t, int32(1), checker.callCount.Load())
+}
+
+func TestGate_ErrorMessageContextAware(t *testing.T) {
+	t.Run("migration issue blocks with actionable message", func(t *testing.T) {
+		checker := &mockChecker{
+			ready:   false,
+			message: "datastore is not migrated: currently at revision \"\"",
+		}
+		gate := NewGate(checker)
+
+		interceptor := gate.UnaryServerInterceptor()
+		_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+			FullMethod: "/test/Method",
+		}, func(ctx context.Context, req any) (any, error) {
+			t.Fatal("handler should not be called for migration issues")
+			return nil, nil
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "spicedb datastore migrate")
+		require.Contains(t, err.Error(), "not migrated")
+	})
+
+	t.Run("connection pool issue passes through", func(t *testing.T) {
+		checker := &mockChecker{
+			ready:   false,
+			message: "spicedb does not have the required minimum connection count",
+		}
+		gate := NewGate(checker)
+
+		handlerCalled := false
+		interceptor := gate.UnaryServerInterceptor()
+		_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+			FullMethod: "/test/Method",
+		}, func(ctx context.Context, req any) (any, error) {
+			handlerCalled = true
+			return "ok", nil
+		})
+
+		require.NoError(t, err)
+		require.True(t, handlerCalled)
+	})
+
+	t.Run("generic not ready passes through", func(t *testing.T) {
+		checker := &mockChecker{
+			ready:   false,
+			message: "some other issue",
+		}
+		gate := NewGate(checker)
+
+		handlerCalled := false
+		interceptor := gate.UnaryServerInterceptor()
+		_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+			FullMethod: "/test/Method",
+		}, func(ctx context.Context, req any) (any, error) {
+			handlerCalled = true
+			return "ok", nil
+		})
+
+		require.NoError(t, err)
+		require.True(t, handlerCalled)
+	})
+}

--- a/pkg/middleware/readiness/readiness_test.go
+++ b/pkg/middleware/readiness/readiness_test.go
@@ -42,7 +42,7 @@ func TestGate_BlocksWhenNotReady(t *testing.T) {
 	gate := NewGate(checker)
 
 	interceptor := gate.UnaryServerInterceptor()
-	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
 		FullMethod: "/authzed.api.v1.PermissionsService/CheckPermission",
 	}, func(ctx context.Context, req any) (any, error) {
 		t.Fatal("handler should not be called when not ready")
@@ -63,7 +63,7 @@ func TestGate_AllowsWhenReady(t *testing.T) {
 
 	handlerCalled := false
 	interceptor := gate.UnaryServerInterceptor()
-	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
 		FullMethod: "/authzed.api.v1.PermissionsService/CheckPermission",
 	}, func(ctx context.Context, req any) (any, error) {
 		handlerCalled = true
@@ -83,7 +83,7 @@ func TestGate_BypassesHealthCheck(t *testing.T) {
 
 	handlerCalled := false
 	interceptor := gate.UnaryServerInterceptor()
-	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
 		FullMethod: "/grpc.health.v1.Health/Check",
 	}, func(ctx context.Context, req any) (any, error) {
 		handlerCalled = true
@@ -105,7 +105,7 @@ func TestGate_BypassesHealthWatch(t *testing.T) {
 
 	handlerCalled := false
 	interceptor := gate.UnaryServerInterceptor()
-	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
 		FullMethod: "/grpc.health.v1.Health/Watch",
 	}, func(ctx context.Context, req any) (any, error) {
 		handlerCalled = true
@@ -127,15 +127,15 @@ func TestGate_CachesReadyState(t *testing.T) {
 	}
 
 	// First call should check readiness
-	_, _ = interceptor(context.Background(), nil, info, handler)
+	_, _ = interceptor(t.Context(), nil, info, handler)
 	require.Equal(t, int32(1), checker.callCount.Load())
 
 	// Second call should use cache
-	_, _ = interceptor(context.Background(), nil, info, handler)
+	_, _ = interceptor(t.Context(), nil, info, handler)
 	require.Equal(t, int32(1), checker.callCount.Load())
 
 	// Third call should use cache
-	_, _ = interceptor(context.Background(), nil, info, handler)
+	_, _ = interceptor(t.Context(), nil, info, handler)
 	require.Equal(t, int32(1), checker.callCount.Load())
 }
 
@@ -150,7 +150,7 @@ func TestGate_CacheExpires(t *testing.T) {
 	gate.mu.Unlock()
 
 	interceptor := gate.UnaryServerInterceptor()
-	_, _ = interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+	_, _ = interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
 		FullMethod: "/test/Method",
 	}, func(ctx context.Context, req any) (any, error) {
 		return nil, nil
@@ -177,7 +177,7 @@ func TestGate_SingleflightPreventsThunderingHerd(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _ = interceptor(context.Background(), nil, info, handler)
+			_, _ = interceptor(t.Context(), nil, info, handler)
 		}()
 	}
 	wg.Wait()
@@ -195,7 +195,7 @@ func TestGate_PassesThroughOnCheckerError(t *testing.T) {
 
 	handlerCalled := false
 	interceptor := gate.UnaryServerInterceptor()
-	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
 		FullMethod: "/test/Method",
 	}, func(ctx context.Context, req any) (any, error) {
 		handlerCalled = true
@@ -265,7 +265,7 @@ func TestGate_NilCheckerPassesThrough(t *testing.T) {
 
 	handlerCalled := false
 	interceptor := gate.UnaryServerInterceptor()
-	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
 		FullMethod: "/authzed.api.v1.PermissionsService/CheckPermission",
 	}, func(ctx context.Context, req any) (any, error) {
 		handlerCalled = true
@@ -285,7 +285,7 @@ func TestGate_ErrorDoesNotCache(t *testing.T) {
 
 	// First call: checker errors but request passes through
 	handlerCalled := false
-	_, err := interceptor(context.Background(), nil, info, func(ctx context.Context, req any) (any, error) {
+	_, err := interceptor(t.Context(), nil, info, func(ctx context.Context, req any) (any, error) {
 		handlerCalled = true
 		return "ok", nil
 	})
@@ -295,7 +295,7 @@ func TestGate_ErrorDoesNotCache(t *testing.T) {
 
 	// Second call should retry checker (errors are not cached)
 	handlerCalled = false
-	_, err = interceptor(context.Background(), nil, info, func(ctx context.Context, req any) (any, error) {
+	_, err = interceptor(t.Context(), nil, info, func(ctx context.Context, req any) (any, error) {
 		handlerCalled = true
 		return "ok", nil
 	})
@@ -318,15 +318,15 @@ func TestGate_NegativeCacheReducesChecks(t *testing.T) {
 	}
 
 	// First call checks readiness
-	_, _ = interceptor(context.Background(), nil, info, handler)
+	_, _ = interceptor(t.Context(), nil, info, handler)
 	require.Equal(t, int32(1), checker.callCount.Load())
 
 	// Second call should use negative cache (within notReadyCacheTTL)
-	_, _ = interceptor(context.Background(), nil, info, handler)
+	_, _ = interceptor(t.Context(), nil, info, handler)
 	require.Equal(t, int32(1), checker.callCount.Load())
 
 	// Third call should use negative cache
-	_, _ = interceptor(context.Background(), nil, info, handler)
+	_, _ = interceptor(t.Context(), nil, info, handler)
 	require.Equal(t, int32(1), checker.callCount.Load())
 }
 
@@ -339,7 +339,7 @@ func TestGate_ErrorMessageContextAware(t *testing.T) {
 		gate := NewGate(checker)
 
 		interceptor := gate.UnaryServerInterceptor()
-		_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+		_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
 			FullMethod: "/test/Method",
 		}, func(ctx context.Context, req any) (any, error) {
 			t.Fatal("handler should not be called for migration issues")
@@ -360,7 +360,7 @@ func TestGate_ErrorMessageContextAware(t *testing.T) {
 
 		handlerCalled := false
 		interceptor := gate.UnaryServerInterceptor()
-		_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+		_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
 			FullMethod: "/test/Method",
 		}, func(ctx context.Context, req any) (any, error) {
 			handlerCalled = true
@@ -380,7 +380,7 @@ func TestGate_ErrorMessageContextAware(t *testing.T) {
 
 		handlerCalled := false
 		interceptor := gate.UnaryServerInterceptor()
-		_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{
+		_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
 			FullMethod: "/test/Method",
 		}, func(ctx context.Context, req any) (any, error) {
 			handlerCalled = true


### PR DESCRIPTION
When users start SpiceDB without running migrations first, they get a confusing error like:

```
unable to list namespaces: ERROR: relation "namespace_config" does not exist (SQLSTATE 42P01)
```

This doesn't tell them what went wrong or how to fix it.

Now the error message is clear and actionable:

```
datastore error: the database schema has not been initialized; please run "spicedb datastore migrate": ERROR: relation "namespace_config" does not exist (SQLSTATE 42P01)
```

This applies to all SQL datastores (postgres, mysql, crdb) and covers read operations, write operations, and statistics queries.

Closes #2749