### PR TITLE
chore: refactor resolvers

### DIFF
--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -222,7 +222,7 @@ func (s *Server) textDocHover(_ context.Context, r *jsonrpc2.Request) (*Hover, e
 			return err
 		}
 
-		resolver, err := development.NewResolver(compiled)
+		resolver, err := development.NewSchemaPositionMapper(compiled)
 		if err != nil {
 			return err
 		}

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -265,7 +265,7 @@ func loadCompiled(
 	rwt datastore.ReadWriteTransaction,
 ) ([]*devinterface.DeveloperError, error) {
 	errors := make([]*devinterface.DeveloperError, 0, len(compiled.OrderedDefinitions))
-	ts := schema.NewTypeSystem(schema.ResolverForCompiledSchema(*compiled))
+	ts := schema.NewTypeSystem(schema.ResolverForCompiledSchema(compiled))
 
 	for _, caveatDef := range compiled.CaveatDefinitions {
 		cverr := namespace.ValidateCaveatDefinition(caveattypes.Default.TypeSet, caveatDef)

--- a/pkg/development/schema_position_mapper_test.go
+++ b/pkg/development/schema_position_mapper_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
 )
 
-func TestResolver(t *testing.T) {
+func TestSchemaPositionMapper(t *testing.T) {
 	testSource := input.Source("test")
 
 	tcs := []struct {
@@ -410,10 +410,10 @@ definition document {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			resolver, err := NewResolver(compiled)
+			schemaPositionMapper, err := NewSchemaPositionMapper(compiled)
 			require.NoError(t, err)
 
-			ref, err := resolver.ReferenceAtPosition(input.Source("test"), input.Position{
+			ref, err := schemaPositionMapper.ReferenceAtPosition(input.Source("test"), input.Position{
 				LineNumber:     tc.line,
 				ColumnPosition: tc.column,
 			})

--- a/pkg/development/warnings.go
+++ b/pkg/development/warnings.go
@@ -61,7 +61,7 @@ func warningForPosition(warningName string, message string, sourceCode string, s
 // GetWarnings returns a list of warnings for the given developer context.
 func GetWarnings(ctx context.Context, devCtx *DevContext) ([]*devinterface.DeveloperWarning, error) {
 	warnings := []*devinterface.DeveloperWarning{}
-	res := schema.ResolverForCompiledSchema(*devCtx.CompiledSchema)
+	res := schema.ResolverForCompiledSchema(devCtx.CompiledSchema)
 	ts := schema.NewTypeSystem(res)
 
 	for _, def := range devCtx.CompiledSchema.ObjectDefinitions {

--- a/pkg/schema/arrows_test.go
+++ b/pkg/schema/arrows_test.go
@@ -127,7 +127,7 @@ func TestLookupTuplesetArrows(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			res := ResolverForCompiledSchema(*schema)
+			res := ResolverForCompiledSchema(schema)
 			arrowSet, err := buildArrowSet(t.Context(), res)
 			require.NoError(t, err)
 
@@ -259,7 +259,7 @@ func TestAllReachableRelations(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			res := ResolverForCompiledSchema(*schema)
+			res := ResolverForCompiledSchema(schema)
 			arrows, err := buildArrowSet(t.Context(), res)
 			require.NoError(t, err)
 
@@ -520,7 +520,7 @@ func TestLookupArrowsWithComputedUserset(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			res := ResolverForCompiledSchema(*schema)
+			res := ResolverForCompiledSchema(schema)
 			arrowSet, err := buildArrowSet(t.Context(), res)
 			require.NoError(t, err)
 

--- a/pkg/schema/compiled_schema_resolver.go
+++ b/pkg/schema/compiled_schema_resolver.go
@@ -10,18 +10,18 @@ import (
 // FullSchemaResolver is a superset of a resolver that knows how to retrieve all definitions
 // from its source by name (by having a complete list of names).
 type FullSchemaResolver interface {
-	Resolver
+	TypeSystemResolver
 	AllDefinitionNames() []string
 }
 
 // CompiledSchemaResolver is a resolver for a fully compiled schema. It implements FullSchemaResolver,
 // as it has the full context of the schema.
 type CompiledSchemaResolver struct {
-	schema compiler.CompiledSchema
+	schema *compiler.CompiledSchema
 }
 
 // ResolverForCompiledSchema builds a resolver from a compiled schema.
-func ResolverForCompiledSchema(schema compiler.CompiledSchema) *CompiledSchemaResolver {
+func ResolverForCompiledSchema(schema *compiler.CompiledSchema) *CompiledSchemaResolver {
 	return &CompiledSchemaResolver{
 		schema: schema,
 	}

--- a/pkg/schema/errors.go
+++ b/pkg/schema/errors.go
@@ -299,7 +299,7 @@ func NewRelationNotFoundErr(nsName string, relationName string) error {
 // NewCaveatNotFoundErr constructs a new caveat not found error.
 func NewCaveatNotFoundErr(caveatName string) error {
 	return CaveatNotFoundError{
-		error:      fmt.Errorf("caveat `%s` not found", caveatName),
+		error:      fmt.Errorf("caveat with name `%s` not found", caveatName),
 		caveatName: caveatName,
 	}
 }

--- a/pkg/schema/full_reachability.go
+++ b/pkg/schema/full_reachability.go
@@ -17,15 +17,15 @@ type Graph struct {
 	referenceInfoMap map[nsAndRel][]RelationReferenceInfo
 }
 
-// BuildGraph builds the graph of all reachable information in the schema.
-func BuildGraph(ctx context.Context, r *CompiledSchemaResolver) (*Graph, error) {
-	arrowSet, err := buildArrowSet(ctx, r)
+// NewGraph builds the graph of all reachable information in the schema.
+func NewGraph(ctx context.Context, compiledSchemaResolver *CompiledSchemaResolver) (*Graph, error) {
+	arrowSet, err := buildArrowSet(ctx, compiledSchemaResolver)
 	if err != nil {
 		return nil, err
 	}
 
-	ts := NewTypeSystem(r)
-	referenceInfoMap, err := preComputeRelationReferenceInfo(ctx, arrowSet, r, ts)
+	ts := NewTypeSystem(compiledSchemaResolver)
+	referenceInfoMap, err := preComputeRelationReferenceInfo(ctx, arrowSet, compiledSchemaResolver, ts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/schema/full_reachability_test.go
+++ b/pkg/schema/full_reachability_test.go
@@ -359,8 +359,8 @@ func TestRelationsReferencing(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			res := ResolverForCompiledSchema(*schema)
-			graph, err := BuildGraph(t.Context(), res)
+			res := ResolverForCompiledSchema(schema)
+			graph, err := NewGraph(t.Context(), res)
 			require.NoError(t, err)
 
 			for _, resource := range schema.ObjectDefinitions {
@@ -414,8 +414,8 @@ func BenchmarkRelationsReferencing(b *testing.B) {
 	}, compiler.AllowUnprefixedObjectType())
 	require.NoError(b, err)
 
-	res := ResolverForCompiledSchema(*schema)
-	graph, err := BuildGraph(b.Context(), res)
+	res := ResolverForCompiledSchema(schema)
+	graph, err := NewGraph(b.Context(), res)
 	require.NoError(b, err)
 
 	b.ResetTimer()

--- a/pkg/schema/type_check_test.go
+++ b/pkg/schema/type_check_test.go
@@ -212,7 +212,7 @@ func TestTypecheckingJustTypes(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			res := ResolverForCompiledSchema(*schema)
+			res := ResolverForCompiledSchema(schema)
 			ts := NewTypeSystem(res)
 			for _, resource := range schema.ObjectDefinitions {
 				for _, relation := range resource.Relation {
@@ -395,7 +395,7 @@ func TestTypecheckingWithSubrelations(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			res := ResolverForCompiledSchema(*schema)
+			res := ResolverForCompiledSchema(schema)
 			ts := NewTypeSystem(res)
 			for _, resource := range schema.ObjectDefinitions {
 				for _, relation := range resource.Relation {
@@ -503,7 +503,7 @@ func TestTypeAnnotationsValidation(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(t, err)
 
-			res := ResolverForCompiledSchema(*schema)
+			res := ResolverForCompiledSchema(schema)
 			ts := NewTypeSystem(res)
 
 			var foundError error
@@ -579,7 +579,7 @@ func TestIncompleteSchema(t *testing.T) {
 			}
 			schema.ObjectDefinitions = missingDefs
 
-			res := ResolverForCompiledSchema(*schema)
+			res := ResolverForCompiledSchema(schema)
 			ts := NewTypeSystem(res)
 			_, err = ts.GetRecursiveTerminalTypesForRelation(t.Context(), "resource", "view")
 			require.Error(t, err)

--- a/pkg/schema/typesystem.go
+++ b/pkg/schema/typesystem.go
@@ -22,12 +22,12 @@ type (
 type TypeSystem struct {
 	sync.Mutex
 	validatedDefinitions map[string]*ValidatedDefinition // GUARDED_BY(Mutex)
-	resolver             Resolver
+	resolver             TypeSystemResolver
 	wildcardCheckCache   map[string]*WildcardTypeReference
 }
 
-// NewTypeSystem builds a TypeSystem object from a resolver, which can look up the definitions.
-func NewTypeSystem(resolver Resolver) *TypeSystem {
+// NewTypeSystem builds a TypeSystem object from a resolver, which can look up type definitions and caveats.
+func NewTypeSystem(resolver TypeSystemResolver) *TypeSystem {
 	return &TypeSystem{
 		validatedDefinitions: make(map[string]*ValidatedDefinition),
 		resolver:             resolver,
@@ -39,6 +39,11 @@ func NewTypeSystem(resolver Resolver) *TypeSystem {
 func (ts *TypeSystem) GetDefinition(ctx context.Context, definition string) (*Definition, error) {
 	v, _, err := ts.getDefinition(ctx, definition)
 	return v, err
+}
+
+// GetCaveat looks up and returns a caveat struct.
+func (ts *TypeSystem) GetCaveat(ctx context.Context, caveatName string) (*Caveat, error) {
+	return ts.resolver.LookupCaveat(ctx, caveatName)
 }
 
 // getDefinition is an internal helper for GetDefinition and GetValidatedDefinition

--- a/pkg/schema/typesystem_validation.go
+++ b/pkg/schema/typesystem_validation.go
@@ -277,7 +277,7 @@ func (def *Definition) Validate(ctx context.Context) (*ValidatedDefinition, erro
 
 			// Check the caveat, if any.
 			if allowedRelation.GetRequiredCaveat() != nil {
-				_, err := def.TypeSystem().resolver.LookupCaveat(ctx, allowedRelation.GetRequiredCaveat().CaveatName)
+				_, err := def.TypeSystem().GetCaveat(ctx, allowedRelation.GetRequiredCaveat().CaveatName)
 				if err != nil {
 					return nil, NewTypeWithSourceError(
 						fmt.Errorf("could not lookup caveat `%s` for relation `%s`: %w", allowedRelation.GetRequiredCaveat().CaveatName, relation.Name, err),

--- a/pkg/schema/v2/todefinitions_typesystem_test.go
+++ b/pkg/schema/v2/todefinitions_typesystem_test.go
@@ -387,7 +387,7 @@ func TestToDefinitionsRoundTripWithTypeSystem(t *testing.T) {
 				ObjectDefinitions: defs,
 				CaveatDefinitions: caveats,
 			}
-			resolver := pkgschema.ResolverForSchema(*compiled2)
+			resolver := pkgschema.ResolverForSchema(compiled2)
 			ts := pkgschema.NewTypeSystem(resolver)
 
 			// Step 5: Run tester functions for each definition
@@ -633,7 +633,7 @@ func TestToDefinitionsFlattenedRoundTripWithTypeSystem(t *testing.T) {
 				ObjectDefinitions: defs,
 				CaveatDefinitions: caveats,
 			}
-			resolver := pkgschema.ResolverForSchema(*compiled2)
+			resolver := pkgschema.ResolverForSchema(compiled2)
 			ts := pkgschema.NewTypeSystem(resolver)
 
 			// Step 7: Run tester functions for each definition
@@ -690,7 +690,7 @@ func TestToDefinitionsRoundTripWithTypeSystemNegativeCases(t *testing.T) {
 		ObjectDefinitions: defs,
 		CaveatDefinitions: caveats,
 	}
-	resolver := pkgschema.ResolverForSchema(*compiled2)
+	resolver := pkgschema.ResolverForSchema(compiled2)
 	ts := pkgschema.NewTypeSystem(resolver)
 
 	def, err := ts.GetDefinition(ctx, "resource")

--- a/pkg/validationfile/loader_test.go
+++ b/pkg/validationfile/loader_test.go
@@ -154,7 +154,7 @@ func TestPopulateFromFiles(t *testing.T) {
 			name:          "invalid caveat",
 			filePaths:     []string{"testdata/invalid_caveat.yaml"},
 			want:          nil,
-			expectedError: &ExpectedError{message: "could not lookup caveat `some_caveat` for relation `reader`: caveat `some_caveat` not found"},
+			expectedError: &ExpectedError{message: "could not lookup caveat `some_caveat` for relation `reader`: caveat with name `some_caveat` not found"},
 		},
 		{
 			name:          "invalid caveated relationship",


### PR DESCRIPTION
No functional changes.

- A few renames
- Simplified the setup of some unit tests that _don't_ need a full blown datastore to pass