### PR TITLE
fix: issue with multiple imports leading to empty output

### DIFF
--- a/pkg/composableschemadsl/compiler/importer-test/many-imports/apps.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/many-imports/apps.zed
@@ -1,0 +1,8 @@
+import "caveat.zed"
+import "teams.zed"
+
+// apps
+definition apps {
+	relation d_caveat: d_caveat
+	relation teams: teams
+}

--- a/pkg/composableschemadsl/compiler/importer-test/many-imports/aws.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/many-imports/aws.zed
@@ -1,0 +1,8 @@
+import "caveat.zed"
+import "teams.zed"
+
+// aws
+definition aws {
+	relation d_caveat: d_caveat
+	relation teams: teams
+}

--- a/pkg/composableschemadsl/compiler/importer-test/many-imports/caveat.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/many-imports/caveat.zed
@@ -1,0 +1,2 @@
+// caveat
+definition d_caveat {}

--- a/pkg/composableschemadsl/compiler/importer-test/many-imports/expected.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/many-imports/expected.zed
@@ -1,0 +1,32 @@
+// caveat
+definition d_caveat {}
+
+// teams
+definition teams {
+	relation d_caveat: d_caveat
+}
+
+// apps
+definition apps {
+	relation d_caveat: d_caveat
+	relation teams: teams
+}
+
+// aws
+definition aws {
+	relation d_caveat: d_caveat
+	relation teams: teams
+}
+
+// iam
+definition iam {
+	relation apps: apps
+	relation d_caveat: d_caveat
+	relation teams: teams
+}
+
+// okta
+definition okta {
+	relation d_caveat: d_caveat
+	relation teams: teams
+}

--- a/pkg/composableschemadsl/compiler/importer-test/many-imports/iam.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/many-imports/iam.zed
@@ -1,0 +1,10 @@
+import "apps.zed"
+import "caveat.zed"
+import "teams.zed"
+
+// iam
+definition iam {
+	relation apps: apps
+	relation d_caveat: d_caveat
+	relation teams: teams
+}

--- a/pkg/composableschemadsl/compiler/importer-test/many-imports/okta.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/many-imports/okta.zed
@@ -1,0 +1,8 @@
+import "caveat.zed"
+import "teams.zed"
+
+// okta
+definition okta {
+	relation d_caveat: d_caveat
+	relation teams: teams
+}

--- a/pkg/composableschemadsl/compiler/importer-test/many-imports/root.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/many-imports/root.zed
@@ -1,0 +1,6 @@
+import "apps.zed"
+import "aws.zed"
+import "caveat.zed"
+import "iam.zed"
+import "okta.zed"
+import "teams.zed"

--- a/pkg/composableschemadsl/compiler/importer-test/many-imports/teams.zed
+++ b/pkg/composableschemadsl/compiler/importer-test/many-imports/teams.zed
@@ -1,0 +1,6 @@
+import "caveat.zed"
+
+// teams
+definition teams {
+	relation d_caveat: d_caveat
+}

--- a/pkg/composableschemadsl/compiler/importer_test.go
+++ b/pkg/composableschemadsl/compiler/importer_test.go
@@ -63,6 +63,7 @@ func TestImporter(t *testing.T) {
 		{"diamond-shaped imports are fine", "diamond-shaped"},
 		{"multiple use directives are fine", "multiple-use-directives"},
 		{"expiration works correctly across multiple files", "expiration-usage"},
+		{"many imports are correctly resolved", "many-imports"},
 	}
 
 	for _, test := range importerTests {

--- a/pkg/composableschemadsl/compiler/translator.go
+++ b/pkg/composableschemadsl/compiler/translator.go
@@ -813,8 +813,8 @@ func translateImports(itctx importResolutionContext, root *dslNode) error {
 				// by not reading the schema file in and compiling a schema with an empty string.
 				// This prevents duplicate definitions from ending up in the output, as well
 				// as preventing circular imports.
-				log.Debug().Str("filepath", filePath).Msg("file %s has already been visited in another part of the walk")
-				return nil
+				log.Debug().Str("filepath", filePath).Msg("file has already been visited in another part of the walk")
+				continue
 			}
 
 			// Do the actual import here


### PR DESCRIPTION
## Description
We had a report that a particular schema structure wasn't working for a user. This adds a test for that structure and fixes the issue.

The tl;dr: is that schema content was being dropped when a previously-encountered import was seen again, because we were `return`ing instead of `continue`ing.

## Changes
* Fix log message
* Change `return` to `continue`
* Add test and fix test
## Testing
Review. See that tests pass