### PR TITLE
fix: segfault with datastore bootstrap files

### DIFF
--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -206,6 +206,10 @@ func RegisterDatastoreFlagsWithPrefix(flagSet *pflag.FlagSet, prefix string, opt
 	}
 	defaults := DefaultDatastoreConfig()
 
+	// NOTE: we set this manually here because this is a value that was never intended to be
+	// controlled by an external flag, but we still want the default value to be propagated through.
+	opts.CaveatTypeSet = defaults.CaveatTypeSet
+
 	flagSet.StringVar(&opts.Engine, flagName("datastore-engine"), defaults.Engine, fmt.Sprintf(`type of datastore to initialize (%s)`, datastore.EngineOptions()))
 	flagSet.StringVar(&opts.URI, flagName("datastore-conn-uri"), defaults.URI, `connection string used by remote datastores (e.g. "postgres://postgres:password@localhost:5432/spicedb")`)
 	flagSet.StringVar(&opts.CredentialsProviderName, flagName("datastore-credentials-provider-name"), defaults.CredentialsProviderName, fmt.Sprintf(`retrieve datastore credentials dynamically using (%s)`, datastore.CredentialsProviderOptions()))
@@ -364,6 +368,7 @@ func DefaultDatastoreConfig() *Config {
 		ExperimentalColumnOptimization:   true,
 		IncludeQueryParametersInTraces:   false,
 		WriteAcquisitionTimeout:          30 * time.Millisecond,
+		CaveatTypeSet:                    caveattypes.Default.TypeSet,
 	}
 }
 


### PR DESCRIPTION
Fixes #2783 

## Description
In #2315, we added support for different caveat typesets being handed to the startup process. Further down in the tree, if a typeset is missing, it will default to the default set, but we weren't doing that in the validationfile logic that supports `--datastore-bootstrap-files`.

This PR sets that default fairly high in the tree so that it's available for the validationfile logic.

## Note
Given that this default behavior isn't causing problems elsewhere in the tree, I'm not entirely sure that setting the default this high makes sense. It might be preferable to make the validationfile logic use a default if the typeset isn't provided.

## Changes
* Set default in `Complete()` so that it's available for the validationfile logic.
## Testing
Review. See that the repro steps in #2783 no longer repro.