### PR TITLE
chore: fix prealloc lints

### DIFF
--- a/internal/datastore/common/chunkbytes_test.go
+++ b/internal/datastore/common/chunkbytes_test.go
@@ -637,7 +637,7 @@ func TestChunkData(t *testing.T) {
 
 			// Verify that reassembling gives us the original data
 			if tt.expectedCount > 0 {
-				var reassembled []byte
+				var reassembled []byte //nolint: prealloc  // it's hard to know the combined length here
 				for _, chunk := range chunks {
 					reassembled = append(reassembled, chunk...)
 				}

--- a/internal/developmentmembership/membership_test.go
+++ b/internal/developmentmembership/membership_test.go
@@ -474,8 +474,9 @@ func TestMembershipSetWithCaveats(t *testing.T) {
 }
 
 func verifySubjects(t *testing.T, require *require.Assertions, fs FoundSubjects, expected ...string) {
-	foundSubjects := []tuple.ObjectAndRelation{}
-	for _, found := range fs.ListFound() {
+	foundList := fs.ListFound()
+	foundSubjects := make([]tuple.ObjectAndRelation, 0, len(foundList))
+	for _, found := range foundList {
 		foundSubjects = append(foundSubjects, found.Subject())
 
 		_, ok := fs.LookupSubject(found.Subject())

--- a/internal/developmentmembership/trackingsubjectset.go
+++ b/internal/developmentmembership/trackingsubjectset.go
@@ -200,7 +200,7 @@ func (tss *TrackingSubjectSet) removeExact(subjects ...tuple.ObjectAndRelation) 
 }
 
 func (tss *TrackingSubjectSet) getSubjects() []string {
-	var subjects []string
+	var subjects []string //nolint: prealloc  // we can't really know the length here
 	for _, subjectSet := range tss.setByType {
 		for _, foundSubject := range subjectSet.AsSlice() {
 			subjects = append(subjects, tuple.StringONR(foundSubject.subject))
@@ -211,7 +211,7 @@ func (tss *TrackingSubjectSet) getSubjects() []string {
 
 // ToSlice returns a slice of all subjects found in the set.
 func (tss *TrackingSubjectSet) ToSlice() []FoundSubject {
-	subjects := []FoundSubject{}
+	subjects := []FoundSubject{} //nolint: prealloc  // we can't really know the length here
 	for _, bss := range tss.setByType {
 		subjects = append(subjects, bss.AsSlice()...)
 	}

--- a/internal/dispatch/graph/lookupresources2_test.go
+++ b/internal/dispatch/graph/lookupresources2_test.go
@@ -296,11 +296,12 @@ func TestLookupResourcesCursorStability2(t *testing.T) {
 }
 
 func processResults2(stream *dispatch.CollectingDispatchStream[*v1.DispatchLookupResources2Response]) ([]*v1.PossibleResource, uint32, uint32, uint32) {
-	foundResources := []*v1.PossibleResource{}
+	streamResults := stream.Results()
+	foundResources := make([]*v1.PossibleResource, 0, len(streamResults))
 	var maxDepthRequired uint32
 	var maxDispatchCount uint32
 	var maxCachedDispatchCount uint32
-	for _, result := range stream.Results() {
+	for _, result := range streamResults {
 		result.Resource.ForSubjectIds = nil
 		foundResources = append(foundResources, result.Resource)
 		maxDepthRequired = max(maxDepthRequired, result.Metadata.DepthRequired)
@@ -1501,11 +1502,12 @@ func genResourceIds(resourceName string, number int) []string {
 }
 
 func processResults(stream *dispatch.CollectingDispatchStream[*v1.DispatchLookupResources2Response]) ([]*v1.PossibleResource, uint32, uint32, uint32) {
-	foundResources := []*v1.PossibleResource{}
+	streamResults := stream.Results()
+	foundResources := make([]*v1.PossibleResource, 0, len(streamResults))
 	var maxDepthRequired uint32
 	var maxDispatchCount uint32
 	var maxCachedDispatchCount uint32
-	for _, result := range stream.Results() {
+	for _, result := range streamResults {
 		foundResources = append(foundResources, result.Resource)
 		maxDepthRequired = max(maxDepthRequired, result.Metadata.DepthRequired)
 		maxDispatchCount = max(maxDispatchCount, result.Metadata.DispatchCount)

--- a/internal/dispatch/graph/lookupresources3_test.go
+++ b/internal/dispatch/graph/lookupresources3_test.go
@@ -238,7 +238,7 @@ func TestSimpleLookupResourcesWithCursor3(t *testing.T) {
 }
 
 func processResults3(stream *dispatch.CloningCollectingDispatchStream[*v1.DispatchLookupResources3Response]) []*v1.PossibleResource {
-	foundResources := []*v1.PossibleResource{}
+	foundResources := []*v1.PossibleResource{} //nolint: prealloc  // we can't easily know the length of foundResources
 	for _, result := range stream.Results() {
 		for _, item := range result.Items {
 			foundResources = append(foundResources, &v1.PossibleResource{

--- a/internal/dispatch/graph/lookupsubjects_test.go
+++ b/internal/dispatch/graph/lookupsubjects_test.go
@@ -1025,7 +1025,7 @@ func TestLookupSubjectsOverSchema(t *testing.T) {
 			}, stream)
 			require.NoError(err)
 
-			results := []*v1.FoundSubject{}
+			results := []*v1.FoundSubject{} //nolint: prealloc  // we can't easily know the correct size
 			for _, streamResult := range stream.Results() {
 				for _, foundSubjects := range streamResult.FoundSubjectsByResourceId {
 					results = append(results, foundSubjects.FoundSubjects...)

--- a/internal/dispatch/remote/expr.go
+++ b/internal/dispatch/remote/expr.go
@@ -37,9 +37,10 @@ func ParseDispatchExpression(methodName string, exprString string) (*DispatchExp
 		return nil, errors.New("unable to initialize dispatch expression type registry")
 	}
 
-	opts := make([]cel.EnvOption, 0)
-	opts = append(opts, cel.OptionalTypes(cel.OptionalTypesVersion(0)))
-	opts = append(opts, cel.Variable("request", cel.DynType))
+	opts := []cel.EnvOption{
+		cel.OptionalTypes(cel.OptionalTypesVersion(0)),
+		cel.Variable("request", cel.DynType),
+	}
 
 	celEnv, err := cel.NewEnv(opts...)
 	if err != nil {

--- a/internal/services/v1/grouping_test.go
+++ b/internal/services/v1/grouping_test.go
@@ -179,7 +179,7 @@ func TestGroupItems(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			var items []*v1.CheckBulkPermissionsRequestItem
+			items := make([]*v1.CheckBulkPermissionsRequestItem, 0, len(tt.requests))
 			for _, r := range tt.requests {
 				rel, err := tuple.ParseV1Rel(r)
 				require.NoError(t, err)

--- a/internal/services/v1/permissions.go
+++ b/internal/services/v1/permissions.go
@@ -309,7 +309,7 @@ func TranslateRelationshipTree(tree *v1.PermissionRelationshipTree) *core.Relati
 			panic("unknown set operation")
 		}
 
-		children := []*core.RelationTupleTreeNode{}
+		children := make([]*core.RelationTupleTreeNode, 0, len(t.Intermediate.Children))
 		for _, child := range t.Intermediate.Children {
 			children = append(children, TranslateRelationshipTree(child))
 		}
@@ -363,8 +363,9 @@ func TranslateExpansionTree(node *core.RelationTupleTreeNode) *v1.PermissionRela
 			panic("unknown set operation")
 		}
 
-		var children []*v1.PermissionRelationshipTree
-		for _, child := range node.GetIntermediateNode().ChildNodes {
+		childNodes := node.GetIntermediateNode().ChildNodes
+		children := make([]*v1.PermissionRelationshipTree, 0, len(childNodes))
+		for _, child := range childNodes {
 			children = append(children, TranslateExpansionTree(child))
 		}
 

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -886,7 +886,7 @@ func TestInvalidWriteRelationship(t *testing.T) {
 					client := v1.NewPermissionsServiceClient(conn)
 					t.Cleanup(cleanup)
 
-					var preconditions []*v1.Precondition
+					preconditions := make([]*v1.Precondition, 0, len(tc.preconditions))
 					for _, filter := range tc.preconditions {
 						preconditions = append(preconditions, &v1.Precondition{
 							Operation: v1.Precondition_OPERATION_MUST_MATCH,
@@ -894,7 +894,7 @@ func TestInvalidWriteRelationship(t *testing.T) {
 						})
 					}
 
-					var mutations []*v1.RelationshipUpdate
+					mutations := make([]*v1.RelationshipUpdate, 0, len(tc.relationships))
 					for _, rel := range tc.relationships {
 						mutations = append(mutations, &v1.RelationshipUpdate{
 							Operation:    v1.RelationshipUpdate_OPERATION_TOUCH,
@@ -2317,7 +2317,7 @@ func TestReadRelationshipsWithTraitsAndFilters(t *testing.T) {
 
 			// Write the test relationships if any
 			if len(tc.setupRelationships) > 0 {
-				var updates []*v1.RelationshipUpdate
+				updates := make([]*v1.RelationshipUpdate, 0, len(tc.setupRelationships))
 				for _, relStr := range tc.setupRelationships {
 					rel := tuple.MustParse(relStr)
 					updates = append(updates, &v1.RelationshipUpdate{

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -191,7 +191,7 @@ func TestClusterWithDispatchAndCacheConfig(t testing.TB, size uint, ds datastore
 		dispatcher, err := combineddispatch.NewDispatcher(dispatcherOptions...)
 		require.NoError(t, err)
 
-		serverOptions := []server.ConfigOption{
+		serverOptions := []server.ConfigOption{ //nolint: prealloc  // we're not worried about perf here
 			server.WithDatastore(ds),
 			server.WithDispatcher(dispatcher),
 			server.WithDispatchMaxDepth(50),

--- a/pkg/caveats/replacer/replacer.go
+++ b/pkg/caveats/replacer/replacer.go
@@ -13,8 +13,7 @@ func ReplaceVariable(e *cel.Env, existingAst *cel.Ast, oldVarName string, newVar
 		return nil, fmt.Errorf("failed to compile new variable name: %w", iss.Err())
 	}
 
-	inlinedVars := []*InlineVariable{}
-	inlinedVars = append(inlinedVars, newInlineVariable(oldVarName, newExpr))
+	inlinedVars := []*InlineVariable{newInlineVariable(oldVarName, newExpr)}
 
 	opt := cel.NewStaticOptimizer(newModifiedInliningOptimizer(inlinedVars...))
 	optimized, iss := opt.Optimize(e, existingAst)

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -619,7 +619,7 @@ func commonPostgresDatastoreOptions(opts Config) ([]postgres.Option, error) {
 }
 
 func newPostgresReplicaDatastore(ctx context.Context, replicaIndex uint32, replicaURI string, opts Config) (datastore.StrictReadDatastore, error) {
-	pgOpts := []postgres.Option{
+	pgOpts := []postgres.Option{ //nolint: prealloc  // we're not worried about perf here
 		postgres.CredentialsProviderName(opts.ReadReplicaCredentialsProviderName),
 		postgres.ReadConnsMaxOpen(opts.ReadReplicaConnPool.MaxOpenConns),
 		postgres.ReadConnsMinOpen(opts.ReadReplicaConnPool.MinOpenConns),
@@ -639,7 +639,7 @@ func newPostgresReplicaDatastore(ctx context.Context, replicaIndex uint32, repli
 }
 
 func newPostgresPrimaryDatastore(ctx context.Context, opts Config) (datastore.Datastore, error) {
-	pgOpts := []postgres.Option{
+	pgOpts := []postgres.Option{ //nolint: prealloc  // we're not worried about perf here
 		postgres.CredentialsProviderName(opts.CredentialsProviderName),
 		postgres.GCWindow(opts.GCWindow),
 		postgres.GCEnabled(!opts.ReadOnly),
@@ -758,7 +758,7 @@ func commonMySQLDatastoreOptions(opts Config) ([]mysql.Option, error) {
 }
 
 func newMySQLReplicaDatastore(ctx context.Context, replicaIndex uint32, replicaURI string, opts Config) (datastore.ReadOnlyDatastore, error) {
-	mysqlOpts := []mysql.Option{
+	mysqlOpts := []mysql.Option{ //nolint: prealloc  // we're not concerned about perf here
 		mysql.MaxOpenConns(opts.ReadReplicaConnPool.MaxOpenConns),
 		mysql.ConnMaxIdleTime(opts.ReadReplicaConnPool.MaxIdleTime),
 		mysql.ConnMaxLifetime(opts.ReadReplicaConnPool.MaxLifetime),
@@ -776,7 +776,7 @@ func newMySQLReplicaDatastore(ctx context.Context, replicaIndex uint32, replicaU
 }
 
 func newMySQLPrimaryDatastore(ctx context.Context, opts Config) (datastore.Datastore, error) {
-	mysqlOpts := []mysql.Option{
+	mysqlOpts := []mysql.Option{ //nolint: prealloc  // we're not concerned about perf here
 		mysql.GCInterval(opts.GCInterval),
 		mysql.GCWindow(opts.GCWindow),
 		mysql.GCInterval(opts.GCInterval),

--- a/pkg/composableschemadsl/compiler/translator.go
+++ b/pkg/composableschemadsl/compiler/translator.go
@@ -519,7 +519,7 @@ func translateExpressionDirect(tctx *translationContext, expressionNode *dslNode
 		if err != nil {
 			return nil, err
 		}
-		var ops []*core.SetOperation_Child
+		var ops []*core.SetOperation_Child //nolint: prealloc  // we can't really know the length of ops ahead of time
 		ops = append(ops, collapseOps(leftOperation, lookup)...)
 		ops = append(ops, collapseOps(rightOperation, lookup)...)
 		return builder(ops[0], ops[1:]...), nil

--- a/pkg/composableschemadsl/parser/parser_test.go
+++ b/pkg/composableschemadsl/parser/parser_test.go
@@ -175,7 +175,7 @@ func getParseTree(currentNode *testNode, indentation int) string {
 	parseTree += fmt.Sprintf("%v", currentNode.nodeType)
 	parseTree += "\n"
 
-	keys := make([]string, 0)
+	keys := make([]string, 0, len(currentNode.properties))
 
 	for key := range currentNode.properties {
 		keys = append(keys, key)
@@ -189,7 +189,7 @@ func getParseTree(currentNode *testNode, indentation int) string {
 		parseTree += "\n"
 	}
 
-	keys = make([]string, 0)
+	keys = make([]string, 0, len(currentNode.children))
 
 	for key := range currentNode.children {
 		keys = append(keys, key)

--- a/pkg/datastore/test/relationships.go
+++ b/pkg/datastore/test/relationships.go
@@ -1782,7 +1782,7 @@ func QueryRelationshipsWithVariousFiltersTest(t *testing.T, tester DatastoreTest
 			iter, err := reader.QueryRelationships(ctx, tc.filter, options.WithSkipCaveats(tc.withoutCaveats), options.WithSkipExpiration(tc.withoutExpiration), options.WithQueryShape(queryshape.Varying))
 			require.NoError(err)
 
-			var results []string
+			var results []string //nolint: prealloc  // we don't know the length of this iterator ahead of time
 			for rel, err := range iter {
 				require.NoError(err)
 				results = append(results, tuple.MustString(rel))

--- a/pkg/development/assertions.go
+++ b/pkg/development/assertions.go
@@ -16,7 +16,7 @@ const maxDispatchDepth = 25
 // RunAllAssertions runs all assertions found in the given assertions block against the
 // developer context, returning whether any errors occurred.
 func RunAllAssertions(devContext *DevContext, assertions *blocks.Assertions) ([]*devinterface.DeveloperError, error) {
-	var allFailures []*devinterface.DeveloperError
+	var allFailures []*devinterface.DeveloperError //nolint: prealloc  // we can't really know in advance how many failures there will be
 
 	trueFailures, err := runAssertions(devContext, assertions.AssertTrue, v1.ResourceCheckResult_MEMBER, "Expected relation or permission %s to exist")
 	if err != nil {

--- a/pkg/development/validation.go
+++ b/pkg/development/validation.go
@@ -241,8 +241,9 @@ func GenerateValidation(membershipSet *developmentmembership.Set) (string, error
 
 	for _, onrString := range onrStrings {
 		foundSubjects := subjectsByONR[onrString]
-		var strs []string
-		for _, fs := range foundSubjects.ListFound() {
+		subjectList := foundSubjects.ListFound()
+		strs := make([]string, 0, len(subjectList))
+		for _, fs := range subjectList {
 			strs = append(strs,
 				fmt.Sprintf("[%s] is %s",
 					fs.ToValidationString(),

--- a/pkg/query/context_test.go
+++ b/pkg/query/context_test.go
@@ -247,11 +247,8 @@ func TestContext(t *testing.T) {
 		require.NotNil(wrappedSeq)
 
 		// Collect results to verify it works
-		var paths []Path
-		for path, err := range wrappedSeq {
-			require.NoError(err)
-			paths = append(paths, path)
-		}
+		paths, err := CollectAll(wrappedSeq)
+		require.NoError(err)
 		require.Len(paths, 1)
 		require.Equal(testPath, paths[0])
 	})
@@ -276,12 +273,9 @@ func TestContext(t *testing.T) {
 		wrappedSeq := ctx.wrapPathSeqForTracing(iterator, originalSeq)
 
 		// Collect results
-		var paths []Path
-		for path, err := range wrappedSeq {
-			require.NoError(err)
-			paths = append(paths, path)
-		}
+		paths, err := CollectAll(wrappedSeq)
 
+		require.NoError(err)
 		require.Len(paths, 1)
 		require.Equal(testPath, paths[0])
 

--- a/pkg/schema/v2/flatten_test.go
+++ b/pkg/schema/v2/flatten_test.go
@@ -308,7 +308,7 @@ definition folder {
 				})
 			}
 
-			var schemaDefinitions []compiler.SchemaDefinition
+			schemaDefinitions := make([]compiler.SchemaDefinition, 0, len(defs)+len(caveats))
 			for _, def := range defs {
 				schemaDefinitions = append(schemaDefinitions, def)
 			}
@@ -346,7 +346,7 @@ definition folder {
 				})
 			}
 
-			var expectedSchemaDefinitions []compiler.SchemaDefinition
+			expectedSchemaDefinitions := make([]compiler.SchemaDefinition, 0, len(expectedCompiled.ObjectDefinitions)+len(expectedCompiled.CaveatDefinitions))
 			for _, def := range expectedCompiled.ObjectDefinitions {
 				expectedSchemaDefinitions = append(expectedSchemaDefinitions, def)
 			}
@@ -655,7 +655,7 @@ definition user {}`,
 				})
 			}
 
-			var schemaDefinitions []compiler.SchemaDefinition
+			schemaDefinitions := make([]compiler.SchemaDefinition, 0, len(defs)+len(caveats))
 			for _, def := range defs {
 				schemaDefinitions = append(schemaDefinitions, def)
 			}
@@ -693,7 +693,7 @@ definition user {}`,
 				})
 			}
 
-			var expectedSchemaDefinitions []compiler.SchemaDefinition
+			expectedSchemaDefinitions := make([]compiler.SchemaDefinition, 0, len(expectedCompiled.ObjectDefinitions)+len(expectedCompiled.CaveatDefinitions))
 			for _, def := range expectedCompiled.ObjectDefinitions {
 				expectedSchemaDefinitions = append(expectedSchemaDefinitions, def)
 			}
@@ -1097,7 +1097,7 @@ definition user {}
 				})
 			}
 
-			var schemaDefinitions []compiler.SchemaDefinition
+			schemaDefinitions := make([]compiler.SchemaDefinition, 0, len(defs)+len(caveats))
 			for _, def := range defs {
 				schemaDefinitions = append(schemaDefinitions, def)
 			}
@@ -1135,7 +1135,7 @@ definition user {}
 				})
 			}
 
-			var expectedSchemaDefinitions []compiler.SchemaDefinition
+			expectedSchemaDefinitions := make([]compiler.SchemaDefinition, 0, len(expectedCompiled.ObjectDefinitions)+len(expectedCompiled.CaveatDefinitions))
 			for _, def := range expectedCompiled.ObjectDefinitions {
 				expectedSchemaDefinitions = append(expectedSchemaDefinitions, def)
 			}

--- a/pkg/schemadsl/compiler/translator.go
+++ b/pkg/schemadsl/compiler/translator.go
@@ -508,7 +508,7 @@ func translateExpressionDirect(tctx *translationContext, expressionNode *dslNode
 		if err != nil {
 			return nil, err
 		}
-		var ops []*core.SetOperation_Child
+		var ops []*core.SetOperation_Child //nolint: prealloc  // we can't know how long `ops` should be ahead of time
 		ops = append(ops, collapseOps(leftOperation, lookup)...)
 		ops = append(ops, collapseOps(rightOperation, lookup)...)
 		return builder(ops[0], ops[1:]...), nil

--- a/pkg/schemadsl/parser/parser_test.go
+++ b/pkg/schemadsl/parser/parser_test.go
@@ -172,7 +172,7 @@ func getParseTree(currentNode *testNode, indentation int) string {
 	parseTree += fmt.Sprintf("%v", currentNode.nodeType)
 	parseTree += "\n"
 
-	keys := make([]string, 0)
+	keys := make([]string, 0, len(currentNode.properties))
 
 	for key := range currentNode.properties {
 		keys = append(keys, key)
@@ -186,7 +186,7 @@ func getParseTree(currentNode *testNode, indentation int) string {
 		parseTree += "\n"
 	}
 
-	keys = make([]string, 0)
+	keys = make([]string, 0, len(currentNode.children))
 
 	for key := range currentNode.children {
 		keys = append(keys, key)

--- a/pkg/validationfile/blocks/expectedrelations.go
+++ b/pkg/validationfile/blocks/expectedrelations.go
@@ -230,7 +230,7 @@ func (vs ValidationString) Subject() (*SubjectWithExceptions, *spiceerrors.WithS
 // ONRStrings returns the ONRs contained in the ValidationString, if any.
 func (vs ValidationString) ONRStrings() []string {
 	results := vsObjectAndRelationRegex.FindAllStringSubmatch(string(vs), -1)
-	onrStrings := []string{}
+	onrStrings := make([]string, 0, len(results))
 	for _, result := range results {
 		onrStrings = append(onrStrings, result[2])
 	}

--- a/pkg/validationfile/blocks/expectedrelations_test.go
+++ b/pkg/validationfile/blocks/expectedrelations_test.go
@@ -143,8 +143,8 @@ func TestValidationString(t *testing.T) {
 				}
 			}
 
-			foundONRStrings := []string{}
 			onrs, _ := vs.ONRS()
+			foundONRStrings := make([]string, 0, len(onrs))
 			for _, onr := range onrs {
 				foundONRStrings = append(foundONRStrings, tuple.StringONR(onr))
 			}


### PR DESCRIPTION
## Description
These started failing with golangci-lint v2.8.0. This fixes them.

## Changes
* Fix prealloc lints

## Testing
Review. See that tests still pass.