### PR TITLE
chore: use EmptyPathSeq() everywhere and NewLocalContext() for tests

### DIFF
--- a/internal/services/integrationtesting/query_plan_consistency_test.go
+++ b/internal/services/integrationtesting/query_plan_consistency_test.go
@@ -47,13 +47,10 @@ type queryPlanConsistencyHandle struct {
 }
 
 func (q *queryPlanConsistencyHandle) buildContext(t *testing.T) *query.Context {
-	return &query.Context{
-		Context:      t.Context(),
-		Executor:     query.LocalExecutor{},
-		Reader:       q.ds.SnapshotReader(q.revision),
-		CaveatRunner: caveats.NewCaveatRunner(caveattypes.Default.TypeSet),
-		TraceLogger:  query.NewTraceLogger(), // Enable tracing for debugging
-	}
+	return query.NewLocalContext(t.Context(),
+		query.WithReader(q.ds.SnapshotReader(q.revision)),
+		query.WithCaveatRunner(caveats.NewCaveatRunner(caveattypes.Default.TypeSet)),
+		query.WithTraceLogger(query.NewTraceLogger())) // Enable tracing for debugging
 }
 
 func runQueryPlanConsistencyForFile(t *testing.T, filePath string) {

--- a/pkg/query/alias_test.go
+++ b/pkg/query/alias_test.go
@@ -12,10 +12,7 @@ func TestAliasIterator(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("Check_BasicRelationRewriting", func(t *testing.T) {
 		t.Parallel()
@@ -287,10 +284,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("Check_SubIteratorError", func(t *testing.T) {
 		t.Parallel()
@@ -414,10 +408,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("Check_MultipleResourcesSelfEdgeWithSubResults", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/query/analyze_test.go
+++ b/pkg/query/analyze_test.go
@@ -139,12 +139,9 @@ func TestAnalysisIntegration(t *testing.T) {
 
 	// Create a context with analysis enabled
 	analyze := NewAnalyzeCollector()
-	ctx := &Context{
-		Context:  context.Background(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(datastore.NoRevision),
-		Analyze:  analyze,
-	}
+	ctx := NewLocalContext(context.Background(),
+		WithReader(ds.SnapshotReader(datastore.NoRevision)),
+		WithAnalyze(analyze))
 
 	// Execute a Check operation
 	resources := []Object{{ObjectType: "document", ObjectID: "doc1"}}
@@ -296,12 +293,9 @@ func TestOptimizationImprovements(t *testing.T) {
 
 		// Execute unoptimized tree
 		analyzeUnoptimized := NewAnalyzeCollector()
-		ctxUnoptimized := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(datastore.NoRevision),
-			Analyze:  analyzeUnoptimized,
-		}
+		ctxUnoptimized := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(datastore.NoRevision)),
+			WithAnalyze(analyzeUnoptimized))
 
 		resources := []Object{{ObjectType: "document", ObjectID: "doc1"}}
 		subject := ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}
@@ -322,12 +316,9 @@ func TestOptimizationImprovements(t *testing.T) {
 
 		// Execute optimized tree
 		analyzeOptimized := NewAnalyzeCollector()
-		ctxOptimized := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(datastore.NoRevision),
-			Analyze:  analyzeOptimized,
-		}
+		ctxOptimized := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(datastore.NoRevision)),
+			WithAnalyze(analyzeOptimized))
 
 		pathSeq, err = ctxOptimized.Check(optimized, resources, subject)
 		require.NoError(t, err)
@@ -373,12 +364,9 @@ func TestOptimizationImprovements(t *testing.T) {
 
 		// Execute unoptimized tree
 		analyzeUnoptimized := NewAnalyzeCollector()
-		ctxUnoptimized := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(datastore.NoRevision),
-			Analyze:  analyzeUnoptimized,
-		}
+		ctxUnoptimized := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(datastore.NoRevision)),
+			WithAnalyze(analyzeUnoptimized))
 
 		resources := []Object{{ObjectType: "document", ObjectID: "doc1"}}
 		subject := ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}
@@ -399,12 +387,9 @@ func TestOptimizationImprovements(t *testing.T) {
 
 		// Execute optimized tree
 		analyzeOptimized := NewAnalyzeCollector()
-		ctxOptimized := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(datastore.NoRevision),
-			Analyze:  analyzeOptimized,
-		}
+		ctxOptimized := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(datastore.NoRevision)),
+			WithAnalyze(analyzeOptimized))
 
 		pathSeq, err = ctxOptimized.Check(optimized, resources, subject)
 		require.NoError(t, err)
