### PR TITLE
chore: fix query plan alias iterator LR behavior

### DIFF
--- a/pkg/query/alias_test.go
+++ b/pkg/query/alias_test.go
@@ -9,13 +9,12 @@ import (
 func TestAliasIterator(t *testing.T) {
 	t.Parallel()
 
-	require := require.New(t)
-
 	// Create test context
 	ctx := NewLocalContext(t.Context())
 
 	t.Run("Check_BasicRelationRewriting", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create a sub-iterator with document relations
 		subIt := NewDocumentAccessFixedIterator()
@@ -46,6 +45,7 @@ func TestAliasIterator(t *testing.T) {
 
 	t.Run("Check_SelfEdgeDetection", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create an empty sub-iterator since we only want to test self-edge detection
 		subIt := NewEmptyFixedIterator()
@@ -77,6 +77,7 @@ func TestAliasIterator(t *testing.T) {
 
 	t.Run("Check_NoSelfEdge", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create a sub-iterator
 		subIt := NewSingleUserFixedIterator("bob")
@@ -100,6 +101,7 @@ func TestAliasIterator(t *testing.T) {
 
 	t.Run("Check_MultipleResources", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewDocumentAccessFixedIterator()
 		aliasIt := NewAlias("access", subIt)
@@ -126,6 +128,7 @@ func TestAliasIterator(t *testing.T) {
 
 	t.Run("IterSubjects_RelationRewriting", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewDocumentAccessFixedIterator()
 		aliasIt := NewAlias("permission", subIt)
@@ -146,6 +149,7 @@ func TestAliasIterator(t *testing.T) {
 
 	t.Run("IterResources_RelationRewriting", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewDocumentAccessFixedIterator()
 		aliasIt := NewAlias("can_view", subIt)
@@ -162,8 +166,41 @@ func TestAliasIterator(t *testing.T) {
 		}
 	})
 
+	t.Run("IterResources_SelfEdgeDetection", func(t *testing.T) {
+		t.Parallel()
+		require := require.New(t)
+
+		// Create an empty sub-iterator since we only want to test self-edge detection
+		subIt := NewEmptyFixedIterator()
+
+		// Create an alias iterator that rewrites to "admin"
+		aliasIt := NewAlias("admin", subIt)
+
+		// Check for a self-edge: user:alice#admin@user:alice#admin
+		subject := NewObjectAndRelation("alice", "user", "admin")
+		pathSeq, err := ctx.IterResources(aliasIt, subject)
+		require.NoError(err)
+
+		rels, err := CollectAll(pathSeq)
+		require.NoError(err)
+
+		// Should find exactly one relation (the self-edge)
+		require.Len(rels, 1, "should find exactly one self-edge relation")
+
+		// Verify it's the correct self-edge relation
+		rel := rels[0]
+		expectedResource := NewObjectAndRelation("alice", "user", "admin")
+		require.Equal(expectedResource.ObjectID, rel.Resource.ObjectID)
+		require.Equal(expectedResource.ObjectType, rel.Resource.ObjectType)
+		require.Equal(expectedResource.Relation, rel.Relation)
+		require.Equal(subject.ObjectID, rel.Subject.ObjectID)
+		require.Equal(subject.ObjectType, rel.Subject.ObjectType)
+		require.Equal(subject.Relation, rel.Subject.Relation)
+	})
+
 	t.Run("Check_EmptySubIterator", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewEmptyFixedIterator()
 		aliasIt := NewAlias("empty_alias", subIt)
@@ -178,6 +215,7 @@ func TestAliasIterator(t *testing.T) {
 
 	t.Run("Check_SelfEdgeWithEmptySubIterator", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create empty sub-iterator
 		subIt := NewEmptyFixedIterator()
@@ -198,6 +236,7 @@ func TestAliasIterator(t *testing.T) {
 
 	t.Run("Check_SelfEdgeExactMatch", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewEmptyFixedIterator()
 		aliasIt := NewAlias("owner", subIt)
@@ -249,10 +288,9 @@ func TestAliasIteratorClone(t *testing.T) {
 func TestAliasIteratorExplain(t *testing.T) {
 	t.Parallel()
 
-	require := require.New(t)
-
 	t.Run("ExplainWithSubIterator", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewDocumentAccessFixedIterator()
 		aliasIt := NewAlias("test_relation", subIt)
@@ -268,6 +306,7 @@ func TestAliasIteratorExplain(t *testing.T) {
 
 	t.Run("ExplainWithEmptySubIterator", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewEmptyFixedIterator()
 		aliasIt := NewAlias("empty_test", subIt)
@@ -281,13 +320,12 @@ func TestAliasIteratorExplain(t *testing.T) {
 func TestAliasIteratorErrorHandling(t *testing.T) {
 	t.Parallel()
 
-	require := require.New(t)
-
 	// Create test context
 	ctx := NewLocalContext(t.Context())
 
 	t.Run("Check_SubIteratorError", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create a faulty sub-iterator
 		faultyIt := NewFaultyIterator(true, false)
@@ -299,6 +337,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 
 	t.Run("Check_SubIteratorCollectionError", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create a faulty sub-iterator that fails during collection
 		faultyIt := NewFaultyIterator(false, true)
@@ -314,6 +353,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 
 	t.Run("IterSubjects_SubIteratorError", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create a faulty sub-iterator that fails on IterSubjectsImpl
 		faultyIt := NewFaultyIterator(true, false)
@@ -326,6 +366,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 
 	t.Run("IterSubjects_SubIteratorCollectionError", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create a faulty sub-iterator that fails during collection
 		faultyIt := NewFaultyIterator(false, true)
@@ -342,6 +383,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 
 	t.Run("IterResources_SubIteratorError", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create a faulty sub-iterator that fails on IterResourcesImpl
 		faultyIt := NewFaultyIterator(true, false)
@@ -354,6 +396,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 
 	t.Run("IterResources_SubIteratorCollectionError", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create a faulty sub-iterator that fails during collection
 		faultyIt := NewFaultyIterator(false, true)
@@ -370,6 +413,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 
 	t.Run("Check_SelfEdgeWithSubIteratorError", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create a faulty sub-iterator that errors on CheckImpl
 		faultyIt := NewFaultyIterator(true, false)
@@ -385,6 +429,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 
 	t.Run("Check_SelfEdgeWithSubIteratorCollectionError", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create a faulty sub-iterator that fails during collection
 		faultyIt := NewFaultyIterator(false, true)
@@ -405,13 +450,12 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 	t.Parallel()
 
-	require := require.New(t)
-
 	// Create test context
 	ctx := NewLocalContext(t.Context())
 
 	t.Run("Check_MultipleResourcesSelfEdgeWithSubResults", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create sub-iterator with real data
 		subIt := NewDocumentAccessFixedIterator()
@@ -451,6 +495,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 	t.Run("Check_MultipleResourcesMultipleSelfEdges", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Create empty sub-iterator to isolate self-edge logic
 		subIt := NewEmptyFixedIterator()
@@ -478,6 +523,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 	t.Run("IterSubjects_EmptySubIterator", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewEmptyFixedIterator()
 		aliasIt := NewAlias("empty_relation", subIt)
@@ -492,6 +538,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 	t.Run("IterResources_EmptySubIterator", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewEmptyFixedIterator()
 		aliasIt := NewAlias("empty_relation", subIt)
@@ -506,6 +553,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 	t.Run("Check_LargeResultSet", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Use iterator with many results
 		subIt := NewLargeFixedIterator()
@@ -529,6 +577,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 	t.Run("Clone_Independence", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewDocumentAccessFixedIterator()
 		original := NewAlias("original", subIt)
@@ -564,6 +613,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 	t.Run("Check_EarlyReturnBasicRewriting", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewDocumentAccessFixedIterator()
 		aliasIt := NewAlias("early_test", subIt)
@@ -586,6 +636,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 	t.Run("Check_EarlyReturnSelfEdgeWithSubResults", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewDocumentAccessFixedIterator()
 		aliasIt := NewAlias("admin", subIt)
@@ -610,6 +661,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 	t.Run("IterSubjects_EarlyReturn", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewDocumentAccessFixedIterator()
 		aliasIt := NewAlias("early_subjects", subIt)
@@ -632,6 +684,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 	t.Run("IterResources_EarlyReturn", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		subIt := NewDocumentAccessFixedIterator()
 		aliasIt := NewAlias("early_resources", subIt)
@@ -654,6 +707,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 	t.Run("Check_SelfEdgeWithSubIteratorPathRewriting", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 
 		// Use sub-iterator that will return paths that need rewriting
 		subIt := NewDocumentAccessFixedIterator()


### PR DESCRIPTION
## Description
The `CheckImpl` on the `Alias` iterator accounts for self paths. The LR also needs to, because the semantic ends up being the same in that case.

## Changes
* Implement the self path logic for LR
* Add unit test
* Update alias test usage of `require.New()`

## Testing
See that `TEST_QUERY_PLAN_RESOURCES=true go test ./internal/services/integrationtesting -run "TestQueryPlanConsistency/arrowoversametype.yaml/lookup_resources/validate_lookup_resources_folder_parent_/folder:folder2#parent"` now passes