### PR TITLE
chore: add LR implementation for Relation iterator

### DIFF
--- a/pkg/query/context.go
+++ b/pkg/query/context.go
@@ -57,6 +57,7 @@ func (t *TraceLogger) EnterIterator(it Iterator, resources []Object, subject Obj
 	for i, r := range resources {
 		resourceStrs[i] = fmt.Sprintf("%s:%s", r.ObjectType, r.ObjectID)
 	}
+	// TODO: plumb in the operation and replace check( with that operation
 	t.traces = append(t.traces, fmt.Sprintf("%s-> %s: check(%s, %s:%s)",
 		indent, idPrefix, strings.Join(resourceStrs, ","), subject.ObjectType, subject.ObjectID))
 	t.depth++


### PR DESCRIPTION
## Description
There's a chunk of the LR consistency tests that are failing because wildcards weren't handled by the Datastore iterator in the correct way. This adds that implementation.

## Changes
* Add TODO
* Add implementation
## Testing
```
TEST_QUERY_PLAN_RESOURCES=true go test ./internal/services/integrationtesting -run "TestQueryPlanConsistency/arrowovermultiexclusion.yaml"
```
and see that it passes where it doesn't on main