### PR TITLE
ci: fix docs update workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,7 +35,8 @@ jobs:
         run: |
           set -e # Have script exit in the event of a failed command.
           cp -v docs/spicedb.md docs-repo/$TARGET_DOCS_FILE
-          if [[ -n "$(git status --porcelain ./docs-repo)" ]]; then
+          if [[ -n "$(git -C docs-repo status --porcelain)" ]]; then
+            echo "changes were made"
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else
             echo "no changes were made"


### PR DESCRIPTION
Fixes build alerts that fire because `docs_changed` is being set to true incorrectly.

```
:x: [@eng-oss](https://authzed.slack.com/admin/user_groups) Could not sync docs from spicedb repo to the docs repo. Please take a look.
Repository: [authzed/spicedb](https://github.com/authzed/spicedb)
Job Run: https://github.com/authzed/spicedb/actions/runs/20610396785
```