### PR TITLE
Support reading Composable Schemas from fs.FS

### DIFF
--- a/pkg/composableschemadsl/compiler/importer.go
+++ b/pkg/composableschemadsl/compiler/importer.go
@@ -2,7 +2,7 @@ package compiler
 
 import (
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -16,8 +16,8 @@ type CircularImportError struct {
 	filePath string
 }
 
-func importFile(filePath string) (*dslNode, error) {
-	schemaBytes, err := os.ReadFile(filePath)
+func importFile(fsys fs.FS, filePath string) (*dslNode, error) {
+	schemaBytes, err := fs.ReadFile(fsys, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read import in schema file: %w", err)
 	}

--- a/pkg/composableschemadsl/compiler/importer_test.go
+++ b/pkg/composableschemadsl/compiler/importer_test.go
@@ -1,9 +1,12 @@
 package compiler_test
 
 import (
+	"embed"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +21,9 @@ type importerTest struct {
 	name   string
 	folder string
 }
+
+//go:embed importer-test
+var testFS embed.FS
 
 func (it *importerTest) input() string {
 	b, err := os.ReadFile(fmt.Sprintf("importer-test/%s/root.zed", it.folder))
@@ -79,6 +85,33 @@ func TestImporter(t *testing.T) {
 				SchemaString: inputSchema,
 			}, compiler.AllowUnprefixedObjectType(),
 				compiler.SourceFolder(sourceFolder))
+			require.NoError(t, err)
+
+			generated, _, err := generator.GenerateSchema(compiled.OrderedDefinitions)
+			require.NoError(t, err)
+
+			if os.Getenv("REGEN") == "true" {
+				test.writeExpected(generated)
+			} else {
+				expected := test.expected()
+				if !assert.Equal(t, expected, generated, test.name) {
+					t.Log(generated)
+				}
+			}
+		})
+		t.Run("fs/"+test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fsys, err := fs.Sub(testFS, filepath.Join("importer-test", test.folder))
+			require.NoError(t, err)
+
+			inputSchema := test.input()
+
+			compiled, err := compiler.Compile(compiler.InputSchema{
+				Source:       input.Source("schema"),
+				SchemaString: inputSchema,
+			}, compiler.AllowUnprefixedObjectType(),
+				compiler.SourceFS(fsys))
 			require.NoError(t, err)
 
 			generated, _, err := generator.GenerateSchema(compiled.OrderedDefinitions)


### PR DESCRIPTION
## Description

Enhance the `composableschemadsl/compiler.Compile` API by adding a new option `SourceFS` which instead of reading from the filesystem, reads from a virtual go filesystem. This makes no changes to the zed command line, but opens up the possibility to add something like `zed compile --using-archive schemapackage.zip root.zed` in the future.

## Testing

I ran the unit tests and verified they passed, and I also added a trivial test for `SourceFS`.

## References

https://github.com/authzed/spicedb/issues/2807
