### PR TITLE
feat: add warning for mixed operators without parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [1.56.0] - 2026-07-24
 ### Added
 - New metric `check_permissionship_total` for CheckPermission and CheckBulkPermissions that counts the number of requests that returned HAS_PERMISSION. Also, `write_relationships_updates` also includes BulkImport calls (https://github.com/authzed/spicedb/pull/3240)
+- Lint warning for permission expressions that mix operators (union, intersection, exclusion) at the same scope level without explicit parentheses (https://github.com/authzed/spicedb/pull/2786)
 
 ### Changed
 - Schema: reads inside write transactions now use a cheap hash-only lookup (`schema_revision`) to check the cache before loading the full schema blob, reducing DB round-trips on cache hits (https://github.com/authzed/spicedb/pull/3160)

--- a/pkg/development/warningdefs.go
+++ b/pkg/development/warningdefs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/authzed/spicedb/pkg/namespace"
 	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
 	devinterface "github.com/authzed/spicedb/pkg/proto/developer/v1"
 	"github.com/authzed/spicedb/pkg/schema"
@@ -230,6 +231,35 @@ var lintArrowReferencingRelation = ttuCheck{
 					sourcePosition,
 				), nil
 			}
+		}
+
+		return nil, nil
+	},
+}
+
+var lintMixedOperatorsWithoutParentheses = relationCheck{
+	"mixed-operators-without-parentheses",
+	func(
+		ctx context.Context,
+		relation *corev1.Relation,
+		def *schema.Definition,
+		_ *schema.TypeSystem,
+	) (*devinterface.DeveloperWarning, error) {
+		if !def.IsPermission(relation.Name) {
+			return nil, nil
+		}
+
+		if namespace.HasMixedOperatorsWithoutParens(relation) {
+			position := namespace.GetMixedOperatorsPosition(relation)
+			return warningForPosition(
+				"mixed-operators-without-parentheses",
+				fmt.Sprintf(
+					"Permission %q mixes operators (union, intersection, exclusion) at the same level without explicit parentheses; consider adding parentheses to clarify precedence",
+					relation.Name,
+				),
+				relation.Name,
+				position,
+			), nil
 		}
 
 		return nil, nil

--- a/pkg/development/warnings.go
+++ b/pkg/development/warnings.go
@@ -19,6 +19,7 @@ import (
 var allChecks = checks{
 	relationChecks: []relationCheck{
 		lintRelationReferencesParentType,
+		lintMixedOperatorsWithoutParentheses,
 	},
 	computedUsersetChecks: []computedUsersetCheck{
 		lintPermissionReferencingItself,

--- a/pkg/development/warnings_test.go
+++ b/pkg/development/warnings_test.go
@@ -249,6 +249,51 @@ func TestWarnings(t *testing.T) {
 			`,
 			expectedWarning: nil,
 		},
+		{
+			name:   "mixed operators exclusion and intersection",
+			schema: "definition user {}\ndefinition doc {\nrelation viewer: user\nrelation editor: user\nrelation blocked: user\npermission view = viewer - blocked & editor\n}",
+			expectedWarning: &developerv1.DeveloperWarning{
+				Message:    "Permission \"view\" mixes operators (union, intersection, exclusion) at the same level without explicit parentheses; consider adding parentheses to clarify precedence (mixed-operators-without-parentheses)",
+				Line:       6,
+				Column:     28,
+				SourceCode: "view",
+			},
+		},
+		{
+			name:   "mixed operators union and exclusion",
+			schema: "definition user {}\ndefinition doc {\nrelation a1a: user\nrelation b1b: user\nrelation c1c: user\npermission view = a1a + b1b - c1c\n}",
+			expectedWarning: &developerv1.DeveloperWarning{
+				Message:    "Permission \"view\" mixes operators (union, intersection, exclusion) at the same level without explicit parentheses; consider adding parentheses to clarify precedence (mixed-operators-without-parentheses)",
+				Line:       6,
+				Column:     19,
+				SourceCode: "view",
+			},
+		},
+		{
+			name:            "mixed operators with explicit parentheses",
+			schema:          "definition user {}\ndefinition doc {\nrelation a1a: user\nrelation b1b: user\nrelation c1c: user\npermission view = (a1a - b1b) & c1c\n}",
+			expectedWarning: nil,
+		},
+		{
+			name:   "mixed operators within nested parentheses",
+			schema: "definition user {}\ndefinition doc {\nrelation a1a: user\nrelation b1b: user\nrelation c1c: user\nrelation d1d: user\npermission view = a1a & (b1b + c1c - d1d)\n}",
+			expectedWarning: &developerv1.DeveloperWarning{
+				Message:    "Permission \"view\" mixes operators (union, intersection, exclusion) at the same level without explicit parentheses; consider adding parentheses to clarify precedence (mixed-operators-without-parentheses)",
+				Line:       7,
+				Column:     26,
+				SourceCode: "view",
+			},
+		},
+		{
+			name:            "mixed operators suppressed via ignore-warning comment",
+			schema:          "definition user {}\ndefinition doc {\nrelation viewer: user\nrelation editor: user\nrelation blocked: user\n// spicedb-ignore-warning: mixed-operators-without-parentheses\npermission view = viewer - blocked & editor\n}",
+			expectedWarning: nil,
+		},
+		{
+			name:            "same operator repeated is not mixed",
+			schema:          "definition user {}\ndefinition doc {\nrelation a1a: user\nrelation b1b: user\nrelation c1c: user\npermission view = a1a + b1b + c1c\n}",
+			expectedWarning: nil,
+		},
 	}
 
 	for _, tc := range tcs {

--- a/pkg/namespace/builder.go
+++ b/pkg/namespace/builder.go
@@ -347,6 +347,18 @@ func MustFunctionedTupleToUserset(tuplesetRelation, functionName, usersetRelatio
 	return operation
 }
 
+// MustWithMixedOperators marks the relation as having mixed operators without parentheses.
+func MustWithMixedOperators(rel *core.Relation, line uint64, column uint64) *core.Relation {
+	position := &core.SourcePosition{
+		ZeroIndexedLineNumber:     line,
+		ZeroIndexedColumnPosition: column,
+	}
+	if err := SetMixedOperatorsWithoutParens(rel, true, position); err != nil {
+		panic(spiceerrors.MustBugf("failed to set mixed operators: %s", err.Error()))
+	}
+	return rel
+}
+
 // Rewrite wraps a rewrite as a set operation child of another rewrite.
 func Rewrite(rewrite *core.UsersetRewrite) *core.SetOperation_Child {
 	return &core.SetOperation_Child{

--- a/pkg/namespace/metadata.go
+++ b/pkg/namespace/metadata.go
@@ -193,3 +193,92 @@ func SetTypeAnnotations(relation *core.Relation, typeAnnotations []string) error
 	relation.Metadata.MetadataMessage = append(relation.Metadata.MetadataMessage, metadataAny)
 	return nil
 }
+
+// HasMixedOperatorsWithoutParens returns whether the permission expression contains mixed operators
+// (union, intersection, exclusion) at the same scope level without explicit parentheses.
+func HasMixedOperatorsWithoutParens(relation *core.Relation) bool {
+	if relation.Metadata == nil {
+		return false
+	}
+
+	for _, metadataAny := range relation.Metadata.MetadataMessage {
+		var relationMetadata iv1.RelationMetadata
+		if err := metadataAny.UnmarshalTo(&relationMetadata); err != nil {
+			continue
+		}
+
+		if relationMetadata.Kind == iv1.RelationMetadata_PERMISSION {
+			return relationMetadata.HasMixedOperatorsWithoutParentheses
+		}
+	}
+
+	return false
+}
+
+// GetMixedOperatorsPosition returns the source position of the first mixed operator found,
+// or nil if none.
+func GetMixedOperatorsPosition(relation *core.Relation) *core.SourcePosition {
+	if relation.Metadata == nil {
+		return nil
+	}
+
+	for _, metadataAny := range relation.Metadata.MetadataMessage {
+		var relationMetadata iv1.RelationMetadata
+		if err := metadataAny.UnmarshalTo(&relationMetadata); err != nil {
+			continue
+		}
+
+		if relationMetadata.Kind == iv1.RelationMetadata_PERMISSION {
+			return relationMetadata.MixedOperatorsPosition
+		}
+	}
+
+	return nil
+}
+
+// SetMixedOperatorsWithoutParens sets the mixed operators flag and position for a permission relation.
+func SetMixedOperatorsWithoutParens(relation *core.Relation, hasMixed bool, position *core.SourcePosition) error {
+	if relation.Metadata == nil {
+		if !hasMixed {
+			return nil
+		}
+		relation.Metadata = &core.Metadata{}
+	}
+
+	for i, metadataAny := range relation.Metadata.MetadataMessage {
+		var relationMetadata iv1.RelationMetadata
+		if err := metadataAny.UnmarshalTo(&relationMetadata); err != nil {
+			continue
+		}
+
+		if relationMetadata.Kind == iv1.RelationMetadata_PERMISSION {
+			relationMetadata.HasMixedOperatorsWithoutParentheses = hasMixed
+			relationMetadata.MixedOperatorsPosition = position
+
+			updatedAny, err := anypb.New(&relationMetadata)
+			if err != nil {
+				return err
+			}
+
+			relation.Metadata.MetadataMessage[i] = updatedAny
+			return nil
+		}
+	}
+
+	if hasMixed {
+		relationMetadata := &iv1.RelationMetadata{
+			Kind:                                iv1.RelationMetadata_PERMISSION,
+			HasMixedOperatorsWithoutParentheses: hasMixed,
+			MixedOperatorsPosition:              position,
+		}
+
+		metadataAny, err := anypb.New(relationMetadata)
+		if err != nil {
+			return err
+		}
+
+		relation.Metadata.MetadataMessage = append(relation.Metadata.MetadataMessage, metadataAny)
+	}
+
+	return nil
+}

--- a/pkg/namespace/metadata_test.go
+++ b/pkg/namespace/metadata_test.go
@@ -9,6 +9,7 @@ import (
 
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	iv1 "github.com/authzed/spicedb/pkg/proto/impl/v1"
+	"github.com/authzed/spicedb/pkg/testutil"
 )
 
 func TestMetadata(t *testing.T) {
@@ -216,4 +217,69 @@ func TestTypeAnnotations(t *testing.T) {
 			require.Equal(t, tt.expectedAnnotations, annotations)
 		})
 	}
+}
+
+func TestMixedOperatorsWithoutParens(t *testing.T) {
+	position := &core.SourcePosition{ZeroIndexedLineNumber: 3, ZeroIndexedColumnPosition: 17}
+
+	t.Run("get from relation with no metadata", func(t *testing.T) {
+		rel := &core.Relation{Name: "test"}
+		require.False(t, HasMixedOperatorsWithoutParens(rel))
+		require.Nil(t, GetMixedOperatorsPosition(rel))
+	})
+
+	t.Run("set false on relation with no metadata is a no-op", func(t *testing.T) {
+		rel := &core.Relation{Name: "test"}
+		require.NoError(t, SetMixedOperatorsWithoutParens(rel, false, nil))
+		require.Nil(t, rel.Metadata)
+		require.False(t, HasMixedOperatorsWithoutParens(rel))
+	})
+
+	t.Run("set true on relation with no metadata creates permission metadata", func(t *testing.T) {
+		rel := &core.Relation{Name: "test"}
+		require.NoError(t, SetMixedOperatorsWithoutParens(rel, true, position))
+		require.True(t, HasMixedOperatorsWithoutParens(rel))
+		testutil.RequireProtoEqual(t, position, GetMixedOperatorsPosition(rel), "mismatched position")
+	})
+
+	t.Run("set true updates existing permission metadata in place", func(t *testing.T) {
+		relationMetadata := &iv1.RelationMetadata{Kind: iv1.RelationMetadata_PERMISSION}
+		metadataAny, err := anypb.New(relationMetadata)
+		require.NoError(t, err)
+		rel := &core.Relation{
+			Name:     "test",
+			Metadata: &core.Metadata{MetadataMessage: []*anypb.Any{metadataAny}},
+		}
+
+		require.NoError(t, SetMixedOperatorsWithoutParens(rel, true, position))
+		require.True(t, HasMixedOperatorsWithoutParens(rel))
+		testutil.RequireProtoEqual(t, position, GetMixedOperatorsPosition(rel), "mismatched position")
+		require.Len(t, rel.Metadata.MetadataMessage, 1, "should update in place, not append")
+	})
+
+	t.Run("set true appends permission metadata when only other metadata exists", func(t *testing.T) {
+		docAny, err := anypb.New(&iv1.DocComment{Comment: "test"})
+		require.NoError(t, err)
+		rel := &core.Relation{
+			Name:     "test",
+			Metadata: &core.Metadata{MetadataMessage: []*anypb.Any{docAny}},
+		}
+
+		require.NoError(t, SetMixedOperatorsWithoutParens(rel, true, position))
+		require.True(t, HasMixedOperatorsWithoutParens(rel))
+		testutil.RequireProtoEqual(t, position, GetMixedOperatorsPosition(rel), "mismatched position")
+		require.Len(t, rel.Metadata.MetadataMessage, 2, "should append a permission metadata entry")
+	})
+
+	t.Run("get ignores non-permission metadata", func(t *testing.T) {
+		relationMetadata := &iv1.RelationMetadata{Kind: iv1.RelationMetadata_RELATION}
+		metadataAny, err := anypb.New(relationMetadata)
+		require.NoError(t, err)
+		rel := &core.Relation{
+			Name:     "test",
+			Metadata: &core.Metadata{MetadataMessage: []*anypb.Any{metadataAny}},
+		}
+		require.False(t, HasMixedOperatorsWithoutParens(rel))
+		require.Nil(t, GetMixedOperatorsPosition(rel))
+	})
 }

--- a/pkg/proto/impl/v1/impl.pb.go
+++ b/pkg/proto/impl/v1/impl.pb.go
@@ -7,6 +7,7 @@
 package implv1
 
 import (
+	v1 "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1alpha1 "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -581,8 +582,13 @@ type RelationMetadata struct {
 	state           protoimpl.MessageState        `protogen:"open.v1"`
 	Kind            RelationMetadata_RelationKind `protobuf:"varint,1,opt,name=kind,proto3,enum=impl.v1.RelationMetadata_RelationKind" json:"kind,omitempty"`
 	TypeAnnotations *TypeAnnotations              `protobuf:"bytes,2,opt,name=type_annotations,json=typeAnnotations,proto3" json:"type_annotations,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Indicates whether the permission expression contains mixed operators (union, intersection,
+	// exclusion) at the same scope level without explicit parentheses.
+	HasMixedOperatorsWithoutParentheses bool `protobuf:"varint,3,opt,name=has_mixed_operators_without_parentheses,json=hasMixedOperatorsWithoutParentheses,proto3" json:"has_mixed_operators_without_parentheses,omitempty"`
+	// The source position of the first mixed operator found, if any.
+	MixedOperatorsPosition *v1.SourcePosition `protobuf:"bytes,4,opt,name=mixed_operators_position,json=mixedOperatorsPosition,proto3" json:"mixed_operators_position,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *RelationMetadata) Reset() {
@@ -625,6 +631,20 @@ func (x *RelationMetadata) GetKind() RelationMetadata_RelationKind {
 func (x *RelationMetadata) GetTypeAnnotations() *TypeAnnotations {
 	if x != nil {
 		return x.TypeAnnotations
+	}
+	return nil
+}
+
+func (x *RelationMetadata) GetHasMixedOperatorsWithoutParentheses() bool {
+	if x != nil {
+		return x.HasMixedOperatorsWithoutParentheses
+	}
+	return false
+}
+
+func (x *RelationMetadata) GetMixedOperatorsPosition() *v1.SourcePosition {
+	if x != nil {
+		return x.MixedOperatorsPosition
 	}
 	return nil
 }
@@ -926,7 +946,7 @@ var File_impl_v1_impl_proto protoreflect.FileDescriptor
 
 const file_impl_v1_impl_proto_rawDesc = "" +
 	"\n" +
-	"\x12impl/v1/impl.proto\x12\aimpl.v1\x1a&google/api/expr/v1alpha1/checked.proto\"l\n" +
+	"\x12impl/v1/impl.proto\x12\aimpl.v1\x1a\x12core/v1/core.proto\x1a&google/api/expr/v1alpha1/checked.proto\"l\n" +
 	"\rDecodedCaveat\x129\n" +
 	"\x03cel\x18\x01 \x01(\v2%.google.api.expr.v1alpha1.CheckedExprH\x00R\x03cel\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04nameB\f\n" +
@@ -973,10 +993,12 @@ const file_impl_v1_impl_proto_rawDesc = "" +
 	"DocComment\x12\x18\n" +
 	"\acomment\x18\x01 \x01(\tR\acomment\"'\n" +
 	"\x0fTypeAnnotations\x12\x14\n" +
-	"\x05types\x18\x01 \x03(\tR\x05types\"\xd3\x01\n" +
+	"\x05types\x18\x01 \x03(\tR\x05types\"\xfc\x02\n" +
 	"\x10RelationMetadata\x12:\n" +
 	"\x04kind\x18\x01 \x01(\x0e2&.impl.v1.RelationMetadata.RelationKindR\x04kind\x12C\n" +
-	"\x10type_annotations\x18\x02 \x01(\v2\x18.impl.v1.TypeAnnotationsR\x0ftypeAnnotations\">\n" +
+	"\x10type_annotations\x18\x02 \x01(\v2\x18.impl.v1.TypeAnnotationsR\x0ftypeAnnotations\x12T\n" +
+	"'has_mixed_operators_without_parentheses\x18\x03 \x01(\bR#hasMixedOperatorsWithoutParentheses\x12Q\n" +
+	"\x18mixed_operators_position\x18\x04 \x01(\v2\x17.core.v1.SourcePositionR\x16mixedOperatorsPosition\">\n" +
 	"\fRelationKind\x12\x10\n" +
 	"\fUNKNOWN_KIND\x10\x00\x12\f\n" +
 	"\bRELATION\x10\x01\x12\x0e\n" +
@@ -1021,6 +1043,7 @@ var file_impl_v1_impl_proto_goTypes = []any{
 	(*DecodedZedToken_V1ZedToken)(nil), // 14: impl.v1.DecodedZedToken.V1ZedToken
 	nil,                                // 15: impl.v1.V1Cursor.FlagsEntry
 	(*v1alpha1.CheckedExpr)(nil),       // 16: google.api.expr.v1alpha1.CheckedExpr
+	(*v1.SourcePosition)(nil),          // 17: core.v1.SourcePosition
 }
 var file_impl_v1_impl_proto_depIdxs = []int32{
 	16, // 0: impl.v1.DecodedCaveat.cel:type_name -> google.api.expr.v1alpha1.CheckedExpr
@@ -1032,12 +1055,13 @@ var file_impl_v1_impl_proto_depIdxs = []int32{
 	15, // 6: impl.v1.V1Cursor.flags:type_name -> impl.v1.V1Cursor.FlagsEntry
 	0,  // 7: impl.v1.RelationMetadata.kind:type_name -> impl.v1.RelationMetadata.RelationKind
 	7,  // 8: impl.v1.RelationMetadata.type_annotations:type_name -> impl.v1.TypeAnnotations
-	9,  // 9: impl.v1.V1Alpha1Revision.ns_revisions:type_name -> impl.v1.NamespaceAndRevision
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	17, // 9: impl.v1.RelationMetadata.mixed_operators_position:type_name -> core.v1.SourcePosition
+	9,  // 10: impl.v1.V1Alpha1Revision.ns_revisions:type_name -> impl.v1.NamespaceAndRevision
+	11, // [11:11] is the sub-list for method output_type
+	11, // [11:11] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_impl_v1_impl_proto_init() }

--- a/pkg/proto/impl/v1/impl_vtproto.pb.go
+++ b/pkg/proto/impl/v1/impl_vtproto.pb.go
@@ -6,6 +6,7 @@ package implv1
 
 import (
 	fmt "fmt"
+	v1 "github.com/authzed/spicedb/pkg/proto/core/v1"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	v1alpha1 "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	proto "google.golang.org/protobuf/proto"
@@ -322,6 +323,14 @@ func (m *RelationMetadata) CloneVT() *RelationMetadata {
 	r := new(RelationMetadata)
 	r.Kind = m.Kind
 	r.TypeAnnotations = m.TypeAnnotations.CloneVT()
+	r.HasMixedOperatorsWithoutParentheses = m.HasMixedOperatorsWithoutParentheses
+	if rhs := m.MixedOperatorsPosition; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *v1.SourcePosition }); ok {
+			r.MixedOperatorsPosition = vtpb.CloneVT()
+		} else {
+			r.MixedOperatorsPosition = proto.Clone(rhs).(*v1.SourcePosition)
+		}
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -836,6 +845,16 @@ func (this *RelationMetadata) EqualVT(that *RelationMetadata) bool {
 		return false
 	}
 	if !this.TypeAnnotations.EqualVT(that.TypeAnnotations) {
+		return false
+	}
+	if this.HasMixedOperatorsWithoutParentheses != that.HasMixedOperatorsWithoutParentheses {
+		return false
+	}
+	if equal, ok := interface{}(this.MixedOperatorsPosition).(interface{ EqualVT(*v1.SourcePosition) bool }); ok {
+		if !equal.EqualVT(that.MixedOperatorsPosition) {
+			return false
+		}
+	} else if !proto.Equal(this.MixedOperatorsPosition, that.MixedOperatorsPosition) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1609,6 +1628,38 @@ func (m *RelationMetadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.MixedOperatorsPosition != nil {
+		if vtmsg, ok := interface{}(m.MixedOperatorsPosition).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.MixedOperatorsPosition)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.HasMixedOperatorsWithoutParentheses {
+		i--
+		if m.HasMixedOperatorsWithoutParentheses {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
 	if m.TypeAnnotations != nil {
 		size, err := m.TypeAnnotations.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -2014,6 +2065,19 @@ func (m *RelationMetadata) SizeVT() (n int) {
 	}
 	if m.TypeAnnotations != nil {
 		l = m.TypeAnnotations.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.HasMixedOperatorsWithoutParentheses {
+		n += 2
+	}
+	if m.MixedOperatorsPosition != nil {
+		if size, ok := interface{}(m.MixedOperatorsPosition).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.MixedOperatorsPosition)
+		}
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -3550,6 +3614,70 @@ func (m *RelationMetadata) UnmarshalVT(dAtA []byte) error {
 			}
 			if err := m.TypeAnnotations.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HasMixedOperatorsWithoutParentheses", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.HasMixedOperatorsWithoutParentheses = bool(v != 0)
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MixedOperatorsPosition", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MixedOperatorsPosition == nil {
+				m.MixedOperatorsPosition = &v1.SourcePosition{}
+			}
+			if unmarshal, ok := interface{}(m.MixedOperatorsPosition).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.MixedOperatorsPosition); err != nil {
+					return err
+				}
 			}
 			iNdEx = postIndex
 		default:

--- a/pkg/schemadsl/compiler/compiler_test.go
+++ b/pkg/schemadsl/compiler/compiler_test.go
@@ -599,16 +599,18 @@ func TestCompile(t *testing.T) {
 			"",
 			[]SchemaDefinition{
 				namespace.Namespace("sometenant/complex",
-					namespace.MustRelation("foos",
-						namespace.Exclusion(
-							namespace.Rewrite(
-								namespace.Union(
-									namespace.ComputedUserset("bars"),
-									namespace.ComputedUserset("bazs"),
+					namespace.MustWithMixedOperators(
+						namespace.MustRelation("foos",
+							namespace.Exclusion(
+								namespace.Rewrite(
+									namespace.Union(
+										namespace.ComputedUserset("bars"),
+										namespace.ComputedUserset("bazs"),
+									),
 								),
+								namespace.ComputedUserset("mehs"),
 							),
-							namespace.ComputedUserset("mehs"),
-						),
+						), 1, 22,
 					),
 				),
 			},
@@ -631,6 +633,24 @@ func TestCompile(t *testing.T) {
 									namespace.ComputedUserset("mehs"),
 								),
 							),
+						),
+					),
+				),
+			},
+		},
+		{
+			"top-level parens permission",
+			withTenantPrefix,
+			`definition complex {
+				permission foos = (bars + bazs);
+			}`,
+			"",
+			[]SchemaDefinition{
+				namespace.Namespace("sometenant/complex",
+					namespace.MustRelation("foos",
+						namespace.Union(
+							namespace.ComputedUserset("bars"),
+							namespace.ComputedUserset("bazs"),
 						),
 					),
 				),

--- a/pkg/schemadsl/compiler/translator.go
+++ b/pkg/schemadsl/compiler/translator.go
@@ -454,6 +454,9 @@ func translatePermission(tctx *translationContext, permissionNode *dslNode) (*co
 		return nil, permissionNode.Errorf("invalid permission expression: %w", err)
 	}
 
+	// Detect mixed operators without parentheses before translation (which may flatten the AST).
+	mixedOpsPosition := detectMixedOperatorsWithoutParens(tctx, expressionNode)
+
 	rewrite, err := translateExpression(tctx, expressionNode)
 	if err != nil {
 		return nil, err
@@ -469,6 +472,14 @@ func translatePermission(tctx *translationContext, permissionNode *dslNode) (*co
 		err = namespace.SetTypeAnnotations(permission, typeAnnotations)
 		if err != nil {
 			return nil, permissionNode.Errorf("error adding type annotations to metadata: %w", err)
+		}
+	}
+
+	// Store mixed operators flag in metadata
+	if mixedOpsPosition != nil {
+		err = namespace.SetMixedOperatorsWithoutParens(permission, true, mixedOpsPosition)
+		if err != nil {
+			return nil, permissionNode.Errorf("error adding mixed operators flag to metadata: %w", err)
 		}
 	}
 
@@ -568,6 +579,16 @@ func translateExpressionDirect(tctx *translationContext, expressionNode *dslNode
 	}
 
 	switch expressionNode.GetType() {
+	case dslshape.NodeTypeParenthesizedExpression:
+		// Top-level parentheses do not change the meaning of the expression, so unwrap and
+		// translate the inner expression directly. This keeps the compiled rewrite shape
+		// identical to the unparenthesized form (e.g. `(a + b)` compiles the same as `a + b`).
+		innerExprNode, err := expressionNode.Lookup(dslshape.NodeParenthesizedExpressionPredicateInnerExpr)
+		if err != nil {
+			return nil, err
+		}
+		return translateExpressionDirect(tctx, innerExprNode)
+
 	case dslshape.NodeTypeUnionExpression:
 		return translate(namespace.Union, func(rewrite *core.UsersetRewrite) *core.SetOperation {
 			return rewrite.GetUnion()
@@ -597,6 +618,17 @@ func translateExpressionDirect(tctx *translationContext, expressionNode *dslNode
 }
 
 func translateExpressionOperation(tctx *translationContext, expressionOpNode *dslNode) (*core.SetOperation_Child, error) {
+	// Unwrap parenthesized operands so both the translation and the recorded source position
+	// reflect the inner expression rather than the opening parenthesis. The parentheses do not
+	// change the meaning of a single operand (e.g. `a + (b)` is equivalent to `a + b`).
+	for expressionOpNode.GetType() == dslshape.NodeTypeParenthesizedExpression {
+		innerExprNode, err := expressionOpNode.Lookup(dslshape.NodeParenthesizedExpressionPredicateInnerExpr)
+		if err != nil {
+			return nil, err
+		}
+		expressionOpNode = innerExprNode
+	}
+
 	translated, err := translateExpressionOperationDirect(tctx, expressionOpNode)
 	if err != nil {
 		return translated, err
@@ -1006,5 +1038,84 @@ func translateUseFlag(tctx *translationContext, useFlagNode *dslNode) error {
 	// TODO: make this check the list of allowed flags. this will be required for
 	// `use import` support.
 	tctx.enabledFlags.Insert(flagName)
+	return nil
+}
+
+// operatorType represents the type of set operator in an expression.
+type operatorType int
+
+const (
+	operatorTypeUnknown operatorType = iota
+	operatorTypeUnion
+	operatorTypeIntersection
+	operatorTypeExclusion
+)
+
+// getOperatorType returns the operator type for a given node type, or operatorTypeUnknown if not a set operator.
+func getOperatorType(nodeType dslshape.NodeType) operatorType {
+	switch nodeType {
+	case dslshape.NodeTypeUnionExpression:
+		return operatorTypeUnion
+	case dslshape.NodeTypeIntersectExpression:
+		return operatorTypeIntersection
+	case dslshape.NodeTypeExclusionExpression:
+		return operatorTypeExclusion
+	default:
+		return operatorTypeUnknown
+	}
+}
+
+// detectMixedOperatorsWithoutParens walks the expression AST and detects if there are mixed
+// operators (union, intersection, exclusion) at the same scope level without explicit parentheses.
+// Returns the source position of the first mixed operator found, or nil if none.
+func detectMixedOperatorsWithoutParens(tctx *translationContext, node *dslNode) *core.SourcePosition {
+	return detectMixedOperatorsInScope(tctx, node, operatorTypeUnknown)
+}
+
+// detectMixedOperatorsInScope recursively checks for mixed operators within a scope.
+func detectMixedOperatorsInScope(tctx *translationContext, node *dslNode, parentOp operatorType) *core.SourcePosition {
+	nodeType := node.GetType()
+
+	// A parenthesized expression starts a new scope: the parentheses make precedence explicit
+	// at this level, but an internally-mixed group such as `(a + b - c)` is still ambiguous and
+	// should be flagged. Recurse into the inner expression with no parent operator so that
+	// explicit grouping like `(a - b) & c` is respected as a boundary while inner mixes are caught.
+	if nodeType == dslshape.NodeTypeParenthesizedExpression {
+		innerNode, err := node.Lookup(dslshape.NodeParenthesizedExpressionPredicateInnerExpr)
+		if err != nil {
+			return nil
+		}
+		return detectMixedOperatorsInScope(tctx, innerNode, operatorTypeUnknown)
+	}
+
+	currentOp := getOperatorType(nodeType)
+
+	// If this is a set operator and we've seen a different operator at this scope, it's mixed.
+	if currentOp != operatorTypeUnknown && parentOp != operatorTypeUnknown && currentOp != parentOp {
+		return getSourcePosition(node, tctx.mapper)
+	}
+
+	// If this is a set operator, check children with this operator as the scope's operator.
+	if currentOp != operatorTypeUnknown {
+		effectiveOp := currentOp
+		if parentOp != operatorTypeUnknown {
+			effectiveOp = parentOp
+		}
+
+		leftChild, err := node.Lookup(dslshape.NodeExpressionPredicateLeftExpr)
+		if err == nil {
+			if pos := detectMixedOperatorsInScope(tctx, leftChild, effectiveOp); pos != nil {
+				return pos
+			}
+		}
+
+		rightChild, err := node.Lookup(dslshape.NodeExpressionPredicateRightExpr)
+		if err == nil {
+			if pos := detectMixedOperatorsInScope(tctx, rightChild, effectiveOp); pos != nil {
+				return pos
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/schemadsl/dslshape/dslshape.go
+++ b/pkg/schemadsl/dslshape/dslshape.go
@@ -33,9 +33,10 @@ const (
 
 	NodeTypeArrowExpression // A TTU in arrow form.
 
-	NodeTypeIdentifier     // An identifier under an expression.
-	NodeTypeNilExpression  // A nil keyword
-	NodeTypeSelfExpression // A self keyword
+	NodeTypeIdentifier              // An identifier under an expression.
+	NodeTypeNilExpression           // A nil keyword
+	NodeTypeSelfExpression          // A self keyword
+	NodeTypeParenthesizedExpression // A parenthesized expression wrapper.
 
 	NodeTypeCaveatTypeReference // A type reference for a caveat parameter.
 
@@ -222,6 +223,13 @@ const (
 	//
 	NodeExpressionPredicateLeftExpr  = "left-expr"
 	NodeExpressionPredicateRightExpr = "right-expr"
+
+	//
+	// NodeTypeParenthesizedExpression
+	//
+
+	// The inner expression wrapped by parentheses.
+	NodeParenthesizedExpressionPredicateInnerExpr = "inner-expr"
 
 	//
 	// NodeTypeImport

--- a/pkg/schemadsl/dslshape/zz_generated.nodetype_string.go
+++ b/pkg/schemadsl/dslshape/zz_generated.nodetype_string.go
@@ -30,15 +30,16 @@ func _() {
 	_ = x[NodeTypeIdentifier-19]
 	_ = x[NodeTypeNilExpression-20]
 	_ = x[NodeTypeSelfExpression-21]
-	_ = x[NodeTypeCaveatTypeReference-22]
-	_ = x[NodeTypeImport-23]
-	_ = x[NodeTypePartial-24]
-	_ = x[NodeTypePartialReference-25]
+	_ = x[NodeTypeParenthesizedExpression-22]
+	_ = x[NodeTypeCaveatTypeReference-23]
+	_ = x[NodeTypeImport-24]
+	_ = x[NodeTypePartial-25]
+	_ = x[NodeTypePartialReference-26]
 }
 
-const _NodeType_name = "NodeTypeErrorNodeTypeFileNodeTypeCommentNodeTypeUseFlagNodeTypeDefinitionNodeTypeCaveatDefinitionNodeTypeCaveatParameterNodeTypeCaveatExpressionNodeTypeRelationNodeTypePermissionNodeTypeTypeAnnotationNodeTypeTypeReferenceNodeTypeSpecificTypeReferenceNodeTypeCaveatReferenceNodeTypeTraitReferenceNodeTypeUnionExpressionNodeTypeIntersectExpressionNodeTypeExclusionExpressionNodeTypeArrowExpressionNodeTypeIdentifierNodeTypeNilExpressionNodeTypeSelfExpressionNodeTypeCaveatTypeReferenceNodeTypeImportNodeTypePartialNodeTypePartialReference"
+const _NodeType_name = "NodeTypeErrorNodeTypeFileNodeTypeCommentNodeTypeUseFlagNodeTypeDefinitionNodeTypeCaveatDefinitionNodeTypeCaveatParameterNodeTypeCaveatExpressionNodeTypeRelationNodeTypePermissionNodeTypeTypeAnnotationNodeTypeTypeReferenceNodeTypeSpecificTypeReferenceNodeTypeCaveatReferenceNodeTypeTraitReferenceNodeTypeUnionExpressionNodeTypeIntersectExpressionNodeTypeExclusionExpressionNodeTypeArrowExpressionNodeTypeIdentifierNodeTypeNilExpressionNodeTypeSelfExpressionNodeTypeParenthesizedExpressionNodeTypeCaveatTypeReferenceNodeTypeImportNodeTypePartialNodeTypePartialReference"
 
-var _NodeType_index = [...]uint16{0, 13, 25, 40, 55, 73, 97, 120, 144, 160, 178, 200, 221, 250, 273, 295, 318, 345, 372, 395, 413, 434, 456, 483, 497, 512, 536}
+var _NodeType_index = [...]uint16{0, 13, 25, 40, 55, 73, 97, 120, 144, 160, 178, 200, 221, 250, 273, 295, 318, 345, 372, 395, 413, 434, 456, 487, 514, 528, 543, 567}
 
 func (i NodeType) String() string {
 	idx := int(i) - 0

--- a/pkg/schemadsl/parser/parser.go
+++ b/pkg/schemadsl/parser/parser.go
@@ -712,18 +712,23 @@ func (p *sourceParser) tryConsumeArrowExpression() (AstNode, bool) {
 // ```self```
 func (p *sourceParser) tryConsumeBaseExpression() (AstNode, bool) {
 	switch {
-	// Nested expression.
+	// Nested expression - wrap in NodeTypeParenthesizedExpression to preserve parentheses info.
 	case p.isToken(lexer.TokenTypeLeftParen):
 		comments := p.currentToken.comments
 
+		wrapperNode := p.startNode(dslshape.NodeTypeParenthesizedExpression)
+
 		p.consume(lexer.TokenTypeLeftParen)
-		exprNode := p.consumeComputeExpression()
+		innerExprNode := p.consumeComputeExpression()
 		p.consume(lexer.TokenTypeRightParen)
 
-		// Attach any comments found to the consumed expression.
-		p.decorateComments(exprNode, comments)
+		wrapperNode.Connect(dslshape.NodeParenthesizedExpressionPredicateInnerExpr, innerExprNode)
+		p.mustFinishNode()
 
-		return exprNode, true
+		// Attach any comments found to the wrapper node.
+		p.decorateComments(wrapperNode, comments)
+
+		return wrapperNode, true
 
 	// Self expression.
 	case p.isKeyword("self"):

--- a/pkg/schemadsl/parser/tests/basic.zed.expected
+++ b/pkg/schemadsl/parser/tests/basic.zed.expected
@@ -84,22 +84,27 @@ NodeTypeFile
               input-source = basic definition test
               start-rune = 208
               left-expr =>
-                NodeTypeExclusionExpression
-                  end-rune = 217
+                NodeTypeParenthesizedExpression
+                  end-rune = 218
                   input-source = basic definition test
-                  start-rune = 209
-                  left-expr =>
-                    NodeTypeIdentifier
-                      end-rune = 211
-                      identifier-value = foo
+                  start-rune = 208
+                  inner-expr =>
+                    NodeTypeExclusionExpression
+                      end-rune = 217
                       input-source = basic definition test
                       start-rune = 209
-                  right-expr =>
-                    NodeTypeIdentifier
-                      end-rune = 217
-                      identifier-value = meh
-                      input-source = basic definition test
-                      start-rune = 215
+                      left-expr =>
+                        NodeTypeIdentifier
+                          end-rune = 211
+                          identifier-value = foo
+                          input-source = basic definition test
+                          start-rune = 209
+                      right-expr =>
+                        NodeTypeIdentifier
+                          end-rune = 217
+                          identifier-value = meh
+                          input-source = basic definition test
+                          start-rune = 215
               right-expr =>
                 NodeTypeIdentifier
                   end-rune = 224

--- a/pkg/schemadsl/parser/tests/multiparen.zed.expected
+++ b/pkg/schemadsl/parser/tests/multiparen.zed.expected
@@ -42,58 +42,68 @@ NodeTypeFile
                           input-source = multiple parens test
                           start-rune = 44
                   right-expr =>
-                    NodeTypeExclusionExpression
-                      end-rune = 61
+                    NodeTypeParenthesizedExpression
+                      end-rune = 62
                       input-source = multiple parens test
-                      start-rune = 51
-                      left-expr =>
-                        NodeTypeArrowExpression
-                          end-rune = 54
+                      start-rune = 50
+                      inner-expr =>
+                        NodeTypeExclusionExpression
+                          end-rune = 61
                           input-source = multiple parens test
                           start-rune = 51
                           left-expr =>
-                            NodeTypeIdentifier
-                              end-rune = 51
-                              identifier-value = a
+                            NodeTypeArrowExpression
+                              end-rune = 54
                               input-source = multiple parens test
                               start-rune = 51
+                              left-expr =>
+                                NodeTypeIdentifier
+                                  end-rune = 51
+                                  identifier-value = a
+                                  input-source = multiple parens test
+                                  start-rune = 51
+                              right-expr =>
+                                NodeTypeIdentifier
+                                  end-rune = 54
+                                  identifier-value = b
+                                  input-source = multiple parens test
+                                  start-rune = 54
                           right-expr =>
-                            NodeTypeIdentifier
-                              end-rune = 54
-                              identifier-value = b
-                              input-source = multiple parens test
-                              start-rune = 54
-                      right-expr =>
-                        NodeTypeArrowExpression
-                          end-rune = 61
-                          input-source = multiple parens test
-                          start-rune = 58
-                          left-expr =>
-                            NodeTypeIdentifier
-                              end-rune = 58
-                              identifier-value = c
+                            NodeTypeArrowExpression
+                              end-rune = 61
                               input-source = multiple parens test
                               start-rune = 58
-                          right-expr =>
-                            NodeTypeIdentifier
-                              end-rune = 61
-                              identifier-value = d
-                              input-source = multiple parens test
-                              start-rune = 61
+                              left-expr =>
+                                NodeTypeIdentifier
+                                  end-rune = 58
+                                  identifier-value = c
+                                  input-source = multiple parens test
+                                  start-rune = 58
+                              right-expr =>
+                                NodeTypeIdentifier
+                                  end-rune = 61
+                                  identifier-value = d
+                                  input-source = multiple parens test
+                                  start-rune = 61
               right-expr =>
-                NodeTypeIntersectExpression
-                  end-rune = 75
+                NodeTypeParenthesizedExpression
+                  end-rune = 76
                   input-source = multiple parens test
-                  start-rune = 67
-                  left-expr =>
-                    NodeTypeIdentifier
-                      end-rune = 69
-                      identifier-value = maz
+                  start-rune = 66
+                  inner-expr =>
+                    NodeTypeIntersectExpression
+                      end-rune = 75
                       input-source = multiple parens test
                       start-rune = 67
-                  right-expr =>
-                    NodeTypeIdentifier
-                      end-rune = 75
-                      identifier-value = beh
-                      input-source = multiple parens test
-                      start-rune = 73
+                      left-expr =>
+                        NodeTypeIdentifier
+                          end-rune = 69
+                          identifier-value = maz
+                          input-source = multiple parens test
+                          start-rune = 67
+                      right-expr =>
+                        NodeTypeIdentifier
+                          end-rune = 75
+                          identifier-value = beh
+                          input-source = multiple parens test
+                          start-rune = 73

--- a/pkg/schemadsl/parser/tests/nil.zed.expected
+++ b/pkg/schemadsl/parser/tests/nil.zed.expected
@@ -67,32 +67,37 @@ NodeTypeFile
                   input-source = nil test
                   start-rune = 117
                   left-expr =>
-                    NodeTypeUnionExpression
-                      end-rune = 128
+                    NodeTypeParenthesizedExpression
+                      end-rune = 129
                       input-source = nil test
-                      start-rune = 118
-                      left-expr =>
+                      start-rune = 117
+                      inner-expr =>
                         NodeTypeUnionExpression
-                          end-rune = 122
+                          end-rune = 128
                           input-source = nil test
                           start-rune = 118
                           left-expr =>
-                            NodeTypeIdentifier
-                              end-rune = 118
-                              identifier-value = a
+                            NodeTypeUnionExpression
+                              end-rune = 122
                               input-source = nil test
                               start-rune = 118
+                              left-expr =>
+                                NodeTypeIdentifier
+                                  end-rune = 118
+                                  identifier-value = a
+                                  input-source = nil test
+                                  start-rune = 118
+                              right-expr =>
+                                NodeTypeIdentifier
+                                  end-rune = 122
+                                  identifier-value = b
+                                  input-source = nil test
+                                  start-rune = 122
                           right-expr =>
-                            NodeTypeIdentifier
-                              end-rune = 122
-                              identifier-value = b
+                            NodeTypeNilExpression
+                              end-rune = 128
                               input-source = nil test
-                              start-rune = 122
-                      right-expr =>
-                        NodeTypeNilExpression
-                          end-rune = 128
-                          input-source = nil test
-                          start-rune = 126
+                              start-rune = 126
                   right-expr =>
                     NodeTypeIdentifier
                       end-rune = 133

--- a/pkg/schemadsl/parser/tests/parens.zed.expected
+++ b/pkg/schemadsl/parser/tests/parens.zed.expected
@@ -15,19 +15,24 @@ NodeTypeFile
           relation-name = bar
           start-rune = 21
           compute-expression =>
-            NodeTypeIntersectExpression
-              end-rune = 47
+            NodeTypeParenthesizedExpression
+              end-rune = 48
               input-source = parens test
-              start-rune = 39
-              left-expr =>
-                NodeTypeIdentifier
-                  end-rune = 41
-                  identifier-value = maz
+              start-rune = 38
+              inner-expr =>
+                NodeTypeIntersectExpression
+                  end-rune = 47
                   input-source = parens test
                   start-rune = 39
-              right-expr =>
-                NodeTypeIdentifier
-                  end-rune = 47
-                  identifier-value = beh
-                  input-source = parens test
-                  start-rune = 45
+                  left-expr =>
+                    NodeTypeIdentifier
+                      end-rune = 41
+                      identifier-value = maz
+                      input-source = parens test
+                      start-rune = 39
+                  right-expr =>
+                    NodeTypeIdentifier
+                      end-rune = 47
+                      identifier-value = beh
+                      input-source = parens test
+                      start-rune = 45

--- a/pkg/schemadsl/parser/tests/permission_edge_cases.zed.expected
+++ b/pkg/schemadsl/parser/tests/permission_edge_cases.zed.expected
@@ -135,22 +135,27 @@ NodeTypeFile
                   input-source = permission edge cases test
                   start-rune = 340
               right-expr =>
-                NodeTypeExclusionExpression
-                  end-rune = 364
+                NodeTypeParenthesizedExpression
+                  end-rune = 365
                   input-source = permission edge cases test
-                  start-rune = 350
-                  left-expr =>
-                    NodeTypeIdentifier
-                      end-rune = 355
-                      identifier-value = viewer
+                  start-rune = 349
+                  inner-expr =>
+                    NodeTypeExclusionExpression
+                      end-rune = 364
                       input-source = permission edge cases test
                       start-rune = 350
-                  right-expr =>
-                    NodeTypeIdentifier
-                      end-rune = 364
-                      identifier-value = viewer
-                      input-source = permission edge cases test
-                      start-rune = 359
+                      left-expr =>
+                        NodeTypeIdentifier
+                          end-rune = 355
+                          identifier-value = viewer
+                          input-source = permission edge cases test
+                          start-rune = 350
+                      right-expr =>
+                        NodeTypeIdentifier
+                          end-rune = 364
+                          identifier-value = viewer
+                          input-source = permission edge cases test
+                          start-rune = 359
           type-annotations =>
             NodeTypeTypeAnnotation
               end-rune = 336

--- a/pkg/schemadsl/parser/tests/use_self.zed.expected
+++ b/pkg/schemadsl/parser/tests/use_self.zed.expected
@@ -72,32 +72,37 @@ NodeTypeFile
                   input-source = self test
                   start-rune = 125
                   left-expr =>
-                    NodeTypeUnionExpression
-                      end-rune = 137
+                    NodeTypeParenthesizedExpression
+                      end-rune = 138
                       input-source = self test
-                      start-rune = 126
-                      left-expr =>
+                      start-rune = 125
+                      inner-expr =>
                         NodeTypeUnionExpression
-                          end-rune = 130
+                          end-rune = 137
                           input-source = self test
                           start-rune = 126
                           left-expr =>
-                            NodeTypeIdentifier
-                              end-rune = 126
-                              identifier-value = a
+                            NodeTypeUnionExpression
+                              end-rune = 130
                               input-source = self test
                               start-rune = 126
+                              left-expr =>
+                                NodeTypeIdentifier
+                                  end-rune = 126
+                                  identifier-value = a
+                                  input-source = self test
+                                  start-rune = 126
+                              right-expr =>
+                                NodeTypeIdentifier
+                                  end-rune = 130
+                                  identifier-value = b
+                                  input-source = self test
+                                  start-rune = 130
                           right-expr =>
-                            NodeTypeIdentifier
-                              end-rune = 130
-                              identifier-value = b
+                            NodeTypeSelfExpression
+                              end-rune = 137
                               input-source = self test
-                              start-rune = 130
-                      right-expr =>
-                        NodeTypeSelfExpression
-                          end-rune = 137
-                          input-source = self test
-                          start-rune = 134
+                              start-rune = 134
                   right-expr =>
                     NodeTypeIdentifier
                       end-rune = 142

--- a/proto/internal/impl/v1/impl.proto
+++ b/proto/internal/impl/v1/impl.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package impl.v1;
 
+import "core/v1/core.proto";
 import "google/api/expr/v1alpha1/checked.proto";
 
 option go_package = "github.com/authzed/spicedb/pkg/proto/impl/v1";
@@ -99,6 +100,13 @@ message RelationMetadata {
 
   RelationKind kind = 1;
   TypeAnnotations type_annotations = 2;
+
+  // Indicates whether the permission expression contains mixed operators (union, intersection,
+  // exclusion) at the same scope level without explicit parentheses.
+  bool has_mixed_operators_without_parentheses = 3;
+
+  // The source position of the first mixed operator found, if any.
+  core.v1.SourcePosition mixed_operators_position = 4;
 }
 
 message NamespaceAndRevision {


### PR DESCRIPTION
When writing permission expressions like `viewer - blocked & editor`, it's easy to assume arithmetic-style precedence. But SpiceDB's actual precedence (exclusion binds loosest, then intersection, then union) can lead to unexpected behavior.

This adds a lint warning that flags mixed operators at the same scope, nudging users to add parentheses and make their intent explicit.

**Example:**
```
permission view = viewer - blocked & editor  // warns
permission view = (viewer - blocked) & editor  // ok
permission view = viewer + editor + blocked  // ok (same operator)
```

The warning can be suppressed with:
```
// spicedb-ignore-warning: mixed-operators-without-parentheses
permission view = viewer - blocked & editor
```

Fixes https://github.com/authzed/zed/issues/598