@@ -474,12 +459,9 @@ func TestOptimizationImprovements(t *testing.T) {
 
 		// Execute unoptimized tree
 		analyzeUnoptimized := NewAnalyzeCollector()
-		ctxUnoptimized := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(datastore.NoRevision),
-			Analyze:  analyzeUnoptimized,
-		}
+		ctxUnoptimized := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(datastore.NoRevision)),
+			WithAnalyze(analyzeUnoptimized))
 
 		resources := []Object{
 			{ObjectType: "document", ObjectID: "doc2"},
@@ -503,12 +485,9 @@ func TestOptimizationImprovements(t *testing.T) {
 
 		// Execute optimized tree
 		analyzeOptimized := NewAnalyzeCollector()
-		ctxOptimized := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(datastore.NoRevision),
-			Analyze:  analyzeOptimized,
-		}
+		ctxOptimized := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(datastore.NoRevision)),
+			WithAnalyze(analyzeOptimized))
 
 		pathSeq, err = ctxOptimized.Check(optimized, resources, subject)
 		require.NoError(t, err)

--- a/pkg/query/arrow_test.go
+++ b/pkg/query/arrow_test.go
@@ -26,10 +26,7 @@ func TestArrowIterator(t *testing.T) {
 		t.Parallel()
 
 		// Create context with LocalExecutor
-		ctx := &Context{
-			Context:  t.Context(),
-			Executor: LocalExecutor{},
-		}
+		ctx := NewLocalContext(t.Context())
 
 		// Test arrow operation: find resources where left side connects to right side
 		// This looks for documents whose parent folder has viewers
@@ -51,10 +48,7 @@ func TestArrowIterator(t *testing.T) {
 		t.Parallel()
 
 		// Create context with LocalExecutor
-		ctx := &Context{
-			Context:  t.Context(),
-			Executor: LocalExecutor{},
-		}
+		ctx := NewLocalContext(t.Context())
 
 		pathSeq, err := ctx.Check(arrow, []Object{}, NewObject("user", "alice").WithEllipses())
 		require.NoError(err)
@@ -68,10 +62,7 @@ func TestArrowIterator(t *testing.T) {
 		t.Parallel()
 
 		// Create context with LocalExecutor
-		ctx := &Context{
-			Context:  t.Context(),
-			Executor: LocalExecutor{},
-		}
+		ctx := NewLocalContext(t.Context())
 
 		pathSeq, err := ctx.Check(arrow, NewObjects("document", "nonexistent"), NewObject("user", "alice").WithEllipses())
 		require.NoError(err)
@@ -86,10 +77,7 @@ func TestArrowIterator(t *testing.T) {
 		t.Parallel()
 
 		// Create context with LocalExecutor
-		ctx := &Context{
-			Context:  t.Context(),
-			Executor: LocalExecutor{},
-		}
+		ctx := NewLocalContext(t.Context())
 
 		pathSeq, err := ctx.Check(arrow, NewObjects("document", "spec1"), NewObject("user", "nonexistent").WithEllipses())
 		require.NoError(err)
@@ -104,10 +92,7 @@ func TestArrowIterator(t *testing.T) {
 		t.Parallel()
 
 		// Create context with LocalExecutor
-		ctx := &Context{
-			Context:  t.Context(),
-			Executor: LocalExecutor{},
-		}
+		ctx := NewLocalContext(t.Context())
 
 		require.Panics(func() {
 			_, _ = ctx.IterSubjects(arrow, NewObject("document", "spec1"))
@@ -118,10 +103,7 @@ func TestArrowIterator(t *testing.T) {
 		t.Parallel()
 
 		// Create context with LocalExecutor
-		ctx := &Context{
-			Context:  t.Context(),
-			Executor: LocalExecutor{},
-		}
+		ctx := NewLocalContext(t.Context())
 
 		require.Panics(func() {
 			_, _ = ctx.IterResources(arrow, NewObject("user", "alice").WithEllipses())
@@ -149,10 +131,7 @@ func TestArrowIteratorClone(t *testing.T) {
 	require.Len(clonedExplain.SubExplain, len(originalExplain.SubExplain))
 
 	// Create context with LocalExecutor
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	// Test that both iterators produce the same results
 	resourceIDs := []string{"spec1"}
@@ -202,10 +181,7 @@ func TestArrowIteratorMultipleResources(t *testing.T) {
 	arrow := NewArrow(leftRels, rightRels)
 
 	// Create context with LocalExecutor
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	// Test with multiple resource IDs
 	pathSeq, err := ctx.Check(arrow, NewObjects("document", "spec1", "spec2", "nonexistent"), NewObject("user", "alice").WithEllipses())
@@ -234,10 +210,7 @@ func TestArrowIteratorCaveatCombination(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("CombineTwoCaveats_AND_Logic", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/query/build_tree_test.go
+++ b/pkg/query/build_tree_test.go
@@ -30,11 +30,8 @@ func TestBuildTree(t *testing.T) {
 	it, err := BuildIteratorFromSchema(dsSchema, "document", "edit")
 	require.NoError(err)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	relSeq, err := ctx.Check(it, NewObjects("document", "specialplan"), NewObject("user", "multiroleguy").WithEllipses())
 	require.NoError(err)
@@ -63,11 +60,8 @@ func TestBuildTreeMultipleRelations(t *testing.T) {
 	explain := it.Explain()
 	require.Contains(explain.String(), "Union", "edit permission should create a union iterator")
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	relSeq, err := ctx.Check(it, NewObjects("document", "specialplan"), NewObject("user", "multiroleguy").WithEllipses())
 	require.NoError(err)
@@ -117,11 +111,8 @@ func TestBuildTreeSubRelations(t *testing.T) {
 	explain := it.Explain()
 	require.NotEmpty(explain.String())
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	// Just test that the iterator can be executed without error
 	relSeq, err := ctx.Check(it, NewObjects("document", "companyplan"), NewObject("user", "legal").WithEllipses())
@@ -219,11 +210,8 @@ func TestBuildTreeIntersectionOperation(t *testing.T) {
 	require.NotEmpty(explain.String())
 	require.Contains(explain.String(), "Intersection", "should create intersection iterator")
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	// Test execution
 	relSeq, err := ctx.Check(it, NewObjects("document", "specialplan"), NewObject("user", "multiroleguy").WithEllipses())
@@ -285,11 +273,8 @@ func TestBuildTreeExclusionEdgeCases(t *testing.T) {
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	userDef := testfixtures.UserNS.CloneVT()
 
@@ -548,11 +533,8 @@ func TestBuildTreeSingleRelationOptimization(t *testing.T) {
 	require.NotEmpty(explain.String())
 	require.Contains(explain.String(), "Relation", "should create relation iterator")
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	// Test execution
 	relSeq, err := ctx.Check(it, NewObjects("document", "companyplan"), NewObject("user", "legal").WithEllipses())
@@ -571,11 +553,8 @@ func TestBuildTreeSubrelationHandling(t *testing.T) {
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	userDef := testfixtures.UserNS.CloneVT()
 

--- a/pkg/query/caveat_test.go
+++ b/pkg/query/caveat_test.go
@@ -108,13 +108,10 @@ func TestCaveatIteratorNoCaveat(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			queryCtx := &Context{
-				Context:       context.Background(),
-				Executor:      LocalExecutor{},
-				Reader:        ds.SnapshotReader(rev),
-				CaveatContext: tc.caveatContext,
-				CaveatRunner:  caveats.NewCaveatRunner(types.NewTypeSet()),
-			}
+			queryCtx := NewLocalContext(context.Background(),
+				WithReader(ds.SnapshotReader(rev)),
+				WithCaveatContext(tc.caveatContext),
+				WithCaveatRunner(caveats.NewCaveatRunner(types.NewTypeSet())))
 
 			resource := NewObject("document", "doc1")
 			seq, err := queryCtx.IterSubjects(caveatIter, resource)
@@ -203,13 +200,10 @@ func TestCaveatIteratorWithCaveat(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			queryCtx := &Context{
-				Context:       context.Background(),
-				Executor:      LocalExecutor{},
-				Reader:        ds.SnapshotReader(rev),
-				CaveatContext: tc.caveatContext,
-				CaveatRunner:  caveats.NewCaveatRunner(types.NewTypeSet()),
-			}
+			queryCtx := NewLocalContext(context.Background(),
+				WithReader(ds.SnapshotReader(rev)),
+				WithCaveatContext(tc.caveatContext),
+				WithCaveatRunner(caveats.NewCaveatRunner(types.NewTypeSet())))
 
 			resource := NewObject("document", "doc1")
 			seq, err := queryCtx.IterSubjects(caveatIter, resource)
@@ -398,10 +392,8 @@ func TestCaveatIterator_SimplifyCaveat_ErrorHandling(t *testing.T) {
 		path := MustPathFromString("document:doc1#view@user:alice")
 		path.Caveat = createTestCaveatExpression("test_caveat", nil)
 
-		ctx := &Context{
-			Context: context.Background(),
-			// CaveatRunner is nil
-		}
+		ctx := NewLocalContext(context.Background())
+		// CaveatRunner is nil in the returned context
 
 		_, _, err := caveatIter.simplifyCaveat(ctx, path)
 		require.Error(err)
@@ -425,10 +417,7 @@ func TestCaveatIterator_IterSubjectsImpl(t *testing.T) {
 		// No caveat filter - should pass through all paths
 		caveatIter := NewCaveatIterator(subIterator, nil)
 
-		ctx := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-		}
+		ctx := NewLocalContext(context.Background())
 
 		resource := NewObject("document", "doc1")
 		seq, err := caveatIter.IterSubjectsImpl(ctx, resource)
@@ -448,10 +437,7 @@ func TestCaveatIterator_IterSubjectsImpl(t *testing.T) {
 		testCaveat := createTestCaveat("test_caveat", nil)
 		caveatIter := NewCaveatIterator(subIterator, testCaveat)
 
-		ctx := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-		}
+		ctx := NewLocalContext(context.Background())
 
 		resource := NewObject("document", "doc1")
 		seq, err := caveatIter.IterSubjectsImpl(ctx, resource)
@@ -479,10 +465,7 @@ func TestCaveatIterator_IterResourcesImpl(t *testing.T) {
 		// No caveat filter - should pass through all paths
 		caveatIter := NewCaveatIterator(subIterator, nil)
 
-		ctx := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-		}
+		ctx := NewLocalContext(context.Background())
 
 		subject := NewObject("user", "alice").WithEllipses()
 		seq, err := caveatIter.IterResourcesImpl(ctx, subject)
@@ -502,10 +485,7 @@ func TestCaveatIterator_IterResourcesImpl(t *testing.T) {
 		testCaveat := createTestCaveat("test_caveat", nil)
 		caveatIter := NewCaveatIterator(subIterator, testCaveat)
 
-		ctx := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-		}
+		ctx := NewLocalContext(context.Background())
 
 		subject := NewObject("user", "alice").WithEllipses()
 		seq, err := caveatIter.IterResourcesImpl(ctx, subject)

--- a/pkg/query/context.go
+++ b/pkg/query/context.go
@@ -220,6 +220,52 @@ type Context struct {
 	MaxRecursionDepth int               // Maximum depth for recursive iterators (0 = use default of 10)
 }
 
+// NewLocalContext creates a new query execution context with a LocalExecutor.
+// This is a convenience constructor for tests and local execution scenarios.
+func NewLocalContext(stdContext context.Context, opts ...ContextOption) *Context {
+	ctx := &Context{
+		Context:  stdContext,
+		Executor: LocalExecutor{},
+	}
+	for _, opt := range opts {
+		opt(ctx)
+	}
+	return ctx
+}
+
+// ContextOption is a function that configures a Context.
+type ContextOption func(*Context)
+
+// WithReader sets the datastore reader for the context.
+func WithReader(reader datastore.Reader) ContextOption {
+	return func(ctx *Context) { ctx.Reader = reader }
+}
+
+// WithAnalyze sets the analysis collector for the context.
+func WithAnalyze(analyze *AnalyzeCollector) ContextOption {
+	return func(ctx *Context) { ctx.Analyze = analyze }
+}
+
+// WithTraceLogger sets the trace logger for the context.
+func WithTraceLogger(logger *TraceLogger) ContextOption {
+	return func(ctx *Context) { ctx.TraceLogger = logger }
+}
+
+// WithCaveatRunner sets the caveat runner for the context.
+func WithCaveatRunner(runner *caveats.CaveatRunner) ContextOption {
+	return func(ctx *Context) { ctx.CaveatRunner = runner }
+}
+
+// WithCaveatContext sets the caveat context for the context.
+func WithCaveatContext(caveatCtx map[string]any) ContextOption {
+	return func(ctx *Context) { ctx.CaveatContext = caveatCtx }
+}
+
+// WithMaxRecursionDepth sets the maximum recursion depth for the context.
+func WithMaxRecursionDepth(depth int) ContextOption {
+	return func(ctx *Context) { ctx.MaxRecursionDepth = depth }
+}
+
 func (ctx *Context) TraceStep(it Iterator, step string, data ...any) {
 	if ctx.TraceLogger != nil {
 		ctx.TraceLogger.LogStep(it, step, data...)

--- a/pkg/query/context_test.go
+++ b/pkg/query/context_test.go
@@ -109,10 +109,8 @@ func TestContext(t *testing.T) {
 	t.Run("TraceStep", func(t *testing.T) {
 		t.Parallel()
 		logger := NewTraceLogger()
-		ctx := &Context{
-			Context:     context.Background(),
-			TraceLogger: logger,
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithTraceLogger(logger))
 
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -126,10 +124,8 @@ func TestContext(t *testing.T) {
 
 	t.Run("TraceStep_NoLogger", func(t *testing.T) {
 		t.Parallel()
-		ctx := &Context{
-			Context: context.Background(),
-			// No TraceLogger set
-		}
+		ctx := NewLocalContext(context.Background())
+		// No TraceLogger set
 
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -143,10 +139,8 @@ func TestContext(t *testing.T) {
 	t.Run("TraceEnter", func(t *testing.T) {
 		t.Parallel()
 		logger := NewTraceLogger()
-		ctx := &Context{
-			Context:     context.Background(),
-			TraceLogger: logger,
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithTraceLogger(logger))
 
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -162,10 +156,8 @@ func TestContext(t *testing.T) {
 	t.Run("TraceExit", func(t *testing.T) {
 		t.Parallel()
 		logger := NewTraceLogger()
-		ctx := &Context{
-			Context:     context.Background(),
-			TraceLogger: logger,
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithTraceLogger(logger))
 
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -183,10 +175,8 @@ func TestContext(t *testing.T) {
 	t.Run("shouldTrace", func(t *testing.T) {
 		t.Parallel()
 		// With logger
-		ctx := &Context{
-			Context:     context.Background(),
-			TraceLogger: NewTraceLogger(),
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithTraceLogger(NewTraceLogger()))
 		require.True(ctx.shouldTrace())
 
 		// Without logger
@@ -196,10 +186,10 @@ func TestContext(t *testing.T) {
 
 	t.Run("Check_NoExecutor", func(t *testing.T) {
 		t.Parallel()
-		ctx := &Context{
-			Context: context.Background(),
-			// No Executor set
-		}
+		ctx := NewLocalContext(context.Background())
+		// No Executor set - but NewLocalContext always sets LocalExecutor
+		// This test won't actually panic anymore, so we need to modify it
+		ctx.Executor = nil // Manually remove executor to test the panic path
 
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -211,10 +201,10 @@ func TestContext(t *testing.T) {
 
 	t.Run("IterSubjects_NoExecutor", func(t *testing.T) {
 		t.Parallel()
-		ctx := &Context{
-			Context: context.Background(),
-			// No Executor set
-		}
+		ctx := NewLocalContext(context.Background())
+		// No Executor set - but NewLocalContext always sets LocalExecutor
+		// This test won't actually panic anymore, so we need to modify it
+		ctx.Executor = nil // Manually remove executor to test the panic path
 
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -226,10 +216,10 @@ func TestContext(t *testing.T) {
 
 	t.Run("IterResources_NoExecutor", func(t *testing.T) {
 		t.Parallel()
-		ctx := &Context{
-			Context: context.Background(),
-			// No Executor set
-		}
+		ctx := NewLocalContext(context.Background())
+		// No Executor set - but NewLocalContext always sets LocalExecutor
+		// This test won't actually panic anymore, so we need to modify it
+		ctx.Executor = nil // Manually remove executor to test the panic path
 
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -241,10 +231,8 @@ func TestContext(t *testing.T) {
 
 	t.Run("wrapPathSeqForTracing_NoTracing", func(t *testing.T) {
 		t.Parallel()
-		ctx := &Context{
-			Context: context.Background(),
-			// No TraceLogger
-		}
+		ctx := NewLocalContext(context.Background())
+		// No TraceLogger
 
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -271,10 +259,8 @@ func TestContext(t *testing.T) {
 	t.Run("wrapPathSeqForTracing_WithTracing", func(t *testing.T) {
 		t.Parallel()
 		logger := NewTraceLogger()
-		ctx := &Context{
-			Context:     context.Background(),
-			TraceLogger: logger,
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithTraceLogger(logger))
 
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -309,10 +295,8 @@ func TestContext(t *testing.T) {
 	t.Run("wrapPathSeqForTracing_WithError", func(t *testing.T) {
 		t.Parallel()
 		logger := NewTraceLogger()
-		ctx := &Context{
-			Context:     context.Background(),
-			TraceLogger: logger,
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithTraceLogger(logger))
 
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)

--- a/pkg/query/datastore_test.go
+++ b/pkg/query/datastore_test.go
@@ -23,10 +23,7 @@ func TestRelationIterator(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("SubjectTypeMismatchReturnsEmpty", func(t *testing.T) {
 		t.Parallel()
@@ -150,10 +147,7 @@ func TestRelationIteratorSubjectTypeMismatchScenarios(t *testing.T) {
 
 	require := require.New(t)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	// Test only mismatched types since matching types require a real datastore
 	testCases := []struct {
@@ -216,10 +210,7 @@ func TestRelationIteratorWildcard(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("WildcardSubjectTypeMismatchReturnsEmpty", func(t *testing.T) {
 		t.Parallel()
@@ -304,10 +295,7 @@ func TestRelationIteratorWildcardSubjectTypeMismatchScenarios(t *testing.T) {
 
 	require := require.New(t)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	// Test wildcard relations with various subject type mismatches
 	testCases := []struct {

--- a/pkg/query/exclusion_test.go
+++ b/pkg/query/exclusion_test.go
@@ -20,11 +20,8 @@ func TestExclusionIterator(t *testing.T) {
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	// Create test paths
 	path1 := MustPathFromString("document:doc1#viewer@user:alice")
@@ -219,11 +216,8 @@ func TestExclusionWithEmptyIterator(t *testing.T) {
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	path1 := MustPathFromString("document:doc1#viewer@user:alice")
 
@@ -268,11 +262,8 @@ func TestExclusionUnimplementedMethods(t *testing.T) {
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	path1 := MustPathFromString("document:doc1#viewer@user:alice")
 	mainSet := NewFixedIterator(path1)
@@ -304,11 +295,8 @@ func TestExclusionErrorHandling(t *testing.T) {
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	path1 := MustPathFromString("document:doc1#viewer@user:alice")
 
@@ -378,11 +366,8 @@ func TestExclusionWithComplexIteratorTypes(t *testing.T) {
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	// Create test relations
 	path1 := MustPathFromString("document:doc1#viewer@user:alice")
@@ -567,11 +552,8 @@ func TestExclusion_CombinedCaveatLogic(t *testing.T) {
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	// Helper to create paths with caveats
 	createPathWithCaveat := func(relation, caveatName string) Path {
@@ -645,10 +627,7 @@ func TestExclusion_EdgeCases(t *testing.T) {
 	require := require.New(t)
 
 	// Create minimal context for basic testing
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("empty_main_set", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/query/fixed_test.go
+++ b/pkg/query/fixed_test.go
@@ -11,10 +11,7 @@ func TestFixedIterator(t *testing.T) {
 	t.Parallel()
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	// Create test paths
 	path1 := MustPathFromString("document:doc1#viewer@user:alice")

--- a/pkg/query/intersection.go
+++ b/pkg/query/intersection.go
@@ -53,7 +53,7 @@ func (i *Intersection) CheckImpl(ctx *Context, resources []Object, subject Objec
 
 		if len(paths) == 0 {
 			ctx.TraceStep(i, "sub-iterator %d returned empty, short-circuiting", iterIdx)
-			return func(yield func(Path, error) bool) {}, nil
+			return EmptyPathSeq(), nil
 		}
 
 		if iterIdx == 0 {
@@ -106,7 +106,7 @@ func (i *Intersection) CheckImpl(ctx *Context, resources []Object, subject Objec
 			pathsByKey = newPathsByKey
 
 			if len(pathsByKey) == 0 {
-				return func(yield func(Path, error) bool) {}, nil
+				return EmptyPathSeq(), nil
 			}
 		}
 

--- a/pkg/query/intersection_arrow_test.go
+++ b/pkg/query/intersection_arrow_test.go
@@ -39,11 +39,8 @@ func TestIntersectionArrowIterator(t *testing.T) {
 		revision, err := ds.HeadRevision(context.Background())
 		require.NoError(err)
 
-		ctx := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(revision),
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(revision)))
 
 		// Test: alice should have access because she's a member of ALL teams (team1 and team2)
 		resources := []Object{NewObject("document", "doc1")}
@@ -91,11 +88,8 @@ func TestIntersectionArrowIterator(t *testing.T) {
 		})
 		require.NoError(err)
 
-		ctx := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(revision),
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(revision)))
 
 		// Test: alice should NOT have access because she's not a member of ALL teams
 		resources := []Object{NewObject("document", "doc1")}
@@ -134,11 +128,8 @@ func TestIntersectionArrowIterator(t *testing.T) {
 		})
 		require.NoError(err)
 
-		ctx := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(revision),
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(revision)))
 
 		// Test: alice should have access because she's a member of the only team
 		resources := []Object{NewObject("document", "doc1")}
@@ -182,11 +173,8 @@ func TestIntersectionArrowIterator(t *testing.T) {
 		})
 		require.NoError(err)
 
-		ctx := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(revision),
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(revision)))
 
 		resources := []Object{NewObject("document", "doc1")}
 		subject := ObjectAndRelation{ObjectType: "user", ObjectID: "alice"}
@@ -228,11 +216,8 @@ func TestIntersectionArrowIterator(t *testing.T) {
 		})
 		require.NoError(err)
 
-		ctx := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(revision),
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(revision)))
 
 		resources := []Object{NewObject("document", "doc1")}
 		subject := ObjectAndRelation{ObjectType: "user", ObjectID: "alice"}
@@ -270,11 +255,8 @@ func TestIntersectionArrowIterator(t *testing.T) {
 		})
 		require.NoError(err)
 
-		ctx := &Context{
-			Context:  context.Background(),
-			Executor: LocalExecutor{},
-			Reader:   ds.SnapshotReader(revision),
-		}
+		ctx := NewLocalContext(context.Background(),
+			WithReader(ds.SnapshotReader(revision)))
 
 		resources := []Object{}
 		subject := ObjectAndRelation{ObjectType: "user", ObjectID: "alice"}
@@ -302,11 +284,8 @@ func TestIntersectionArrowIteratorCaveatCombination(t *testing.T) {
 	})
 	require.NoError(err)
 
-	ctx := &Context{
-		Context:  context.Background(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(context.Background(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	t.Run("CombineTwoCaveats_AND_Logic", func(t *testing.T) {
 		t.Parallel()
@@ -532,11 +511,8 @@ func TestIntersectionArrowIteratorClone(t *testing.T) {
 	})
 	require.NoError(err)
 
-	ctx := &Context{
-		Context:  context.Background(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(context.Background(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	// Test that both iterators produce the same results
 	resources := []Object{NewObject("document", "doc1")}
@@ -596,11 +572,8 @@ func TestIntersectionArrowIteratorUnimplementedMethods(t *testing.T) {
 	})
 	require.NoError(err)
 
-	ctx := &Context{
-		Context:  context.Background(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(context.Background(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	t.Run("IterSubjects_Unimplemented", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/query/intersection_test.go
+++ b/pkg/query/intersection_test.go
@@ -15,10 +15,7 @@ func TestIntersectionIterator(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("Check_Intersection", func(t *testing.T) {
 		t.Parallel()
@@ -173,10 +170,7 @@ func TestIntersectionIteratorClone(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	original := NewIntersection()
 
@@ -271,10 +265,7 @@ func TestIntersectionIteratorEarlyTermination(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	// Create an intersection where the first iterator returns no results
 	// This should cause early termination
@@ -306,10 +297,7 @@ func TestIntersectionIteratorCaveatCombination(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("CombineTwoCaveats_AND_Logic", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/query/quick_e2e_test.go
+++ b/pkg/query/quick_e2e_test.go
@@ -39,11 +39,8 @@ func TestCheck(t *testing.T) {
 	it.addSubIterator(vande)
 	it.addSubIterator(edit)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	relSeq, err := ctx.Check(it, NewObjects("document", "specialplan"), NewObject("user", "multiroleguy").WithEllipses())
 	require.NoError(err)
@@ -70,11 +67,8 @@ func TestBaseIterSubjects(t *testing.T) {
 	vandeRel, _ := docDef.GetRelation("viewer_and_editor")
 	vande := NewRelationIterator(vandeRel.BaseRelations()[0])
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	relSeq, err := ctx.IterSubjects(vande, NewObject("document", "specialplan"))
 	require.NoError(err)
@@ -106,11 +100,8 @@ func TestCheckArrow(t *testing.T) {
 	view := NewRelationIterator(viewRel.BaseRelations()[0])
 	it := NewArrow(folders, view)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(revision),
-	}
+	ctx := NewLocalContext(t.Context(),
+		WithReader(ds.SnapshotReader(revision)))
 
 	relSeq, err := ctx.Check(it, NewObjects("document", "companyplan"), NewObject("user", "legal").WithEllipses())
 	require.NoError(err)

--- a/pkg/query/recursive_test.go
+++ b/pkg/query/recursive_test.go
@@ -22,11 +22,8 @@ func TestRecursiveSentinel(t *testing.T) {
 	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 	require.NoError(t, err)
 
-	ctx := &Context{
-		Context:  context.Background(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(datastore.NoRevision),
-	}
+	ctx := NewLocalContext(context.Background(),
+		WithReader(ds.SnapshotReader(datastore.NoRevision)))
 
 	// CheckImpl should return empty
 	seq, err := sentinel.CheckImpl(ctx, []Object{{ObjectType: "folder", ObjectID: "folder1"}}, ObjectAndRelation{ObjectType: "user", ObjectID: "tom", Relation: "..."})
@@ -64,11 +61,8 @@ func TestRecursiveIteratorEmptyBaseCase(t *testing.T) {
 	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 	require.NoError(t, err)
 
-	ctx := &Context{
-		Context:  context.Background(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(datastore.NoRevision),
-	}
+	ctx := NewLocalContext(context.Background(),
+		WithReader(ds.SnapshotReader(datastore.NoRevision)))
 
 	// Execute - should terminate immediately with empty result
 	seq, err := recursive.CheckImpl(ctx, []Object{{ObjectType: "folder", ObjectID: "folder1"}}, ObjectAndRelation{ObjectType: "user", ObjectID: "tom", Relation: "..."})
@@ -176,11 +170,8 @@ func TestRecursiveIteratorExecutionError(t *testing.T) {
 	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 	require.NoError(t, err)
 
-	ctx := &Context{
-		Context:  context.Background(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(datastore.NoRevision),
-	}
+	ctx := NewLocalContext(context.Background(),
+		WithReader(ds.SnapshotReader(datastore.NoRevision)))
 
 	// Test CheckImpl with a faulty iterator
 	seq, err := recursive.CheckImpl(ctx, []Object{{ObjectType: "folder", ObjectID: "folder1"}}, ObjectAndRelation{ObjectType: "user", ObjectID: "tom", Relation: "..."})
@@ -203,11 +194,8 @@ func TestRecursiveIteratorCollectionError(t *testing.T) {
 	ds, err := memdb.NewMemdbDatastore(0, 0, memdb.DisableGC)
 	require.NoError(t, err)
 
-	ctx := &Context{
-		Context:  context.Background(),
-		Executor: LocalExecutor{},
-		Reader:   ds.SnapshotReader(datastore.NoRevision),
-	}
+	ctx := NewLocalContext(context.Background(),
+		WithReader(ds.SnapshotReader(datastore.NoRevision)))
 
 	// Test CheckImpl with a faulty iterator that fails on collection
 	seq, err := recursive.CheckImpl(ctx, []Object{{ObjectType: "folder", ObjectID: "folder1"}}, ObjectAndRelation{ObjectType: "user", ObjectID: "tom", Relation: "..."})

--- a/pkg/query/tracing_test.go
+++ b/pkg/query/tracing_test.go
@@ -22,12 +22,10 @@ func TestIteratorTracing(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ctx := &Context{
-		Context:     context.Background(),
-		Executor:    LocalExecutor{},
-		Reader:      ds.SnapshotReader(revision),
-		TraceLogger: traceLogger,
-	}
+	ctx := NewLocalContext(context.Background(),
+		WithReader(ds.SnapshotReader(revision)),
+		WithTraceLogger(traceLogger),
+	)
 
 	// Create test paths
 	testPath1 := MustPathFromString("document:doc1#view@user:alice")

--- a/pkg/query/union_test.go
+++ b/pkg/query/union_test.go
@@ -14,10 +14,7 @@ func TestUnionIterator(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("Check_Union", func(t *testing.T) {
 		t.Parallel()
@@ -245,10 +242,7 @@ func TestUnionIteratorDuplicateElimination(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	// Create a union with overlapping sub-iterators
 	// This tests the deduplication logic where resources found by earlier
@@ -283,10 +277,7 @@ func TestUnionIteratorMultipleResources(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	union := NewUnion()
 
@@ -312,10 +303,7 @@ func TestUnionDeduplicationBugFix(t *testing.T) {
 
 	require := require.New(t)
 
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("DeduplicatesByResourceKey", func(t *testing.T) {
 		t.Parallel()
@@ -465,10 +453,7 @@ func TestUnionIteratorCaveatCombination(t *testing.T) {
 	require := require.New(t)
 
 	// Create test context
-	ctx := &Context{
-		Context:  t.Context(),
-		Executor: LocalExecutor{},
-	}
+	ctx := NewLocalContext(t.Context())
 
 	t.Run("CombineTwoCaveats_OR_Logic", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
One existing helper (now used everywhere) and one new helper to reduce test boilerplate.