### PR TITLE
test: reduce flakiness of RegisterRelationshipCountersInParallelTest

### DIFF
--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -24,7 +24,7 @@ import (
 const (
 	Engine                   = "memory"
 	defaultWatchBufferLength = 128
-	numAttempts              = 10
+	maxRetries               = 10
 )
 
 var (
@@ -159,7 +159,7 @@ func (mdb *memdbDatastore) ReadWriteTx(
 	opts ...options.RWTOptionsOption,
 ) (datastore.Revision, error) {
 	config := options.NewRWTOptionsWithOptions(opts...)
-	txNumAttempts := numAttempts
+	txNumAttempts := maxRetries // TODO every other datastore has a configurable MaxRetries. why not this one?
 	if config.DisableRetries {
 		txNumAttempts = 1
 	}

--- a/internal/datastore/memdb/memdb_test.go
+++ b/internal/datastore/memdb/memdb_test.go
@@ -27,10 +27,7 @@ func (mdbt memDBTest) New(revisionQuantization, _, gcWindow time.Duration, watch
 
 func TestMemdbDatastore(t *testing.T) {
 	t.Parallel()
-	// NOTE: The individual tests are not parallelized because enough write traffic will cause
-	// the memdb instance to reject requests with serialization errors, which results in
-	// flaky tests.
-	test.All(t, memDBTest{}, false)
+	test.All(t, memDBTest{}, true)
 }
 
 func TestConcurrentWritePanic(t *testing.T) {


### PR DESCRIPTION
## Description
See https://github.com/authzed/spicedb/actions/runs/21007920564/job/60396619281?pr=2818. We were getting test flakes from write failures that were the result of too much load on the memdb instance. For this reason, we're allowing the set of Memdb tests to run in parallel with other tests, but the test itself will not be parallelized to ensure that we aren't hammering the instance.

## Changes
* Turn off parallelism for memdb tests
## Testing
Review.