### PR TITLE
feat: Initial implementation of the PostgresFDW

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 # use `docker buildx imagetools inspect <image>` to get the multi-platform sha256
-FROM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS spicedb-builder
+# Note: Using Debian-based golang image (not alpine) to build with glibc for postgres-fdw support
+FROM golang:1.25.5@sha256:8bbd14091f2c61916134fa6aeb8f76b18693fcb29a39ec6d8be9242c0a7e9260 AS spicedb-builder
 WORKDIR /go/src/app
-RUN apk update && apk add --no-cache git
+RUN apt-get update && apt-get install -y --no-install-recommends git gcc libc6-dev && rm -rf /var/lib/apt/lists/*
 COPY . .
 # https://github.com/odigos-io/go-rtml#about-ldflags-checklinkname0
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 go build -tags memoryprotection -v -ldflags=-checklinkname=0 -o spicedb ./cmd/spicedb
+# Build with CGO enabled for postgres-fdw support
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=1 go build -tags memoryprotection -v -ldflags=-checklinkname=0 -o spicedb ./cmd/spicedb
 
 # use `docker buildx imagetools inspect <image>` to get the multi-platform sha256
 FROM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS health-probe-builder
@@ -16,7 +18,8 @@ RUN git checkout main
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 # use `crane digest <image>` to get the multi-platform sha256
-FROM cgr.dev/chainguard/static@sha256:b2e1c3d3627093e54f6805823e73edd17ab93d6c7202e672988080c863e0412b
+# Note: Using glibc-dynamic base instead of static because the postgres-fdw command requires libc
+FROM cgr.dev/chainguard/glibc-dynamic@sha256:2c50486a00691ab9bf245c5e5e456777ff4bb25c8635be898bd5e2f0ab72eedb
 COPY --from=health-probe-builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 COPY --from=spicedb-builder /go/src/app/spicedb /usr/local/bin/spicedb
 ENV PATH="$PATH:/usr/local/bin"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,6 +1,7 @@
 # vim: syntax=dockerfile
 # use `docker buildx imagetools inspect <image>` to get the multi-platform sha256
-ARG BASE=cgr.dev/chainguard/static@sha256:b2e1c3d3627093e54f6805823e73edd17ab93d6c7202e672988080c863e0412b
+# Note: Using glibc-dynamic base instead of static because the postgres-fdw command requires libc
+ARG BASE=cgr.dev/chainguard/glibc-dynamic@sha256:2c50486a00691ab9bf245c5e5e456777ff4bb25c8635be898bd5e2f0ab72eedb
 FROM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS health-probe-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git

--- a/configuration.sql
+++ b/configuration.sql
@@ -1,0 +1,34 @@
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+CREATE SERVER spicedb_fdw FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'host.docker.internal', dbname 'default', port '5433', use_remote_estimate 'true');
+
+CREATE USER MAPPING FOR postgres SERVER spicedb_fdw OPTIONS (user 'postgres', password 'proxypassword');
+
+CREATE SCHEMA spicedb;
+
+-- IMPORT FOREIGN SCHEMA spicedb FROM SERVER spicedb_fdw INTO spicedb;
+
+CREATE FOREIGN TABLE relationships ( 
+    resource_type text NOT NULL,
+    resource_id text NOT NULL,
+    relation text NOT NULL,
+    subject_type text NOT NULL,
+    subject_id text NOT NULL,
+    optional_subject_relation text default '',
+    caveat_name text default '',
+    caveat_context text default '',
+    consistency text default ''
+) SERVER spicedb_fdw;
+
+CREATE FOREIGN TABLE permissions (
+    resource_type text NOT NULL,
+    resource_id text NOT NULL,
+    permission text NOT NULL,
+    subject_type text NOT NULL,
+    subject_id text NOT NULL,
+    optional_subject_relation text NOT NULL,
+    has_permission boolean, -- NULL when maybe
+    consistency text default ''
+) SERVER spicedb_fdw;
+
+CREATE FOREIGN TABLE schema ( schema_text text ) SERVER spicedb_fdw;

--- a/docs/spicedb.md
+++ b/docs/spicedb.md
@@ -30,6 +30,7 @@ A database that stores and computes permissions
 - [spicedb datastore](#reference-spicedb-datastore)	 - datastore operations
 - [spicedb lsp](#reference-spicedb-lsp)	 - serve language server protocol
 - [spicedb man](#reference-spicedb-man)	 - Generate man page
+- [spicedb postgres-fdw](#reference-spicedb-postgres-fdw)	 - serve a Postgres Foreign Data Wrapper for SpiceDB (EXPERIMENTAL)
 - [spicedb serve](#reference-spicedb-serve)	 - serve the permissions database
 - [spicedb serve-testing](#reference-spicedb-serve-testing)	 - test server with an in-memory datastore
 - [spicedb version](#reference-spicedb-version)	 - displays the version of SpiceDB
@@ -358,6 +359,36 @@ Generate a man page for SpiceDB.
 
 ```
 spicedb man
+```
+
+### Options Inherited From Parent Flags
+
+```
+      --log-format string    format of logs ("auto", "console", "json") (default "auto")
+      --log-level string     verbosity of logging ("trace", "debug", "info", "warn", "error") (default "info")
+      --skip-release-check   if true, skips checking for new SpiceDB releases
+```
+
+
+
+## Reference: `spicedb postgres-fdw`
+
+EXPERIMENTAL: Serves a Postgres-compatible interface for querying SpiceDB data using foreign data wrappers. This feature is experimental and subject to change.
+
+```
+spicedb postgres-fdw [flags]
+```
+
+### Options
+
+```
+      --postgres-access-token-secret string   (required) The password that Postgres will use to authenticate to the FDW proxy (configured in the Postgres FDW extension's OPTIONS)
+      --postgres-endpoint string              The endpoint at which to serve the Postgres protocol (default ":5432")
+      --postgres-username string              The username that Postgres will use to connect to the FDW proxy (default "postgres")
+      --shutdown-grace-period duration        The duration to wait for the server to shutdown gracefully
+      --spicedb-access-token-secret string    (required) Access token for calling the SpiceDB API
+      --spicedb-api-endpoint string           SpiceDB API endpoint (default "localhost:50051")
+      --spicedb-insecure                      Use insecure connection to SpiceDB API
 ```
 
 ### Options Inherited From Parent Flags

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.15
 	github.com/benbjohnson/clock v1.3.5
 	github.com/bits-and-blooms/bloom/v3 v3.7.1
+	github.com/bmizerany/perks v0.0.0-20230307044200-03f9df79da1e
 	github.com/caio/go-tdigest/v4 v4.1.0
 	github.com/ccoveille/go-safecast/v2 v2.0.0
 	github.com/cenkalti/backoff/v5 v5.0.3
@@ -69,9 +70,11 @@ require (
 	github.com/jackc/pgio v1.0.0
 	github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb
 	github.com/jackc/pgx/v5 v5.7.6
+	github.com/jeroenrinzema/psql-wire v0.17.0
 	github.com/jzelinskie/cobrautil/v2 v2.0.0-20240819150235-f7fe73942d0f
 	github.com/jzelinskie/persistent v0.0.0-20230816160542-1205ef8f0e15
 	github.com/jzelinskie/stringz v0.0.3
+	github.com/lib/pq v1.10.9
 	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/lthibault/jitterbug v2.0.0+incompatible
 	github.com/mattn/go-isatty v0.0.20
@@ -81,9 +84,11 @@ require (
 	github.com/muesli/roff v0.1.0
 	github.com/ngrok/sqlmw v0.0.0-20220520173518-97c9c04efc79
 	github.com/odigos-io/go-rtml v0.0.1
+	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/outcaste-io/ristretto v0.2.3
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
+	github.com/pganalyze/pg_query_go/v6 v6.1.0
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240917153116-6f2963f01587
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
@@ -213,6 +218,7 @@ require (
 	github.com/butuzov/mirror v1.3.0 // indirect
 	github.com/catenacyber/perfsprint v0.10.0 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.4 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/charithe/durationcheck v0.0.11 // indirect
@@ -290,6 +296,7 @@ require (
 	github.com/gostaticanalysis/comment v1.5.0 // indirect
 	github.com/gostaticanalysis/forcetypeassert v0.2.0 // indirect
 	github.com/gostaticanalysis/nilerr v0.1.2 // indirect
+	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
@@ -451,6 +458,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gotest.tools v2.2.0+incompatible // indirect
 	honnef.co/go/tools v0.6.1 // indirect
 	k8s.io/api v0.34.1 // indirect
 	k8s.io/apimachinery v0.34.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -779,6 +779,8 @@ github.com/bkielbasa/cyclop v1.2.3 h1:faIVMIGDIANuGPWH031CZJTi2ymOQBULs9H21HSMa5
 github.com/bkielbasa/cyclop v1.2.3/go.mod h1:kHTwA9Q0uZqOADdupvcFJQtp/ksSnytRMe8ztxG8Fuo=
 github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ089M=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
+github.com/bmizerany/perks v0.0.0-20230307044200-03f9df79da1e h1:mWOqoK5jV13ChKf/aF3plwQ96laasTJgZi4f1aSOu+M=
+github.com/bmizerany/perks v0.0.0-20230307044200-03f9df79da1e/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/bombsimon/wsl/v4 v4.7.0 h1:1Ilm9JBPRczjyUs6hvOPKvd7VL1Q++PL8M0SXBDf+jQ=
 github.com/bombsimon/wsl/v4 v4.7.0/go.mod h1:uV/+6BkffuzSAVYD+yGyld1AChO7/EuLrCF/8xTiapg=
 github.com/bombsimon/wsl/v5 v5.3.0 h1:nZWREJFL6U3vgW/B1lfDOigl+tEF6qgs6dGGbFeR0UM=
@@ -801,6 +803,8 @@ github.com/ccojocar/zxcvbn-go v1.0.4 h1:FWnCIRMXPj43ukfX000kvBZvV6raSxakYr1nzyNr
 github.com/ccojocar/zxcvbn-go v1.0.4/go.mod h1:3GxGX+rHmueTUMvm5ium7irpyjmm7ikxYFOSJB21Das=
 github.com/ccoveille/go-safecast/v2 v2.0.0 h1:+5eyITXAUj3wMjad6cRVJKGnC7vDS55zk0INzJagub0=
 github.com/ccoveille/go-safecast/v2 v2.0.0/go.mod h1:JIYA4CAR33blIDuE6fSwCp2sz1oOBahXnvmdBhOAABs=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -1220,6 +1224,8 @@ github.com/gostaticanalysis/nilerr v0.1.2/go.mod h1:A19UHhoY3y8ahoL7YKz6sdjDtduw
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.5.0 h1:Dq4wT1DdTwTGCQQv3rl3IvD5Ld0E6HiY+3Zh0sUGqw8=
 github.com/gostaticanalysis/testutil v0.5.0/go.mod h1:OLQSbuM6zw2EvCcXTz1lVq5unyoNft372msDY0nY5Hs=
+github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
+github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
@@ -1273,6 +1279,8 @@ github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
 github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/jeroenrinzema/psql-wire v0.17.0 h1:2U5ElqxglXbStaoh6liohLjxkWIjvUamgVwcr8a90Mk=
+github.com/jeroenrinzema/psql-wire v0.17.0/go.mod h1:i7+aXJyIrgcXmbTkij68LdFs03w2f9kt18HIUo+eXmY=
 github.com/jgautheron/goconst v1.8.2 h1:y0XF7X8CikZ93fSNT6WBTb/NElBu9IjaY7CCYQrCMX4=
 github.com/jgautheron/goconst v1.8.2/go.mod h1:A0oxgBCHy55NQn6sYpO7UdnA9p+h7cPtoOZUmvNIako=
 github.com/jingyugao/rowserrcheck v1.1.1 h1:zibz55j/MJtLsjP1OF4bSdgXxwL1b+Vn7Tjzq7gFzUs=
@@ -1451,6 +1459,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81U=
 github.com/nakabonne/nestif v0.3.1/go.mod h1:9EtoZochLn5iUprVDmDjqGKPofoUEBL8U4Ngq6aY7OE=
+github.com/neilotoole/slogt v1.1.0 h1:c7qE92sq+V0yvCuaxph+RQ2jOKL61c4hqS1Bv9W7FZE=
+github.com/neilotoole/slogt v1.1.0/go.mod h1:RCrGXkPc/hYybNulqQrMHRtvlQ7F6NktNVLuLwk6V+w=
 github.com/ngrok/sqlmw v0.0.0-20220520173518-97c9c04efc79 h1:Dmx8g2747UTVPzSkmohk84S3g/uWqd6+f4SSLPhLcfA=
 github.com/ngrok/sqlmw v0.0.0-20220520173518-97c9c04efc79/go.mod h1:E26fwEtRNigBfFfHDWsklmo0T7Ixbg0XXgck+Hq4O9k=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=
@@ -1473,6 +1483,8 @@ github.com/opencontainers/runc v1.2.8 h1:RnEICeDReapbZ5lZEgHvj7E9Q3Eex9toYmaGBsb
 github.com/opencontainers/runc v1.2.8/go.mod h1:cC0YkmZcuvr+rtBZ6T7NBoVbMGNAdLa/21vIElJDOzI=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
+github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
+github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/ory/dockertest/v3 v3.12.0 h1:3oV9d0sDzlSQfHtIaB5k6ghUCVMVLpAY8hwrqoCyRCw=
 github.com/ory/dockertest/v3 v3.12.0/go.mod h1:aKNDTva3cp8dwOWwb9cWuX84aH5akkxXRvO7KCwWVjE=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
@@ -1488,6 +1500,8 @@ github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2D
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pganalyze/pg_query_go/v6 v6.1.0 h1:jG5ZLhcVgL1FAw4C/0VNQaVmX1SUJx71wBGdtTtBvls=
+github.com/pganalyze/pg_query_go/v6 v6.1.0/go.mod h1:nvTHIuoud6e1SfrUaFwHqT0i4b5Nr+1rPWVds3B5+50=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
@@ -2510,6 +2524,7 @@ google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
@@ -2538,6 +2553,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
 gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/fdw/Architecture.md
+++ b/internal/fdw/Architecture.md
@@ -1,0 +1,917 @@
+# SpiceDB Postgres FDW Proxy Architecture
+
+## Overview
+
+The SpiceDB Postgres FDW (Foreign Data Wrapper) proxy is a translation layer that implements the PostgreSQL wire protocol and converts SQL queries into SpiceDB API calls. This allows standard PostgreSQL clients and tools to interact with SpiceDB's permissions and relationships data as if they were querying regular PostgreSQL tables.
+It also allows existing Postgres *databases* to access SpiceDB data, so long as they have the Postgres Foreign Data Wrapper [postgres_fdw](https://www.postgresql.org/docs/current/postgres-fdw.html) support enabled.
+
+```
+┌─────────────────┐
+│  PostgreSQL     │
+│  Client/Tool    │
+│  (psql, app)    │
+└────────┬────────┘
+         │ SQL Query
+         ▼
+┌─────────────────────────────────────┐
+│      PostgreSQL Database            │
+│  ┌───────────────────────────────┐  │
+│  │   postgres_fdw Extension      │  │
+│  │  (Foreign Data Wrapper)       │  │
+│  └───────────┬───────────────────┘  │
+│              │                      │
+│  ┌───────────▼───────────────────┐  │
+│  │   Foreign Server Config       │  │
+│  │   host: fdw-proxy-host        │  │
+│  │   port: 5432                  │  │
+│  └───────────┬───────────────────┘  │
+│              │                      │
+│  ┌───────────▼───────────────────┐  │
+│  │   Foreign Tables              │  │
+│  │   • permissions               │  │
+│  │   • relationships             │  │
+│  │   • schema                    │  │
+│  └───────────┬───────────────────┘  │
+└──────────────┼──────────────────────┘
+               │ Postgres Wire Protocol
+               ▼
+┌─────────────────────────────────────┐
+│      FDW Proxy (PgBackend)          │
+│  ┌───────────────────────────────┐  │
+│  │   Wire Protocol Handler       │  │
+│  │  (Authentication, Parsing)    │  │
+│  └───────────┬───────────────────┘  │
+│              │                      │
+│  ┌───────────▼───────────────────┐  │
+│  │   Query Router                │  │
+│  │  (SELECT, INSERT, DELETE,     │  │
+│  │   EXPLAIN, CURSOR ops)        │  │
+│  └───────────┬───────────────────┘  │
+│              │                      │
+│  ┌───────────▼───────────────────┐  │
+│  │   Table Handlers              │  │
+│  │  • permissions                │  │
+│  │  • relationships              │  │
+│  │  • schema                     │  │
+│  └───────────┬───────────────────┘  │
+└──────────────┼──────────────────────┘
+               │ SpiceDB gRPC API Calls
+               ▼
+┌─────────────────────────────────────┐
+│         SpiceDB Server              │
+│  • CheckPermission                  │
+│  • LookupResources                  │
+│  • LookupSubjects                   │
+│  • ReadRelationships                │
+│  • WriteRelationships               │
+│  • DeleteRelationships              │
+│  • ReadSchema                       │
+└─────────────────────────────────────┘
+```
+
+## Core Components
+
+### 1. PgBackend - Wire Protocol Server
+
+**Location**: `pgserver.go`
+
+The `PgBackend` struct is the main entry point that implements the PostgreSQL wire protocol server:
+
+```go
+type PgBackend struct {
+    client   *authzed.Client  // SpiceDB API client
+    server   *wire.Server     // Postgres wire protocol server
+    username string            // Authentication username
+    password string            // Authentication password
+}
+```
+
+**Responsibilities**:
+
+- Listen on a TCP port for PostgreSQL protocol connections
+- Authenticate incoming connections using cleartext password authentication
+- Parse incoming SQL queries using the `pg_query` parser
+- Route queries to appropriate handlers
+- Manage the lifecycle of the server
+
+**Flow**:
+```
+Client Connect
+     │
+     ▼
+┌────────────────┐
+│ validateAuth() │ ───> Check username/password
+└────────┬───────┘
+         │ Success
+         ▼
+┌────────────────┐
+│ handler()      │ ───> Parse & route SQL query
+└────────────────┘
+```
+
+### 2. Session Management
+
+**Location**: `session.go`
+
+Each PostgreSQL connection maintains a session that tracks:
+
+- Transaction state (in/out of transaction)
+- Active cursors (name → cursor mapping)
+
+```
+┌─────────────────────────────────────┐
+│           Session                   │
+│  ┌───────────────────────────────┐  │
+│  │  withinTransaction: bool      │  │
+│  └───────────────────────────────┘  │
+│                                     │
+│  ┌───────────────────────────────┐  │
+│  │  cursors: map[string]*cursor  │  │
+│  │    "cursor1" → cursor{...}    │  │
+│  │    "cursor2" → cursor{...}    │  │
+│  └───────────────────────────────┘  │
+└─────────────────────────────────────┘
+```
+
+**Middleware**: The `sessionMiddleware` function initializes a new session for each connection and stores it in the request context.
+
+### 3. Transaction Handling
+
+**Location**: `transaction.go`
+
+The FDW proxy implements basic transaction semantics for PostgreSQL compatibility:
+
+```
+BEGIN
+  │
+  ├─> Set withinTransaction = true
+  │
+  ├─> [Execute queries...]
+  │
+  └─> COMMIT/ROLLBACK
+        │
+        └─> Set withinTransaction = false
+```
+
+**Important Notes**:
+
+- Transactions are tracked for cursor lifetime management
+- SpiceDB operations are still atomic per-API-call but are *not* transactionally executed themselves
+- Transaction state primarily controls cursor lifecycle
+
+### 4. Query Routing
+
+**Location**: `pgserver.go` (`handler()` method)
+
+The query router examines the parsed SQL AST and dispatches to specialized handlers:
+
+```
+    SQL Query
+        │
+        ▼
+   ┌─────────┐
+   │  Parse  │
+   └────┬────┘
+        │
+        ▼
+   ┌─────────────────────────────────┐
+   │    Statement Type Switch        │
+   └─────┬───────────────────────────┘
+         │
+    ┌────┴────┬────────┬─────────┬──────────┬────────────┐
+    │         │        │         │          │            │
+    ▼         ▼        ▼         ▼          ▼            ▼
+  SELECT   INSERT   DELETE   EXPLAIN   CURSOR ops    SET/TXNS
+    │         │        │         │          │            │
+    ▼         ▼        ▼         ▼          ▼            ▼
+ [Table   [Table   [Table   [Explain  [Cursor      [Metadata
+Handler]  Handler] Handler]  Handler]  Handler]     Handler]
+```
+
+**Supported Statement Types**:
+
+- `SET variable = value` - Ignored (for compatibility)
+- `SELECT` - Query data from virtual tables
+- `INSERT` - Write relationships
+- `DELETE` - Remove relationships
+- `EXPLAIN` - Generate query plans with cost estimates
+- `DECLARE CURSOR` - Create named cursor for result streaming
+- `FETCH` - Retrieve rows from cursor
+- `CLOSE` - Close cursor
+- `DEALLOCATE` - Remove cursor or prepared statement
+- `START TRANSACTION / COMMIT / ROLLBACK` - Transaction control
+
+### 5. Table Handlers
+
+**Location**: `tables/` directory
+
+Each table (permissions, relationships, schema) has its own handler that:
+
+1. Validates the query structure
+2. Extracts WHERE clause predicates
+3. Determines which SpiceDB API to call
+4. Executes the API call(s)
+5. Formats results as PostgreSQL rows
+
+#### Permissions Table Handler
+
+**Location**: `tables/permissions.go`
+
+The permissions table supports three distinct query patterns, each mapping to a different SpiceDB API:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│              Permissions Table Query Router                 │
+└──────────────────┬──────────────────────────────────────────┘
+                   │
+      ┌────────────┼────────────┐
+      │            │            │
+      ▼            ▼            ▼
+┌───────────┐ ┌──────────────┐ ┌──────────────┐
+│ALL fields │ │No resource_id│ │No subject_id │
+│ provided  │ │   provided   │ │   provided   │
+└─────┬─────┘ └──────┬───────┘ └──────┬───────┘
+      │              │                │
+      ▼              ▼                ▼
+┌───────────┐ ┌──────────────┐ ┌──────────────┐
+│   Check   │ │   Lookup     │ │   Lookup     │
+│Permission │ │  Resources   │ │  Subjects    │
+└───────────┘ └──────────────┘ └──────────────┘
+```
+
+**Query Pattern Detection**:
+
+1. **CheckPermission** - All fields specified:
+   ```sql
+   SELECT has_permission FROM permissions
+   WHERE resource_type = 'doc' AND resource_id = '1'
+     AND permission = 'view'
+     AND subject_type = 'user' AND subject_id = 'alice';
+   ```
+   → Calls `CheckPermission(doc:1#view@user:alice)`
+
+2. **LookupResources** - Missing `resource_id`:
+   ```sql
+   SELECT resource_id FROM permissions
+   WHERE resource_type = 'doc' AND permission = 'view'
+     AND subject_type = 'user' AND subject_id = 'alice'
+     AND has_permission = true;
+   ```
+   → Calls `LookupResources(user:alice, view, doc)`
+
+3. **LookupSubjects** - Missing `subject_id`:
+   ```sql
+   SELECT subject_id FROM permissions
+   WHERE resource_type = 'doc' AND resource_id = '1'
+     AND permission = 'view'
+     AND subject_type = 'user'
+     AND has_permission = true;
+   ```
+   → Calls `LookupSubjects(doc:1, view, user)`
+
+#### Relationships Table Handler
+
+**Location**: `tables/relationships.go`
+
+Supports CRUD operations on SpiceDB relationships:
+
+```
+┌────────────────────────────────────┐
+│    Relationships Table Handler     │
+└──────────────┬─────────────────────┘
+               │
+    ┌──────────┼──────────┐
+    │          │          │
+    ▼          ▼          ▼
+┌────────┐ ┌────────┐ ┌────────┐
+│ SELECT │ │ INSERT │ │ DELETE │
+└───┬────┘ └───┬────┘ └───┬────┘
+    │          │          │
+    ▼          ▼          ▼
+┌─────────┐ ┌──────────┐ ┌──────────┐
+│  Read   │ │  Write   │ │  Delete  │
+│Relations│ │Relations │ │Relations │
+└─────────┘ └──────────┘ └──────────┘
+```
+
+**Operations**:
+
+- **SELECT**: Streams relationships matching WHERE clause filters
+- **INSERT**: Creates new relationships with optional caveats
+- **DELETE**: Removes relationships matching WHERE clause
+
+#### Schema Table Handler
+
+**Location**: `tables/schema.go`
+
+Provides read-only access to SpiceDB schema definitions:
+
+```sql
+SELECT definition FROM schema;
+```
+→ Calls `ReadSchema()` and returns Zed format definitions
+
+### 6. Cursor Support
+
+**Location**: `cursor.go`
+
+Cursors enable streaming large result sets without loading everything into memory:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    Cursor Lifecycle                      │
+└──────────────────────────────────────────────────────────┘
+
+    DECLARE my_cursor CURSOR FOR SELECT ...
+           │
+           ▼
+    ┌──────────────────┐
+    │  Parse SELECT    │
+    │  statement       │
+    └────────┬─────────┘
+             │
+             ▼
+    ┌──────────────────┐
+    │  Store in        │
+    │  session.cursors │
+    │  map             │
+    └────────┬─────────┘
+             │
+             │
+    ┌────────▼─────────┐
+    │  FETCH 100       │
+    │  FROM my_cursor  │
+    └────────┬─────────┘
+             │
+             ▼
+    ┌──────────────────┐
+    │  Execute query   │
+    │  Get next batch  │
+    │  Store position  │
+    └────────┬─────────┘
+             │
+             │  (Can repeat FETCH)
+             │
+             ▼
+    ┌──────────────────┐
+    │  CLOSE my_cursor │
+    └────────┬─────────┘
+             │
+             ▼
+    ┌──────────────────┐
+    │  Remove from     │
+    │  session.cursors │
+    └──────────────────┘
+```
+
+**Cursor Structure**:
+```go
+type cursor struct {
+    name       string              // Cursor name
+    selectStmt *SelectStatement    // Parsed query
+    parameters []Parameter         // Bound parameters
+    rowsCursor RowsCursor          // Streaming state (table-specific)
+}
+```
+
+**Key Features**:
+
+- Cursors are scoped to a session
+- Support forward-only iteration
+- Maintain streaming state between FETCH operations
+- Automatically cleaned up on DEALLOCATE or session end
+
+### 7. Query Parsing & Pattern Matching
+
+**Location**: `tables/select.go`
+
+The SELECT statement parser extracts structured information from SQL queries:
+
+```
+    Raw SQL Query
+         │
+         ▼
+    ┌─────────────────┐
+    │  pg_query.Parse │  ← PostgreSQL SQL parser
+    └────────┬────────┘
+             │ AST
+             ▼
+    ┌─────────────────┐
+    │  Extract table  │
+    │  name from FROM │
+    └────────┬────────┘
+             │
+             ▼
+    ┌─────────────────┐
+    │  Parse column   │
+    │  list (SELECT)  │
+    └────────┬────────┘
+             │
+             ▼
+    ┌─────────────────────────┐
+    │  PatternMatcher         │
+    │  • Walk WHERE clause    │
+    │  • Extract field=value  │
+    │  • Extract field=$1     │
+    │  • Build field map      │
+    └────────┬────────────────┘
+             │
+             ▼
+    ┌─────────────────────────┐
+    │  Table-specific handler │
+    │  builder (determines    │
+    │  which API to call)     │
+    └─────────────────────────┘
+```
+
+**Supported WHERE Clause Patterns**:
+
+- Simple equality: `field = 'value'`
+- Parameterized: `field = $1`
+- Conjunctions: `field1 = 'a' AND field2 = 'b'`
+
+**Unsupported Features** (return high cost in EXPLAIN):
+
+- Joins across tables
+- Aggregations (SUM, COUNT, etc.)
+- ORDER BY, GROUP BY
+- DISTINCT
+- Subqueries
+- Complex expressions
+
+### 8. Statistics & Query Planning
+
+**Location**: `stats/stats.go`, `explain.go`
+
+The FDW collects runtime statistics to help PostgreSQL make better query planning decisions:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│              Statistics Collection Flow                  │
+└──────────────────────────────────────────────────────────┘
+
+    Query Execution
+         │
+         ▼
+    ┌─────────────────┐
+    │  Execute API    │
+    │  call and track │
+    │  • Cost (ms)    │
+    │  • Row count    │
+    │  • Row width    │
+    └────────┬────────┘
+             │
+             ▼
+    ┌─────────────────┐
+    │  stats.Package  │
+    │  • Quantile     │
+    │    streams      │
+    │  • Median calc  │
+    └────────┬────────┘
+             │
+             │
+    When EXPLAIN query runs:
+             │
+             ▼
+    ┌─────────────────────────┐
+    │  Generate query plan    │
+    │  with median costs      │
+    │                         │
+    │  Foreign Scan on perms  │
+    │    Cost: 10.00..50.00   │
+    │    Rows: 1000           │
+    │    Width: 128           │
+    └─────────────────────────┘
+```
+
+**Statistics Tracked** (per table + operation):
+
+- **Cost**: Query execution time
+- **Rows**: Number of results returned
+- **Width**: Average row size in bytes
+
+**Purpose**: PostgreSQL uses EXPLAIN cost estimates to:
+
+1. Choose between local and foreign table scans
+2. Decide join strategies
+3. Optimize multi-table queries
+
+### 9. Error Handling
+
+**Location**: `common/errors.go`
+
+The FDW uses typed errors to distinguish between different failure modes:
+
+```
+┌──────────────────────────────────────┐
+│         Error Type Hierarchy         │
+└──────────────────────────────────────┘
+
+    fdw.Error (interface)
+         │
+    ┌────┴────┬──────────┬───────────┐
+    │         │          │           │
+    ▼         ▼          ▼           ▼
+Semantics  Unsupported Query    Internal
+  Error      Error     Error      Error
+    │          │         │           │
+    │          │         │           │
+Examples:  Examples:  Examples:  Examples:
+• Bad       • JOINs    • Missing  • SpiceDB
+  syntax    • GROUP BY   required   API errors
+• Invalid   • Subquery   field    • Network
+  column    • Complex  • Type       failures
+• Cursor      WHERE      mismatch
+  not found
+```
+
+**Error Flow**:
+```
+SpiceDB API Error
+       │
+       ▼
+┌──────────────┐
+│ Wrap in      │
+│ fdw.Error    │
+└──────┬───────┘
+       │
+       ▼
+┌──────────────┐
+│ Return to    │
+│ wire protocol│
+└──────┬───────┘
+       │
+       ▼
+PostgreSQL Client
+   sees SQL error
+```
+
+### 10. Consistency Control
+
+**Location**: `tables/util.go`
+
+The FDW supports SpiceDB's consistency guarantees through a special `consistency` column:
+
+```
+┌─────────────────────────────────────────────┐
+│        Consistency Models                   │
+└─────────────────────────────────────────────┘
+
+"minimize_latency" (default)
+    │
+    ├─> Use newest available snapshot
+    └─> Lowest latency, may see slight staleness
+
+"fully_consistent"
+    │
+    ├─> Wait for fully consistent view
+    └─> Higher latency, guaranteed fresh
+
+"<zedtoken>"
+    │
+    ├─> At least as fresh as the provided token's timestamp
+    └─> Read-your-writes consistency
+
+"@<zedtoken>"
+    │
+    ├─> Exact snapshot match (may fail if GC'd)
+    └─> Strict point-in-time reads
+```
+
+**Usage in Queries**:
+```sql
+-- Get consistency token from INSERT/DELETE operations via RETURNING
+INSERT INTO relationships
+  (resource_type, resource_id, relation, subject_type, subject_id)
+VALUES
+  ('doc', 'readme', 'viewer', 'user', 'alice')
+RETURNING consistency;
+
+-- Use returned token in subsequent query for read-your-writes consistency
+SELECT * FROM relationships
+WHERE ... AND consistency = '<returned-token>';
+
+-- Or request fully consistent reads directly
+SELECT resource_id FROM permissions
+WHERE ... AND consistency = 'fully_consistent';
+```
+
+## Data Flow Examples
+
+### Example 1: CheckPermission Query
+
+```
+1. Client sends SQL:
+   SELECT has_permission FROM permissions
+   WHERE resource_type = 'doc' AND resource_id = 'readme'
+     AND permission = 'view' AND subject_type = 'user'
+     AND subject_id = 'alice';
+
+2. FDW Proxy:
+   ┌──────────────────────────────────┐
+   │ Parse SQL → Identify all fields  │
+   │ specified                        │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Route to CheckPermission handler │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Build CheckPermissionRequest:    │
+   │   resource: doc:readme           │
+   │   permission: view               │
+   │   subject: user:alice            │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Call SpiceDB API                 │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Response: { permissionship: ... }│
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Format as PostgreSQL row:        │
+   │ | has_permission | consistency | │
+   │ | true           | GxQv...     | │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+3. Client receives result set
+```
+
+### Example 2: LookupResources with Cursor
+
+```
+1. Client sends:
+   BEGIN;
+   DECLARE c CURSOR FOR
+     SELECT resource_id FROM permissions
+     WHERE resource_type = 'doc' AND permission = 'view'
+       AND subject_type = 'user' AND subject_id = 'alice'
+       AND has_permission = true;
+
+2. FDW Proxy:
+   ┌──────────────────────────────────┐
+   │ START TRANSACTION                │
+   │   → Set withinTransaction = true │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ DECLARE CURSOR                   │
+   │   → Parse SELECT statement       │
+   │   → Store in session.cursors["c"]│
+   │   → Don't execute yet            │
+   └──────────────────────────────────┘
+
+3. Client sends:
+   FETCH 100 FROM c;
+
+4. FDW Proxy:
+   ┌──────────────────────────────────┐
+   │ Lookup cursor "c"                │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Determine query type:            │
+   │   → LookupResources (no res_id)  │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Build LookupResourcesRequest:    │
+   │   subject: user:alice            │
+   │   permission: view               │
+   │   resource_type: doc             │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Stream SpiceDB API results       │
+   │ (yields: doc:1, doc:2, ...)      │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Return first 100 rows            │
+   │ Store stream continuation token  │
+   │ in cursor.rowsCursor             │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Format as PostgreSQL rows:       │
+   │ | resource_id |                  │
+   │ | doc:1       |                  │
+   │ | doc:2       |                  │
+   │ | ...         |                  │
+   └──────────────────────────────────┘
+
+5. Client can repeat:
+   FETCH 100 FROM c;  -- Get next batch
+
+6. Client ends:
+   CLOSE c;
+   COMMIT;
+```
+
+### Example 3: Insert Relationships
+
+```
+1. Client sends SQL:
+   INSERT INTO relationships
+     (resource_type, resource_id, relation,
+      subject_type, subject_id)
+   VALUES
+     ('doc', 'readme', 'viewer', 'user', 'alice'),
+     ('doc', 'readme', 'viewer', 'user', 'bob');
+
+2. FDW Proxy:
+   ┌──────────────────────────────────┐
+   │ Parse INSERT statement           │
+   │   → Extract column names         │
+   │   → Extract value tuples         │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Build WriteRelationshipsRequest: │
+   │   updates: [                     │
+   │     TOUCH doc:readme#viewer@...  │
+   │     TOUCH doc:readme#viewer@...  │
+   │   ]                              │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Call SpiceDB API                 │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Response: { written_at: ... }    │
+   └────────────┬─────────────────────┘
+                │
+                ▼
+   ┌──────────────────────────────────┐
+   │ Return INSERT completion         │
+   │ "INSERT 0 2"                     │
+   └──────────────────────────────────┘
+
+3. Client receives success
+```
+
+## Key Design Decisions
+
+### 1. Stateless Query Execution
+
+Each query is independent except for:
+
+- Cursor state (stored in session)
+- Transaction boundaries (tracked but **not affecting SpiceDB calls**)
+
+This simplifies the implementation since SpiceDB APIs are already atomic, but does mean if Postgres rolls back
+its own transaction, SpiceDB operations will still remain applied.
+
+In the future, we will investigate having the SpiceDB operations also rolled-back.
+
+### 2. Pattern-Based Query Routing
+
+The FDW examines which fields are specified in WHERE clauses to determine which SpiceDB API to call. This is more intuitive than requiring users to call functions or use special syntax.
+
+### 3. Streaming via Cursors
+
+Large result sets (especially LookupResources/LookupSubjects) are streamed using PostgreSQL cursors rather than materializing everything in memory.
+
+### 4. Statistics-Based Query Planning
+
+By collecting runtime statistics and providing them via EXPLAIN, the FDW helps PostgreSQL make intelligent decisions when the foreign tables are used in complex queries.
+
+In the future, these statistics will come directly from the SpiceDB query planner and/or Materialize, further
+improving decision making by Postgres.
+
+## Performance Considerations
+
+### Query Pattern Optimization
+
+**Best Performance**:
+```sql
+-- Specific, targeted queries
+SELECT has_permission FROM permissions WHERE ...;  -- CheckPermission
+```
+
+**Moderate Performance**:
+```sql
+-- Streaming with cursors
+DECLARE c CURSOR FOR SELECT resource_id FROM permissions WHERE ...;
+FETCH 100 FROM c;  -- LookupResources in batches
+```
+
+**Avoid**:
+```sql
+-- Full table scans (not supported)
+SELECT * FROM permissions;  -- No WHERE clause
+
+-- Complex queries (not supported)
+SELECT * FROM permissions p1 JOIN permissions p2 ...;
+```
+
+### Consistency Trade-offs
+
+- `minimize_latency`: Best performance, eventual consistency
+- `fully_consistent`: Higher latency, strong consistency
+- Specific token: Read-your-writes, consistent views across queries
+
+### Cursor vs Direct SELECT
+
+Use cursors when:
+
+- Result set may be large (>1000 rows)
+- Processing results incrementally
+- Need to limit memory usage
+
+Use direct SELECT when:
+
+- Small result sets expected
+- Simple one-time queries
+- No need for result streaming
+
+## Security Model
+
+### Authentication Flow
+
+```
+PostgreSQL Client
+      │
+      │ username, password
+      ▼
+┌──────────────────┐
+│ FDW Proxy        │
+│ validateAuth()   │
+└────────┬─────────┘
+         │ SpiceDB token (from config)
+         ▼
+┌──────────────────┐
+│ SpiceDB Server   │
+└──────────────────┘
+```
+
+**Two-Layer Authentication**:
+
+1. Client → FDW Proxy: PostgreSQL username/password
+2. FDW Proxy → SpiceDB: Bearer token (gRPC)
+
+**Important**: The FDW proxy uses a single SpiceDB token for all client connections. Per-client authorization must be handled at the PostgreSQL level or within your application.
+
+## Future Enhancements
+
+Potential areas for improvement:
+
+1. **Per-Client SpiceDB Tokens**: Map PostgreSQL users to different SpiceDB tokens
+2. **Prepared Statement Caching**: Cache parsed query plans
+3. **Connection Pooling**: Reuse SpiceDB gRPC connections
+4. **Push-down Aggregations**: Support COUNT(*) by calling SpiceDB APIs differently
+5. **Schema Mutation**: Support CREATE/ALTER table syntax for schema updates
+6. **Batch Operations**: Combine multiple INSERTs/DELETEs into single API calls
+7. **Query Hints**: Allow SQL comments to control consistency, caveats, etc.
+
+## Debugging & Observability
+
+### Enable Debug Logging
+
+```bash
+spicedb postgres-fdw --log-level debug ...
+```
+
+### Useful Log Events
+
+- Query parsing and routing decisions
+- SpiceDB API calls and responses
+- Cursor creation/fetch/close operations
+- Statistics updates
+
+### EXPLAIN Analysis
+
+```sql
+-- See query plan and estimated costs
+EXPLAIN SELECT * FROM permissions WHERE ...;
+```
+
+Helps understand:
+
+- Which operation will be used (CheckPermission, LookupResources, etc.)
+- Estimated costs and row counts
+- Whether query is supported
+
+## Conclusion
+
+The SpiceDB Postgres FDW proxy provides a powerful bridge between the SQL world and SpiceDB's authorization model. By implementing the PostgreSQL wire protocol and translating queries into appropriate SpiceDB API calls, it enables seamless integration with existing PostgreSQL tools and workflows while maintaining the full power and consistency guarantees of SpiceDB.

--- a/internal/fdw/README.md
+++ b/internal/fdw/README.md
@@ -1,0 +1,333 @@
+# SpiceDB Postgres Foreign Data Wrapper (FDW)
+
+> **EXPERIMENTAL**: This feature is experimental and subject to change. The API, behavior, and configuration options may change in future releases without notice.
+
+The SpiceDB Postgres FDW provides a Postgres-compatible interface for querying SpiceDB permissions and relationships data using standard SQL. This allows you to integrate SpiceDB with existing Postgres-based tools and applications through Foreign Data Wrapper support.
+
+## Overview
+
+The FDW proxy implements the Postgres wire protocol and translates SQL queries into SpiceDB API calls. It exposes virtual SQL tables that map to SpiceDB concepts:
+
+- **`permissions`**: Query and check permissions (CheckPermission, LookupResources, LookupSubjects)
+- **`relationships`**: Read, insert, and delete relationships
+- **`schema`**: Read SpiceDB schema definitions
+
+## Quick Start
+
+### 1. Start the FDW Proxy
+
+#### Using Docker (Recommended)
+
+```bash
+docker run --rm -p 5432:5432 \
+  authzed/spicedb \
+  postgres-fdw \
+  --spicedb-api-endpoint localhost:50051 \
+  --spicedb-access-token-secret "your-spicedb-token" \
+  --postgres-endpoint ":5432" \
+  --postgres-username "postgres" \
+  --postgres-access-token-secret "your-fdw-password"
+```
+
+#### Using the Binary
+
+```bash
+spicedb postgres-fdw \
+  --spicedb-api-endpoint localhost:50051 \
+  --spicedb-access-token-secret "your-spicedb-token" \
+  --postgres-endpoint ":5432" \
+  --postgres-username "postgres" \
+  --postgres-access-token-secret "your-fdw-password"
+```
+
+Or using environment variables:
+
+```bash
+export SPICEDB_SPICEDB_API_ENDPOINT="localhost:50051"
+export SPICEDB_SPICEDB_ACCESS_TOKEN_SECRET="your-spicedb-token"
+export SPICEDB_POSTGRES_ENDPOINT=":5432"
+export SPICEDB_POSTGRES_USERNAME="postgres"
+export SPICEDB_POSTGRES_ACCESS_TOKEN_SECRET="your-fdw-password"
+
+spicedb postgres-fdw
+```
+
+### 2. Configure Postgres Foreign Data Wrapper
+
+In your Postgres database, install and configure the FDW extension. See [`configuration.sql`](../../configuration.sql) for a complete setup example:
+
+```sql
+-- Install the postgres_fdw extension
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+-- Create a foreign server pointing to the FDW proxy
+CREATE SERVER spicedb_server
+  FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (
+    host 'localhost',
+    port '5432',
+    dbname 'ignored'
+  );
+
+-- Create user mapping with authentication credentials
+CREATE USER MAPPING FOR CURRENT_USER
+  SERVER spicedb_server
+  OPTIONS (
+    user 'postgres',
+    password 'your-fdw-password'
+  );
+
+-- Import foreign tables
+IMPORT FOREIGN SCHEMA public
+  LIMIT TO (permissions, relationships, schema)
+  FROM SERVER spicedb_server
+  INTO public;
+```
+
+### 3. Query SpiceDB Data
+
+Once configured, you can query SpiceDB using standard SQL:
+
+#### Check Permissions
+
+```sql
+-- Check if user:alice has permission to view document:readme
+SELECT has_permission
+FROM permissions
+WHERE resource_type = 'document'
+  AND resource_id = 'readme'
+  AND permission = 'view'
+  AND subject_type = 'user'
+  AND subject_id = 'alice';
+```
+
+#### Lookup Resources
+
+```sql
+-- Find all documents that user:alice can view
+SELECT resource_id
+FROM permissions
+WHERE resource_type = 'document'
+  AND permission = 'view'
+  AND subject_type = 'user'
+  AND subject_id = 'alice'
+  AND has_permission = true;
+```
+
+#### Lookup Subjects
+
+```sql
+-- Find all users who can view document:readme
+SELECT subject_id
+FROM permissions
+WHERE resource_type = 'document'
+  AND resource_id = 'readme'
+  AND permission = 'view'
+  AND subject_type = 'user'
+  AND has_permission = true;
+```
+
+#### Query Relationships
+
+```sql
+-- Read relationships for a specific resource
+SELECT resource_type, resource_id, relation, subject_type, subject_id
+FROM relationships
+WHERE resource_type = 'document'
+  AND resource_id = 'readme';
+```
+
+#### Insert Relationships
+
+```sql
+-- Add a new relationship
+INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id)
+VALUES ('document', 'readme', 'viewer', 'user', 'alice');
+```
+
+#### Delete Relationships
+
+```sql
+-- Remove a relationship
+DELETE FROM relationships
+WHERE resource_type = 'document'
+  AND resource_id = 'readme'
+  AND relation = 'viewer'
+  AND subject_type = 'user'
+  AND subject_id = 'alice';
+```
+
+#### Read Schema
+
+```sql
+-- Get all schema definitions
+SELECT definition FROM schema;
+```
+
+## Configuration Options
+
+### Command Line Flags
+
+**SpiceDB Connection:**
+
+- `--spicedb-api-endpoint`: SpiceDB API endpoint (default: `localhost:50051`)
+- `--spicedb-access-token-secret`: **(required)** SpiceDB API access token
+- `--spicedb-insecure`: Use insecure connection to SpiceDB
+
+**FDW Server:**
+
+- `--postgres-endpoint`: FDW server listen address (default: `:5432`)
+- `--postgres-username`: Username for Postgres authentication (default: `postgres`)
+- `--postgres-access-token-secret`: **(required)** Password for Postgres authentication
+- `--shutdown-grace-period`: Graceful shutdown timeout (default: `0s`)
+
+### Environment Variables
+
+All flags can be set via environment variables with the `SPICEDB_` prefix:
+
+```bash
+SPICEDB_SPICEDB_API_ENDPOINT
+SPICEDB_SPICEDB_ACCESS_TOKEN_SECRET
+SPICEDB_SPICEDB_INSECURE
+SPICEDB_POSTGRES_ENDPOINT
+SPICEDB_POSTGRES_USERNAME
+SPICEDB_POSTGRES_ACCESS_TOKEN_SECRET
+SPICEDB_SHUTDOWN_GRACE_PERIOD
+```
+
+## Table Schemas
+
+### `permissions` Table
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `resource_type` | text | Resource type (e.g., 'document') |
+| `resource_id` | text | Resource ID |
+| `permission` | text | Permission name |
+| `subject_type` | text | Subject type (e.g., 'user') |
+| `subject_id` | text | Subject ID |
+| `optional_subject_relation` | text | Optional subject relation |
+| `has_permission` | boolean | Whether permission is granted |
+| `consistency` | text | Consistency token (ZedToken) |
+
+**Supported Operations:**
+
+- SELECT (CheckPermission, LookupResources, LookupSubjects)
+
+### `relationships` Table
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `resource_type` | text | Resource type |
+| `resource_id` | text | Resource ID |
+| `relation` | text | Relation name |
+| `subject_type` | text | Subject type |
+| `subject_id` | text | Subject ID |
+| `optional_subject_relation` | text | Optional subject relation |
+| `optional_caveat_name` | text | Optional caveat name |
+| `optional_caveat_context` | jsonb | Optional caveat context |
+| `consistency` | text | Consistency token (ZedToken) |
+
+**Supported Operations:**
+
+- SELECT (ReadRelationships)
+- INSERT (WriteRelationships)
+- DELETE (DeleteRelationships)
+
+### `schema` Table
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `definition` | text | Schema definition in Zed format |
+
+**Supported Operations:**
+
+- SELECT (ReadSchema)
+
+## Consistency and Transactions
+
+The FDW supports consistency control through the `consistency` column:
+
+- **`minimize_latency`**: Default, uses the newest available snapshot
+- **`fully_consistent`**: Waits for a fully consistent view
+- **`<zedtoken>`**: Uses a specific consistency token
+- **`@<zedtoken>`**: Uses exact snapshot matching
+
+Example:
+
+```sql
+-- Get a consistent view
+SELECT resource_id, consistency
+FROM permissions
+WHERE resource_type = 'document'
+  AND permission = 'view'
+  AND subject_type = 'user'
+  AND subject_id = 'alice'
+  AND consistency = 'fully_consistent';
+```
+
+## Cursors
+
+The FDW supports Postgres cursors for large result sets:
+
+```sql
+BEGIN;
+
+DECLARE my_cursor CURSOR FOR
+  SELECT resource_id FROM permissions
+  WHERE resource_type = 'document'
+    AND permission = 'view'
+    AND subject_type = 'user'
+    AND subject_id = 'alice';
+
+FETCH 100 FROM my_cursor;
+FETCH 100 FROM my_cursor;
+
+CLOSE my_cursor;
+COMMIT;
+```
+
+## Limitations
+
+- **Joins**: Cross-table joins are not supported
+- **Aggregations**: SUM, COUNT, etc. are not supported (performed client-side by Postgres)
+- **Ordering**: ORDER BY clauses are not supported by the FDW itself
+- **Subqueries**: Not supported
+- **Complex WHERE clauses**: Only simple equality predicates and AND conditions are supported
+
+## Performance Considerations
+
+1. **Query Planning**: The FDW collects statistics to help Postgres make better query planning decisions
+2. **Cursors**: Use cursors for large result sets to avoid loading everything into memory
+3. **Consistency**: Use `minimize_latency` for best performance when strong consistency isn't required
+4. **Filtering**: Push down as many WHERE conditions as possible to reduce data transfer
+
+## Architecture
+
+The FDW implementation consists of:
+
+- **`fdw`**: Main package with Postgres wire protocol server (`PgBackend`)
+- **`fdw/tables`**: SQL table handlers (permissions, relationships, schema)
+- **`fdw/common`**: Error handling utilities
+- **`fdw/explain`**: EXPLAIN query plan generation
+- **`fdw/stats`**: Query statistics collection
+
+## Examples
+
+For complete configuration examples and SQL setup scripts, see:
+
+- [`configuration.sql`](./configuration.sql) - Full Postgres FDW setup
+
+### Query Errors
+
+Enable debug logging:
+
+```bash
+spicedb postgres-fdw --log-level debug ...
+```
+
+Common issues:
+
+- **"table does not exist"**: Table name must be `permissions`, `relationships`, or `schema`
+- **"feature not supported"**: Query uses unsupported SQL features (see Limitations)
+- **"invalid username"**: Check `--postgres-username` matches user mapping in Postgres

--- a/internal/fdw/common/docs.go
+++ b/internal/fdw/common/docs.go
@@ -1,0 +1,6 @@
+// Package common provides error handling utilities for the FDW package.
+//
+// This package defines error constructors that wrap errors with appropriate
+// Postgres error codes and severity levels for proper client error reporting.
+// It also provides conversions from gRPC status codes to Postgres error codes.
+package common

--- a/internal/fdw/common/errors.go
+++ b/internal/fdw/common/errors.go
@@ -1,0 +1,52 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/jeroenrinzema/psql-wire/codes"
+	psqlerr "github.com/jeroenrinzema/psql-wire/errors"
+	grpccodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// NewUnsupportedError wraps an error as a Postgres "feature not supported" error.
+// This is used when a query or feature is not implemented by the FDW.
+func NewUnsupportedError(baseErr error) error {
+	err := fmt.Errorf("unsupported feature or query type: %w", baseErr)
+	err = psqlerr.WithCode(err, codes.FeatureNotSupported)
+	err = psqlerr.WithSeverity(err, psqlerr.LevelFatal)
+	return err
+}
+
+// NewSemanticsError wraps an error as a Postgres semantic error with fatal severity.
+// This is used when a query is syntactically valid but semantically incorrect.
+func NewSemanticsError(baseErr error) error {
+	err := fmt.Errorf("semantic error: %w", baseErr)
+	err = psqlerr.WithCode(err, codes.InvalidParameterValue)
+	err = psqlerr.WithSeverity(err, psqlerr.LevelFatal)
+	return err
+}
+
+// NewQueryError wraps an error as a Postgres query error.
+// This is used for runtime query execution errors.
+func NewQueryError(baseErr error) error {
+	err := fmt.Errorf("query error: %w", baseErr)
+	err = psqlerr.WithCode(err, codes.InvalidParameterValue)
+	err = psqlerr.WithSeverity(err, psqlerr.LevelError)
+	return err
+}
+
+// ConvertError converts gRPC status errors to appropriate Postgres errors.
+func ConvertError(err error) error {
+	if s, ok := status.FromError(err); ok {
+		switch s.Code() {
+		case grpccodes.InvalidArgument:
+			fallthrough
+
+		case grpccodes.FailedPrecondition:
+			return NewQueryError(err)
+		}
+	}
+
+	return err
+}

--- a/internal/fdw/common/errors_test.go
+++ b/internal/fdw/common/errors_test.go
@@ -1,0 +1,182 @@
+package common
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jeroenrinzema/psql-wire/codes"
+	psqlerr "github.com/jeroenrinzema/psql-wire/errors"
+	"github.com/stretchr/testify/require"
+	grpccodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNewUnsupportedError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		baseErr        error
+		expectedPrefix string
+		expectedCode   codes.Code
+	}{
+		{
+			name:           "basic error",
+			baseErr:        errors.New("feature not available"),
+			expectedPrefix: "unsupported feature or query type:",
+			expectedCode:   codes.FeatureNotSupported,
+		},
+		{
+			name:           "wrapped error",
+			baseErr:        errors.New("SELECT DISTINCT not supported"),
+			expectedPrefix: "unsupported feature or query type:",
+			expectedCode:   codes.FeatureNotSupported,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := NewUnsupportedError(tc.baseErr)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expectedPrefix)
+			require.ErrorIs(t, err, tc.baseErr)
+
+			// Verify error is properly wrapped with psql codes
+			code := psqlerr.GetCode(err)
+			require.Equal(t, tc.expectedCode, code)
+		})
+	}
+}
+
+func TestNewSemanticsError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		baseErr        error
+		expectedPrefix string
+		expectedCode   codes.Code
+	}{
+		{
+			name:           "basic semantic error",
+			baseErr:        errors.New("invalid schema definition"),
+			expectedPrefix: "semantic error:",
+			expectedCode:   codes.InvalidParameterValue,
+		},
+		{
+			name:           "type mismatch error",
+			baseErr:        errors.New("column type mismatch"),
+			expectedPrefix: "semantic error:",
+			expectedCode:   codes.InvalidParameterValue,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := NewSemanticsError(tc.baseErr)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expectedPrefix)
+			require.ErrorIs(t, err, tc.baseErr)
+
+			// Verify error is properly wrapped with psql codes
+			code := psqlerr.GetCode(err)
+			require.Equal(t, tc.expectedCode, code)
+		})
+	}
+}
+
+func TestNewQueryError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		baseErr        error
+		expectedPrefix string
+		expectedCode   codes.Code
+	}{
+		{
+			name:           "basic query error",
+			baseErr:        errors.New("failed to execute query"),
+			expectedPrefix: "query error:",
+			expectedCode:   codes.InvalidParameterValue,
+		},
+		{
+			name:           "connection error",
+			baseErr:        errors.New("connection lost"),
+			expectedPrefix: "query error:",
+			expectedCode:   codes.InvalidParameterValue,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := NewQueryError(tc.baseErr)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expectedPrefix)
+			require.ErrorIs(t, err, tc.baseErr)
+
+			// Verify error is properly wrapped with psql codes
+			code := psqlerr.GetCode(err)
+			require.Equal(t, tc.expectedCode, code)
+		})
+	}
+}
+
+func TestConvertError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		inputErr    error
+		expectWraps bool
+	}{
+		{
+			name:        "grpc InvalidArgument",
+			inputErr:    status.Error(grpccodes.InvalidArgument, "invalid argument"),
+			expectWraps: true,
+		},
+		{
+			name:        "grpc FailedPrecondition",
+			inputErr:    status.Error(grpccodes.FailedPrecondition, "precondition failed"),
+			expectWraps: true,
+		},
+		{
+			name:        "grpc NotFound - pass through",
+			inputErr:    status.Error(grpccodes.NotFound, "not found"),
+			expectWraps: false,
+		},
+		{
+			name:        "grpc Internal - pass through",
+			inputErr:    status.Error(grpccodes.Internal, "internal error"),
+			expectWraps: false,
+		},
+		{
+			name:        "non-grpc error - pass through",
+			inputErr:    errors.New("regular error"),
+			expectWraps: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ConvertError(tc.inputErr)
+			require.Error(t, err)
+
+			if tc.expectWraps {
+				// Should be wrapped as a query error
+				require.ErrorContains(t, err, "query error:")
+			} else {
+				// Should pass through unchanged
+				require.Equal(t, tc.inputErr, err)
+			}
+		})
+	}
+}

--- a/internal/fdw/configuration.sql
+++ b/internal/fdw/configuration.sql
@@ -1,0 +1,34 @@
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+CREATE SERVER spicedb_fdw FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'hostofproxy', dbname 'default', port '5432', use_remote_estimate 'true');
+
+CREATE USER MAPPING FOR postgres SERVER spicedb_fdw OPTIONS (user 'proxyusername', password 'proxypassword');
+
+CREATE SCHEMA spicedb;
+
+-- IMPORT FOREIGN SCHEMA spicedb FROM SERVER spicedb_fdw INTO spicedb;
+
+CREATE FOREIGN TABLE relationships ( 
+    resource_type text NOT NULL,
+    resource_id text NOT NULL,
+    relation text NOT NULL,
+    subject_type text NOT NULL,
+    subject_id text NOT NULL,
+    optional_subject_relation text default '',
+    caveat_name text default '',
+    caveat_context text default '',
+    consistency text default ''
+) SERVER spicedb_fdw;
+
+CREATE FOREIGN TABLE permissions (
+    resource_type text NOT NULL,
+    resource_id text NOT NULL,
+    permission text NOT NULL,
+    subject_type text NOT NULL,
+    subject_id text NOT NULL,
+    optional_subject_relation text NOT NULL,
+    has_permission boolean, -- NULL when maybe
+    consistency text default ''
+) SERVER spicedb_fdw;
+
+CREATE FOREIGN TABLE schema ( schema_text text ) SERVER spicedb_fdw;

--- a/internal/fdw/cursor.go
+++ b/internal/fdw/cursor.go
@@ -1,0 +1,92 @@
+package fdw
+
+import (
+	"context"
+	"errors"
+	"maps"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/spicedb/internal/fdw/common"
+	"github.com/authzed/spicedb/internal/fdw/tables"
+)
+
+type cursor struct {
+	name       string
+	selectStmt *tables.SelectStatement
+	parameters []wire.Parameter
+	rowsCursor tables.RowsCursor
+}
+
+// See: https://www.postgresql.org/docs/current/sql-declare.html
+func (p *PgBackend) handleDeclareCursorStmt(_ context.Context, stmt *pg_query.DeclareCursorStmt, query string) (wire.PreparedStatements, error) {
+	selectStmt, err := tables.ParseSelectStatement(stmt.Query.GetSelectStmt(), false)
+	if err != nil {
+		return nil, err
+	}
+
+	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
+		session := mustSession(ctx)
+		session.addCursor(&cursor{stmt.Portalname, selectStmt, parameters, nil})
+		return writer.Complete("declare cursor completed")
+	}
+
+	params := wire.ParseParameters(query)
+	return wire.Prepared(wire.NewStatement(handle, wire.WithParameters(params))), nil
+}
+
+// See: https://www.postgresql.org/docs/current/sql-fetch.html
+func (p *PgBackend) handleFetchStmt(ctx context.Context, stmt *pg_query.FetchStmt, _ string) (wire.PreparedStatements, error) {
+	session := mustSession(ctx)
+	cursorName := stmt.Portalname
+	if cursorName == "" {
+		session.mu.Lock()
+		if len(session.cursors) != 1 {
+			session.mu.Unlock()
+			return nil, common.NewSemanticsError(errors.New("cursor name is required when multiple cursors are present"))
+		}
+		cursorName = mustFirst(maps.Keys(session.cursors))
+		session.mu.Unlock()
+	}
+
+	if stmt.Direction != pg_query.FetchDirection_FETCH_FORWARD {
+		return nil, common.NewUnsupportedError(errors.New("only forward fetch direction is supported"))
+	}
+
+	cursor, err := session.lookupCursor(cursorName)
+	if err != nil {
+		return nil, err
+	}
+
+	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
+		updatedRowsCursor, err := cursor.selectStmt.Fetch(ctx, p.client, parameters, writer, stmt.HowMany, cursor.rowsCursor, cursor.selectStmt)
+		if err != nil {
+			return err
+		}
+		cursor.rowsCursor = updatedRowsCursor
+		return nil
+	}
+	return wire.Prepared(wire.NewStatement(handle, wire.WithColumns(cursor.selectStmt.Schema()))), nil
+}
+
+// See: https://www.postgresql.org/docs/current/sql-close.html
+func (p *PgBackend) handleClosePortalStmt(_ context.Context, stmt *pg_query.ClosePortalStmt, _ string) (wire.PreparedStatements, error) {
+	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
+		session := mustSession(ctx)
+		cursorName := stmt.Portalname
+		if cursorName == "" {
+			session.mu.Lock()
+			if len(session.cursors) != 1 {
+				session.mu.Unlock()
+				return common.NewSemanticsError(errors.New("cursor name is required when multiple cursors are present"))
+			}
+			cursorName = mustFirst(maps.Keys(session.cursors))
+			session.mu.Unlock()
+		}
+
+		session.deleteCursor(cursorName)
+		return writer.Complete("CLOSED")
+	}
+	return wire.Prepared(wire.NewStatement(handle)), nil
+}

--- a/internal/fdw/delete.go
+++ b/internal/fdw/delete.go
@@ -1,0 +1,24 @@
+package fdw
+
+import (
+	"context"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/spicedb/internal/fdw/tables"
+)
+
+func (p *PgBackend) handleDeleteStmt(ctx context.Context, stmt *pg_query.DeleteStmt, query string) (wire.PreparedStatements, error) {
+	parsed, err := tables.ParseDeleteStatement(ctx, stmt)
+	if err != nil {
+		return nil, err
+	}
+
+	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
+		return parsed.ExecuteDelete(ctx, p.client, writer, parameters)
+	}
+
+	params := wire.ParseParameters(query)
+	return wire.Prepared(wire.NewStatement(handle, wire.WithParameters(params), wire.WithColumns(parsed.ReturningColumns()))), nil
+}

--- a/internal/fdw/docs.go
+++ b/internal/fdw/docs.go
@@ -1,0 +1,23 @@
+// Package fdw implements a Postgres Foreign Data Wrapper (FDW) proxy server for SpiceDB.
+//
+// This package provides a Postgres-compatible interface that allows querying SpiceDB
+// permissions data using standard SQL queries through Postgres Foreign Data Wrapper.
+// The proxy accepts Postgres wire protocol connections and translates SQL queries into
+// SpiceDB API calls.
+//
+// The main entry point is PgBackend, which handles the Postgres wire protocol and routes
+// queries to the appropriate handlers for permissions, relationships, and schema operations.
+//
+// Supported Operations:
+//   - SELECT queries on permissions and relationships tables
+//   - INSERT/DELETE operations on relationships
+//   - Transaction management (BEGIN, COMMIT, ABORT)
+//   - Cursor-based result iteration (DECLARE, FETCH, CLOSE)
+//   - EXPLAIN queries for query planning
+//
+// Example Usage:
+//
+//	client := authzed.NewClient(...)
+//	backend := fdw.NewPgBackend(client, "postgres", "password")
+//	err := backend.Run(ctx, ":5432")
+package fdw

--- a/internal/fdw/explain.go
+++ b/internal/fdw/explain.go
@@ -1,0 +1,42 @@
+package fdw
+
+import (
+	"context"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/lib/pq/oid"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/spicedb/internal/fdw/explain"
+	"github.com/authzed/spicedb/internal/fdw/tables"
+)
+
+var explainSchema = wire.Columns{
+	{
+		Table: 0,
+		Name:  "QUERY PLAN",
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+}
+
+func (p *PgBackend) handleExplainStmt(_ context.Context, stmt *pg_query.ExplainStmt, _ string) (wire.PreparedStatements, error) {
+	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
+		selectStatement, err := tables.ParseSelectStatement(stmt.GetQuery().GetSelectStmt(), true)
+		if selectStatement != nil && selectStatement.IsUnsupported() {
+			// Return an EXPLAIN plan that shows an insanely high cost to ensure PG does not select the unsupported
+			// query plan.
+			if err := writer.Row([]any{explain.Unsupported}); err != nil {
+				return err
+			}
+			return writer.Complete("EXPLAIN")
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return selectStatement.Explain(ctx, p.client, writer)
+	}
+	return wire.Prepared(wire.NewStatement(handle, wire.WithColumns(explainSchema))), nil
+}

--- a/internal/fdw/explain/docs.go
+++ b/internal/fdw/explain/docs.go
@@ -1,0 +1,7 @@
+// Package explain provides EXPLAIN query plan generation for the FDW.
+//
+// This package formats query execution plans in Postgres-compatible format,
+// including cost estimates and row count predictions. It supports generating
+// both default plans and plans marked as unsupported to guide Postgres query
+// planner decisions.
+package explain

--- a/internal/fdw/explain/explain.go
+++ b/internal/fdw/explain/explain.go
@@ -1,0 +1,36 @@
+package explain
+
+import "fmt"
+
+// Explain represents a Postgres EXPLAIN query plan with cost and row estimates.
+type Explain struct {
+	Operation                    string
+	TableName                    string
+	StartupCost                  float32
+	TotalCost                    float32
+	EstimatedRows                int32
+	EstimatedAverageWidthInBytes int32
+}
+
+// String formats the explain plan in Postgres EXPLAIN output format.
+func (e Explain) String() string {
+	return fmt.Sprintf("%s on %s (cost=%.2f..%.2f rows=%d width=%d)",
+		e.Operation,
+		e.TableName,
+		e.StartupCost,
+		e.TotalCost,
+		e.EstimatedRows,
+		e.EstimatedAverageWidthInBytes,
+	)
+}
+
+const expensive = 500_000
+
+// Default returns a default explain plan with conservative cost estimates.
+func Default(operation, tableName string) Explain {
+	return Explain{operation, tableName, 10, 10, 1000, 100}
+}
+
+// Unsupported is a pre-formatted EXPLAIN plan with extremely high cost.
+// This is used to discourage Postgres from selecting unsupported query plans.
+var Unsupported = Explain{"Unsupported", "irrelevant", expensive, expensive, expensive, expensive}.String()

--- a/internal/fdw/explain/explain_test.go
+++ b/internal/fdw/explain/explain_test.go
@@ -1,0 +1,148 @@
+package explain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExplainString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		explain  Explain
+		expected string
+	}{
+		{
+			name: "basic explain",
+			explain: Explain{
+				Operation:                    "Seq Scan",
+				TableName:                    "relationships",
+				StartupCost:                  0.00,
+				TotalCost:                    100.00,
+				EstimatedRows:                1000,
+				EstimatedAverageWidthInBytes: 50,
+			},
+			expected: "Seq Scan on relationships (cost=0.00..100.00 rows=1000 width=50)",
+		},
+		{
+			name: "explain with high cost",
+			explain: Explain{
+				Operation:                    "Foreign Scan",
+				TableName:                    "permissions",
+				StartupCost:                  10.00,
+				TotalCost:                    50000.00,
+				EstimatedRows:                100000,
+				EstimatedAverageWidthInBytes: 200,
+			},
+			expected: "Foreign Scan on permissions (cost=10.00..50000.00 rows=100000 width=200)",
+		},
+		{
+			name: "explain with zero values",
+			explain: Explain{
+				Operation:                    "Test Scan",
+				TableName:                    "test_table",
+				StartupCost:                  0,
+				TotalCost:                    0,
+				EstimatedRows:                0,
+				EstimatedAverageWidthInBytes: 0,
+			},
+			expected: "Test Scan on test_table (cost=0.00..0.00 rows=0 width=0)",
+		},
+		{
+			name: "explain with fractional costs",
+			explain: Explain{
+				Operation:                    "Index Scan",
+				TableName:                    "schema",
+				StartupCost:                  1.5,
+				TotalCost:                    25.75,
+				EstimatedRows:                10,
+				EstimatedAverageWidthInBytes: 512,
+			},
+			expected: "Index Scan on schema (cost=1.50..25.75 rows=10 width=512)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tc.explain.String()
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestDefault(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		operation string
+		tableName string
+	}{
+		{
+			name:      "relationships table",
+			operation: "Foreign Scan",
+			tableName: "relationships",
+		},
+		{
+			name:      "permissions table",
+			operation: "Foreign Scan",
+			tableName: "permissions",
+		},
+		{
+			name:      "schema table",
+			operation: "Seq Scan",
+			tableName: "schema",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := Default(tc.operation, tc.tableName)
+			require.Equal(t, tc.operation, result.Operation)
+			require.Equal(t, tc.tableName, result.TableName)
+			require.InDelta(t, float32(10), result.StartupCost, 0.01)
+			require.InDelta(t, float32(10), result.TotalCost, 0.01)
+			require.Equal(t, int32(1000), result.EstimatedRows)
+			require.Equal(t, int32(100), result.EstimatedAverageWidthInBytes)
+
+			// Verify it produces a valid string
+			str := result.String()
+			require.Contains(t, str, tc.operation)
+			require.Contains(t, str, tc.tableName)
+			require.Contains(t, str, "cost=10.00..10.00")
+			require.Contains(t, str, "rows=1000")
+			require.Contains(t, str, "width=100")
+		})
+	}
+}
+
+func TestUnsupported(t *testing.T) {
+	t.Parallel()
+
+	// Verify Unsupported is a string with very high costs
+	require.Contains(t, Unsupported, "Unsupported")
+	require.Contains(t, Unsupported, "irrelevant")
+	require.Contains(t, Unsupported, "500000")
+
+	// Verify it follows the expected format
+	require.Contains(t, Unsupported, "cost=")
+	require.Contains(t, Unsupported, "rows=")
+	require.Contains(t, Unsupported, "width=")
+}
+
+func TestExplainComparison(t *testing.T) {
+	t.Parallel()
+
+	// Test that Default produces lower cost than Unsupported constants
+	defaultExplain := Default("Foreign Scan", "test")
+	require.Less(t, defaultExplain.StartupCost, float32(expensive))
+	require.Less(t, defaultExplain.TotalCost, float32(expensive))
+	require.Less(t, defaultExplain.EstimatedRows, int32(expensive))
+	require.Less(t, defaultExplain.EstimatedAverageWidthInBytes, int32(expensive))
+}

--- a/internal/fdw/insert.go
+++ b/internal/fdw/insert.go
@@ -1,0 +1,24 @@
+package fdw
+
+import (
+	"context"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/spicedb/internal/fdw/tables"
+)
+
+func (p *PgBackend) handleInsertStmt(ctx context.Context, stmt *pg_query.InsertStmt, query string) (wire.PreparedStatements, error) {
+	parsed, err := tables.ParseInsertStatement(ctx, stmt)
+	if err != nil {
+		return nil, err
+	}
+
+	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
+		return parsed.ExecuteInsert(ctx, p.client, writer, parameters)
+	}
+
+	params := wire.ParseParameters(query)
+	return wire.Prepared(wire.NewStatement(handle, wire.WithParameters(params), wire.WithColumns(parsed.ReturningColumns()))), nil
+}

--- a/internal/fdw/pgserver.go
+++ b/internal/fdw/pgserver.go
@@ -1,0 +1,174 @@
+package fdw
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/authzed-go/v1"
+
+	log "github.com/authzed/spicedb/internal/logging"
+)
+
+// PgBackend implements a Postgres wire protocol server that translates SQL queries
+// into SpiceDB API calls. It handles authentication, query parsing, and routing to
+// appropriate table handlers.
+type PgBackend struct {
+	client   *authzed.Client
+	server   *wire.Server // GUARDED_BY(mu)
+	username string
+	password string
+	mu       sync.RWMutex
+	wg       sync.WaitGroup
+	closed   bool // GUARDED_BY(mu)
+}
+
+// NewPgBackend creates a new Postgres FDW backend server.
+// The username and password are used for Postgres wire protocol authentication.
+func NewPgBackend(client *authzed.Client, username, password string) *PgBackend {
+	connHandler := &PgBackend{client: client, username: username, password: password}
+	return connHandler
+}
+
+// Run starts the Postgres wire protocol server on the specified endpoint.
+// It blocks until the context is cancelled or an error occurs.
+func (p *PgBackend) Run(ctx context.Context, endpoint string) error {
+	server, err := wire.NewServer(p.handler, wire.SessionMiddleware(sessionMiddleware))
+	if err != nil {
+		return err
+	}
+
+	server.Auth = wire.ClearTextPassword(p.validateAuth)
+
+	// NOTE: uncomment to enable debug logging of the actual Postgres protocol.
+	// slog.SetLogLoggerLevel(slog.LevelDebug)
+
+	p.mu.Lock()
+	p.server = server
+	p.mu.Unlock()
+
+	p.wg.Add(1)
+	defer p.wg.Done()
+
+	// Monitor context cancellation in a separate goroutine
+	go func() {
+		<-ctx.Done()
+		// Don't call p.Close() here to avoid deadlock (Close waits on wg)
+		// Just close the server directly, which will cause ListenAndServe to return
+		// Use the closed flag to ensure we only close once
+		p.mu.Lock()
+		if !p.closed {
+			p.closed = true
+			srv := p.server
+			p.mu.Unlock()
+			if srv != nil {
+				srv.Close()
+			}
+		} else {
+			p.mu.Unlock()
+		}
+	}()
+
+	return p.server.ListenAndServe(endpoint)
+}
+
+func (p *PgBackend) validateAuth(ctx context.Context, database, username, password string) (context.Context, bool, error) {
+	if username != p.username {
+		return ctx, false, fmt.Errorf("invalid username; expected %s", p.username)
+	}
+
+	if password != p.password {
+		return ctx, false, errors.New("invalid password")
+	}
+
+	return ctx, true, nil
+}
+
+// Close gracefully shuts down the Postgres server.
+func (p *PgBackend) Close() error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	server := p.server
+	p.mu.Unlock()
+
+	if server == nil {
+		return nil
+	}
+
+	// Close the server (this will cause ListenAndServe to return)
+	err := server.Close()
+
+	// Wait for the Run goroutine to complete
+	p.wg.Wait()
+
+	return err
+}
+
+func (p *PgBackend) handler(ctx context.Context, query string) (wire.PreparedStatements, error) {
+	parsed, err := pg_query.Parse(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query: %w", err)
+	}
+
+	if len(parsed.Stmts) != 1 {
+		return nil, errors.New("multiple statements not supported")
+	}
+
+	log.Trace().Str("query", query).Msg("pg backend query")
+
+	stmt := parsed.Stmts[0].Stmt
+	switch {
+	// SET variable = value
+	case stmt.GetVariableSetStmt() != nil:
+		handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
+			return writer.Complete("set ignored")
+		}
+		return wire.Prepared(wire.NewStatement(handle)), nil
+
+	// EXPLAIN SELECT ...
+	case stmt.GetExplainStmt() != nil:
+		return p.handleExplainStmt(ctx, stmt.GetExplainStmt(), query)
+
+	// DEALLOCATE c1
+	// DEALLOCATE ALL
+	case stmt.GetDeallocateStmt() != nil:
+		return p.handleDeallocateStmt(ctx, stmt.GetDeallocateStmt(), query)
+
+	// INSERT INTO ...
+	case stmt.GetInsertStmt() != nil:
+		return p.handleInsertStmt(ctx, stmt.GetInsertStmt(), query)
+
+	// DELETE FROM ...
+	case stmt.GetDeleteStmt() != nil:
+		return p.handleDeleteStmt(ctx, stmt.GetDeleteStmt(), query)
+
+	// DECLARE c1 CURSOR FOR SELECT ...
+	case stmt.GetDeclareCursorStmt() != nil:
+		return p.handleDeclareCursorStmt(ctx, stmt.GetDeclareCursorStmt(), query)
+
+	// FETCH 100 FROM c1
+	case stmt.GetFetchStmt() != nil:
+		return p.handleFetchStmt(ctx, stmt.GetFetchStmt(), query)
+
+	// CLOSE c1
+	case stmt.GetClosePortalStmt() != nil:
+		return p.handleClosePortalStmt(ctx, stmt.GetClosePortalStmt(), query)
+
+	// START TRANSACTION
+	// COMMIT
+	// ABORT TRANSACTION
+	case stmt.GetTransactionStmt() != nil:
+		return p.handleTransactionStmt(ctx, stmt.GetTransactionStmt(), query)
+
+	default:
+		return nil, fmt.Errorf("not implemented: %v", stmt)
+	}
+}

--- a/internal/fdw/pgserver_e2e_test.go
+++ b/internal/fdw/pgserver_e2e_test.go
@@ -1,0 +1,823 @@
+//go:build ci && !skipintegrationtests
+
+package fdw_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/ory/dockertest"
+	"github.com/ory/dockertest/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/authzed-go/v1"
+	"github.com/authzed/grpcutil"
+
+	"github.com/authzed/spicedb/internal/fdw"
+	"github.com/authzed/spicedb/pkg/cmd/datastore"
+	spicedbserver "github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/cmd/util"
+	"github.com/authzed/spicedb/pkg/tuple"
+)
+
+const (
+	pgVersion                  = "17.2"
+	dockerBootTimeout          = 10 * time.Second
+	postgresTestUser           = "postgres"
+	postgresTestPassword       = "secret"
+	postgresTestPort           = "5432"
+	postgresTestMaxConnections = "3000"
+	pgbouncerTestPort          = "6432"
+	fdwPassword                = "proxypassword"
+)
+
+type qar struct {
+	name                string
+	query               string
+	args                []any
+	expectedRows        [][]any
+	expectedResponseTag string
+	expectedError       string
+}
+
+type e2eTestCase struct {
+	name          string
+	schema        string
+	relationships []string
+	queries       []qar
+}
+
+func TestEndToEnd(t *testing.T) {
+	tcs := []e2eTestCase{
+		{
+			name: "simple",
+			schema: `definition user {}
+
+			definition document {
+				relation viewer: user
+			}
+			`,
+			relationships: []string{
+				"document:firstdoc#viewer@user:tom",
+			},
+			queries: []qar{
+				{
+					name:  "single result",
+					query: `SELECT resource_id FROM relationships WHERE resource_type = $1`,
+					args:  []any{"document"},
+					expectedRows: [][]any{
+						{"firstdoc"},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+				{
+					name:                "no results",
+					query:               `SELECT resource_id FROM relationships WHERE resource_id = $1`,
+					args:                []any{"notfound"},
+					expectedRows:        [][]any{},
+					expectedResponseTag: "SELECT 0",
+				},
+				{
+					name:          "no results with unknown type",
+					query:         `SELECT resource_id FROM relationships WHERE resource_type = $1`,
+					args:          []any{"unknown"},
+					expectedError: "object definition `unknown` not found",
+				},
+			},
+		},
+		{
+			name: "schema read/write",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+	relation writer: user
+	permission edit = writer
+	permission view = reader + edit
+}`,
+			queries: []qar{
+				{
+					name:  "read schema",
+					query: `SELECT * FROM schema`,
+					expectedRows: [][]any{
+						{`definition document {
+	relation reader: user
+	relation writer: user
+	permission edit = writer
+	permission view = reader + edit
+}
+
+definition user {}`},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+				{
+					name:  "write new schema",
+					query: `INSERT INTO schema VALUES ($1)`,
+					args: []any{`definition user {}
+
+definition document {
+	relation reader: user
+	relation writer: user
+	relation owner: user
+	permission edit = writer + owner
+	permission view = reader + edit
+}`},
+					expectedRows:        [][]any{},
+					expectedResponseTag: "INSERT 0 1",
+				},
+				{
+					name:  "read updated schema",
+					query: `SELECT * FROM schema`,
+					expectedRows: [][]any{
+						{`definition document {
+	relation reader: user
+	relation writer: user
+	relation owner: user
+	permission edit = writer + owner
+	permission view = reader + edit
+}
+
+definition user {}`},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+			},
+		},
+		{
+			name: "relationships read/write/delete",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+	relation writer: user
+}`,
+			relationships: []string{
+				"document:firstdoc#reader@user:tom",
+				"document:firstdoc#reader@user:jerry",
+				"document:seconddoc#reader@user:jerry",
+			},
+			queries: []qar{
+				{
+					name:  "select all relationships by resource_type",
+					query: `SELECT resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation, caveat_name, caveat_context FROM relationships WHERE resource_type = $1 ORDER BY resource_id, subject_id`,
+					args:  []any{"document"},
+					expectedRows: [][]any{
+						{"document", "firstdoc", "reader", "user", "jerry", "", "", ""},
+						{"document", "firstdoc", "reader", "user", "tom", "", "", ""},
+						{"document", "seconddoc", "reader", "user", "jerry", "", "", ""},
+					},
+					expectedResponseTag: "SELECT 3",
+				},
+				{
+					name:  "select relationships by resource_id",
+					query: `SELECT subject_id FROM relationships WHERE resource_type = $1 AND resource_id = $2 ORDER BY subject_id`,
+					args:  []any{"document", "firstdoc"},
+					expectedRows: [][]any{
+						{"jerry"},
+						{"tom"},
+					},
+					expectedResponseTag: "SELECT 2",
+				},
+				{
+					name:                "insert new relationship",
+					query:               `INSERT INTO relationships VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+					args:                []any{"document", "thirddoc", "reader", "user", "sarah", "", "", "", ""},
+					expectedRows:        [][]any{},
+					expectedResponseTag: "INSERT 0 1",
+				},
+				{
+					name:  "verify inserted relationship",
+					query: `SELECT subject_id FROM relationships WHERE resource_type = $1 AND resource_id = $2`,
+					args:  []any{"document", "thirddoc"},
+					expectedRows: [][]any{
+						{"sarah"},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+				{
+					name:                "delete relationship",
+					query:               `DELETE FROM relationships WHERE resource_type = $1 AND resource_id = $2 AND relation = $3 AND subject_type = $4 AND subject_id = $5`,
+					args:                []any{"document", "seconddoc", "reader", "user", "jerry"},
+					expectedRows:        [][]any{},
+					expectedResponseTag: "DELETE 1",
+				},
+				{
+					name:                "verify deleted relationship",
+					query:               `SELECT resource_id FROM relationships WHERE resource_type = $1 AND resource_id = $2`,
+					args:                []any{"document", "seconddoc"},
+					expectedRows:        [][]any{},
+					expectedResponseTag: "SELECT 0",
+				},
+			},
+		},
+		{
+			name: "insert returning zedtoken",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+}`,
+			queries: []qar{
+				{
+					name:                "insert with returning",
+					query:               `INSERT INTO relationships VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING consistency`,
+					args:                []any{"document", "testdoc", "reader", "user", "alice", "", "", ""},
+					expectedResponseTag: "INSERT 0 1",
+					// We expect one row with a non-empty consistency token
+					// The actual value will vary, so we'll check in a separate test below
+				},
+			},
+		},
+		{
+			name: "permissions check",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+	relation writer: user
+	permission edit = writer
+	permission view = reader + edit
+}`,
+			relationships: []string{
+				"document:firstdoc#reader@user:tom",
+				"document:firstdoc#writer@user:jerry",
+			},
+			queries: []qar{
+				{
+					name:  "check permission - has permission",
+					query: `SELECT resource_type, resource_id, permission, subject_type, subject_id FROM permissions WHERE resource_type = $1 AND resource_id = $2 AND permission = $3 AND subject_type = $4 AND subject_id = $5`,
+					args:  []any{"document", "firstdoc", "view", "user", "tom"},
+					expectedRows: [][]any{
+						{"document", "firstdoc", "view", "user", "tom"},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+				{
+					name:  "check permission - no permission",
+					query: `SELECT resource_type, resource_id, permission, subject_type, subject_id, has_permission FROM permissions WHERE resource_type = $1 AND resource_id = $2 AND permission = $3 AND subject_type = $4 AND subject_id = $5`,
+					args:  []any{"document", "firstdoc", "view", "user", "alice"},
+					expectedRows: [][]any{
+						{"document", "firstdoc", "view", "user", "alice", false},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+				{
+					name:  "check permission - derived from writer",
+					query: `SELECT resource_type, resource_id, permission, subject_type, subject_id FROM permissions WHERE resource_type = $1 AND resource_id = $2 AND permission = $3 AND subject_type = $4 AND subject_id = $5`,
+					args:  []any{"document", "firstdoc", "view", "user", "jerry"},
+					expectedRows: [][]any{
+						{"document", "firstdoc", "view", "user", "jerry"},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+			},
+		},
+		{
+			name: "permissions lookupresources",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+	relation writer: user
+	permission view = reader + writer
+}`,
+			relationships: []string{
+				"document:firstdoc#reader@user:tom",
+				"document:seconddoc#reader@user:tom",
+				"document:thirddoc#reader@user:jerry",
+			},
+			queries: []qar{
+				{
+					name:  "lookup resources for tom",
+					query: `SELECT resource_id FROM permissions WHERE resource_type = $1 AND permission = $2 AND subject_type = $3 AND subject_id = $4 ORDER BY resource_id`,
+					args:  []any{"document", "view", "user", "tom"},
+					expectedRows: [][]any{
+						{"firstdoc"},
+						{"seconddoc"},
+					},
+					expectedResponseTag: "SELECT 2",
+				},
+				{
+					name:  "lookup resources for jerry",
+					query: `SELECT resource_id FROM permissions WHERE resource_type = $1 AND permission = $2 AND subject_type = $3 AND subject_id = $4`,
+					args:  []any{"document", "view", "user", "jerry"},
+					expectedRows: [][]any{
+						{"thirddoc"},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+				{
+					name:                "lookup resources for user with no access",
+					query:               `SELECT resource_id FROM permissions WHERE resource_type = $1 AND permission = $2 AND subject_type = $3 AND subject_id = $4`,
+					args:                []any{"document", "view", "user", "alice"},
+					expectedRows:        [][]any{},
+					expectedResponseTag: "SELECT 0",
+				},
+			},
+		},
+		{
+			name: "permissions lookupsubjects",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+	permission view = reader
+}`,
+			relationships: []string{
+				"document:firstdoc#reader@user:tom",
+				"document:firstdoc#reader@user:jerry",
+				"document:firstdoc#reader@user:sarah",
+			},
+			queries: []qar{
+				{
+					name:  "lookup subjects for resource",
+					query: `SELECT subject_id FROM permissions WHERE resource_type = $1 AND resource_id = $2 AND permission = $3 AND subject_type = $4 ORDER BY subject_id`,
+					args:  []any{"document", "firstdoc", "view", "user"},
+					expectedRows: [][]any{
+						{"jerry"},
+						{"sarah"},
+						{"tom"},
+					},
+					expectedResponseTag: "SELECT 3",
+				},
+				{
+					name:                "lookup subjects for non-existent resource",
+					query:               `SELECT subject_id FROM permissions WHERE resource_type = $1 AND resource_id = $2 AND permission = $3 AND subject_type = $4`,
+					args:                []any{"document", "notfound", "view", "user"},
+					expectedRows:        [][]any{},
+					expectedResponseTag: "SELECT 0",
+				},
+			},
+		},
+		{
+			name: "consistency fully_consistent",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+	permission view = reader
+}`,
+			relationships: []string{
+				"document:firstdoc#reader@user:tom",
+			},
+			queries: []qar{
+				{
+					name:  "check with fully_consistent",
+					query: `SELECT resource_type, resource_id, permission, subject_type, subject_id FROM permissions WHERE resource_type = $1 AND resource_id = $2 AND permission = $3 AND subject_type = $4 AND subject_id = $5 AND consistency = $6`,
+					args:  []any{"document", "firstdoc", "view", "user", "tom", "fully_consistent"},
+					expectedRows: [][]any{
+						{"document", "firstdoc", "view", "user", "tom"},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+			},
+		},
+		{
+			name: "consistency at_least_as_fresh",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+	permission view = reader
+}`,
+			queries: []qar{
+				{
+					name:                "insert relationship and get zedtoken",
+					query:               `INSERT INTO relationships VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING consistency`,
+					args:                []any{"document", "firstdoc", "reader", "user", "tom", "", "", ""},
+					expectedResponseTag: "INSERT 0 1",
+				},
+				{
+					name:  "verify at_least_as_fresh - will use zedtoken from previous query in test runner",
+					query: `SELECT resource_type, resource_id, permission, subject_type, subject_id FROM permissions WHERE resource_type = $1 AND resource_id = $2 AND permission = $3 AND subject_type = $4 AND subject_id = $5`,
+					args:  []any{"document", "firstdoc", "view", "user", "tom"},
+					expectedRows: [][]any{
+						{"document", "firstdoc", "view", "user", "tom"},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+			},
+		},
+		{
+			name: "consistency at_exact_snapshot",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+	permission view = reader
+}`,
+			queries: []qar{
+				{
+					name:                "insert relationship and get zedtoken",
+					query:               `INSERT INTO relationships VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING consistency`,
+					args:                []any{"document", "firstdoc", "reader", "user", "tom", "", "", ""},
+					expectedResponseTag: "INSERT 0 1",
+				},
+				{
+					name:  "verify at_exact_snapshot - will use @zedtoken from previous query in test runner",
+					query: `SELECT resource_type, resource_id, permission, subject_type, subject_id FROM permissions WHERE resource_type = $1 AND resource_id = $2 AND permission = $3 AND subject_type = $4 AND subject_id = $5`,
+					args:  []any{"document", "firstdoc", "view", "user", "tom"},
+					expectedRows: [][]any{
+						{"document", "firstdoc", "view", "user", "tom"},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+			},
+		},
+		{
+			name: "join with local table",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+	permission view = reader
+}`,
+			relationships: []string{
+				"document:firstdoc#reader@user:jerry",
+				"document:seconddoc#reader@user:jerry",
+				"document:thirddoc#reader@user:tom",
+			},
+			queries: []qar{
+				{
+					name: "create local documents table",
+					query: `CREATE TABLE document (
+						id text PRIMARY KEY,
+						title text NOT NULL,
+						contents text NOT NULL
+					)`,
+					expectedRows:        [][]any{},
+					expectedResponseTag: "CREATE TABLE",
+				},
+				{
+					name:                "insert local documents",
+					query:               `INSERT INTO document (id, title, contents) VALUES ($1, $2, $3), ($4, $5, $6), ($7, $8, $9)`,
+					args:                []any{"firstdoc", "Document 1", "Contents of document 1", "seconddoc", "Document 2", "Contents of document 2", "thirddoc", "Document 3", "Contents of document 3"},
+					expectedRows:        [][]any{},
+					expectedResponseTag: "INSERT 0 3",
+				},
+				{
+					name:  "join documents with permissions for jerry",
+					query: `SELECT document.id, document.title FROM document JOIN permissions ON permissions.resource_id = document.id WHERE permissions.resource_type = $1 AND permissions.permission = $2 AND permissions.subject_type = $3 AND permissions.subject_id = $4 ORDER BY document.title DESC`,
+					args:  []any{"document", "view", "user", "jerry"},
+					expectedRows: [][]any{
+						{"seconddoc", "Document 2"},
+						{"firstdoc", "Document 1"},
+					},
+					expectedResponseTag: "SELECT 2",
+				},
+				{
+					name:  "join documents with permissions for tom",
+					query: `SELECT document.id, document.title FROM document JOIN permissions ON permissions.resource_id = document.id WHERE permissions.resource_type = $1 AND permissions.permission = $2 AND permissions.subject_type = $3 AND permissions.subject_id = $4`,
+					args:  []any{"document", "view", "user", "tom"},
+					expectedRows: [][]any{
+						{"thirddoc", "Document 3"},
+					},
+					expectedResponseTag: "SELECT 1",
+				},
+			},
+		},
+		{
+			name: "cursor support",
+			schema: `definition user {}
+
+definition document {
+	relation reader: user
+	permission view = reader
+}`,
+			relationships: []string{
+				"document:doc1#reader@user:alice",
+				"document:doc2#reader@user:alice",
+				"document:doc3#reader@user:alice",
+				"document:doc4#reader@user:alice",
+				"document:doc5#reader@user:alice",
+			},
+			queries: []qar{
+				{
+					name:                "begin transaction",
+					query:               `BEGIN`,
+					expectedRows:        [][]any{},
+					expectedResponseTag: "BEGIN",
+				},
+				{
+					name:                "declare cursor",
+					query:               `DECLARE my_cursor CURSOR FOR SELECT resource_id FROM permissions WHERE resource_type = $1 AND permission = $2 AND subject_type = $3 AND subject_id = $4`,
+					args:                []any{"document", "view", "user", "alice"},
+					expectedRows:        [][]any{},
+					expectedResponseTag: "DECLARE CURSOR",
+				},
+				{
+					name:                "fetch from cursor - first batch",
+					query:               `FETCH 2 FROM my_cursor`,
+					expectedResponseTag: "FETCH 2",
+				},
+				{
+					name:                "fetch from cursor - second batch",
+					query:               `FETCH 2 FROM my_cursor`,
+					expectedResponseTag: "FETCH 2",
+				},
+				{
+					name:                "close cursor",
+					query:               `CLOSE my_cursor`,
+					expectedRows:        [][]any{},
+					expectedResponseTag: "CLOSE CURSOR",
+				},
+				{
+					name:                "commit transaction",
+					query:               `COMMIT`,
+					expectedRows:        [][]any{},
+					expectedResponseTag: "COMMIT",
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			runEndToEndTest(t, tc)
+		})
+	}
+}
+
+func runEndToEndTest(t *testing.T, tc e2eTestCase) {
+	// Start SpiceDB server.
+	t.Log("Starting SpiceDB")
+	client := runSpiceDB(t)
+	t.Log("SpiceDB started")
+
+	// Write initial schema and relationships.
+	t.Log("Writing initial schema and relationships")
+	_, err := client.WriteSchema(context.Background(), &v1.WriteSchemaRequest{
+		Schema: tc.schema,
+	})
+	require.NoError(t, err)
+
+	updates := make([]*v1.RelationshipUpdate, 0, len(tc.relationships))
+	for _, rel := range tc.relationships {
+		updates = append(updates, &v1.RelationshipUpdate{
+			Relationship: tuple.MustParseV1Rel(rel),
+			Operation:    v1.RelationshipUpdate_OPERATION_CREATE,
+		})
+	}
+
+	if len(updates) > 0 {
+		_, err = client.WriteRelationships(context.Background(), &v1.WriteRelationshipsRequest{
+			Updates: updates,
+		})
+		require.NoError(t, err)
+		t.Log("Initial schema and relationships written")
+
+		// Sanity check that rels can be read.
+		s, err := client.ReadRelationships(context.Background(), &v1.ReadRelationshipsRequest{
+			RelationshipFilter: &v1.RelationshipFilter{
+				ResourceType: "document",
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = s.Recv()
+		require.NoError(t, err)
+	} else {
+		t.Log("Initial schema written (no relationships)")
+	}
+
+	// Start PGServer.
+	t.Log("Starting PGServer")
+	pgServerPort := runPGServer(t, client)
+	t.Log("PGServer started")
+
+	// Start Postgres.
+	t.Log("Starting Postgres")
+	pgconn := runPostgres(t)
+	t.Log("Postgres started")
+
+	// Read the commands from the configuration.sql file.
+	_, filename, _, _ := runtime.Caller(1) // 1 for the parent caller.
+	dat, err := os.ReadFile(path.Join(path.Dir(filename), "../../configuration.sql"))
+	require.NoError(t, err)
+	createCommandsTemplate := string(dat)
+
+	// Replace the hardcoded port with the dynamically allocated port.
+	createCommands := strings.ReplaceAll(createCommandsTemplate, "port '5433'", fmt.Sprintf("port '%d'", pgServerPort))
+
+	// Invoke initial Postgres commands.
+	_, err = pgconn.Exec(context.Background(), createCommands)
+	require.NoError(t, err)
+	t.Log("Initial Postgres commands executed")
+
+	// Run queries.
+	var lastZedToken string
+	for _, q := range tc.queries {
+		t.Run(q.name, func(t *testing.T) {
+			// If this is an at_least_as_fresh test, inject the zedtoken into the query
+			queryToRun := q.query
+			argsToUse := q.args
+			if lastZedToken != "" && tc.name == "consistency at_least_as_fresh" && len(q.args) > 0 {
+				// Add consistency parameter to the WHERE clause
+				queryToRun = q.query + ` AND consistency = $` + fmt.Sprintf("%d", len(q.args)+1)
+				argsToUse = append(argsToUse, lastZedToken)
+			} else if lastZedToken != "" && tc.name == "consistency at_exact_snapshot" && len(q.args) > 0 {
+				// Add consistency parameter with @ prefix for at_exact_snapshot
+				queryToRun = q.query + ` AND consistency = $` + fmt.Sprintf("%d", len(q.args)+1)
+				argsToUse = append(argsToUse, "@"+lastZedToken)
+			}
+
+			rows, err := pgconn.Query(context.Background(), queryToRun, argsToUse...)
+			require.NoError(t, err)
+			defer rows.Close()
+
+			if q.expectedError != "" {
+				require.False(t, rows.Next())
+				require.Error(t, rows.Err())
+				require.ErrorContains(t, rows.Err(), q.expectedError)
+			} else {
+				// Read all rows.
+				foundRows := make([][]any, 0)
+				for rows.Next() {
+					require.NoError(t, rows.Err())
+
+					values, err := rows.Values()
+					require.NoError(t, err)
+					foundRows = append(foundRows, values)
+
+					// If this is a RETURNING consistency query, capture the zedtoken
+					if len(values) == 1 && rows.FieldDescriptions()[0].Name == "consistency" {
+						if token, ok := values[0].(string); ok && token != "" {
+							lastZedToken = token
+							t.Logf("Captured ZedToken: %s", lastZedToken)
+						}
+					}
+				}
+
+				require.NoError(t, rows.Err())
+
+				// For queries with expected rows, verify them
+				if len(q.expectedRows) > 0 {
+					require.Equal(t, q.expectedRows, foundRows)
+				} else if q.query != queryToRun {
+					// For consistency tests that inject parameters, we just verify we got results
+					require.NotEmpty(t, foundRows)
+				}
+				rows.Close()
+				require.Equal(t, q.expectedResponseTag, rows.CommandTag().String())
+			}
+		})
+	}
+}
+
+func runPGServer(t *testing.T, client *authzed.Client) int {
+	pgserver := fdw.NewPgBackend(client, postgresTestUser, fdwPassword)
+
+	port, err := GetFreePort()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, pgserver.Close())
+	})
+
+	go func() {
+		_ = pgserver.Run(ctx, fmt.Sprintf("localhost:%d", port))
+	}()
+
+	// Give PGServer time to start
+	time.Sleep(50 * time.Millisecond)
+
+	return port
+}
+
+// GetFreePort asks the kernel for a free open port that is ready to use.
+// From: https://gist.github.com/sevkin/96bdae9274465b2d09191384f86ef39d
+func GetFreePort() (port int, err error) {
+	var a *net.TCPAddr
+	if a, err = net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
+		var l *net.TCPListener
+		if l, err = net.ListenTCP("tcp", a); err == nil {
+			defer l.Close()
+			return l.Addr().(*net.TCPAddr).Port, nil
+		}
+	}
+	return port, err
+}
+
+func runSpiceDB(t *testing.T) *authzed.Client {
+	port, err := GetFreePort()
+	require.NoError(t, err)
+	address := fmt.Sprintf("localhost:%d", port)
+
+	config := spicedbserver.Config{
+		GRPCServer: util.GRPCServerConfig{
+			Address: address,
+			Network: "tcp",
+			Enabled: true,
+		},
+		PresharedSecureKey: []string{"sometestkey"},
+		DatastoreConfig: datastore.Config{
+			Engine:               "memory",
+			RevisionQuantization: 5 * time.Second,
+			GCWindow:             5 * time.Minute,
+			FilterMaximumIDCount: 100,
+		},
+	}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	runnableServer, err := config.Complete(ctx)
+	require.NoError(t, err)
+
+	serverReady := make(chan bool)
+	go (func() {
+		serverReady <- true
+		_ = runnableServer.Run(ctx)
+	})()
+
+	// Wait for server goroutine to start
+	<-serverReady
+
+	// Verify server is ready
+	var client *authzed.Client
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		var err error
+		client, err = authzed.NewClient(
+			address,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpcutil.WithInsecureBearerToken("sometestkey"),
+		)
+		if err != nil {
+			collect.Errorf("failed to create client: %v", err)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, schemaErr := client.ReadSchema(ctx, &v1.ReadSchemaRequest{})
+
+		// Check for the NotFound, which is expected since no schema is set yet.
+		require.Error(collect, schemaErr, "expected an error from ReadSchema")
+		require.Contains(collect, schemaErr.Error(), "NotFound", "expected NotFound error")
+	}, 5*time.Second, 50*time.Millisecond, "SpiceDB server did not become ready")
+
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	return client
+}
+
+func runPostgres(t *testing.T) (conn *pgx.Conn) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	postgresContainerHostname := fmt.Sprintf("postgres-%s", uuid.New().String())
+	postgres, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Name:       postgresContainerHostname,
+		Repository: "mirror.gcr.io/library/postgres",
+		Tag:        pgVersion,
+		Env: []string{
+			"POSTGRES_USER=" + postgresTestUser,
+			"POSTGRES_PASSWORD=" + postgresTestPassword,
+		},
+		ExposedPorts: []string{postgresTestPort + "/tcp"},
+	}, func(config *docker.HostConfig) {
+		// set AutoRemove to true so that stopped container goes away by itself
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, pool.Purge(postgres))
+	})
+
+	hostname := "localhost"
+	port := postgres.GetPort(postgresTestPort + "/tcp")
+
+	creds := postgresTestUser + ":" + postgresTestPassword
+	uri := fmt.Sprintf("postgresql://%s@%s:%s/?sslmode=disable", creds, hostname, port)
+	err = pool.Retry(func() error {
+		var err error
+		ctx, cancelConnect := context.WithTimeout(context.Background(), dockerBootTimeout)
+		defer cancelConnect()
+		conn, err = pgx.Connect(ctx, uri)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return conn
+}

--- a/internal/fdw/session.go
+++ b/internal/fdw/session.go
@@ -1,0 +1,96 @@
+package fdw
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/ctxkey"
+
+	"github.com/authzed/spicedb/internal/fdw/common"
+)
+
+// session represents a PostgreSQL session state for the FDW.
+// It tracks transaction state and maintains cursors for the current session.
+// All methods are thread-safe.
+type session struct {
+	mu sync.Mutex
+
+	// withinTransaction indicates whether the session is currently inside a transaction.
+	withinTransaction bool // GUARDED_BY(mu)
+
+	// cursors maps cursor names to their corresponding cursor objects.
+	cursors map[string]*cursor // GUARDED_BY(mu)
+}
+
+// addCursor adds a cursor to the session's cursor map.
+// This method is thread-safe.
+func (s *session) addCursor(cursor *cursor) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cursors[cursor.name] = cursor
+}
+
+// deleteCursor removes a cursor from the session by name.
+// This method is thread-safe.
+func (s *session) deleteCursor(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.cursors, name)
+}
+
+// lookupCursor retrieves a cursor by name from the session.
+// Returns an error if the cursor is not found.
+// This method is thread-safe.
+func (s *session) lookupCursor(name string) (*cursor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cursor, ok := s.cursors[name]
+	if !ok {
+		return nil, common.NewSemanticsError(fmt.Errorf("cursor %q not found", name))
+	}
+	return cursor, nil
+}
+
+// sessionKey is the context key used to store and retrieve session state.
+var sessionKey = ctxkey.New[*session]()
+
+// sessionMiddleware is a middleware function that initializes a new session
+// and stores it in the context. This should be called once per connection.
+func sessionMiddleware(ctx context.Context) (context.Context, error) {
+	return sessionKey.Set(ctx, &session{
+		cursors: make(map[string]*cursor),
+	}), nil
+}
+
+// mustSession retrieves the session from the context.
+// Panics if the session is not present in the context.
+func mustSession(ctx context.Context) *session {
+	return sessionKey.MustValue(ctx)
+}
+
+// handleDeallocateStmt handles PostgreSQL DEALLOCATE statements.
+// DEALLOCATE removes prepared statements and cursors by name.
+// If the DEALLOCATE ALL form is used, all cursors are removed.
+func (p *PgBackend) handleDeallocateStmt(_ context.Context, stmt *pg_query.DeallocateStmt, _ string) (wire.PreparedStatements, error) {
+	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
+		session := mustSession(ctx)
+		session.mu.Lock()
+		defer session.mu.Unlock()
+
+		if stmt.GetIsall() {
+			// DEALLOCATE ALL - remove all cursors
+			session.cursors = make(map[string]*cursor)
+			return writer.Complete("deallocated all")
+		}
+
+		// DEALLOCATE <name> - remove specific cursor if it exists
+		delete(session.cursors, stmt.GetName())
+
+		return writer.Complete("deallocated cursor")
+	}
+	return wire.Prepared(wire.NewStatement(handle)), nil
+}

--- a/internal/fdw/stats/docs.go
+++ b/internal/fdw/stats/docs.go
@@ -1,0 +1,7 @@
+// Package stats provides statistics tracking for FDW query operations.
+//
+// This package collects query execution statistics including cost metrics,
+// row counts, and result widths using quantile streams. The statistics are
+// used to generate accurate EXPLAIN plans and help the Postgres query planner
+// make better decisions.
+package stats

--- a/internal/fdw/stats/stats.go
+++ b/internal/fdw/stats/stats.go
@@ -1,0 +1,70 @@
+package stats
+
+import (
+	"sync"
+
+	"github.com/bmizerany/perks/quantile"
+
+	"github.com/authzed/spicedb/internal/fdw/explain"
+)
+
+// Package collects query execution statistics for a specific table and operation.
+// It uses quantile streams to track cost, row count, and result width metrics.
+type Package struct {
+	sync.Mutex
+
+	table     string
+	operation string
+
+	cost  *quantile.Stream // GUARDED_BY(Mutex)
+	rows  *quantile.Stream // GUARDED_BY(Mutex)
+	width *quantile.Stream // GUARDED_BY(Mutex)
+}
+
+const median = 0.5
+
+// NewPackage creates a new statistics package for a table and operation.
+func NewPackage(table, operation string) *Package {
+	return &Package{
+		table:     table,
+		operation: operation,
+		cost:      quantile.NewTargeted(0.5),
+		rows:      quantile.NewTargeted(0.5),
+		width:     quantile.NewTargeted(0.5),
+	}
+}
+
+// AddWidthSample records a result width sample.
+func (p *Package) AddWidthSample(width uint) {
+	p.Lock()
+	defer p.Unlock()
+	p.width.Insert(float64(width))
+}
+
+// AddSample records a cost and row count sample from a query execution.
+func (p *Package) AddSample(cost float32, rows uint) {
+	p.Lock()
+	defer p.Unlock()
+	p.cost.Insert(float64(cost))
+	p.rows.Insert(float64(rows))
+}
+
+// Explain generates an EXPLAIN plan string using collected statistics.
+// If no samples have been collected, returns a default plan.
+// TODO(jschorr): Support getting cost estimates from Materialize.
+func (p *Package) Explain() string {
+	p.Lock()
+	defer p.Unlock()
+	if p.cost.Count() == 0 {
+		return explain.Default(p.operation, p.table).String()
+	}
+
+	return explain.Explain{
+		Operation:                    p.operation,
+		TableName:                    p.table,
+		StartupCost:                  float32(p.cost.Query(median)),
+		TotalCost:                    float32(p.cost.Query(median)),
+		EstimatedRows:                int32(p.rows.Query(median)),
+		EstimatedAverageWidthInBytes: int32(p.width.Query(median)),
+	}.String()
+}

--- a/internal/fdw/stats/stats_test.go
+++ b/internal/fdw/stats/stats_test.go
@@ -1,0 +1,370 @@
+package stats
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/fdw/explain"
+)
+
+func TestNewPackage(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		table     string
+		operation string
+	}{
+		{
+			name:      "relationships table",
+			table:     "relationships",
+			operation: "Foreign Scan",
+		},
+		{
+			name:      "permissions table",
+			table:     "permissions",
+			operation: "Foreign Scan",
+		},
+		{
+			name:      "schema table",
+			table:     "schema",
+			operation: "Seq Scan",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pkg := NewPackage(tc.table, tc.operation)
+			require.NotNil(t, pkg)
+			require.Equal(t, tc.table, pkg.table)
+			require.Equal(t, tc.operation, pkg.operation)
+			require.NotNil(t, pkg.cost)
+			require.NotNil(t, pkg.rows)
+			require.NotNil(t, pkg.width)
+		})
+	}
+}
+
+func TestAddWidthSample(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		samples []uint
+	}{
+		{
+			name:    "single sample",
+			samples: []uint{100},
+		},
+		{
+			name:    "multiple samples",
+			samples: []uint{50, 100, 150, 200},
+		},
+		{
+			name:    "varying widths",
+			samples: []uint{10, 500, 250, 100, 300},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pkg := NewPackage("test_table", "Test Scan")
+			for _, sample := range tc.samples {
+				pkg.AddWidthSample(sample)
+			}
+
+			// Verify the package still works after adding samples
+			explainStr := pkg.Explain()
+			require.NotEmpty(t, explainStr)
+			require.Contains(t, explainStr, "test_table")
+		})
+	}
+}
+
+func TestAddSample(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		samples []struct {
+			cost float32
+			rows uint
+		}
+	}{
+		{
+			name: "single sample",
+			samples: []struct {
+				cost float32
+				rows uint
+			}{
+				{cost: 100.0, rows: 1000},
+			},
+		},
+		{
+			name: "multiple samples",
+			samples: []struct {
+				cost float32
+				rows uint
+			}{
+				{cost: 50.0, rows: 500},
+				{cost: 100.0, rows: 1000},
+				{cost: 150.0, rows: 1500},
+			},
+		},
+		{
+			name: "varying costs and rows",
+			samples: []struct {
+				cost float32
+				rows uint
+			}{
+				{cost: 10.0, rows: 100},
+				{cost: 500.0, rows: 5000},
+				{cost: 250.0, rows: 2500},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pkg := NewPackage("test_table", "Test Scan")
+			for _, sample := range tc.samples {
+				pkg.AddSample(sample.cost, sample.rows)
+			}
+
+			// Verify the package still works after adding samples
+			explainStr := pkg.Explain()
+			require.NotEmpty(t, explainStr)
+			require.Contains(t, explainStr, "test_table")
+		})
+	}
+}
+
+func TestExplainWithNoSamples(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		table     string
+		operation string
+	}{
+		{
+			name:      "relationships",
+			table:     "relationships",
+			operation: "Foreign Scan",
+		},
+		{
+			name:      "permissions",
+			table:     "permissions",
+			operation: "Foreign Scan",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pkg := NewPackage(tc.table, tc.operation)
+			result := pkg.Explain()
+
+			// When no samples, should return default explain
+			expected := explain.Default(tc.operation, tc.table).String()
+			require.Equal(t, expected, result)
+		})
+	}
+}
+
+func TestExplainWithSamples(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		table     string
+		operation string
+		samples   []struct {
+			cost  float32
+			rows  uint
+			width uint
+		}
+		expectedCost   float32
+		expectedRows   int32
+		expectedWidth  int32
+		costTolerance  float32
+		rowsTolerance  int32
+		widthTolerance int32
+	}{
+		{
+			name:      "single sample set",
+			table:     "relationships",
+			operation: "Foreign Scan",
+			samples: []struct {
+				cost  float32
+				rows  uint
+				width uint
+			}{
+				{cost: 100.0, rows: 1000, width: 50},
+			},
+			expectedCost:   100.0,
+			expectedRows:   1000,
+			expectedWidth:  50,
+			costTolerance:  1.0,
+			rowsTolerance:  10,
+			widthTolerance: 5,
+		},
+		{
+			name:      "multiple sample sets - median",
+			table:     "permissions",
+			operation: "Foreign Scan",
+			samples: []struct {
+				cost  float32
+				rows  uint
+				width uint
+			}{
+				{cost: 50.0, rows: 500, width: 40},
+				{cost: 100.0, rows: 1000, width: 50},
+				{cost: 150.0, rows: 1500, width: 60},
+			},
+			// Quantile streams use approximate algorithms, so median might be one of the samples
+			// For 3 samples, expect something in the middle range
+			expectedCost:   100.0,
+			expectedRows:   1000,
+			expectedWidth:  50,
+			costTolerance:  60.0, // Allow for approximate quantile calculation
+			rowsTolerance:  600,  // Allow for approximate quantile calculation
+			widthTolerance: 15,   // Allow for approximate quantile calculation
+		},
+		{
+			name:      "many samples - median calculation",
+			table:     "schema",
+			operation: "Seq Scan",
+			samples: []struct {
+				cost  float32
+				rows  uint
+				width uint
+			}{
+				{cost: 10.0, rows: 100, width: 20},
+				{cost: 20.0, rows: 200, width: 30},
+				{cost: 30.0, rows: 300, width: 40},
+				{cost: 40.0, rows: 400, width: 50},
+				{cost: 50.0, rows: 500, width: 60},
+			},
+			// Median of 5 values should be around the 3rd value (30, 300, 40)
+			expectedCost:   30.0,
+			expectedRows:   300,
+			expectedWidth:  40,
+			costTolerance:  10.0,
+			rowsTolerance:  100,
+			widthTolerance: 10,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pkg := NewPackage(tc.table, tc.operation)
+
+			for _, sample := range tc.samples {
+				pkg.AddSample(sample.cost, sample.rows)
+				pkg.AddWidthSample(sample.width)
+			}
+
+			result := pkg.Explain()
+			require.NotEmpty(t, result)
+			require.Contains(t, result, tc.operation)
+			require.Contains(t, result, tc.table)
+			require.Contains(t, result, "cost=")
+			require.Contains(t, result, "rows=")
+			require.Contains(t, result, "width=")
+
+			// Parse the explain output to verify actual values
+			// Expected format: "Foreign Scan on relationships (cost=100.00..100.00 rows=1000 width=50)"
+			var operation, tableName string
+			var startupCost, totalCost float32
+			var rows, width int32
+
+			_, err := fmt.Sscanf(result,
+				"%s Scan on %s (cost=%f..%f rows=%d width=%d)",
+				&operation, &tableName, &startupCost, &totalCost, &rows, &width)
+			require.NoError(t, err, "Failed to parse explain output: %s", result)
+
+			// Verify values are within tolerance of expected median
+			require.InDelta(t, tc.expectedCost, startupCost, float64(tc.costTolerance),
+				"Startup cost %f not within tolerance %f of expected %f", startupCost, tc.costTolerance, tc.expectedCost)
+			require.InDelta(t, tc.expectedCost, totalCost, float64(tc.costTolerance),
+				"Total cost %f not within tolerance %f of expected %f", totalCost, tc.costTolerance, tc.expectedCost)
+			require.InDelta(t, tc.expectedRows, rows, float64(tc.rowsTolerance),
+				"Rows %d not within tolerance %d of expected %d", rows, tc.rowsTolerance, tc.expectedRows)
+			require.InDelta(t, tc.expectedWidth, width, float64(tc.widthTolerance),
+				"Width %d not within tolerance %d of expected %d", width, tc.widthTolerance, tc.expectedWidth)
+		})
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	pkg := NewPackage("test_table", "Test Scan")
+
+	// Simulate concurrent access from multiple goroutines
+	done := make(chan bool, 3)
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			pkg.AddSample(float32(i), uint(i*10))
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			pkg.AddWidthSample(uint(i * 5))
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			_ = pkg.Explain()
+		}
+		done <- true
+	}()
+
+	// Wait for all goroutines to complete
+	<-done
+	<-done
+	<-done
+
+	// Verify the package is still in a valid state
+	result := pkg.Explain()
+	require.NotEmpty(t, result)
+	require.Contains(t, result, "test_table")
+}
+
+func TestExplainFormat(t *testing.T) {
+	t.Parallel()
+
+	pkg := NewPackage("relationships", "Foreign Scan")
+	pkg.AddSample(123.45, 5000)
+	pkg.AddWidthSample(75)
+
+	result := pkg.Explain()
+
+	// Verify the format matches Postgres EXPLAIN output
+	require.Contains(t, result, "Foreign Scan on relationships")
+	require.True(t, strings.Contains(result, "cost=") && strings.Contains(result, ".."))
+	require.Contains(t, result, "rows=")
+	require.Contains(t, result, "width=")
+
+	// Verify numbers are present (even if we don't know exact median values)
+	parts := strings.Split(result, " ")
+	require.Greater(t, len(parts), 3, "Explain output should have multiple parts")
+}

--- a/internal/fdw/tables/consistency.go
+++ b/internal/fdw/tables/consistency.go
@@ -1,0 +1,84 @@
+package tables
+
+import (
+	"strings"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/lib/pq/oid"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+)
+
+const (
+	// Consistency mode values
+	consistencyMinimizeLatency = "minimize_latency"
+	consistencyFullyConsistent = "fully_consistent"
+	consistencyExactPrefix     = "@"
+
+	fieldConsistency = "consistency"
+)
+
+var consistencyField = wire.Column{
+	Table: 0,
+	Name:  fieldConsistency,
+	Oid:   uint32(oid.T_text),
+	Width: 256,
+}
+
+func consistencyFromFields(fields fieldMap[string], parameters []wire.Parameter) (*v1.Consistency, error) {
+	// If unspecified, default to minimize latency.
+	if _, ok := fields[fieldConsistency]; !ok {
+		return &v1.Consistency{
+			Requirement: &v1.Consistency_MinimizeLatency{
+				MinimizeLatency: true,
+			},
+		}, nil
+	}
+
+	consistencyFieldValue, err := optionalStringValue(fields[fieldConsistency], parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	switch consistencyFieldValue {
+	case consistencyMinimizeLatency:
+		return &v1.Consistency{
+			Requirement: &v1.Consistency_MinimizeLatency{
+				MinimizeLatency: true,
+			},
+		}, nil
+
+	case consistencyFullyConsistent:
+		return &v1.Consistency{
+			Requirement: &v1.Consistency_FullyConsistent{
+				FullyConsistent: true,
+			},
+		}, nil
+
+	default:
+		isAtExactSnapshot := false
+		if strings.HasPrefix(consistencyFieldValue, consistencyExactPrefix) {
+			consistencyFieldValue = strings.TrimPrefix(consistencyFieldValue, consistencyExactPrefix)
+			isAtExactSnapshot = true
+		}
+
+		// Parse as a ZedToken.
+		zedToken := &v1.ZedToken{
+			Token: consistencyFieldValue,
+		}
+
+		if isAtExactSnapshot {
+			return &v1.Consistency{
+				Requirement: &v1.Consistency_AtExactSnapshot{
+					AtExactSnapshot: zedToken,
+				},
+			}, nil
+		} else {
+			return &v1.Consistency{
+				Requirement: &v1.Consistency_AtLeastAsFresh{
+					AtLeastAsFresh: zedToken,
+				},
+			}, nil
+		}
+	}
+}

--- a/internal/fdw/tables/consistency_test.go
+++ b/internal/fdw/tables/consistency_test.go
@@ -1,0 +1,165 @@
+package tables
+
+import (
+	"testing"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsistencyFromFields(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                    string
+		fields                  fieldMap[string]
+		parameters              []wire.Parameter
+		expectedConsistencyType string // Type of consistency requirement
+		expectedToken           string // Expected token value for token-based consistency
+		expectedError           string
+	}{
+		{
+			name:                    "default - no consistency field",
+			fields:                  fieldMap[string]{},
+			expectedConsistencyType: "MinimizeLatency",
+		},
+		{
+			name: "explicit minimize_latency",
+			fields: fieldMap[string]{
+				"consistency": {value: "minimize_latency"},
+			},
+			expectedConsistencyType: "MinimizeLatency",
+		},
+		{
+			name: "fully_consistent",
+			fields: fieldMap[string]{
+				"consistency": {value: "fully_consistent"},
+			},
+			expectedConsistencyType: "FullyConsistent",
+		},
+		{
+			name: "at_least_as_fresh with token",
+			fields: fieldMap[string]{
+				"consistency": {value: "GhUKEzE3MzU2OTQzMDkwMDAwMDAwMDA="},
+			},
+			expectedConsistencyType: "AtLeastAsFresh",
+			expectedToken:           "GhUKEzE3MzU2OTQzMDkwMDAwMDAwMDA=",
+		},
+		{
+			name: "at_exact_snapshot with @ prefix",
+			fields: fieldMap[string]{
+				"consistency": {value: "@GhUKEzE3MzU2OTQzMDkwMDAwMDAwMDA="},
+			},
+			expectedConsistencyType: "AtExactSnapshot",
+			expectedToken:           "GhUKEzE3MzU2OTQzMDkwMDAwMDAwMDA=",
+		},
+		{
+			name: "consistency from parameter",
+			fields: fieldMap[string]{
+				"consistency": {parameterIndex: 1},
+			},
+			parameters:              []wire.Parameter{mockParameter("param0"), mockParameter("fully_consistent")},
+			expectedConsistencyType: "FullyConsistent",
+		},
+		{
+			name: "at_least_as_fresh from parameter",
+			fields: fieldMap[string]{
+				"consistency": {parameterIndex: 1},
+			},
+			parameters:              []wire.Parameter{mockParameter("param0"), mockParameter("SomeZedToken123")},
+			expectedConsistencyType: "AtLeastAsFresh",
+			expectedToken:           "SomeZedToken123",
+		},
+		{
+			name: "at_exact_snapshot from parameter",
+			fields: fieldMap[string]{
+				"consistency": {parameterIndex: 1},
+			},
+			parameters:              []wire.Parameter{mockParameter("param0"), mockParameter("@SomeZedToken456")},
+			expectedConsistencyType: "AtExactSnapshot",
+			expectedToken:           "SomeZedToken456",
+		},
+		{
+			name: "empty string defaults to minimize_latency token",
+			fields: fieldMap[string]{
+				"consistency": {value: ""},
+			},
+			expectedConsistencyType: "AtLeastAsFresh",
+			expectedToken:           "",
+		},
+		{
+			name: "parameter index out of range",
+			fields: fieldMap[string]{
+				"consistency": {parameterIndex: 10},
+			},
+			parameters:    []wire.Parameter{mockParameter("param0")},
+			expectedError: "parameter index out of range",
+		},
+		{
+			name: "subquery placeholder not supported",
+			fields: fieldMap[string]{
+				"consistency": {isSubQueryPlaceholder: true},
+			},
+			expectedError: "subquery placeholders are not supported in permissions table",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			consistency, err := consistencyFromFields(tc.fields, tc.parameters)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, consistency)
+
+			// Verify the consistency type
+			switch tc.expectedConsistencyType {
+			case "MinimizeLatency":
+				require.NotNil(t, consistency.GetMinimizeLatency())
+				require.True(t, consistency.GetMinimizeLatency())
+
+			case "FullyConsistent":
+				require.NotNil(t, consistency.GetFullyConsistent())
+				require.True(t, consistency.GetFullyConsistent())
+
+			case "AtLeastAsFresh":
+				token := consistency.GetAtLeastAsFresh()
+				require.NotNil(t, token)
+				require.Equal(t, tc.expectedToken, token.Token)
+
+			case "AtExactSnapshot":
+				token := consistency.GetAtExactSnapshot()
+				require.NotNil(t, token)
+				require.Equal(t, tc.expectedToken, token.Token)
+
+			default:
+				t.Fatalf("Unknown expected consistency type: %s", tc.expectedConsistencyType)
+			}
+		})
+	}
+}
+
+func TestConsistencyConstants(t *testing.T) {
+	t.Parallel()
+
+	// Verify constants are defined correctly
+	require.Equal(t, "minimize_latency", consistencyMinimizeLatency)
+	require.Equal(t, "fully_consistent", consistencyFullyConsistent)
+	require.Equal(t, "@", consistencyExactPrefix)
+}
+
+func TestConsistencyField(t *testing.T) {
+	t.Parallel()
+
+	// Verify consistencyField is properly configured
+	require.Equal(t, "consistency", consistencyField.Name)
+	require.NotZero(t, consistencyField.Oid)
+	require.Equal(t, int16(256), consistencyField.Width)
+}

--- a/internal/fdw/tables/cost.go
+++ b/internal/fdw/tables/cost.go
@@ -1,0 +1,29 @@
+package tables
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+
+	"github.com/authzed/authzed-go/pkg/responsemeta"
+)
+
+func costFromTrailers(trailersMD metadata.MD) (float32, error) {
+	dispatchCount, trailerErr := responsemeta.GetIntResponseTrailerMetadata(
+		trailersMD,
+		responsemeta.DispatchedOperationsCount,
+	)
+	if trailerErr != nil {
+		return 0, fmt.Errorf("error reading dispatched operations trailer: %w", trailerErr)
+	}
+
+	cachedCount, trailerErr := responsemeta.GetIntResponseTrailerMetadata(
+		trailersMD,
+		responsemeta.CachedOperationsCount,
+	)
+	if trailerErr != nil {
+		return 0, fmt.Errorf("error reading dispatched operations trailer: %w", trailerErr)
+	}
+
+	return float32(dispatchCount + cachedCount), nil
+}

--- a/internal/fdw/tables/delete.go
+++ b/internal/fdw/tables/delete.go
@@ -1,0 +1,103 @@
+package tables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/authzed-go/v1"
+
+	"github.com/authzed/spicedb/internal/fdw/common"
+)
+
+// DeleteStatement represents a parsed DELETE query for SpiceDB tables.
+// It handles deleting relationships from SpiceDB.
+type DeleteStatement struct {
+	isUnsupported    bool
+	tableDef         tableDefinition
+	tableName        string
+	returningColumns []wire.Column
+	fields           map[string]valueOrRef
+}
+
+func (ds *DeleteStatement) ReturningColumns() []wire.Column {
+	return ds.returningColumns
+}
+
+func (ds *DeleteStatement) ExecuteDelete(ctx context.Context, client *authzed.Client, writer wire.DataWriter, parameters []wire.Parameter) error {
+	tableDef := tables[ds.tableName]
+	if tableDef.deleteRunner == nil {
+		return common.NewUnsupportedError(fmt.Errorf("table %s does not support DELETE", ds.tableName))
+	}
+
+	countDeleted, returningValues, err := tableDef.deleteRunner(ctx, client, ds, parameters)
+	if err != nil {
+		return err
+	}
+
+	if len(returningValues) > 0 {
+		if err := writer.Row(returningValues); err != nil {
+			return common.NewQueryError(fmt.Errorf("failed to write returning row: %w", err))
+		}
+	}
+
+	return writer.Complete(fmt.Sprintf("DELETE %d", countDeleted))
+}
+
+// ParseDeleteStatement parses a Postgres DELETE statement into a DeleteStatement.
+// Returns an error if the query is not supported or malformed.
+func ParseDeleteStatement(ctx context.Context, query *pg_query.DeleteStmt) (*DeleteStatement, error) {
+	if query == nil {
+		return nil, common.NewUnsupportedError(errors.New("query must be an DELETE statement"))
+	}
+
+	tableName := query.GetRelation().GetRelname()
+	tableDef, ok := tables[tableName]
+	if !ok {
+		return nil, common.NewUnsupportedError(fmt.Errorf("table %s does not exist", tableName))
+	}
+	if tableDef.deleteRunner == nil {
+		return nil, common.NewUnsupportedError(fmt.Errorf("table %s does not support DELETE", tableName))
+	}
+
+	if len(query.UsingClause) > 0 {
+		return nil, common.NewUnsupportedError(errors.New("DELETE statements with USING are not supported"))
+	}
+
+	if query.WithClause != nil {
+		return nil, common.NewUnsupportedError(errors.New("DELETE statements with WITH are not supported"))
+	}
+
+	returningColumns, err := returningColumnsFromQuery(tableDef, query)
+	if err != nil {
+		return nil, err
+	}
+
+	pm := NewPatternMatcher()
+	fields, err := pm.MatchWhereClause(query.GetWhereClause())
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure all fields match the table definition.
+	for fieldName := range fields {
+		if !tableDef.hasColumn(fieldName) {
+			return &DeleteStatement{
+				isUnsupported: true,
+				tableName:     tableName,
+				tableDef:      tableDef,
+			}, common.NewUnsupportedError(fmt.Errorf("field %s does not exist in table %s", fieldName, tableName))
+		}
+	}
+
+	return &DeleteStatement{
+		isUnsupported:    false,
+		tableName:        tableName,
+		tableDef:         tableDef,
+		returningColumns: returningColumns,
+		fields:           fields,
+	}, nil
+}

--- a/internal/fdw/tables/delete_test.go
+++ b/internal/fdw/tables/delete_test.go
@@ -1,0 +1,164 @@
+package tables
+
+import (
+	"context"
+	"testing"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDeleteStatement(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                string
+		query               string
+		expectedError       string
+		expectedFields      map[string]valueOrRef
+		expectedUnsupported bool
+	}{
+		{
+			name:          "not a delete",
+			query:         "SELECT * FROM relationships",
+			expectedError: "query must be an DELETE statement",
+		},
+		{
+			name:          "unsupported table",
+			query:         "DELETE FROM foo WHERE bar = 'baz'",
+			expectedError: "table foo does not exist",
+		},
+		{
+			name:          "table without delete support",
+			query:         "DELETE FROM permissions WHERE resource_type = 'document'",
+			expectedError: "table permissions does not support DELETE",
+		},
+		{
+			name:          "delete with USING clause",
+			query:         "DELETE FROM relationships USING other_table WHERE relationships.resource_type = other_table.type",
+			expectedError: "DELETE statements with USING are not supported",
+		},
+		{
+			name:          "delete with WITH clause",
+			query:         "WITH temp AS (SELECT * FROM foo) DELETE FROM relationships WHERE resource_type = 'document'",
+			expectedError: "DELETE statements with WITH are not supported",
+		},
+		{
+			name:  "basic delete with where clause",
+			query: "DELETE FROM relationships WHERE resource_type = 'document'",
+			expectedFields: map[string]valueOrRef{
+				"resource_type": {value: "document"},
+			},
+		},
+		{
+			name:  "delete with multiple conditions",
+			query: "DELETE FROM relationships WHERE resource_type = 'document' AND resource_id = 'doc1' AND relation = 'viewer'",
+			expectedFields: map[string]valueOrRef{
+				"resource_type": {value: "document"},
+				"resource_id":   {value: "doc1"},
+				"relation":      {value: "viewer"},
+			},
+		},
+		{
+			name:  "delete with all relationship fields",
+			query: "DELETE FROM relationships WHERE resource_type = 'document' AND resource_id = 'doc1' AND relation = 'viewer' AND subject_type = 'user' AND subject_id = 'alice'",
+			expectedFields: map[string]valueOrRef{
+				"resource_type": {value: "document"},
+				"resource_id":   {value: "doc1"},
+				"relation":      {value: "viewer"},
+				"subject_type":  {value: "user"},
+				"subject_id":    {value: "alice"},
+			},
+		},
+		{
+			name:  "delete with parameters",
+			query: "DELETE FROM relationships WHERE resource_type = $1 AND resource_id = $2",
+			expectedFields: map[string]valueOrRef{
+				"resource_type": {parameterIndex: 1},
+				"resource_id":   {parameterIndex: 2},
+			},
+		},
+		{
+			name:           "delete without where clause",
+			query:          "DELETE FROM relationships",
+			expectedFields: map[string]valueOrRef{},
+		},
+		{
+			name:                "delete with invalid field",
+			query:               "DELETE FROM relationships WHERE invalid_field = 'value'",
+			expectedError:       "field invalid_field does not exist",
+			expectedUnsupported: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := pg_query.Parse(tc.query)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			stmt, err := ParseDeleteStatement(ctx, parsed.Stmts[0].Stmt.GetDeleteStmt())
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+
+				if tc.expectedUnsupported {
+					require.NotNil(t, stmt)
+					require.True(t, stmt.isUnsupported)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, stmt)
+			require.False(t, stmt.isUnsupported)
+			require.Equal(t, tc.expectedFields, stmt.fields)
+		})
+	}
+}
+
+func TestDeleteStatementReturningColumns(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                  string
+		query                 string
+		expectedReturningCols int
+	}{
+		{
+			name:                  "delete without returning",
+			query:                 "DELETE FROM relationships WHERE resource_type = 'document'",
+			expectedReturningCols: 0,
+		},
+		{
+			name:                  "delete with returning",
+			query:                 "DELETE FROM relationships WHERE resource_type = 'document' RETURNING consistency",
+			expectedReturningCols: 1,
+		},
+		{
+			name:                  "delete with returning multiple columns",
+			query:                 "DELETE FROM relationships WHERE resource_type = 'document' RETURNING resource_type, resource_id",
+			expectedReturningCols: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := pg_query.Parse(tc.query)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			stmt, err := ParseDeleteStatement(ctx, parsed.Stmts[0].Stmt.GetDeleteStmt())
+			require.NoError(t, err)
+			require.NotNil(t, stmt)
+
+			cols := stmt.ReturningColumns()
+			require.Len(t, cols, tc.expectedReturningCols)
+		})
+	}
+}

--- a/internal/fdw/tables/docs.go
+++ b/internal/fdw/tables/docs.go
@@ -1,0 +1,12 @@
+// Package tables implements SQL table handlers for SpiceDB entities.
+//
+// This package provides query handlers for virtual SQL tables that map to
+// SpiceDB concepts:
+//   - permissions: Check permissions and lookup resources/subjects
+//   - relationships: Read, write, and delete relationships
+//   - schema: Read SpiceDB schema definitions
+//
+// Each table handler is responsible for parsing SELECT/INSERT/DELETE statements,
+// converting them to appropriate SpiceDB API calls, and formatting results in
+// Postgres wire protocol format.
+package tables

--- a/internal/fdw/tables/insert.go
+++ b/internal/fdw/tables/insert.go
@@ -1,0 +1,116 @@
+package tables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/authzed-go/v1"
+
+	"github.com/authzed/spicedb/internal/fdw/common"
+)
+
+// InsertStatement represents a parsed INSERT query for SpiceDB tables.
+// It handles inserting relationships into SpiceDB.
+type InsertStatement struct {
+	tableName        string
+	colNames         []string
+	metadata         map[string]any
+	returningColumns []wire.Column
+}
+
+func (is *InsertStatement) ReturningColumns() []wire.Column {
+	return is.returningColumns
+}
+
+func (is *InsertStatement) ExecuteInsert(ctx context.Context, client *authzed.Client, writer wire.DataWriter, parameters []wire.Parameter) error {
+	tableDef := tables[is.tableName]
+	if tableDef.insertRunner == nil {
+		return common.NewUnsupportedError(fmt.Errorf("table %s does not support INSERT", is.tableName))
+	}
+
+	countInserted, returningValues, err := tableDef.insertRunner(ctx, client, is, parameters)
+	if err != nil {
+		return err
+	}
+
+	if len(returningValues) > 0 {
+		if err := writer.Row(returningValues); err != nil {
+			return common.NewQueryError(fmt.Errorf("failed to write returning row: %w", err))
+		}
+	}
+
+	return writer.Complete(fmt.Sprintf("INSERT 0 %d", countInserted))
+}
+
+// ParseInsertStatement parses a Postgres INSERT statement into an InsertStatement.
+// Returns an error if the query is not supported or malformed.
+func ParseInsertStatement(ctx context.Context, query *pg_query.InsertStmt) (*InsertStatement, error) {
+	if query == nil {
+		return nil, common.NewUnsupportedError(errors.New("query must be an INSERT statement"))
+	}
+
+	tableName := query.GetRelation().GetRelname()
+	tableDef, ok := tables[tableName]
+	if !ok {
+		return nil, common.NewUnsupportedError(fmt.Errorf("table %s does not exist", tableName))
+	}
+	if tableDef.insertRunner == nil {
+		return nil, common.NewUnsupportedError(fmt.Errorf("table %s does not support INSERT", tableName))
+	}
+
+	columns := query.GetCols()
+	if len(columns) < len(tableDef.requiredInsertColumns) {
+		return nil, common.NewQueryError(fmt.Errorf("expected at least %d columns for insert into relationships", len(tableDef.requiredInsertColumns)))
+	}
+
+	// Collect the column names, in order.
+	colNames := make([]string, 0, len(columns))
+	for colIndex, col := range columns {
+		if col.GetResTarget() == nil {
+			return nil, common.NewQueryError(fmt.Errorf("column %d is missing a name", colIndex))
+		}
+		colName := col.GetResTarget().Name
+		colNames = append(colNames, colName)
+
+		if !tableDef.hasColumn(colName) {
+			return nil, common.NewQueryError(fmt.Errorf("column %s does not exist on table %s", colName, tableName))
+		}
+	}
+
+	// Ensure all required columns were specified.
+	for _, requiredCol := range tableDef.requiredInsertColumns {
+		if !slices.Contains(colNames, requiredCol) {
+			return nil, common.NewQueryError(fmt.Errorf("missing required column %s for insert into relationships", requiredCol))
+		}
+	}
+
+	var metadata map[string]any
+	if tableDef.insertValidator != nil {
+		md, err := tableDef.insertValidator(ctx, query, colNames)
+		if err != nil {
+			return nil, err
+		}
+		metadata = md
+	}
+
+	if query.Override != pg_query.OverridingKind_OVERRIDING_NOT_SET {
+		return nil, common.NewUnsupportedError(errors.New("INSERT ... OVERRIDING is not supported"))
+	}
+
+	returningColumns, err := returningColumnsFromQuery(tableDef, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return &InsertStatement{
+		tableName:        tableName,
+		colNames:         colNames,
+		metadata:         metadata,
+		returningColumns: returningColumns,
+	}, nil
+}

--- a/internal/fdw/tables/insert_test.go
+++ b/internal/fdw/tables/insert_test.go
@@ -1,0 +1,161 @@
+package tables
+
+import (
+	"context"
+	"testing"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseInsertStatement(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		query         string
+		expectedError string
+		expectedCols  []string
+	}{
+		{
+			name:          "not an insert",
+			query:         "SELECT * FROM relationships",
+			expectedError: "query must be an INSERT statement",
+		},
+		{
+			name:          "unsupported table",
+			query:         "INSERT INTO foo (bar) VALUES (1)",
+			expectedError: "table foo does not exist",
+		},
+		{
+			name:          "table without insert support",
+			query:         "INSERT INTO permissions (resource_type) VALUES ('document')",
+			expectedError: "table permissions does not support INSERT",
+		},
+		{
+			name:          "missing required columns",
+			query:         "INSERT INTO relationships (resource_type) VALUES ('document')",
+			expectedError: "expected at least",
+		},
+		{
+			name:          "too few columns",
+			query:         "INSERT INTO relationships (resource_type, resource_id) VALUES ('document', 'doc1')",
+			expectedError: "expected at least",
+		},
+		{
+			name:          "invalid column name",
+			query:         "INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id, invalid_col) VALUES ('document', 'doc1', 'viewer', 'user', 'alice', 'value')",
+			expectedError: "column invalid_col does not exist",
+		},
+		{
+			name:  "basic insert with required columns",
+			query: "INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation) VALUES ('document', 'doc1', 'viewer', 'user', 'alice', '')",
+			expectedCols: []string{
+				"resource_type",
+				"resource_id",
+				"relation",
+				"subject_type",
+				"subject_id",
+				"optional_subject_relation",
+			},
+		},
+		{
+			name:  "insert with all columns",
+			query: "INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation, caveat_name, caveat_context) VALUES ('document', 'doc1', 'viewer', 'user', 'alice', '', '', '')",
+			expectedCols: []string{
+				"resource_type",
+				"resource_id",
+				"relation",
+				"subject_type",
+				"subject_id",
+				"optional_subject_relation",
+				"caveat_name",
+				"caveat_context",
+			},
+		},
+		{
+			name:  "insert with parameters",
+			query: "INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation) VALUES ($1, $2, $3, $4, $5, $6)",
+			expectedCols: []string{
+				"resource_type",
+				"resource_id",
+				"relation",
+				"subject_type",
+				"subject_id",
+				"optional_subject_relation",
+			},
+		},
+		{
+			name:  "insert into schema table",
+			query: "INSERT INTO schema (schema_text) VALUES ('definition user {}')",
+			expectedCols: []string{
+				"schema_text",
+			},
+		},
+		{
+			name:          "insert with OVERRIDING",
+			query:         "INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation) OVERRIDING SYSTEM VALUE VALUES ('document', 'doc1', 'viewer', 'user', 'alice', '')",
+			expectedError: "INSERT ... OVERRIDING is not supported",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := pg_query.Parse(tc.query)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			stmt, err := ParseInsertStatement(ctx, parsed.Stmts[0].Stmt.GetInsertStmt())
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, stmt)
+			require.Equal(t, tc.expectedCols, stmt.colNames)
+		})
+	}
+}
+
+func TestInsertStatementReturningColumns(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                  string
+		query                 string
+		expectedReturningCols int
+	}{
+		{
+			name:                  "insert without returning",
+			query:                 "INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation) VALUES ('document', 'doc1', 'viewer', 'user', 'alice', '')",
+			expectedReturningCols: 0,
+		},
+		{
+			name:                  "insert with returning",
+			query:                 "INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation) VALUES ('document', 'doc1', 'viewer', 'user', 'alice', '') RETURNING consistency",
+			expectedReturningCols: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := pg_query.Parse(tc.query)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			stmt, err := ParseInsertStatement(ctx, parsed.Stmts[0].Stmt.GetInsertStmt())
+			require.NoError(t, err)
+			require.NotNil(t, stmt)
+
+			cols := stmt.ReturningColumns()
+			require.Len(t, cols, tc.expectedReturningCols)
+		})
+	}
+}

--- a/internal/fdw/tables/matcher.go
+++ b/internal/fdw/tables/matcher.go
@@ -1,0 +1,422 @@
+package tables
+
+// Pattern Matching System for pg_query AST Nodes
+//
+// This package provides a declarative pattern matching system for parsing and validating
+// SQL queries represented as pg_query.Node AST structures. It replaces imperative nested
+// if/switch statements with composable patterns.
+//
+// # Overview
+//
+// The pattern matching system provides two main APIs:
+//
+// 1. PatternMatcher - High-level API for common SQL parsing tasks
+// 2. Pattern interface - Low-level composable patterns for custom matching
+//
+// # Using PatternMatcher (Recommended)
+//
+// For most SQL parsing needs, use the PatternMatcher high-level API:
+//
+//	pm := NewPatternMatcher()
+//
+//	// Match a WHERE clause and extract all field conditions
+//	fields, err := pm.MatchWhereClause(whereNode)
+//	// Returns: map[string]valueOrRef{
+//	//     "resource_type": {value: "document"},
+//	//     "resource_id": {parameterIndex: 1},
+//	// }
+//
+//	// Match a single value or reference expression
+//	valOrRef, err := pm.MatchValueOrRef(exprNode)
+//	// Returns: valueOrRef{value: "document"} or
+//	//          valueOrRef{parameterIndex: 1} or
+//	//          valueOrRef{fieldName: "column_name"} or
+//	//          valueOrRef{isSubQueryPlaceholder: true}
+//
+// # Available Patterns
+//
+// The system includes these built-in pattern types:
+//
+// - equalityPattern: Matches "column = value" or "value = column" expressions
+// - columnRefPattern: Matches column references and captures column names
+// - literalPattern: Matches string literal constants
+// - paramRefPattern: Matches parameter references like $1, $2
+// - subQueryPlaceholderPattern: Matches ((SELECT null::text)::text) placeholders
+//
+// # Pattern Results
+//
+// Patterns return a MatchResult containing extracted values:
+//
+//	type MatchResult struct {
+//	    Values map[string]any // Maps capture names to extracted values
+//	}
+
+import (
+	"errors"
+	"fmt"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+// Pattern represents a declarative pattern for matching pg_query nodes.
+// It defines what structure we expect and how to extract values from it.
+type Pattern interface {
+	// Match attempts to match the node against this pattern.
+	// Returns the extracted values and whether the match succeeded.
+	Match(node *pg_query.Node) (MatchResult, bool)
+}
+
+// MatchResult contains values extracted from a successful pattern match.
+type MatchResult struct {
+	// Values maps capture names to their extracted values
+	Values map[string]any
+}
+
+// columnRefPattern matches a column reference and captures its name
+type columnRefPattern struct {
+	CaptureName string // Name to capture the column name as
+}
+
+func (c columnRefPattern) Match(node *pg_query.Node) (MatchResult, bool) {
+	colRef := node.GetColumnRef()
+	if colRef == nil {
+		return MatchResult{}, false
+	}
+
+	if len(colRef.Fields) != 1 {
+		return MatchResult{}, false
+	}
+
+	str := colRef.Fields[0].GetString_()
+	if str == nil {
+		return MatchResult{}, false
+	}
+
+	result := MatchResult{Values: make(map[string]any)}
+	if c.CaptureName != "" {
+		result.Values[c.CaptureName] = str.Sval
+	}
+
+	return result, true
+}
+
+// literalPattern matches a literal constant value
+type literalPattern struct {
+	CaptureName string // Name to capture the literal value as
+}
+
+func (l literalPattern) Match(node *pg_query.Node) (MatchResult, bool) {
+	aConst := node.GetAConst()
+	if aConst == nil {
+		return MatchResult{}, false
+	}
+
+	result := MatchResult{Values: make(map[string]any)}
+	if l.CaptureName != "" {
+		result.Values[l.CaptureName] = aConst.GetSval().Sval
+	}
+
+	return result, true
+}
+
+// paramRefPattern matches a parameter reference like $1, $2, etc.
+type paramRefPattern struct {
+	CaptureName string // Name to capture the parameter index as
+}
+
+func (p paramRefPattern) Match(node *pg_query.Node) (MatchResult, bool) {
+	paramRef := node.GetParamRef()
+	if paramRef == nil {
+		return MatchResult{}, false
+	}
+
+	result := MatchResult{Values: make(map[string]any)}
+	if p.CaptureName != "" {
+		result.Values[p.CaptureName] = paramRef.Number
+	}
+
+	return result, true
+}
+
+// Example usage patterns:
+
+// equalityPattern matches "column = value" or "value = column" or "column = $1"
+type equalityPattern struct{}
+
+func (e equalityPattern) Match(node *pg_query.Node) (MatchResult, bool) {
+	aExpr := node.GetAExpr()
+	if aExpr == nil {
+		return MatchResult{}, false
+	}
+
+	// Check for = operator
+	if len(aExpr.Name) != 1 || aExpr.Name[0].GetString_().Sval != "=" {
+		return MatchResult{}, false
+	}
+
+	pm := NewPatternMatcher()
+	leftRef, leftErr := pm.MatchValueOrRef(aExpr.Lexpr)
+	if leftErr != nil {
+		return MatchResult{}, false
+	}
+
+	rightRef, rightErr := pm.MatchValueOrRef(aExpr.Rexpr)
+	if rightErr != nil {
+		return MatchResult{}, false
+	}
+
+	// Determine which is the column and which is the value
+	var fieldName string
+	var fieldValue valueOrRef
+
+	if leftRef.fieldName != "" && rightRef.fieldName != "" {
+		return MatchResult{}, false // Both sides are columns
+	}
+
+	switch {
+	case leftRef.fieldName != "":
+		fieldName = leftRef.fieldName
+		fieldValue = rightRef
+	case rightRef.fieldName != "":
+		fieldName = rightRef.fieldName
+		fieldValue = leftRef
+	default:
+		return MatchResult{}, false // Neither side is a column
+	}
+
+	return MatchResult{
+		Values: map[string]any{
+			"field_name":  fieldName,
+			"field_value": fieldValue,
+		},
+	}, true
+}
+
+// subQueryPlaceholderPattern matches ((SELECT null::text)::text)
+type subQueryPlaceholderPattern struct{}
+
+func (s subQueryPlaceholderPattern) Match(node *pg_query.Node) (MatchResult, bool) {
+	typeCast := node.GetTypeCast()
+	if typeCast == nil {
+		return MatchResult{}, false
+	}
+
+	// Check outer type cast is text
+	if typeCast.GetTypeName() == nil {
+		return MatchResult{}, false
+	}
+
+	if len(typeCast.GetTypeName().GetNames()) != 1 {
+		return MatchResult{}, false
+	}
+
+	if typeCast.GetTypeName().GetNames()[0].GetString_() == nil {
+		return MatchResult{}, false
+	}
+
+	if typeCast.GetTypeName().GetNames()[0].GetString_().Sval != "text" {
+		return MatchResult{}, false
+	}
+
+	// Check for sublink
+	if typeCast.GetArg() == nil {
+		return MatchResult{}, false
+	}
+
+	sublink := typeCast.GetArg().GetSubLink()
+	if sublink == nil {
+		return MatchResult{}, false
+	}
+
+	if sublink.GetSubLinkType() != pg_query.SubLinkType_EXPR_SUBLINK {
+		return MatchResult{}, false
+	}
+
+	if sublink.GetSubselect() == nil || sublink.GetSubselect().GetSelectStmt() == nil {
+		return MatchResult{}, false
+	}
+
+	targetList := sublink.GetSubselect().GetSelectStmt().GetTargetList()
+	if len(targetList) != 1 {
+		return MatchResult{}, false
+	}
+
+	targetListTypeCast := targetList[0].GetResTarget().GetVal().GetTypeCast()
+	if targetListTypeCast == nil {
+		return MatchResult{}, false
+	}
+
+	// Check inner type cast
+	if targetListTypeCast.GetTypeName() == nil {
+		return MatchResult{}, false
+	}
+
+	if len(targetListTypeCast.GetTypeName().GetNames()) != 1 {
+		return MatchResult{}, false
+	}
+
+	if targetListTypeCast.GetTypeName().GetNames()[0].GetString_() == nil {
+		return MatchResult{}, false
+	}
+
+	if targetListTypeCast.GetTypeName().GetNames()[0].GetString_().Sval != "text" {
+		return MatchResult{}, false
+	}
+
+	// Check for null constant
+	if targetListTypeCast.GetArg() == nil || targetListTypeCast.GetArg().GetAConst() == nil {
+		return MatchResult{}, false
+	}
+
+	if !targetListTypeCast.GetArg().GetAConst().Isnull {
+		return MatchResult{}, false
+	}
+
+	return MatchResult{
+		Values: map[string]any{
+			"is_placeholder": true,
+		},
+	}, true
+}
+
+// PatternMatcher is a high-level API for common SQL pattern matching
+type PatternMatcher struct{}
+
+// NewPatternMatcher creates a new pattern matcher
+func NewPatternMatcher() *PatternMatcher {
+	return &PatternMatcher{}
+}
+
+// MatchWhereClause matches a WHERE clause and extracts field conditions
+func (pm *PatternMatcher) MatchWhereClause(node *pg_query.Node) (map[string]valueOrRef, error) {
+	if node == nil {
+		return make(map[string]valueOrRef), nil
+	}
+
+	fields := make(map[string]valueOrRef)
+
+	// Try to match as AND expression
+	if boolExpr := node.GetBoolExpr(); boolExpr != nil {
+		if boolExpr.Boolop != pg_query.BoolExprType_AND_EXPR {
+			return nil, errors.New("only AND supported")
+		}
+
+		for _, arg := range boolExpr.Args {
+			if err := pm.matchSingleCondition(arg, fields); err != nil {
+				return nil, err
+			}
+		}
+
+		return fields, nil
+	}
+
+	// Try to match as single condition
+	if err := pm.matchSingleCondition(node, fields); err != nil {
+		return nil, err
+	}
+
+	return fields, nil
+}
+
+// matchSingleCondition matches a single WHERE condition (e.g., "column = value")
+func (pm *PatternMatcher) matchSingleCondition(node *pg_query.Node, fields map[string]valueOrRef) error {
+	// Check if this is an AExpr (binary operation)
+	aExpr := node.GetAExpr()
+	if aExpr != nil {
+		// Check operator
+		if len(aExpr.Name) != 1 || aExpr.Name[0].GetString_().Sval != "=" {
+			return errors.New("only = supported")
+		}
+
+		// Try to parse both sides
+		leftRef, leftErr := pm.MatchValueOrRef(aExpr.Lexpr)
+		rightRef, rightErr := pm.MatchValueOrRef(aExpr.Rexpr)
+
+		// If either side failed to parse, return that error
+		if leftErr != nil {
+			return leftErr
+		}
+		if rightErr != nil {
+			return rightErr
+		}
+
+		// Check for both sides being columns
+		if leftRef.fieldName != "" && rightRef.fieldName != "" {
+			return errors.New("only one side of the expression can be a column")
+		}
+
+		// Check for neither side being a column
+		if leftRef.fieldName == "" && rightRef.fieldName == "" {
+			return errors.New("missing column name")
+		}
+	}
+
+	// Try equality pattern
+	eqPattern := equalityPattern{}
+	if result, ok := eqPattern.Match(node); ok {
+		fieldName, ok := result.Values["field_name"].(string)
+		if !ok {
+			return errors.New("equality pattern did not capture field_name as string")
+		}
+		fieldValue, ok := result.Values["field_value"].(valueOrRef)
+		if !ok {
+			return errors.New("equality pattern did not capture field_value as valueOrRef")
+		}
+
+		if _, exists := fields[fieldName]; exists {
+			return fmt.Errorf("field %s already set", fieldName)
+		}
+
+		fields[fieldName] = fieldValue
+		return nil
+	}
+
+	return fmt.Errorf("operation not supported: %v", node)
+}
+
+// MatchValueOrRef matches a value or reference expression
+func (pm *PatternMatcher) MatchValueOrRef(node *pg_query.Node) (valueOrRef, error) {
+	// Try literal
+	litPattern := literalPattern{CaptureName: "value"}
+	if result, ok := litPattern.Match(node); ok {
+		value, ok := result.Values["value"].(string)
+		if !ok {
+			return valueOrRef{}, errors.New("literal pattern did not capture string value")
+		}
+		return valueOrRef{value: value}, nil
+	}
+
+	// Try parameter
+	paramPattern := paramRefPattern{CaptureName: "param"}
+	if result, ok := paramPattern.Match(node); ok {
+		paramIndex, ok := result.Values["param"].(int32)
+		if !ok {
+			return valueOrRef{}, errors.New("parameter pattern did not capture int32 value")
+		}
+		return valueOrRef{parameterIndex: paramIndex}, nil
+	}
+
+	// Try column reference
+	colPattern := columnRefPattern{CaptureName: "column"}
+	if result, ok := colPattern.Match(node); ok {
+		fieldName, ok := result.Values["column"].(string)
+		if !ok {
+			return valueOrRef{}, errors.New("column pattern did not capture string value")
+		}
+		return valueOrRef{fieldName: fieldName}, nil
+	}
+
+	// Try subquery placeholder
+	subqPattern := subQueryPlaceholderPattern{}
+	if result, ok := subqPattern.Match(node); ok {
+		isPlaceholder, ok := result.Values["is_placeholder"].(bool)
+		if !ok {
+			return valueOrRef{}, errors.New("subquery placeholder pattern did not capture bool value")
+		}
+		if isPlaceholder {
+			return valueOrRef{isSubQueryPlaceholder: true}, nil
+		}
+	}
+
+	return valueOrRef{}, errors.New("unsupported expression type")
+}

--- a/internal/fdw/tables/matcher_test.go
+++ b/internal/fdw/tables/matcher_test.go
@@ -1,0 +1,282 @@
+package tables
+
+import (
+	"testing"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPatternMatcher(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		query          string
+		expectedFields map[string]valueOrRef
+		expectedError  string
+	}{
+		{
+			name:  "simple equality",
+			query: "SELECT * FROM relationships WHERE resource_type = 'document'",
+			expectedFields: map[string]valueOrRef{
+				"resource_type": {value: "document"},
+			},
+		},
+		{
+			name:  "multiple conditions with AND",
+			query: "SELECT * FROM relationships WHERE resource_type = 'document' AND resource_id = 'doc1'",
+			expectedFields: map[string]valueOrRef{
+				"resource_type": {value: "document"},
+				"resource_id":   {value: "doc1"},
+			},
+		},
+		{
+			name:  "parameter reference",
+			query: "SELECT * FROM relationships WHERE resource_type = $1",
+			expectedFields: map[string]valueOrRef{
+				"resource_type": {parameterIndex: 1},
+			},
+		},
+		{
+			name:  "inverted equality",
+			query: "SELECT * FROM relationships WHERE $1 = resource_type",
+			expectedFields: map[string]valueOrRef{
+				"resource_type": {parameterIndex: 1},
+			},
+		},
+		{
+			name:          "unsupported OR",
+			query:         "SELECT * FROM relationships WHERE resource_type = 'document' OR resource_id = 'doc1'",
+			expectedError: "only AND supported",
+		},
+		{
+			name:          "unsupported LIKE",
+			query:         "SELECT * FROM relationships WHERE resource_type LIKE 'doc%'",
+			expectedError: "only = supported",
+		},
+		{
+			name:           "empty WHERE",
+			query:          "SELECT * FROM relationships",
+			expectedFields: map[string]valueOrRef{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := pg_query.Parse(tc.query)
+			require.NoError(t, err)
+
+			selectStmt := parsed.Stmts[0].Stmt.GetSelectStmt()
+			require.NotNil(t, selectStmt)
+
+			pm := NewPatternMatcher()
+			fields, err := pm.MatchWhereClause(selectStmt.GetWhereClause())
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedFields, fields)
+		})
+	}
+}
+
+func TestEqualityPattern(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name               string
+		query              string
+		expectedFieldName  string
+		expectedFieldValue valueOrRef
+		shouldMatch        bool
+	}{
+		{
+			name:               "column = literal",
+			query:              "SELECT * FROM relationships WHERE resource_type = 'document'",
+			expectedFieldName:  "resource_type",
+			expectedFieldValue: valueOrRef{value: "document"},
+			shouldMatch:        true,
+		},
+		{
+			name:               "literal = column",
+			query:              "SELECT * FROM relationships WHERE 'document' = resource_type",
+			expectedFieldName:  "resource_type",
+			expectedFieldValue: valueOrRef{value: "document"},
+			shouldMatch:        true,
+		},
+		{
+			name:               "column = parameter",
+			query:              "SELECT * FROM relationships WHERE resource_type = $1",
+			expectedFieldName:  "resource_type",
+			expectedFieldValue: valueOrRef{parameterIndex: 1},
+			shouldMatch:        true,
+		},
+		{
+			name:        "column != literal (not equals)",
+			query:       "SELECT * FROM relationships WHERE resource_type != 'document'",
+			shouldMatch: false,
+		},
+		{
+			name:        "column LIKE pattern",
+			query:       "SELECT * FROM relationships WHERE resource_type LIKE 'doc%'",
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := pg_query.Parse(tc.query)
+			require.NoError(t, err)
+
+			selectStmt := parsed.Stmts[0].Stmt.GetSelectStmt()
+			require.NotNil(t, selectStmt)
+
+			whereClause := selectStmt.GetWhereClause()
+			require.NotNil(t, whereClause)
+
+			pattern := equalityPattern{}
+			result, ok := pattern.Match(whereClause)
+
+			if !tc.shouldMatch {
+				require.False(t, ok)
+				return
+			}
+
+			require.True(t, ok)
+			require.Equal(t, tc.expectedFieldName, result.Values["field_name"])
+			require.Equal(t, tc.expectedFieldValue, result.Values["field_value"])
+		})
+	}
+}
+
+func TestSubQueryPlaceholderPattern(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		query       string
+		shouldMatch bool
+	}{
+		{
+			name:        "subquery placeholder",
+			query:       "SELECT * FROM relationships WHERE ((SELECT null::text)::text) = resource_id",
+			shouldMatch: true,
+		},
+		{
+			name:        "regular literal",
+			query:       "SELECT * FROM relationships WHERE resource_id = 'doc1'",
+			shouldMatch: false,
+		},
+		{
+			name:        "parameter",
+			query:       "SELECT * FROM relationships WHERE resource_id = $1",
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := pg_query.Parse(tc.query)
+			require.NoError(t, err)
+
+			selectStmt := parsed.Stmts[0].Stmt.GetSelectStmt()
+			require.NotNil(t, selectStmt)
+
+			whereClause := selectStmt.GetWhereClause()
+			require.NotNil(t, whereClause)
+
+			// Get the left expression of the equality
+			aExpr := whereClause.GetAExpr()
+			require.NotNil(t, aExpr)
+
+			pattern := subQueryPlaceholderPattern{}
+			result, ok := pattern.Match(aExpr.Lexpr)
+
+			require.Equal(t, tc.shouldMatch, ok)
+			if ok {
+				require.True(t, result.Values["is_placeholder"].(bool))
+			}
+		})
+	}
+}
+
+func TestColumnRefPattern(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		query           string
+		captureName     string
+		expectedCapture string
+		shouldMatch     bool
+	}{
+		{
+			name:            "simple column reference",
+			query:           "SELECT * FROM relationships WHERE resource_type = 'document'",
+			captureName:     "col",
+			expectedCapture: "resource_type",
+			shouldMatch:     true,
+		},
+		{
+			name:        "not a column reference",
+			query:       "SELECT * FROM relationships WHERE 'literal' = 'value'",
+			captureName: "col",
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := pg_query.Parse(tc.query)
+			require.NoError(t, err)
+
+			selectStmt := parsed.Stmts[0].Stmt.GetSelectStmt()
+			require.NotNil(t, selectStmt)
+
+			whereClause := selectStmt.GetWhereClause()
+			require.NotNil(t, whereClause)
+
+			aExpr := whereClause.GetAExpr()
+			require.NotNil(t, aExpr)
+
+			pattern := columnRefPattern{CaptureName: tc.captureName}
+			result, ok := pattern.Match(aExpr.Lexpr)
+
+			require.Equal(t, tc.shouldMatch, ok)
+			if ok && tc.captureName != "" {
+				require.Equal(t, tc.expectedCapture, result.Values[tc.captureName])
+			}
+		})
+	}
+}
+
+// BenchmarkPatternMatcher compares the performance of pattern matching vs old approach
+func BenchmarkPatternMatcher(b *testing.B) {
+	query := "SELECT * FROM relationships WHERE resource_type = 'document' AND resource_id = 'doc1' AND relation = 'viewer'"
+	parsed, err := pg_query.Parse(query)
+	require.NoError(b, err)
+
+	selectStmt := parsed.Stmts[0].Stmt.GetSelectStmt()
+	require.NotNil(b, selectStmt)
+
+	whereClause := selectStmt.GetWhereClause()
+
+	pm := NewPatternMatcher()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = pm.MatchWhereClause(whereClause)
+	}
+}

--- a/internal/fdw/tables/permissions.go
+++ b/internal/fdw/tables/permissions.go
@@ -1,0 +1,479 @@
+package tables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/lib/pq/oid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/authzed-go/v1"
+
+	"github.com/authzed/spicedb/internal/fdw/common"
+	"github.com/authzed/spicedb/internal/fdw/stats"
+	log "github.com/authzed/spicedb/internal/logging"
+)
+
+// permissionsField represents a field name in the permissions table
+type permissionsField string
+
+const (
+	permissionsResourceTypeField            permissionsField = "resource_type"
+	permissionsResourceIDField              permissionsField = "resource_id"
+	permissionsPermissionField              permissionsField = "permission"
+	permissionsSubjectTypeField             permissionsField = "subject_type"
+	permissionsSubjectIDField               permissionsField = "subject_id"
+	permissionsOptionalSubjectRelationField permissionsField = "optional_subject_relation"
+	permissionsHasPermissionField           permissionsField = "has_permission"
+)
+
+var permissionsSchema = wire.Columns{
+	{
+		Table: 0,
+		Name:  string(permissionsResourceTypeField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(permissionsResourceIDField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(permissionsPermissionField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(permissionsSubjectTypeField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(permissionsSubjectIDField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(permissionsOptionalSubjectRelationField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(permissionsHasPermissionField),
+		Oid:   uint32(oid.T_bool),
+		Width: 256,
+	},
+	consistencyField,
+}
+
+var (
+	lrStats    = stats.NewPackage("permissions", "LookupResources")
+	checkStats = stats.NewPackage("permissions", "CheckPermission")
+	lsStats    = stats.NewPackage("permissions", "LookupSubjects")
+)
+
+func statsAndHandlerForFields(fields fieldMap[permissionsField]) (*stats.Package, func(fieldMap[permissionsField]) (selectHandler, error), error) {
+	// If all fields are defined, this is a CheckPermission request.
+	if fields.hasFields(permissionsResourceTypeField, permissionsResourceIDField, permissionsPermissionField, permissionsSubjectTypeField, permissionsSubjectIDField) {
+		return checkStats, buildCheckPermissionHandler, nil
+	}
+
+	// If all fields except resource_id are defined, this is a LookupResources request.
+	if fields.hasFields(permissionsResourceTypeField, permissionsPermissionField, permissionsSubjectTypeField, permissionsSubjectIDField) {
+		return lrStats, buildLookupResourcesHandler, nil
+	}
+
+	// If all fields except subject_id are defined, this is a LookupSubjects request.
+	if fields.hasFields(permissionsResourceTypeField, permissionsResourceIDField, permissionsPermissionField, permissionsSubjectTypeField) {
+		return lsStats, buildLookupSubjectsHandler, nil
+	}
+
+	// Otherwise, this is unsupported.
+	return nil, nil, common.NewQueryError(errors.New("unsupported query for permissions table"))
+}
+
+func buildPermissionsSelectHandler(fields fieldMap[string]) (selectHandler, error) {
+	typedFields := fieldMap[permissionsField]{}
+	for k, v := range fields {
+		typedFields[permissionsField(k)] = v
+	}
+
+	if _, ok := typedFields[permissionsHasPermissionField]; ok {
+		return nil, common.NewQueryError(errors.New("cannot select has_permission value"))
+	}
+
+	_, builder, err := statsAndHandlerForFields(typedFields)
+	if err != nil {
+		return nil, err
+	}
+
+	return builder(typedFields)
+}
+
+func buildCheckPermissionHandler(fields fieldMap[permissionsField]) (selectHandler, error) {
+	return func(ctx context.Context, client *authzed.Client, parameters []wire.Parameter, howMany int64, writer wire.DataWriter, rowsCursor RowsCursor, selectStatement *SelectStatement) (RowsCursor, error) {
+		consistency, err := consistencyFromFields(convertFieldMap(fields), parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting consistency: %w", err)
+		}
+
+		resourceType, err := stringValue(fields[permissionsResourceTypeField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting resource_type: %w", err)
+		}
+
+		resourceID, err := stringValue(fields[permissionsResourceIDField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting resource_id: %w", err)
+		}
+
+		permission, err := stringValue(fields[permissionsPermissionField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting permission: %w", err)
+		}
+
+		subjectType, err := stringValue(fields[permissionsSubjectTypeField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting subject_type: %w", err)
+		}
+
+		subjectID, err := stringValue(fields[permissionsSubjectIDField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting subject_id: %w", err)
+		}
+
+		optionalSubjectRelation, err := optionalStringValue(fields[permissionsOptionalSubjectRelationField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting optional_subject_relation: %w", err)
+		}
+
+		var trailerMD metadata.MD
+
+		// TODO: caveat context
+		checkResult, err := client.CheckPermission(ctx, &v1.CheckPermissionRequest{
+			Resource: &v1.ObjectReference{
+				ObjectType: resourceType,
+				ObjectId:   resourceID,
+			},
+			Permission: permission,
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: subjectType,
+					ObjectId:   subjectID,
+				},
+				OptionalRelation: optionalSubjectRelation,
+			},
+			Consistency: consistency,
+		}, grpc.Trailer(&trailerMD))
+		if err != nil {
+			return nil, common.ConvertError(err)
+		}
+
+		cost, err := costFromTrailers(trailerMD)
+		if err != nil {
+			log.Error().Err(err).Msg("error reading cost from trailers")
+		} else {
+			checkStats.AddSample(cost, 1)
+		}
+
+		hasPermission := checkResult.Permissionship == v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION
+		isMaybe := checkResult.Permissionship == v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+
+		rowValues, width, buildErr := buildRowValues(
+			selectStatement,
+			resourceType,
+			resourceID,
+			permission,
+			subjectType,
+			subjectID,
+			optionalSubjectRelation,
+			hasPermission,
+			isMaybe,
+			checkResult.CheckedAt,
+		)
+		if buildErr != nil {
+			return nil, fmt.Errorf("error building row values: %w", buildErr)
+		}
+		checkStats.AddWidthSample(width)
+
+		if err := writer.Row(rowValues); err != nil {
+			return nil, fmt.Errorf("error writing check result row: %w", err)
+		}
+		return nil, writer.Complete("SELECT")
+	}, nil
+}
+
+func buildRowValues(
+	selectStatement *SelectStatement,
+	resourceType string,
+	resourceID string,
+	permission string,
+	subjectType string,
+	subjectID string,
+	optionalSubjectRelation string,
+	hasPermission bool,
+	isMaybe bool,
+	zedToken *v1.ZedToken,
+) ([]any, uint, error) {
+	rowValues := make([]any, 0, len(selectStatement.columnNames))
+	for _, colName := range selectStatement.columnNames {
+		switch colName {
+		case "resource_type":
+			rowValues = append(rowValues, resourceType)
+		case "resource_id":
+			rowValues = append(rowValues, resourceID)
+		case "permission":
+			rowValues = append(rowValues, permission)
+		case "subject_type":
+			rowValues = append(rowValues, subjectType)
+		case "subject_id":
+			rowValues = append(rowValues, subjectID)
+		case "optional_subject_relation":
+			rowValues = append(rowValues, optionalSubjectRelation)
+		case "has_permission":
+			if isMaybe {
+				rowValues = append(rowValues, nil)
+			} else {
+				rowValues = append(rowValues, hasPermission)
+			}
+		case "consistency":
+			rowValues = append(rowValues, zedToken.Token)
+		default:
+			return nil, 0, fmt.Errorf("unsupported column %q", colName)
+		}
+	}
+
+	var width uint = 1
+	for _, value := range rowValues {
+		if value == nil {
+			continue
+		}
+
+		strValue, ok := value.(string)
+		if ok {
+			width += uint(len(strValue))
+		}
+	}
+
+	return rowValues, width, nil
+}
+
+func buildLookupResourcesHandler(fields fieldMap[permissionsField]) (selectHandler, error) {
+	return func(ctx context.Context, client *authzed.Client, parameters []wire.Parameter, howMany int64, writer wire.DataWriter, rowsCursor RowsCursor, selectStatement *SelectStatement) (RowsCursor, error) {
+		consistency, err := consistencyFromFields(convertFieldMap(fields), parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting consistency: %w", err)
+		}
+
+		resourceType, err := stringValue(fields[permissionsResourceTypeField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting resource_type: %w", err)
+		}
+
+		permission, err := stringValue(fields[permissionsPermissionField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting permission: %w", err)
+		}
+
+		subjectType, err := stringValue(fields[permissionsSubjectTypeField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting subject_type: %w", err)
+		}
+
+		subjectID, err := stringValue(fields[permissionsSubjectIDField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting subject_id: %w", err)
+		}
+
+		optionalSubjectRelation, err := optionalStringValue(fields[permissionsOptionalSubjectRelationField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting optional_subject_relation: %w", err)
+		}
+
+		// TODO: support cursors
+		// TODO: support caveat context
+		stream, err := client.LookupResources(ctx, &v1.LookupResourcesRequest{
+			ResourceObjectType: resourceType,
+			Permission:         permission,
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: subjectType,
+					ObjectId:   subjectID,
+				},
+				OptionalRelation: optionalSubjectRelation,
+			},
+			Consistency: consistency,
+		})
+		if err != nil {
+			return nil, common.ConvertError(err)
+		}
+
+		for {
+			result, err := stream.Recv()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, common.ConvertError(err)
+			}
+
+			hasPermission := result.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION
+			isMaybe := result.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+
+			rowValues, width, buildErr := buildRowValues(
+				selectStatement,
+				resourceType,
+				result.ResourceObjectId,
+				permission,
+				subjectType,
+				subjectID,
+				optionalSubjectRelation,
+				hasPermission,
+				isMaybe,
+				result.LookedUpAt,
+			)
+			if buildErr != nil {
+				return nil, fmt.Errorf("error building row values: %w", buildErr)
+			}
+			lrStats.AddWidthSample(width)
+
+			if err := writer.Row(rowValues); err != nil {
+				return nil, fmt.Errorf("error writing LR result row: %w", err)
+			}
+		}
+
+		cost, err := costFromTrailers(stream.Trailer())
+		if err != nil {
+			log.Error().Err(err).Msg("error reading cost from trailers")
+		} else {
+			lrStats.AddSample(cost, uint(writer.Written()))
+		}
+
+		return nil, writer.Complete("SELECT")
+	}, nil
+}
+
+func buildLookupSubjectsHandler(fields fieldMap[permissionsField]) (selectHandler, error) {
+	return func(ctx context.Context, client *authzed.Client, parameters []wire.Parameter, howMany int64, writer wire.DataWriter, rowsCursor RowsCursor, selectStatement *SelectStatement) (RowsCursor, error) {
+		consistency, err := consistencyFromFields(convertFieldMap(fields), parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting consistency: %w", err)
+		}
+
+		resourceType, err := stringValue(fields[permissionsResourceTypeField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting resource_type: %w", err)
+		}
+
+		resourceID, err := stringValue(fields[permissionsResourceIDField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting resource_id: %w", err)
+		}
+
+		permission, err := stringValue(fields[permissionsPermissionField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting permission: %w", err)
+		}
+
+		subjectType, err := stringValue(fields[permissionsSubjectTypeField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting subject_type: %w", err)
+		}
+
+		optionalSubjectRelation, err := optionalStringValue(fields[permissionsOptionalSubjectRelationField], parameters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting optional_subject_relation: %w", err)
+		}
+
+		stream, err := client.LookupSubjects(ctx, &v1.LookupSubjectsRequest{
+			Resource: &v1.ObjectReference{
+				ObjectType: resourceType,
+				ObjectId:   resourceID,
+			},
+			SubjectObjectType: subjectType,
+			Permission:        permission,
+			Consistency:       consistency,
+		})
+		if err != nil {
+			return nil, common.ConvertError(err)
+		}
+
+		for {
+			result, err := stream.Recv()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, common.ConvertError(err)
+			}
+
+			hasPermission := result.Subject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION
+			isMaybe := result.Subject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+
+			rowValues, width, buildErr := buildRowValues(
+				selectStatement,
+				resourceType,
+				resourceID,
+				permission,
+				subjectType,
+				result.Subject.SubjectObjectId,
+				optionalSubjectRelation,
+				hasPermission,
+				isMaybe,
+				result.LookedUpAt,
+			)
+			if buildErr != nil {
+				return nil, fmt.Errorf("error building row values: %w", buildErr)
+			}
+			lsStats.AddWidthSample(width)
+
+			if err := writer.Row(rowValues); err != nil {
+				return nil, fmt.Errorf("error writing LS result row: %w", err)
+			}
+		}
+
+		cost, err := costFromTrailers(stream.Trailer())
+		if err != nil {
+			log.Error().Err(err).Msg("error reading cost from trailers")
+		} else {
+			lsStats.AddSample(cost, uint(writer.Written()))
+		}
+
+		return nil, writer.Complete("SELECT")
+	}, nil
+}
+
+func buildPermissionsExplainHandler(fields fieldMap[string]) (explainHandler, error) {
+	typedFields := fieldMap[permissionsField]{}
+	for k, v := range fields {
+		typedFields[permissionsField(k)] = v
+	}
+
+	stats, _, err := statsAndHandlerForFields(typedFields)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(ctx context.Context, client *authzed.Client, writer wire.DataWriter) error {
+		cost := stats.Explain()
+		log.Debug().Str("cost", cost).Msg("permissions explain cost")
+		if err := writer.Row([]any{cost}); err != nil {
+			return fmt.Errorf("error writing permissions explain row: %w", err)
+		}
+		return writer.Complete("EXPLAIN")
+	}, nil
+}

--- a/internal/fdw/tables/relationships.go
+++ b/internal/fdw/tables/relationships.go
@@ -1,0 +1,388 @@
+package tables
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/lib/pq/oid"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/authzed-go/v1"
+
+	"github.com/authzed/spicedb/internal/fdw/common"
+	"github.com/authzed/spicedb/internal/fdw/explain"
+	log "github.com/authzed/spicedb/internal/logging"
+)
+
+// relationshipsField represents a field name in the relationships table
+type relationshipsField string
+
+const (
+	relationshipsResourceTypeField            relationshipsField = "resource_type"
+	relationshipsResourceIDField              relationshipsField = "resource_id"
+	relationshipsRelationField                relationshipsField = "relation"
+	relationshipsSubjectTypeField             relationshipsField = "subject_type"
+	relationshipsSubjectIDField               relationshipsField = "subject_id"
+	relationshipsOptionalSubjectRelationField relationshipsField = "optional_subject_relation"
+	relationshipsCaveatNameField              relationshipsField = "caveat_name"
+	relationshipsCaveatContextField           relationshipsField = "caveat_context"
+	relationshipsConsistencyField             relationshipsField = fieldConsistency
+)
+
+var relationshipsRequiredInsertColumns = []string{
+	string(relationshipsResourceTypeField),
+	string(relationshipsResourceIDField),
+	string(relationshipsRelationField),
+	string(relationshipsSubjectTypeField),
+	string(relationshipsSubjectIDField),
+	string(relationshipsOptionalSubjectRelationField),
+}
+
+var relationshipsSchema = wire.Columns{
+	{
+		Table: 0,
+		Name:  string(relationshipsResourceTypeField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(relationshipsResourceIDField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(relationshipsRelationField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(relationshipsSubjectTypeField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(relationshipsSubjectIDField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(relationshipsOptionalSubjectRelationField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(relationshipsCaveatNameField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	{
+		Table: 0,
+		Name:  string(relationshipsCaveatContextField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+	consistencyField,
+}
+
+func buildRelationshipsSelectHandler(fields fieldMap[string]) (selectHandler, error) {
+	typedFields := fieldMap[relationshipsField]{}
+	for k, v := range fields {
+		typedFields[relationshipsField(k)] = v
+	}
+
+	filter, err := filterFromFields(typedFields, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	consistency, err := consistencyFromFields(convertFieldMap(typedFields), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return readRelationshipsWithFilter(filter, consistency), nil
+}
+
+func filterFromFields(fields fieldMap[relationshipsField], _ []wire.Parameter) (*v1.RelationshipFilter, error) {
+	if _, ok := fields[relationshipsCaveatNameField]; ok {
+		return nil, errors.New("caveat_name is not supported in WHERE")
+	}
+
+	if _, ok := fields[relationshipsCaveatContextField]; ok {
+		return nil, errors.New("caveat_context is not supported in WHERE")
+	}
+
+	if _, ok := fields[relationshipsConsistencyField]; ok {
+		return nil, errors.New("consistency is not supported in WHERE")
+	}
+
+	for fieldName, fieldValue := range fields {
+		if fieldValue.value == "" && fieldValue.parameterIndex == 0 && !fieldValue.isSubQueryPlaceholder {
+			return nil, fmt.Errorf("field %q cannot be empty", fieldName)
+		}
+	}
+
+	filter := &v1.RelationshipFilter{}
+	if resourceType, ok := fields[relationshipsResourceTypeField]; ok {
+		filter.ResourceType = resourceType.value
+	}
+	if resourceID, ok := fields[relationshipsResourceIDField]; ok {
+		filter.OptionalResourceId = resourceID.value
+	}
+	if relation, ok := fields[relationshipsRelationField]; ok {
+		filter.OptionalRelation = relation.value
+	}
+
+	if subjectType, ok := fields[relationshipsSubjectTypeField]; ok {
+		if filter.OptionalSubjectFilter == nil {
+			filter.OptionalSubjectFilter = &v1.SubjectFilter{}
+		}
+		filter.OptionalSubjectFilter.SubjectType = subjectType.value
+	}
+
+	if subjectID, ok := fields[relationshipsSubjectIDField]; ok {
+		if filter.OptionalSubjectFilter == nil {
+			filter.OptionalSubjectFilter = &v1.SubjectFilter{}
+		}
+		filter.OptionalSubjectFilter.OptionalSubjectId = subjectID.value
+	}
+
+	if subjectRelation, ok := fields[relationshipsOptionalSubjectRelationField]; ok {
+		if filter.OptionalSubjectFilter == nil {
+			filter.OptionalSubjectFilter = &v1.SubjectFilter{}
+		}
+		filter.OptionalSubjectFilter.OptionalRelation = &v1.SubjectFilter_RelationFilter{
+			Relation: subjectRelation.value,
+		}
+	}
+
+	return filter, nil
+}
+
+func readRelationshipsWithFilter(filter *v1.RelationshipFilter, consistency *v1.Consistency) selectHandler {
+	return func(ctx context.Context, client *authzed.Client, parameters []wire.Parameter, howMany int64, writer wire.DataWriter, rowsCursor RowsCursor, selectStatement *SelectStatement) (RowsCursor, error) {
+		var currentCursor *v1.Cursor
+		if rowsCursor != nil {
+			currentCursor = rowsCursor.(*v1.Cursor)
+		}
+
+		stream, err := client.ReadRelationships(ctx, &v1.ReadRelationshipsRequest{
+			RelationshipFilter: filter,
+			OptionalLimit:      uint32(howMany),
+			OptionalCursor:     currentCursor,
+			Consistency:        consistency,
+		})
+		if err != nil {
+			return nil, common.ConvertError(err)
+		}
+
+		rowCount := 0
+		for {
+			result, err := stream.Recv()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, common.ConvertError(err)
+			}
+
+			rowValues := make([]any, 0, len(selectStatement.columnNames))
+			for _, colName := range selectStatement.columnNames {
+				switch colName {
+				case "resource_type":
+					rowValues = append(rowValues, result.Relationship.Resource.ObjectType)
+				case "resource_id":
+					rowValues = append(rowValues, result.Relationship.Resource.ObjectId)
+				case "relation":
+					rowValues = append(rowValues, result.Relationship.Relation)
+				case "subject_type":
+					rowValues = append(rowValues, result.Relationship.Subject.Object.ObjectType)
+				case "subject_id":
+					rowValues = append(rowValues, result.Relationship.Subject.Object.ObjectId)
+				case "optional_subject_relation":
+					rowValues = append(rowValues, result.Relationship.Subject.OptionalRelation)
+				case "caveat_name":
+					if result.Relationship.OptionalCaveat == nil {
+						rowValues = append(rowValues, "")
+					} else {
+						rowValues = append(rowValues, result.Relationship.OptionalCaveat.CaveatName)
+					}
+				case "caveat_context":
+					if result.Relationship.OptionalCaveat == nil || result.Relationship.OptionalCaveat.Context == nil {
+						rowValues = append(rowValues, "")
+					} else {
+						// Convert the caveat context to a JSON string.
+						caveatContextMap := result.Relationship.OptionalCaveat.Context.AsMap()
+						caveatContextJSON, err := json.Marshal(caveatContextMap)
+						if err != nil {
+							return nil, fmt.Errorf("failed to marshal caveat context: %w", err)
+						}
+
+						rowValues = append(rowValues, string(caveatContextJSON))
+					}
+				case "consistency":
+					rowValues = append(rowValues, result.ReadAt.Token)
+				default:
+					return nil, fmt.Errorf("unsupported column %q", colName)
+				}
+			}
+
+			if err := writer.Row(rowValues); err != nil {
+				return nil, fmt.Errorf("error writing relationship row: %w", err)
+			}
+			currentCursor = result.AfterResultCursor
+			rowCount++
+		}
+
+		return currentCursor, writer.Complete(fmt.Sprintf("SELECT %d", rowCount))
+	}
+}
+
+func buildRelationshipsExplainHandler(fields fieldMap[string]) (explainHandler, error) {
+	return func(ctx context.Context, client *authzed.Client, writer wire.DataWriter) error {
+		cost := explain.Default("read", "relationships").String()
+		log.Debug().Str("cost", cost).Msg("relationships explain cost")
+		if err := writer.Row([]any{cost}); err != nil {
+			return fmt.Errorf("error writing relationship explain row: %w", err)
+		}
+		return writer.Complete("EXPLAIN")
+	}, nil
+}
+
+func relationshipsInsertRunner(ctx context.Context, client *authzed.Client, insertStmt *InsertStatement, parameters []wire.Parameter) (int64, []any, error) {
+	valuesByColumnName := make(map[string]string, len(insertStmt.colNames))
+	for i, colName := range insertStmt.colNames {
+		// TODO: support other column types here if necessary.
+		valuesByColumnName[colName] = string(parameters[i].Value())
+	}
+
+	// Ensure consistency is not specified.
+	if consistency, ok := valuesByColumnName["consistency"]; ok && len(consistency) > 0 {
+		return 0, nil, common.NewQueryError(errors.New("consistency column is not supported on insertion"))
+	}
+
+	rel := &v1.Relationship{
+		Resource: &v1.ObjectReference{
+			ObjectType: valuesByColumnName["resource_type"],
+			ObjectId:   valuesByColumnName["resource_id"],
+		},
+		Relation: valuesByColumnName["relation"],
+		Subject: &v1.SubjectReference{
+			Object: &v1.ObjectReference{
+				ObjectType: valuesByColumnName["subject_type"],
+				ObjectId:   valuesByColumnName["subject_id"],
+			},
+			OptionalRelation: valuesByColumnName["optional_subject_relation"],
+		},
+	}
+
+	if caveatName, ok := valuesByColumnName["caveat_name"]; ok && len(caveatName) > 0 {
+		rel.OptionalCaveat = &v1.ContextualizedCaveat{
+			CaveatName: caveatName,
+		}
+
+		if caveatContextString, ok := valuesByColumnName["caveat_context"]; ok && len(caveatContextString) > 0 {
+			// Parse the caveat context into a structpb.
+			var contextMap map[string]any
+			err := json.Unmarshal([]byte(caveatContextString), &contextMap)
+			if err != nil {
+				return 0, nil, common.NewQueryError(fmt.Errorf("invalid caveat context JSON: %w", err))
+			}
+
+			caveatContext, err := structpb.NewStruct(contextMap)
+			if err != nil {
+				return 0, nil, common.NewQueryError(fmt.Errorf("invalid caveat context: %w", err))
+			}
+
+			rel.OptionalCaveat.Context = caveatContext
+		}
+	}
+
+	// Write the relationship.
+	update := &v1.RelationshipUpdate{
+		Operation:    insertStmt.metadata["writeOp"].(v1.RelationshipUpdate_Operation),
+		Relationship: rel,
+	}
+
+	write, err := client.WriteRelationships(ctx, &v1.WriteRelationshipsRequest{
+		Updates: []*v1.RelationshipUpdate{update},
+	})
+	if err != nil {
+		return 0, nil, common.NewQueryError(fmt.Errorf("failed to write relationship: %w", err))
+	}
+
+	values := make([]any, 0, len(insertStmt.returningColumns))
+	for _, column := range insertStmt.returningColumns {
+		switch column.Name {
+		case "consistency":
+			values = append(values, write.WrittenAt.Token)
+
+		default:
+			return 0, nil, common.NewQueryError(fmt.Errorf("unsupported column %q", column.Name))
+		}
+	}
+
+	return 1, values, nil
+}
+
+func relationshipInsertValidator(ctx context.Context, query *pg_query.InsertStmt, colNames []string) (map[string]any, error) {
+	// Parse the write operation.
+	writeOp := v1.RelationshipUpdate_OPERATION_CREATE
+	if query.GetOnConflictClause() != nil {
+		if query.GetOnConflictClause().Action != pg_query.OnConflictAction_ONCONFLICT_NOTHING {
+			return nil, common.NewQueryError(errors.New("only ON CONFLICT DO NOTHING is supported"))
+		}
+
+		writeOp = v1.RelationshipUpdate_OPERATION_TOUCH
+	}
+
+	return map[string]any{
+		"writeOp": writeOp,
+	}, nil
+}
+
+func relationshipsDeleteRunner(ctx context.Context, client *authzed.Client, deleteStmt *DeleteStatement, parameters []wire.Parameter) (int64, []any, error) {
+	typedFields := fieldMap[relationshipsField]{}
+	for k, v := range deleteStmt.fields {
+		typedFields[relationshipsField(k)] = v
+	}
+
+	filter, err := filterFromFields(typedFields, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	// Delete the relationship(s).
+	deleteResp, err := client.DeleteRelationships(ctx, &v1.DeleteRelationshipsRequest{
+		RelationshipFilter: filter,
+	})
+	if err != nil {
+		return 0, nil, common.NewQueryError(fmt.Errorf("failed to delete relationships: %w", err))
+	}
+
+	values := make([]any, 0, len(deleteStmt.returningColumns))
+	for _, column := range deleteStmt.returningColumns {
+		switch column.Name {
+		case "consistency":
+			values = append(values, deleteResp.DeletedAt.Token)
+
+		default:
+			return 0, nil, common.NewQueryError(fmt.Errorf("unsupported column %q", column.Name))
+		}
+	}
+
+	return int64(deleteResp.RelationshipsDeletedCount), values, nil
+}

--- a/internal/fdw/tables/relationships_test.go
+++ b/internal/fdw/tables/relationships_test.go
@@ -1,0 +1,290 @@
+package tables
+
+import (
+	"testing"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+)
+
+func TestFilterFromFields(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		fields         fieldMap[relationshipsField]
+		parameters     []wire.Parameter
+		expectedFilter *v1.RelationshipFilter
+		expectedError  string
+	}{
+		{
+			name:   "empty fields",
+			fields: fieldMap[relationshipsField]{},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType: "",
+			},
+		},
+		{
+			name: "resource_type only",
+			fields: fieldMap[relationshipsField]{
+				"resource_type": {value: "document"},
+			},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType: "document",
+			},
+		},
+		{
+			name: "resource_type and resource_id",
+			fields: fieldMap[relationshipsField]{
+				"resource_type": {value: "document"},
+				"resource_id":   {value: "doc1"},
+			},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType:       "document",
+				OptionalResourceId: "doc1",
+			},
+		},
+		{
+			name: "resource fields and relation",
+			fields: fieldMap[relationshipsField]{
+				"resource_type": {value: "document"},
+				"resource_id":   {value: "doc1"},
+				"relation":      {value: "viewer"},
+			},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType:       "document",
+				OptionalResourceId: "doc1",
+				OptionalRelation:   "viewer",
+			},
+		},
+		{
+			name: "complete filter with all fields",
+			fields: fieldMap[relationshipsField]{
+				"resource_type": {value: "document"},
+				"resource_id":   {value: "doc1"},
+				"relation":      {value: "viewer"},
+				"subject_type":  {value: "user"},
+				"subject_id":    {value: "alice"},
+			},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType:       "document",
+				OptionalResourceId: "doc1",
+				OptionalRelation:   "viewer",
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					SubjectType:       "user",
+					OptionalSubjectId: "alice",
+				},
+			},
+		},
+		{
+			name: "complete filter with optional_subject_relation",
+			fields: fieldMap[relationshipsField]{
+				"resource_type":             {value: "document"},
+				"resource_id":               {value: "doc1"},
+				"relation":                  {value: "viewer"},
+				"subject_type":              {value: "group"},
+				"subject_id":                {value: "engineering"},
+				"optional_subject_relation": {value: "member"},
+			},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType:       "document",
+				OptionalResourceId: "doc1",
+				OptionalRelation:   "viewer",
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					SubjectType:       "group",
+					OptionalSubjectId: "engineering",
+					OptionalRelation: &v1.SubjectFilter_RelationFilter{
+						Relation: "member",
+					},
+				},
+			},
+		},
+		{
+			name: "subject fields only",
+			fields: fieldMap[relationshipsField]{
+				"subject_type": {value: "user"},
+				"subject_id":   {value: "bob"},
+			},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType: "",
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					SubjectType:       "user",
+					OptionalSubjectId: "bob",
+				},
+			},
+		},
+		{
+			name: "subject_type only creates subject filter",
+			fields: fieldMap[relationshipsField]{
+				"subject_type": {value: "user"},
+			},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType: "",
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					SubjectType: "user",
+				},
+			},
+		},
+		{
+			name: "optional_subject_relation only",
+			fields: fieldMap[relationshipsField]{
+				"optional_subject_relation": {value: "member"},
+			},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType: "",
+				OptionalSubjectFilter: &v1.SubjectFilter{
+					OptionalRelation: &v1.SubjectFilter_RelationFilter{
+						Relation: "member",
+					},
+				},
+			},
+		},
+		{
+			name: "caveat_name not supported",
+			fields: fieldMap[relationshipsField]{
+				"resource_type": {value: "document"},
+				"caveat_name":   {value: "some_caveat"},
+			},
+			expectedError: "caveat_name is not supported in WHERE",
+		},
+		{
+			name: "caveat_context not supported",
+			fields: fieldMap[relationshipsField]{
+				"resource_type":  {value: "document"},
+				"caveat_context": {value: "{}"},
+			},
+			expectedError: "caveat_context is not supported in WHERE",
+		},
+		{
+			name: "consistency not supported in WHERE",
+			fields: fieldMap[relationshipsField]{
+				"resource_type": {value: "document"},
+				"consistency":   {value: "fully_consistent"},
+			},
+			expectedError: "consistency is not supported in WHERE",
+		},
+		{
+			name: "empty value without parameter index",
+			fields: fieldMap[relationshipsField]{
+				"resource_type": {value: ""},
+			},
+			expectedError: `field "resource_type" cannot be empty`,
+		},
+		{
+			name: "parameter index is allowed",
+			fields: fieldMap[relationshipsField]{
+				"resource_type": {parameterIndex: 1},
+			},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType: "",
+			},
+		},
+		{
+			name: "subquery placeholder is allowed",
+			fields: fieldMap[relationshipsField]{
+				"resource_type": {value: "document"},
+				"resource_id":   {isSubQueryPlaceholder: true},
+			},
+			expectedFilter: &v1.RelationshipFilter{
+				ResourceType:       "document",
+				OptionalResourceId: "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter, err := filterFromFields(tc.fields, tc.parameters)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, filter)
+			require.Equal(t, tc.expectedFilter.ResourceType, filter.ResourceType)
+			require.Equal(t, tc.expectedFilter.OptionalResourceId, filter.OptionalResourceId)
+			require.Equal(t, tc.expectedFilter.OptionalRelation, filter.OptionalRelation)
+
+			if tc.expectedFilter.OptionalSubjectFilter == nil {
+				require.Nil(t, filter.OptionalSubjectFilter)
+			} else {
+				require.NotNil(t, filter.OptionalSubjectFilter)
+				require.Equal(t, tc.expectedFilter.OptionalSubjectFilter.SubjectType, filter.OptionalSubjectFilter.SubjectType)
+				require.Equal(t, tc.expectedFilter.OptionalSubjectFilter.OptionalSubjectId, filter.OptionalSubjectFilter.OptionalSubjectId)
+
+				if tc.expectedFilter.OptionalSubjectFilter.OptionalRelation == nil {
+					require.Nil(t, filter.OptionalSubjectFilter.OptionalRelation)
+				} else {
+					require.NotNil(t, filter.OptionalSubjectFilter.OptionalRelation)
+					require.Equal(t,
+						tc.expectedFilter.OptionalSubjectFilter.OptionalRelation.Relation,
+						filter.OptionalSubjectFilter.OptionalRelation.Relation,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildRelationshipsSelectHandler(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		fields        fieldMap[string]
+		expectedError string
+	}{
+		{
+			name: "valid filter",
+			fields: fieldMap[string]{
+				"resource_type": {value: "document"},
+				"resource_id":   {value: "doc1"},
+			},
+		},
+		{
+			name:   "empty fields",
+			fields: fieldMap[string]{},
+		},
+		{
+			name: "unsupported caveat_name",
+			fields: fieldMap[string]{
+				"resource_type": {value: "document"},
+				"caveat_name":   {value: "some_caveat"},
+			},
+			expectedError: "caveat_name is not supported in WHERE",
+		},
+		{
+			name: "invalid consistency in WHERE",
+			fields: fieldMap[string]{
+				"resource_type": {value: "document"},
+				"consistency":   {value: "fully_consistent"},
+			},
+			expectedError: "consistency is not supported in WHERE",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler, err := buildRelationshipsSelectHandler(tc.fields)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				require.Nil(t, handler)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, handler)
+		})
+	}
+}

--- a/internal/fdw/tables/schema.go
+++ b/internal/fdw/tables/schema.go
@@ -1,0 +1,84 @@
+package tables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/lib/pq/oid"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/authzed-go/v1"
+
+	"github.com/authzed/spicedb/internal/fdw/common"
+	"github.com/authzed/spicedb/internal/fdw/explain"
+	log "github.com/authzed/spicedb/internal/logging"
+)
+
+// schemaField represents a field name in the schema table
+type schemaField string
+
+const (
+	schemaSchemaTextField schemaField = "schema_text"
+)
+
+var schemaSchema = wire.Columns{
+	{
+		Table: 0,
+		Name:  string(schemaSchemaTextField),
+		Oid:   uint32(oid.T_text),
+		Width: 256,
+	},
+}
+
+func schemaInsertRunner(ctx context.Context, client *authzed.Client, insertStmt *InsertStatement, parameters []wire.Parameter) (int64, []any, error) {
+	if len(insertStmt.returningColumns) > 0 {
+		return 0, nil, common.NewQueryError(errors.New("unexpected RETURNING clause"))
+	}
+
+	valuesByColumnName := make(map[string]string, len(insertStmt.colNames))
+	for i, colName := range insertStmt.colNames {
+		valuesByColumnName[colName] = string(parameters[i].Value())
+	}
+
+	_, err := client.WriteSchema(ctx, &v1.WriteSchemaRequest{
+		Schema: valuesByColumnName[string(schemaSchemaTextField)],
+	})
+	if err != nil {
+		return 0, nil, common.NewQueryError(fmt.Errorf("failed to write schema: %w", err))
+	}
+
+	return 1, nil, nil
+}
+
+func buildSchemaSelectHandler(fields fieldMap[string]) (selectHandler, error) {
+	return schemaSelectHandler, nil
+}
+
+func schemaSelectHandler(ctx context.Context, client *authzed.Client, parameters []wire.Parameter, howMany int64, writer wire.DataWriter, rowsCursor RowsCursor, selectStmt *SelectStatement) (RowsCursor, error) {
+	schema, err := client.ReadSchema(ctx, &v1.ReadSchemaRequest{})
+	if err != nil {
+		return nil, common.NewQueryError(fmt.Errorf("failed to read schema: %w", err))
+	}
+
+	if err := writer.Row([]any{schema.SchemaText}); err != nil {
+		return nil, common.NewQueryError(fmt.Errorf("failed to write schema row: %w", err))
+	}
+	if err := writer.Complete("SELECT 1"); err != nil {
+		return nil, common.NewQueryError(fmt.Errorf("failed to complete query: %w", err))
+	}
+
+	return nil, nil
+}
+
+func buildSchemaExplainHandler(fields fieldMap[string]) (explainHandler, error) {
+	return func(ctx context.Context, client *authzed.Client, writer wire.DataWriter) error {
+		cost := explain.Default("read", "schema").String()
+		log.Debug().Str("cost", cost).Msg("schema explain cost")
+		if err := writer.Row([]any{cost}); err != nil {
+			return fmt.Errorf("error writing schema explain row: %w", err)
+		}
+		return writer.Complete("EXPLAIN")
+	}, nil
+}

--- a/internal/fdw/tables/select.go
+++ b/internal/fdw/tables/select.go
@@ -1,0 +1,263 @@
+package tables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/authzed-go/v1"
+
+	"github.com/authzed/spicedb/internal/fdw/common"
+)
+
+// RowsCursor is a cursor for iterating over query results.
+type RowsCursor any
+
+// SelectStatement represents a parsed SELECT query for SpiceDB tables.
+// It handles querying permissions, relationships, and schema data.
+type SelectStatement struct {
+	isUnsupported bool
+
+	tableName      string
+	tableDef       tableDefinition
+	columnNames    []string
+	fields         map[string]valueOrRef
+	selectHandler  selectHandler
+	explainHandler explainHandler
+}
+
+// ParseSelectStatement parses a Postgres SELECT statement into a SelectStatement.
+// The forExplain parameter indicates if this is being parsed for an EXPLAIN query.
+// Returns an error if the query is not supported by the FDW.
+func ParseSelectStatement(query *pg_query.SelectStmt, forExplain bool) (*SelectStatement, error) {
+	if query == nil {
+		return nil, common.NewUnsupportedError(errors.New("only SELECT is supported"))
+	}
+
+	// FROM
+	fromClauses := query.GetFromClause()
+	if len(fromClauses) != 1 {
+		return nil, common.NewUnsupportedError(errors.New("a select statement must have exactly one FROM clause"))
+	}
+
+	fromVar := fromClauses[0].GetRangeVar()
+	if fromVar == nil {
+		return nil, common.NewUnsupportedError(errors.New("a select statement must have a FROM clause pointing to a single table"))
+	}
+
+	tableName := fromVar.GetRelname()
+	tableDef, ok := tables[tableName]
+	if !ok {
+		return nil, common.NewUnsupportedError(fmt.Errorf("table %s does not exist", tableName))
+	}
+
+	// Check for * or column names.
+	columnNames := make([]string, 0)
+	if len(query.GetTargetList()) == 1 {
+		target := query.GetTargetList()[0].GetResTarget()
+		if target != nil && target.GetVal() != nil && target.GetVal().GetColumnRef() != nil {
+			fields := target.GetVal().GetColumnRef().GetFields()
+			if len(fields) == 1 && fields[0].GetAStar() != nil {
+				// SELECT *
+				columnNames = tableDef.columnNames()
+			}
+		}
+	}
+
+	if len(columnNames) == 0 {
+		for _, target := range query.GetTargetList() {
+			if target.GetResTarget() == nil {
+				return nil, common.NewUnsupportedError(errors.New("a select statement must have a target list"))
+			}
+
+			if target.GetResTarget().GetVal() == nil {
+				return nil, common.NewUnsupportedError(errors.New("a select statement must have a target list with a value"))
+			}
+
+			if target.GetResTarget().GetVal().GetColumnRef() == nil {
+				return nil, common.NewUnsupportedError(errors.New("a select statement must have a target list with a column reference"))
+			}
+
+			if target.GetResTarget().GetVal().GetColumnRef().GetFields() == nil {
+				return nil, common.NewUnsupportedError(errors.New("a select statement must have a target list with a column reference"))
+			}
+
+			if len(target.GetResTarget().GetVal().GetColumnRef().GetFields()) != 1 {
+				return nil, common.NewUnsupportedError(errors.New("a select statement must have a target list with a single column reference"))
+			}
+
+			if target.GetResTarget().GetVal().GetColumnRef().GetFields()[0].GetString_() == nil {
+				return nil, common.NewUnsupportedError(errors.New("a select statement must have a target list with a column reference"))
+			}
+
+			if target.GetResTarget().GetVal().GetColumnRef().GetFields()[0].GetString_().Sval == "" {
+				return nil, common.NewUnsupportedError(errors.New("a select statement must have a target list with a column reference"))
+			}
+
+			columnName := target.GetResTarget().GetVal().GetColumnRef().GetFields()[0].GetString_().Sval
+			if !tableDef.hasColumn(columnName) {
+				return &SelectStatement{
+					isUnsupported: true,
+					tableName:     tableName,
+					tableDef:      tableDef,
+				}, common.NewUnsupportedError(fmt.Errorf("column %s does not exist in table %s", columnName, tableName))
+			}
+
+			columnNames = append(columnNames, columnName)
+		}
+	}
+
+	// Ensure unused clauses are not present.
+	if err := checkUnusedSelectClauses(query); err != nil {
+		return &SelectStatement{
+			isUnsupported: true,
+			tableName:     tableName,
+			tableDef:      tableDef,
+		}, common.NewUnsupportedError(fmt.Errorf("unsupported select statement: %w", err))
+	}
+
+	pm := NewPatternMatcher()
+	fields, err := pm.MatchWhereClause(query.GetWhereClause())
+	if err != nil {
+		return &SelectStatement{
+			isUnsupported: true,
+			tableName:     tableName,
+			tableDef:      tableDef,
+		}, common.NewUnsupportedError(fmt.Errorf("unsupported select statement: %w", err))
+	}
+
+	// Ensure all fields match the table definition.
+	for fieldName := range fields {
+		if !tableDef.hasColumn(fieldName) {
+			return &SelectStatement{
+				isUnsupported: true,
+				tableName:     tableName,
+				tableDef:      tableDef,
+			}, common.NewUnsupportedError(fmt.Errorf("field %s does not exist in table %s", fieldName, tableName))
+		}
+	}
+
+	if forExplain {
+		buildExplainHandler := tableDef.buildExplainHandler
+		if buildExplainHandler == nil {
+			return nil, common.NewUnsupportedError(fmt.Errorf("table %s does not support EXPLAIN", tableName))
+		}
+
+		explainHandler, err := buildExplainHandler(fields)
+		if err != nil {
+			return &SelectStatement{
+				isUnsupported: true,
+				tableName:     tableName,
+				tableDef:      tableDef,
+			}, common.NewUnsupportedError(fmt.Errorf("unsupported select statement: %w", err))
+		}
+
+		return &SelectStatement{
+			tableName:      tableName,
+			tableDef:       tableDef,
+			fields:         fields,
+			explainHandler: explainHandler,
+		}, nil
+	} else {
+		selectHandler, err := tableDef.buildSelectHandler(fields)
+		if err != nil {
+			return &SelectStatement{
+				isUnsupported: true,
+				tableName:     tableName,
+				tableDef:      tableDef,
+			}, common.NewUnsupportedError(fmt.Errorf("unsupported select statement: %w", err))
+		}
+
+		return &SelectStatement{
+			tableName:     tableName,
+			tableDef:      tableDef,
+			fields:        fields,
+			selectHandler: selectHandler,
+			columnNames:   columnNames,
+		}, nil
+	}
+}
+
+func (ss *SelectStatement) IsUnsupported() bool {
+	return ss.isUnsupported
+}
+
+func (ss *SelectStatement) Schema() wire.Columns {
+	columns := make(wire.Columns, 0, len(ss.columnNames))
+	for _, columnName := range ss.columnNames {
+		schemaColumn, _ := ss.tableDef.getSchemaColumn(columnName)
+		columns = append(columns, schemaColumn)
+	}
+
+	return columns
+}
+
+func (ss *SelectStatement) TableName() string {
+	return ss.tableName
+}
+
+func (ss *SelectStatement) Fetch(ctx context.Context, client *authzed.Client, parameters []wire.Parameter, writer wire.DataWriter, howMany int64, rowsCursor RowsCursor, selectStmt *SelectStatement) (RowsCursor, error) {
+	if ss.isUnsupported {
+		return nil, common.NewUnsupportedError(errors.New("this query is unsupported"))
+	}
+
+	return ss.selectHandler(ctx, client, parameters, howMany, writer, rowsCursor, selectStmt)
+}
+
+func (ss *SelectStatement) Explain(ctx context.Context, client *authzed.Client, writer wire.DataWriter) error {
+	if ss.isUnsupported {
+		return common.NewUnsupportedError(errors.New("this query is unsupported"))
+	}
+
+	return ss.explainHandler(ctx, client, writer)
+}
+
+func checkUnusedSelectClauses(selectStatement *pg_query.SelectStmt) error {
+	if selectStatement.GetDistinctClause() != nil {
+		return errors.New("DISTINCT not supported")
+	}
+
+	if selectStatement.GetGroupClause() != nil {
+		return errors.New("GROUP BY not supported")
+	}
+
+	if selectStatement.GetGroupDistinct() {
+		return errors.New("GROUP BY not supported")
+	}
+
+	if selectStatement.GetHavingClause() != nil {
+		return errors.New("HAVING not supported")
+	}
+
+	if selectStatement.GetIntoClause() != nil {
+		return errors.New("INTO not supported")
+	}
+
+	if selectStatement.GetSortClause() != nil {
+		return errors.New("ORDER BY not supported")
+	}
+
+	if selectStatement.GetLockingClause() != nil {
+		return errors.New("LOCK not supported")
+	}
+
+	if selectStatement.GetWindowClause() != nil {
+		return errors.New("WINDOW not supported")
+	}
+
+	if selectStatement.GetLimitCount() != nil {
+		return errors.New("LIMIT not supported")
+	}
+
+	return nil
+}
+
+type valueOrRef struct {
+	fieldName             string
+	value                 string
+	parameterIndex        int32
+	isSubQueryPlaceholder bool
+}

--- a/internal/fdw/tables/select_test.go
+++ b/internal/fdw/tables/select_test.go
@@ -1,0 +1,196 @@
+package tables
+
+import (
+	"testing"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSelectStatement(t *testing.T) {
+	t.Parallel()
+	tcs := []struct {
+		name                string
+		query               string
+		expectedError       string
+		expectedFields      map[string]valueOrRef
+		expectedUnsupported bool
+	}{
+		{
+			name:          "not a select",
+			query:         "INSERT INTO foo (bar) VALUES (1)",
+			expectedError: "only SELECT is supported",
+		},
+		{
+			name:          "multiple from clauses",
+			query:         "SELECT * FROM foo, bar",
+			expectedError: "a select statement must have exactly one FROM clause",
+		},
+		{
+			name:          "no from clause",
+			query:         "SELECT *",
+			expectedError: "a select statement must have exactly one FROM clause",
+		},
+		{
+			name:          "unsupported table",
+			query:         "SELECT * FROM foo",
+			expectedError: "table foo does not exist",
+		},
+		{
+			name:                "unsupported order by",
+			query:               "SELECT * FROM relationships ORDER BY name",
+			expectedError:       "ORDER BY not supported",
+			expectedUnsupported: true,
+		},
+		{
+			name:           "basic select query",
+			query:          "SELECT * FROM relationships WHERE resource_id='bar' AND resource_type='qux'",
+			expectedFields: map[string]valueOrRef{"resource_id": {value: "bar"}, "resource_type": {value: "qux"}},
+		},
+		{
+			name:                "basic select query with reused field",
+			query:               "SELECT * FROM relationships WHERE foo='bar' AND foo='qux'",
+			expectedError:       "field foo already set",
+			expectedUnsupported: true,
+		},
+		{
+			name:                "basic select query with OR",
+			query:               "SELECT * FROM relationships WHERE foo='bar' OR bar='qux'",
+			expectedError:       "only AND supported",
+			expectedUnsupported: true,
+		},
+		{
+			name:                "basic select with nonequal",
+			query:               "SELECT * FROM relationships WHERE foo != 'bar'",
+			expectedError:       "only = supported",
+			expectedUnsupported: true,
+		},
+		{
+			name:           "basic select with parameter",
+			query:          "SELECT * FROM relationships WHERE resource_id = $1",
+			expectedFields: map[string]valueOrRef{"resource_id": {parameterIndex: 1}},
+		},
+		{
+			name:           "basic select with parameter inverted",
+			query:          "SELECT * FROM relationships WHERE $1 = resource_id",
+			expectedFields: map[string]valueOrRef{"resource_id": {parameterIndex: 1}},
+		},
+		{
+			name:                "basic select with field = field",
+			query:               "SELECT * FROM relationships WHERE bar = foo",
+			expectedUnsupported: true,
+			expectedError:       "only one side of the expression can be a column",
+		},
+		{
+			name:                "missing column name",
+			query:               "SELECT * FROM relationships WHERE 'foo' = 'bar'",
+			expectedUnsupported: true,
+			expectedError:       "missing column name",
+		},
+		{
+			name:  "real SELECT",
+			query: `SELECT resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation FROM public.relationships WHERE ((resource_type = 'document')) AND ((relation = 'view')) AND ((subject_type = 'user')) AND ((subject_id = 'tom'))`,
+			expectedFields: map[string]valueOrRef{
+				"resource_type": {value: "document"},
+				"relation":      {value: "view"},
+				"subject_type":  {value: "user"},
+				"subject_id":    {value: "tom"},
+			},
+		},
+		{
+			name:  "SELECT with null for explain",
+			query: `SELECT * FROM relationships WHERE ((((SELECT null::text)::text) = resource_id))`,
+			expectedFields: map[string]valueOrRef{
+				"resource_id": {isSubQueryPlaceholder: true},
+			},
+		},
+		{
+			name:                "DISTINCT not supported",
+			query:               "SELECT DISTINCT * FROM relationships",
+			expectedError:       "DISTINCT not supported",
+			expectedUnsupported: true,
+		},
+		{
+			name:                "GROUP BY not supported",
+			query:               "SELECT * FROM relationships GROUP BY resource_type",
+			expectedError:       "GROUP BY not supported",
+			expectedUnsupported: true,
+		},
+		{
+			name:                "HAVING not supported",
+			query:               "SELECT * FROM relationships HAVING count(*) > 1",
+			expectedError:       "HAVING not supported",
+			expectedUnsupported: true,
+		},
+		{
+			name:                "INTO not supported",
+			query:               "SELECT * INTO new_table FROM relationships",
+			expectedError:       "INTO not supported",
+			expectedUnsupported: true,
+		},
+		{
+			name:                "LOCK not supported",
+			query:               "SELECT * FROM relationships FOR UPDATE",
+			expectedError:       "LOCK not supported",
+			expectedUnsupported: true,
+		},
+		{
+			name:                "LIMIT not supported",
+			query:               "SELECT * FROM relationships LIMIT 10",
+			expectedError:       "LIMIT not supported",
+			expectedUnsupported: true,
+		},
+		{
+			name:                "invalid column in SELECT",
+			query:               "SELECT nonexistent_column FROM relationships",
+			expectedError:       "column nonexistent_column does not exist in table relationships",
+			expectedUnsupported: true,
+		},
+		{
+			name:                "invalid field in WHERE",
+			query:               "SELECT * FROM relationships WHERE nonexistent_field = 'value'",
+			expectedError:       "field nonexistent_field does not exist in table relationships",
+			expectedUnsupported: true,
+		},
+		{
+			name:           "basic select with specific columns",
+			query:          "SELECT resource_type, resource_id FROM relationships WHERE resource_type = 'document'",
+			expectedFields: map[string]valueOrRef{"resource_type": {value: "document"}},
+		},
+		{
+			name:                "unsupported expression - LIKE",
+			query:               "SELECT * FROM relationships WHERE resource_type LIKE 'doc%'",
+			expectedError:       "only = supported",
+			expectedUnsupported: true,
+		},
+		{
+			name:                "unsupported expression - IN",
+			query:               "SELECT * FROM relationships WHERE resource_type IN ('doc', 'page')",
+			expectedError:       "unsupported expression type",
+			expectedUnsupported: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := pg_query.Parse(tc.query)
+			require.NoError(t, err)
+
+			slc, err := ParseSelectStatement(parsed.Stmts[0].Stmt.GetSelectStmt(), false)
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+
+				if tc.expectedUnsupported {
+					require.Equal(t, tc.expectedUnsupported, slc.isUnsupported)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedFields, slc.fields)
+		})
+	}
+}

--- a/internal/fdw/tables/statement_test.go
+++ b/internal/fdw/tables/statement_test.go
@@ -1,0 +1,147 @@
+package tables
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectStatementAccessors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		stmt         *SelectStatement
+		expectedName string
+	}{
+		{
+			name: "relationships table",
+			stmt: &SelectStatement{
+				tableName: "relationships",
+				tableDef:  tables["relationships"],
+			},
+			expectedName: "relationships",
+		},
+		{
+			name: "permissions table",
+			stmt: &SelectStatement{
+				tableName: "permissions",
+				tableDef:  tables["permissions"],
+			},
+			expectedName: "permissions",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expectedName, tc.stmt.TableName())
+			require.Equal(t, tc.stmt.isUnsupported, tc.stmt.IsUnsupported())
+		})
+	}
+}
+
+func TestFieldMapHasFields(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		fields   fieldMap[string]
+		check    []string
+		expected bool
+	}{
+		{
+			name: "all fields present",
+			fields: fieldMap[string]{
+				"resource_type": {value: "document"},
+				"resource_id":   {value: "doc1"},
+			},
+			check:    []string{"resource_type", "resource_id"},
+			expected: true,
+		},
+		{
+			name: "some fields missing",
+			fields: fieldMap[string]{
+				"resource_type": {value: "document"},
+			},
+			check:    []string{"resource_type", "resource_id"},
+			expected: false,
+		},
+		{
+			name:     "empty map",
+			fields:   fieldMap[string]{},
+			check:    []string{"resource_type"},
+			expected: false,
+		},
+		{
+			name: "checking empty list",
+			fields: fieldMap[string]{
+				"resource_type": {value: "document"},
+			},
+			check:    []string{},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tc.fields.hasFields(tc.check...)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestTableDefinitionMethods(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		tableDef tableDefinition
+	}{
+		{
+			name:     "relationships table",
+			tableDef: tables["relationships"],
+		},
+		{
+			name:     "permissions table",
+			tableDef: tables["permissions"],
+		},
+		{
+			name:     "schema table",
+			tableDef: tables["schema"],
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Test columnNames
+			names := tc.tableDef.columnNames()
+			require.NotEmpty(t, names)
+			require.Len(t, names, len(tc.tableDef.schema))
+
+			// Test hasColumn with valid column
+			if len(names) > 0 {
+				require.True(t, tc.tableDef.hasColumn(names[0]))
+			}
+
+			// Test hasColumn with invalid column
+			require.False(t, tc.tableDef.hasColumn("invalid_column_name"))
+
+			// Test getSchemaColumn with valid column
+			if len(names) > 0 {
+				col, ok := tc.tableDef.getSchemaColumn(names[0])
+				require.True(t, ok)
+				require.Equal(t, names[0], col.Name)
+			}
+
+			// Test getSchemaColumn with invalid column
+			_, ok := tc.tableDef.getSchemaColumn("invalid_column_name")
+			require.False(t, ok)
+		})
+	}
+}

--- a/internal/fdw/tables/tables.go
+++ b/internal/fdw/tables/tables.go
@@ -1,0 +1,112 @@
+package tables
+
+import (
+	"context"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/authzed-go/v1"
+)
+
+type (
+	insertRunner    func(ctx context.Context, client *authzed.Client, insertStmt *InsertStatement, parameters []wire.Parameter) (int64, []any, error)
+	insertValidator func(ctx context.Context, stmt *pg_query.InsertStmt, colNames []string) (map[string]any, error)
+)
+
+type (
+	deleteRunner func(ctx context.Context, client *authzed.Client, deleteStmt *DeleteStatement, parameters []wire.Parameter) (int64, []any, error)
+)
+
+type (
+	selectHandler        func(ctx context.Context, client *authzed.Client, parameters []wire.Parameter, howMany int64, writer wire.DataWriter, rowsCursor RowsCursor, selectStmt *SelectStatement) (RowsCursor, error)
+	selectHandlerBuilder func(fields fieldMap[string]) (selectHandler, error)
+)
+
+type (
+	explainHandler        func(ctx context.Context, client *authzed.Client, writer wire.DataWriter) error
+	explainHandlerBuilder func(fields fieldMap[string]) (explainHandler, error)
+)
+
+type tableDefinition struct {
+	name                  string
+	schema                wire.Columns
+	insertValidator       insertValidator
+	insertRunner          insertRunner
+	deleteRunner          deleteRunner
+	buildSelectHandler    selectHandlerBuilder
+	buildExplainHandler   explainHandlerBuilder
+	requiredInsertColumns []string
+}
+
+func (td tableDefinition) hasColumn(colName string) bool {
+	for _, col := range td.schema {
+		if col.Name == colName {
+			return true
+		}
+	}
+	return false
+}
+
+func (td tableDefinition) columnNames() []string {
+	names := make([]string, len(td.schema))
+	for i, col := range td.schema {
+		names[i] = col.Name
+	}
+	return names
+}
+
+func (td tableDefinition) getSchemaColumn(name string) (wire.Column, bool) {
+	for _, col := range td.schema {
+		if col.Name == name {
+			return col, true
+		}
+	}
+	return wire.Column{}, false
+}
+
+type fieldMap[F ~string] map[F]valueOrRef
+
+func (m fieldMap[F]) hasFields(fieldNames ...F) bool {
+	for _, fieldName := range fieldNames {
+		if _, ok := m[fieldName]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// convertFieldMap converts a typed fieldMap to a string-keyed fieldMap for compatibility with generic functions
+func convertFieldMap[F ~string](fields fieldMap[F]) fieldMap[string] {
+	result := fieldMap[string]{}
+	for k, v := range fields {
+		result[string(k)] = v
+	}
+	return result
+}
+
+var tables = map[string]tableDefinition{
+	"relationships": {
+		name:                  "relationships",
+		schema:                relationshipsSchema,
+		insertRunner:          relationshipsInsertRunner,
+		insertValidator:       relationshipInsertValidator,
+		deleteRunner:          relationshipsDeleteRunner,
+		buildSelectHandler:    buildRelationshipsSelectHandler,
+		buildExplainHandler:   buildRelationshipsExplainHandler,
+		requiredInsertColumns: relationshipsRequiredInsertColumns,
+	},
+	"permissions": {
+		name:                "permissions",
+		schema:              permissionsSchema,
+		buildSelectHandler:  buildPermissionsSelectHandler,
+		buildExplainHandler: buildPermissionsExplainHandler,
+	},
+	"schema": {
+		name:                "schema",
+		schema:              schemaSchema,
+		insertRunner:        schemaInsertRunner,
+		buildSelectHandler:  buildSchemaSelectHandler,
+		buildExplainHandler: buildSchemaExplainHandler,
+	},
+}

--- a/internal/fdw/tables/util.go
+++ b/internal/fdw/tables/util.go
@@ -1,0 +1,86 @@
+package tables
+
+import (
+	"errors"
+	"fmt"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/authzed/spicedb/internal/fdw/common"
+)
+
+func stringValue(valueOrRef valueOrRef, parameters []wire.Parameter) (string, error) {
+	if valueOrRef.isSubQueryPlaceholder {
+		return "", errors.New("subquery placeholders are not supported in permissions table")
+	}
+
+	if valueOrRef.parameterIndex > 0 {
+		if int(valueOrRef.parameterIndex) >= len(parameters) {
+			return "", errors.New("parameter index out of range")
+		}
+		return string(parameters[int(valueOrRef.parameterIndex)].Value()), nil
+	}
+
+	if valueOrRef.value == "" {
+		return "", errors.New("value is empty")
+	}
+
+	return valueOrRef.value, nil
+}
+
+func optionalStringValue(valueOrRef valueOrRef, parameters []wire.Parameter) (string, error) {
+	if valueOrRef.isSubQueryPlaceholder {
+		return "", errors.New("subquery placeholders are not supported in permissions table")
+	}
+
+	if valueOrRef.parameterIndex > 0 {
+		if int(valueOrRef.parameterIndex) >= len(parameters) {
+			return "", errors.New("parameter index out of range")
+		}
+		return string(parameters[int(valueOrRef.parameterIndex)].Value()), nil
+	}
+
+	return valueOrRef.value, nil
+}
+
+type returningQuery interface {
+	GetReturningList() []*pg_query.Node
+}
+
+func returningColumnsFromQuery(tableDef tableDefinition, query returningQuery) ([]wire.Column, error) {
+	returningColumns := make([]wire.Column, 0, len(query.GetReturningList()))
+	for _, returning := range query.GetReturningList() {
+		if returning.GetResTarget() == nil {
+			return nil, common.NewQueryError(errors.New("returning column is missing a name"))
+		}
+
+		columnVal := returning.GetResTarget().GetVal()
+		if columnVal == nil {
+			return nil, common.NewQueryError(errors.New("returning column is missing a value"))
+		}
+
+		if columnVal.GetColumnRef() == nil {
+			return nil, common.NewQueryError(errors.New("returning column is not a column reference"))
+		}
+
+		columnNameFields := columnVal.GetColumnRef().GetFields()
+		if len(columnNameFields) != 1 {
+			return nil, common.NewQueryError(errors.New("returning column has multiple fields"))
+		}
+
+		columnNameString := columnNameFields[0].GetString_()
+		if columnNameString == nil {
+			return nil, common.NewQueryError(errors.New("returning column is not a string"))
+		}
+
+		columnName := columnNameString.Sval
+		column, ok := tableDef.getSchemaColumn(columnName)
+		if !ok {
+			return nil, common.NewQueryError(fmt.Errorf("returning column %q does not exist", columnName))
+		}
+
+		returningColumns = append(returningColumns, column)
+	}
+	return returningColumns, nil
+}

--- a/internal/fdw/tables/util_test.go
+++ b/internal/fdw/tables/util_test.go
@@ -1,0 +1,202 @@
+package tables
+
+import (
+	"testing"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		valueOrRef    valueOrRef
+		parameters    []wire.Parameter
+		expectedValue string
+		expectedError string
+	}{
+		{
+			name:          "direct value",
+			valueOrRef:    valueOrRef{value: "test_value"},
+			expectedValue: "test_value",
+		},
+		{
+			name:          "parameter index",
+			valueOrRef:    valueOrRef{parameterIndex: 1},
+			parameters:    []wire.Parameter{mockParameter("param0"), mockParameter("param1")},
+			expectedValue: "param1",
+		},
+		{
+			name:          "parameter index out of range",
+			valueOrRef:    valueOrRef{parameterIndex: 5},
+			parameters:    []wire.Parameter{mockParameter("param0")},
+			expectedError: "parameter index out of range",
+		},
+		{
+			name:          "empty value",
+			valueOrRef:    valueOrRef{value: ""},
+			expectedError: "value is empty",
+		},
+		{
+			name:          "subquery placeholder not supported",
+			valueOrRef:    valueOrRef{isSubQueryPlaceholder: true},
+			expectedError: "subquery placeholders are not supported in permissions table",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := stringValue(tc.valueOrRef, tc.parameters)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedValue, result)
+		})
+	}
+}
+
+func TestOptionalStringValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		valueOrRef    valueOrRef
+		parameters    []wire.Parameter
+		expectedValue string
+		expectedError string
+	}{
+		{
+			name:          "direct value",
+			valueOrRef:    valueOrRef{value: "test_value"},
+			expectedValue: "test_value",
+		},
+		{
+			name:          "empty value is allowed",
+			valueOrRef:    valueOrRef{value: ""},
+			expectedValue: "",
+		},
+		{
+			name:          "parameter index",
+			valueOrRef:    valueOrRef{parameterIndex: 1},
+			parameters:    []wire.Parameter{mockParameter("param0"), mockParameter("param1")},
+			expectedValue: "param1",
+		},
+		{
+			name:          "parameter index out of range",
+			valueOrRef:    valueOrRef{parameterIndex: 5},
+			parameters:    []wire.Parameter{mockParameter("param0")},
+			expectedError: "parameter index out of range",
+		},
+		{
+			name:          "subquery placeholder not supported",
+			valueOrRef:    valueOrRef{isSubQueryPlaceholder: true},
+			expectedError: "subquery placeholders are not supported in permissions table",
+		},
+		{
+			name:          "zero value",
+			valueOrRef:    valueOrRef{},
+			expectedValue: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := optionalStringValue(tc.valueOrRef, tc.parameters)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedValue, result)
+		})
+	}
+}
+
+func TestReturningColumnsFromQuery(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name               string
+		query              string
+		expectedError      string
+		expectedColumnName string
+	}{
+		{
+			name:               "insert with returning consistency",
+			query:              "INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation) VALUES ('doc', 'id', 'rel', 'user', 'alice', '') RETURNING consistency",
+			expectedColumnName: "consistency",
+		},
+		{
+			name:               "delete with returning consistency",
+			query:              "DELETE FROM relationships WHERE resource_type = 'doc' RETURNING consistency",
+			expectedColumnName: "consistency",
+		},
+		{
+			name:               "insert without returning",
+			query:              "INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation) VALUES ('doc', 'id', 'rel', 'user', 'alice', '')",
+			expectedColumnName: "",
+		},
+		{
+			name:          "returning invalid column",
+			query:         "INSERT INTO relationships (resource_type, resource_id, relation, subject_type, subject_id, optional_subject_relation) VALUES ('doc', 'id', 'rel', 'user', 'alice', '') RETURNING invalid_column",
+			expectedError: "returning column \"invalid_column\" does not exist",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := pg_query.Parse(tc.query)
+			require.NoError(t, err)
+			require.NotEmpty(t, parsed.Stmts)
+
+			var returningQuery returningQuery
+			if insertStmt := parsed.Stmts[0].Stmt.GetInsertStmt(); insertStmt != nil {
+				returningQuery = insertStmt
+			} else if deleteStmt := parsed.Stmts[0].Stmt.GetDeleteStmt(); deleteStmt != nil {
+				returningQuery = deleteStmt
+			} else {
+				t.Fatal("Expected INSERT or DELETE statement")
+			}
+
+			tableDef := tables["relationships"]
+			columns, err := returningColumnsFromQuery(tableDef, returningQuery)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.expectedColumnName == "" {
+				require.Empty(t, columns)
+			} else {
+				require.Len(t, columns, 1)
+				require.Equal(t, tc.expectedColumnName, columns[0].Name)
+			}
+		})
+	}
+}
+
+// mockParameter creates a wire.Parameter for testing
+func mockParameter(value string) wire.Parameter {
+	return wire.NewParameter(nil, wire.TextFormat, []byte(value))
+}

--- a/internal/fdw/transaction.go
+++ b/internal/fdw/transaction.go
@@ -1,0 +1,50 @@
+package fdw
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+func (p *PgBackend) handleTransactionStmt(_ context.Context, stmt *pg_query.TransactionStmt, _ string) (wire.PreparedStatements, error) {
+	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
+		switch stmt.Kind {
+		// START TRANSACTION
+		case pg_query.TransactionStmtKind_TRANS_STMT_START:
+			session := sessionKey.MustValue(ctx)
+			session.mu.Lock()
+			defer session.mu.Unlock()
+
+			if session.withinTransaction {
+				return errors.New("cannot start transaction within a transaction")
+			}
+
+			session.withinTransaction = true
+			return writer.Complete("started")
+
+		// ABORT TRANSACTION
+		case pg_query.TransactionStmtKind_TRANS_STMT_ROLLBACK:
+			fallthrough
+
+		// COMMIT
+		case pg_query.TransactionStmtKind_TRANS_STMT_COMMIT:
+			session := sessionKey.MustValue(ctx)
+			session.mu.Lock()
+			defer session.mu.Unlock()
+
+			if !session.withinTransaction {
+				return errors.New("cannot commit/rollback transaction outside of a transaction")
+			}
+
+			session.withinTransaction = false
+			return writer.Complete("completed")
+
+		default:
+			return fmt.Errorf("not implemented: %v", stmt)
+		}
+	}
+	return wire.Prepared(wire.NewStatement(handle)), nil
+}

--- a/internal/fdw/util.go
+++ b/internal/fdw/util.go
@@ -1,0 +1,10 @@
+package fdw
+
+import "iter"
+
+func mustFirst[T any](slice iter.Seq[T]) T {
+	for v := range slice {
+		return v
+	}
+	panic("mustFirst: slice is empty")
+}

--- a/pkg/cmd/postgresfdw.go
+++ b/pkg/cmd/postgresfdw.go
@@ -1,0 +1,179 @@
+//go:build cgo
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/zerologr"
+	"github.com/jzelinskie/cobrautil/v2"
+	"github.com/jzelinskie/cobrautil/v2/cobrazerolog"
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/authzed/authzed-go/v1"
+	"github.com/authzed/grpcutil"
+
+	"github.com/authzed/spicedb/internal/fdw"
+	"github.com/authzed/spicedb/internal/logging"
+	"github.com/authzed/spicedb/pkg/cmd/termination"
+	"github.com/authzed/spicedb/pkg/releases"
+)
+
+// PostgresFDWConfig is the configuration for the Postgres FDW command.
+type PostgresFDWConfig struct {
+	// SpiceDB connection config
+	SpiceDBEndpoint          string
+	SecureSpiceDBAccessToken string
+	SpiceDBInsecure          bool
+
+	// Postgres FDW server config
+	PostgresEndpoint    string
+	PostgresUsername    string // Username that Postgres will use to connect to the FDW proxy
+	SecureAccessToken   string // Password that Postgres will use to authenticate to the FDW proxy
+	ShutdownGracePeriod time.Duration
+}
+
+// Complete adapts the PostgresFDWConfig into a runnable Postgres FDW server.
+func (c *PostgresFDWConfig) Complete(ctx context.Context) (RunnablePostgresFDWServer, error) {
+	systemCerts, err := grpcutil.WithSystemCerts(grpcutil.VerifyCA)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load system certs: %w", err)
+	}
+
+	if c.SpiceDBEndpoint == "" {
+		return nil, errors.New("missing SpiceDB endpoint")
+	}
+	if c.SecureSpiceDBAccessToken == "" {
+		return nil, errors.New("missing SpiceDB access token")
+	}
+
+	var client *authzed.Client
+	if c.SpiceDBInsecure {
+		logging.Info().Str("endpoint", c.SpiceDBEndpoint).Msg("connecting to SpiceDB insecurely")
+		spicedbClient, err := authzed.NewClient(
+			c.SpiceDBEndpoint,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpcutil.WithInsecureBearerToken(c.SecureSpiceDBAccessToken),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create client: %w", err)
+		}
+		client = spicedbClient
+	} else {
+		logging.Info().Str("endpoint", c.SpiceDBEndpoint).Msg("connecting to SpiceDB securely")
+		spicedbClient, err := authzed.NewClient(
+			c.SpiceDBEndpoint,
+			systemCerts,
+			grpcutil.WithBearerToken(c.SecureSpiceDBAccessToken),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create client: %w", err)
+		}
+		client = spicedbClient
+	}
+
+	if c.SecureAccessToken == "" {
+		return nil, errors.New("missing Postgres secure access token")
+	}
+
+	if c.PostgresUsername == "" {
+		return nil, errors.New("missing Postgres username")
+	}
+
+	pg := fdw.NewPgBackend(client, c.PostgresUsername, c.SecureAccessToken)
+	return &postgresFDWServer{pg: pg, address: c.PostgresEndpoint}, nil
+}
+
+type postgresFDWServer struct {
+	pg      *fdw.PgBackend
+	address string
+}
+
+func (s *postgresFDWServer) Run(ctx context.Context) error {
+	serverError := make(chan error)
+
+	go func() {
+		err := s.pg.Run(ctx, s.address)
+		serverError <- err
+	}()
+
+	select {
+	case err := <-serverError:
+		return err
+	case <-ctx.Done():
+		return s.pg.Close()
+	}
+}
+
+func (s *postgresFDWServer) Close() error {
+	return s.pg.Close()
+}
+
+// RunnablePostgresFDWServer is a Postgres FDW server ready to run
+type RunnablePostgresFDWServer interface {
+	Run(ctx context.Context) error
+	Close() error
+}
+
+func RegisterPostgresFDWFlags(cmd *cobra.Command, config *PostgresFDWConfig) error {
+	nfs := cobrautil.NewNamedFlagSets(cmd)
+
+	spicedbFlagSet := nfs.FlagSet(BoldBlue("spicedb"))
+	spicedbFlagSet.StringVar(&config.SpiceDBEndpoint, "spicedb-api-endpoint", "localhost:50051", "SpiceDB API endpoint")
+	spicedbFlagSet.StringVar(&config.SecureSpiceDBAccessToken, "spicedb-access-token-secret", "", "(required) Access token for calling the SpiceDB API")
+	spicedbFlagSet.BoolVar(&config.SpiceDBInsecure, "spicedb-insecure", false, "Use insecure connection to SpiceDB API")
+	if err := cobra.MarkFlagRequired(spicedbFlagSet, "spicedb-access-token-secret"); err != nil {
+		return fmt.Errorf("failed to mark flag as required: %w", err)
+	}
+
+	serviceFlags := nfs.FlagSet(BoldBlue("service"))
+	serviceFlags.DurationVar(&config.ShutdownGracePeriod, "shutdown-grace-period", 0, "The duration to wait for the server to shutdown gracefully")
+	serviceFlags.StringVar(&config.PostgresEndpoint, "postgres-endpoint", ":5432", "The endpoint at which to serve the Postgres protocol")
+	serviceFlags.StringVar(&config.PostgresUsername, "postgres-username", "postgres", "The username that Postgres will use to connect to the FDW proxy")
+	serviceFlags.StringVar(&config.SecureAccessToken, "postgres-access-token-secret", "", "(required) The password that Postgres will use to authenticate to the FDW proxy (configured in the Postgres FDW extension's OPTIONS)")
+	if err := cobra.MarkFlagRequired(serviceFlags, "postgres-access-token-secret"); err != nil {
+		return fmt.Errorf("failed to mark flag as required: %w", err)
+	}
+
+	// Attach the created flagsets to the command - they're created but not registered
+	// until this function is called.
+	nfs.AddFlagSets(cmd)
+
+	return nil
+}
+
+func NewPostgresFDWCommand(programName string, config *PostgresFDWConfig) *cobra.Command {
+	return &cobra.Command{
+		Use:   "postgres-fdw",
+		Short: "serve a Postgres Foreign Data Wrapper for SpiceDB (EXPERIMENTAL)",
+		Long:  "EXPERIMENTAL: Serves a Postgres-compatible interface for querying SpiceDB data using foreign data wrappers. This feature is experimental and subject to change.",
+		PreRunE: cobrautil.CommandStack(
+			cobrautil.SyncViperDotEnvPreRunE(programName, "spicedb.env", zerologr.New(&logging.Logger)),
+			cobrazerolog.New(
+				cobrazerolog.WithTarget(func(logger zerolog.Logger) {
+					logging.SetGlobalLogger(logger)
+				}),
+			).RunE(),
+			releases.CheckAndLogRunE(),
+		),
+		RunE: termination.PublishError(func(cmd *cobra.Command, args []string) error {
+			srv, err := config.Complete(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			signalctx := SignalContextWithGracePeriod(
+				context.Background(),
+				config.ShutdownGracePeriod,
+			)
+
+			return srv.Run(signalctx)
+		}),
+	}
+}

--- a/pkg/cmd/postgresfdw_nocgo.go
+++ b/pkg/cmd/postgresfdw_nocgo.go
@@ -1,0 +1,41 @@
+//go:build !cgo
+
+package cmd
+
+import (
+	"errors"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// PostgresFDWConfig is the configuration for the Postgres FDW command (stub for non-CGO builds)
+type PostgresFDWConfig struct {
+	// SpiceDB connection config
+	SpiceDBEndpoint          string
+	SecureSpiceDBAccessToken string
+	SpiceDBInsecure          bool
+
+	// Postgres FDW server config
+	PostgresEndpoint    string
+	PostgresUsername    string
+	SecureAccessToken   string
+	ShutdownGracePeriod time.Duration
+}
+
+// NewPostgresFDWCommand returns a command that errors when CGO is not enabled
+func NewPostgresFDWCommand(programName string, config *PostgresFDWConfig) *cobra.Command {
+	return &cobra.Command{
+		Use:   "postgres-fdw",
+		Short: "serve a Postgres Foreign Data Wrapper for SpiceDB (EXPERIMENTAL)",
+		Long:  "EXPERIMENTAL: Serves a Postgres-compatible interface for querying SpiceDB data using foreign data wrappers. This feature requires CGO to be enabled during compilation.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("postgres-fdw command requires CGO to be enabled during compilation")
+		},
+	}
+}
+
+// RegisterPostgresFDWFlags is a no-op when CGO is not enabled
+func RegisterPostgresFDWFlags(cmd *cobra.Command, config *PostgresFDWConfig) error {
+	return nil
+}

--- a/pkg/cmd/postgresfdw_test.go
+++ b/pkg/cmd/postgresfdw_test.go
@@ -1,0 +1,234 @@
+//go:build cgo
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// Run a postgres-fdw command with specified command line args
+// and call `assertConfig` with the merged configuration.
+func RunPostgresFDWTest(t *testing.T, args []string, assertConfig func(t *testing.T, mergedConfig *PostgresFDWConfig)) {
+	config := new(PostgresFDWConfig)
+	cmd := NewPostgresFDWCommand("spicedb", config)
+	err := RegisterRootFlags(cmd)
+	require.NoError(t, err)
+	require.NoError(t, RegisterPostgresFDWFlags(cmd, config))
+
+	cmd.SetArgs(args)
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		assertConfig(t, config)
+		return nil
+	}
+	require.NoError(t, cmd.Execute())
+}
+
+func preparePostgresFDWTempConfigFile(t *testing.T, config string) {
+	confdir := prepareTempConfigDir(t)
+	confFile, err := os.Create(filepath.Join(confdir, "spicedb.env"))
+	require.NoError(t, err)
+	_, err = confFile.WriteString(config)
+	require.NoError(t, err)
+	require.NoError(t, confFile.Close())
+	prevEnv := os.Environ()
+	restore := func() {
+		restoreEnv(prevEnv)
+	}
+	t.Cleanup(restore)
+}
+
+func TestPostgresFDWDefaultConfig(t *testing.T) {
+	flags := []string{
+		"--spicedb-access-token-secret", "test_token",
+		"--postgres-access-token-secret", "postgres_token",
+	}
+	RunPostgresFDWTest(t, flags, func(t *testing.T, mergedConfig *PostgresFDWConfig) {
+		require.Equal(t, "localhost:50051", mergedConfig.SpiceDBEndpoint)
+		require.Equal(t, "test_token", mergedConfig.SecureSpiceDBAccessToken)
+		require.False(t, mergedConfig.SpiceDBInsecure)
+		require.Equal(t, ":5432", mergedConfig.PostgresEndpoint)
+		require.Equal(t, "postgres", mergedConfig.PostgresUsername)
+		require.Equal(t, "postgres_token", mergedConfig.SecureAccessToken)
+	})
+}
+
+func TestPostgresFDWFlagsAreParsed(t *testing.T) {
+	flags := []string{
+		"--spicedb-api-endpoint", "127.0.0.1:50052",
+		"--spicedb-access-token-secret", "test_token",
+		"--spicedb-insecure",
+		"--postgres-endpoint", "127.0.0.1:5433",
+		"--postgres-username", "customuser",
+		"--postgres-access-token-secret", "postgres_token",
+		"--shutdown-grace-period", "10s",
+	}
+	RunPostgresFDWTest(t, flags, func(t *testing.T, mergedConfig *PostgresFDWConfig) {
+		require.Equal(t, "127.0.0.1:50052", mergedConfig.SpiceDBEndpoint)
+		require.Equal(t, "test_token", mergedConfig.SecureSpiceDBAccessToken)
+		require.True(t, mergedConfig.SpiceDBInsecure)
+		require.Equal(t, "127.0.0.1:5433", mergedConfig.PostgresEndpoint)
+		require.Equal(t, "customuser", mergedConfig.PostgresUsername)
+		require.Equal(t, "postgres_token", mergedConfig.SecureAccessToken)
+		require.Equal(t, "10s", mergedConfig.ShutdownGracePeriod.String())
+	})
+}
+
+func TestPostgresFDWEnvVarsAreParsed(t *testing.T) {
+	t.Setenv("SPICEDB_SPICEDB_API_ENDPOINT", "127.0.0.1:50053")
+	t.Setenv("SPICEDB_SPICEDB_ACCESS_TOKEN_SECRET", "test_token")
+	t.Setenv("SPICEDB_SPICEDB_INSECURE", "true")
+	t.Setenv("SPICEDB_POSTGRES_ENDPOINT", "127.0.0.1:5434")
+	t.Setenv("SPICEDB_POSTGRES_USERNAME", "envuser")
+	t.Setenv("SPICEDB_POSTGRES_ACCESS_TOKEN_SECRET", "postgres_token")
+	t.Setenv("SPICEDB_SHUTDOWN_GRACE_PERIOD", "15s")
+	flags := []string{}
+	RunPostgresFDWTest(t, flags, func(t *testing.T, mergedConfig *PostgresFDWConfig) {
+		require.Equal(t, "127.0.0.1:50053", mergedConfig.SpiceDBEndpoint)
+		require.Equal(t, "test_token", mergedConfig.SecureSpiceDBAccessToken)
+		require.True(t, mergedConfig.SpiceDBInsecure)
+		require.Equal(t, "127.0.0.1:5434", mergedConfig.PostgresEndpoint)
+		require.Equal(t, "envuser", mergedConfig.PostgresUsername)
+		require.Equal(t, "postgres_token", mergedConfig.SecureAccessToken)
+		require.Equal(t, "15s", mergedConfig.ShutdownGracePeriod.String())
+	})
+}
+
+func TestPostgresFDWConfigFileValuesAreParsed(t *testing.T) {
+	config := `
+	SPICEDB_SPICEDB_API_ENDPOINT=127.0.0.1:50054
+	SPICEDB_SPICEDB_ACCESS_TOKEN_SECRET=test_token
+	SPICEDB_SPICEDB_INSECURE=true
+	SPICEDB_POSTGRES_ENDPOINT=127.0.0.1:5435
+	SPICEDB_POSTGRES_USERNAME=fileuser
+	SPICEDB_POSTGRES_ACCESS_TOKEN_SECRET=postgres_token
+	SPICEDB_SHUTDOWN_GRACE_PERIOD=20s`
+	preparePostgresFDWTempConfigFile(t, config)
+	flags := []string{}
+	RunPostgresFDWTest(t, flags, func(t *testing.T, mergedConfig *PostgresFDWConfig) {
+		require.Equal(t, "127.0.0.1:50054", mergedConfig.SpiceDBEndpoint)
+		require.Equal(t, "test_token", mergedConfig.SecureSpiceDBAccessToken)
+		require.True(t, mergedConfig.SpiceDBInsecure)
+		require.Equal(t, "127.0.0.1:5435", mergedConfig.PostgresEndpoint)
+		require.Equal(t, "fileuser", mergedConfig.PostgresUsername)
+		require.Equal(t, "postgres_token", mergedConfig.SecureAccessToken)
+		require.Equal(t, "20s", mergedConfig.ShutdownGracePeriod.String())
+	})
+}
+
+func TestPostgresFDWConfigsAreMerged(t *testing.T) {
+	config := `
+	SPICEDB_SPICEDB_API_ENDPOINT=127.0.0.1:50055
+	SPICEDB_SPICEDB_ACCESS_TOKEN_SECRET=test_token`
+	preparePostgresFDWTempConfigFile(t, config)
+
+	t.Setenv("SPICEDB_POSTGRES_ENDPOINT", "127.0.0.1:5436")
+	t.Setenv("SPICEDB_POSTGRES_USERNAME", "mergeduser")
+	t.Setenv("SPICEDB_POSTGRES_ACCESS_TOKEN_SECRET", "postgres_token")
+
+	flags := []string{
+		"--shutdown-grace-period", "25s",
+	}
+	RunPostgresFDWTest(t, flags, func(t *testing.T, mergedConfig *PostgresFDWConfig) {
+		require.Equal(t, "127.0.0.1:50055", mergedConfig.SpiceDBEndpoint)
+		require.Equal(t, "test_token", mergedConfig.SecureSpiceDBAccessToken)
+		require.Equal(t, "127.0.0.1:5436", mergedConfig.PostgresEndpoint)
+		require.Equal(t, "mergeduser", mergedConfig.PostgresUsername)
+		require.Equal(t, "postgres_token", mergedConfig.SecureAccessToken)
+		require.Equal(t, "25s", mergedConfig.ShutdownGracePeriod.String())
+	})
+}
+
+func TestPostgresFDWConfigPrecedence(t *testing.T) {
+	// Config file has lowest precedence (over default values)
+	config := `
+	SPICEDB_SPICEDB_API_ENDPOINT=127.0.0.1:50056
+	SPICEDB_SPICEDB_ACCESS_TOKEN_SECRET=test_token_file
+	SPICEDB_POSTGRES_ENDPOINT=127.0.0.1:5437
+	SPICEDB_POSTGRES_USERNAME=fileuser
+	SPICEDB_POSTGRES_ACCESS_TOKEN_SECRET=postgres_token_file
+	SPICEDB_SHUTDOWN_GRACE_PERIOD=30s`
+	preparePostgresFDWTempConfigFile(t, config)
+
+	// Env variables override config file
+	t.Setenv("SPICEDB_POSTGRES_ENDPOINT", "127.0.0.1:5438")
+	t.Setenv("SPICEDB_POSTGRES_USERNAME", "envuser")
+	t.Setenv("SPICEDB_POSTGRES_ACCESS_TOKEN_SECRET", "postgres_token_env")
+	t.Setenv("SPICEDB_SHUTDOWN_GRACE_PERIOD", "35s")
+
+	// command line flags override everything
+	flags := []string{
+		"--postgres-username", "flaguser",
+		"--shutdown-grace-period", "40s",
+	}
+	RunPostgresFDWTest(t, flags, func(t *testing.T, mergedConfig *PostgresFDWConfig) {
+		require.Equal(t, "127.0.0.1:50056", mergedConfig.SpiceDBEndpoint)
+		require.Equal(t, "test_token_file", mergedConfig.SecureSpiceDBAccessToken)
+		require.Equal(t, "127.0.0.1:5438", mergedConfig.PostgresEndpoint)
+		require.Equal(t, "flaguser", mergedConfig.PostgresUsername)
+		require.Equal(t, "postgres_token_env", mergedConfig.SecureAccessToken)
+		require.Equal(t, "40s", mergedConfig.ShutdownGracePeriod.String())
+	})
+}
+
+func TestPostgresFDWCompleteValidation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("missing SpiceDB endpoint", func(t *testing.T) {
+		config := &PostgresFDWConfig{
+			SpiceDBEndpoint:          "",
+			SecureSpiceDBAccessToken: "test_token",
+			PostgresEndpoint:         ":5432",
+			PostgresUsername:         "postgres",
+			SecureAccessToken:        "postgres_token",
+		}
+		_, err := config.Complete(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing SpiceDB endpoint")
+	})
+
+	t.Run("missing SpiceDB access token", func(t *testing.T) {
+		config := &PostgresFDWConfig{
+			SpiceDBEndpoint:          "localhost:50051",
+			SecureSpiceDBAccessToken: "",
+			PostgresEndpoint:         ":5432",
+			PostgresUsername:         "postgres",
+			SecureAccessToken:        "postgres_token",
+		}
+		_, err := config.Complete(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing SpiceDB access token")
+	})
+
+	t.Run("missing Postgres access token", func(t *testing.T) {
+		config := &PostgresFDWConfig{
+			SpiceDBEndpoint:          "localhost:50051",
+			SecureSpiceDBAccessToken: "test_token",
+			PostgresEndpoint:         ":5432",
+			PostgresUsername:         "postgres",
+			SecureAccessToken:        "",
+		}
+		_, err := config.Complete(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing Postgres secure access token")
+	})
+
+	t.Run("missing Postgres username", func(t *testing.T) {
+		config := &PostgresFDWConfig{
+			SpiceDBEndpoint:          "localhost:50051",
+			SecureSpiceDBAccessToken: "test_token",
+			PostgresEndpoint:         ":5432",
+			PostgresUsername:         "",
+			SecureAccessToken:        "postgres_token",
+		}
+		_, err := config.Complete(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing Postgres username")
+	})
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -106,6 +106,13 @@ func BuildRootCommand() (*cobra.Command, error) {
 	}
 	rootCmd.AddCommand(lspCmd)
 
+	postgresFDWConfig := new(PostgresFDWConfig)
+	postgresFDWCmd := NewPostgresFDWCommand(rootCmd.Use, postgresFDWConfig)
+	if err := RegisterPostgresFDWFlags(postgresFDWCmd, postgresFDWConfig); err != nil {
+		return nil, fmt.Errorf("failed to register postgres-fdw flags: %w", err)
+	}
+	rootCmd.AddCommand(postgresFDWCmd)
+
 	var testServerConfig testserver.Config
 	testingCmd := NewTestingCommand(rootCmd.Use, &testServerConfig)
 	RegisterTestingFlags(testingCmd, &testServerConfig)


### PR DESCRIPTION
The PostgresFDW allows SpiceDB to be used from within Postgres via the Postgres Foreign Data Wrapper protocol, as-if Postgres was speaking to another Postgres.

It supports querying (Check, LookupResources, LookupSubjects), as well as reads (RealRelationships), writes (WriteRelationships) and schema updates (ReadSchema/WriteSchema).

These operations are performed against "virtual" tables (`permissions`, `relationships` and `schema`) that are placed into the Postgres and translated by this proxy.

For more information, see the README.md

This is currently experimental and subject to changes