### PR TITLE
fix(mysql,crdb): touch without expiration should remove the expiration

### DIFF
--- a/internal/datastore/crdb/readwrite.go
+++ b/internal/datastore/crdb/readwrite.go
@@ -56,7 +56,7 @@ type crdbReadWriteTXN struct {
 
 var (
 	upsertTupleSuffixWithoutIntegrity = fmt.Sprintf(
-		"ON CONFLICT (%s,%s,%s,%s,%s,%s) DO UPDATE SET %s = now(), %s = excluded.%s, %s = excluded.%s, %s = excluded.%s WHERE (relation_tuple.%s <> excluded.%s OR relation_tuple.%s <> excluded.%s OR relation_tuple.%s <> excluded.%s)",
+		"ON CONFLICT (%s,%s,%s,%s,%s,%s) DO UPDATE SET %s = now(), %s = excluded.%s, %s = excluded.%s, %s = excluded.%s WHERE (relation_tuple.%s <> excluded.%s OR relation_tuple.%s <> excluded.%s OR relation_tuple.%s IS DISTINCT FROM excluded.%s)",
 		schema.ColNamespace,
 		schema.ColObjectID,
 		schema.ColRelation,
@@ -79,7 +79,7 @@ var (
 	)
 
 	upsertTupleSuffixWithIntegrity = fmt.Sprintf(
-		"ON CONFLICT (%s,%s,%s,%s,%s,%s) DO UPDATE SET %s = now(), %s = excluded.%s, %s = excluded.%s, %s = excluded.%s, %s = excluded.%s, %s = excluded.%s WHERE (relation_tuple_with_integrity.%s <> excluded.%s OR relation_tuple_with_integrity.%s <> excluded.%s OR relation_tuple_with_integrity.%s <> excluded.%s)",
+		"ON CONFLICT (%s,%s,%s,%s,%s,%s) DO UPDATE SET %s = now(), %s = excluded.%s, %s = excluded.%s, %s = excluded.%s, %s = excluded.%s, %s = excluded.%s WHERE (relation_tuple_with_integrity.%s <> excluded.%s OR relation_tuple_with_integrity.%s <> excluded.%s OR relation_tuple_with_integrity.%s IS DISTINCT FROM excluded.%s)",
 		schema.ColNamespace,
 		schema.ColObjectID,
 		schema.ColRelation,

--- a/internal/datastore/mysql/readwrite.go
+++ b/internal/datastore/mysql/readwrite.go
@@ -266,6 +266,7 @@ func (rwt *mysqlReadWriteTXN) WriteRelationships(ctx context.Context, mutations 
 						Relation:   subjectRelation,
 					},
 				},
+				OptionalExpiration: expiration,
 			}
 
 			// if the relationship to be deleted is for a TOUCH operation and the caveat

--- a/pkg/datastore/test/relationships.go
+++ b/pkg/datastore/test/relationships.go
@@ -1917,6 +1917,15 @@ func RelationshipExpirationTest(t *testing.T, tester DatastoreTester) {
 	require.NoError(err)
 	ensureRelationships(ctx, require, ds, rel4)
 	ensureReverseRelationships(ctx, require, ds, rel4)
+
+	// Touch the relationship without an expiration to remove it.
+	rel5, err := tuple.Parse("document:foo#expiring_viewer@user:tom")
+	require.NoError(err)
+
+	_, err = common.WriteRelationships(ctx, ds, tuple.UpdateOperationTouch, rel5)
+	require.NoError(err)
+	ensureRelationships(ctx, require, ds, rel5)
+	ensureReverseRelationships(ctx, require, ds, rel5)
 }
 
 // TypedTouchAlreadyExistingTest tests touching a relationship twice, when valid type information is provided.


### PR DESCRIPTION
## Description

On the MySQL and CRDB datastores, a touch without an expiration will leave the existing expiration intact if the relationship already has one. This is a bug. 