### PR TITLE
chore: improve metrics middleware test

### DIFF
--- a/internal/middleware/usagemetrics/usagemetrics_test.go
+++ b/internal/middleware/usagemetrics/usagemetrics_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/suite"
@@ -111,8 +112,8 @@ func (s *metricsMiddlewareTestSuite) TestTrailers_Stream() {
 func (s *metricsMiddlewareTestSuite) TestErrCtx() {
 	var trailerMD metadata.MD
 
-	// SimpleCtx times out after two seconds
-	_, err := s.Client.PingError(s.SimpleCtx(), &testpb.PingErrorRequest{}, grpc.Trailer(&trailerMD))
+	// Make a request with an immediate deadline
+	_, err := s.Client.PingError(s.DeadlineCtx(time.Now()), &testpb.PingErrorRequest{}, grpc.Trailer(&trailerMD))
 
 	// the error may come from the grpc framework (client-side timeout) or from the API itself (it's a race)
 	s.Require().Equal(codes.DeadlineExceeded, status.Code(err))


### PR DESCRIPTION
## Description
We've seen periodic test flakes on this test even after #2670. I'm not sure that this is a fix, and if it is I'm not entirely sure it's the correct fix, but this makes the test shorter and ideally more deterministic.

I also refactored the middleware to make use of our `ctxkey` package so that we don't have to manually muck about with boxing.

## Changes
* Refactor usagemetrics to use ctxkey
* Refactor test to use an immediate deadline
## Testing
Review.