### PR TITLE
chore: fix query plan intersection arrow LR behavior

### DIFF
--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -7,7 +7,6 @@ import (
 	"maps"
 	"path"
 	"slices"
-	"sort"
 	"testing"
 	"time"
 
@@ -333,19 +332,6 @@ func validateExpansionSubjects(t *testing.T, vctx validationContext) {
 		})
 }
 
-func requireSameSets(t *testing.T, expected []string, found []string) {
-	expectedSet := mapz.NewSet(expected...)
-	foundSet := mapz.NewSet(found...)
-
-	orderedExpected := expectedSet.AsSlice()
-	orderedFound := foundSet.AsSlice()
-
-	sort.Strings(orderedExpected)
-	sort.Strings(orderedFound)
-
-	require.Equal(t, orderedExpected, orderedFound)
-}
-
 func requireSubsetOf(t *testing.T, found []string, expected []string) {
 	if len(expected) == 0 {
 		return
@@ -395,9 +381,10 @@ func validateLookupResources(t *testing.T, vctx validationContext) {
 								}
 							}
 
-							requireSameSets(t,
+							require.ElementsMatch(t,
 								slices.Collect(maps.Keys(accessibleResources)),
 								slices.Collect(maps.Keys(resolvedResources)),
+								"expected accessibleResources in list A don't match actual resolvedResources in list B",
 							)
 
 							// Ensure that every returned concrete object Checks directly.

--- a/internal/services/integrationtesting/query_plan_consistency_test.go
+++ b/internal/services/integrationtesting/query_plan_consistency_test.go
@@ -228,9 +228,10 @@ func runQueryPlanLookupResources(t *testing.T, handle *queryPlanConsistencyHandl
 						}()
 					}
 
-					requireSameSets(t,
+					require.ElementsMatch(t,
 						slices.Collect(maps.Keys(accessibleResources)),
 						slices.Collect(maps.Keys(resolvedResources)),
+						"expected accessibleResources in list A don't match actual resolvedResources in list B",
 					)
 				})
 			}
@@ -287,9 +288,10 @@ func runQueryPlanLookupSubjects(t *testing.T, handle *queryPlanConsistencyHandle
 						}()
 					}
 
-					requireSameSets(t,
+					require.ElementsMatch(t,
 						slices.Collect(maps.Keys(accessibleSubjects)),
 						slices.Collect(maps.Keys(resolvedSubjects)),
+						"expected accessibleSubjects in list A don't match actual resolvedSubjects in list B",
 					)
 				})
 			}

--- a/pkg/query/intersection_arrow.go
+++ b/pkg/query/intersection_arrow.go
@@ -260,7 +260,7 @@ func (ia *IntersectionArrow) IterResourcesImpl(ctx *Context, subject ObjectAndRe
 
 	for _, rightPath := range rightPaths {
 		rightResourceAsSubject := rightPath.Resource.WithEllipses()
-		ctx.TraceStep(ia, "checking left side for right resource %s:%s", rightResourceAsSubject.ObjectType, rightResourceAsSubject.ObjectID)
+		ctx.TraceStep(ia, "looking up left resources for right resource %s:%s", rightResourceAsSubject.ObjectType, rightResourceAsSubject.ObjectID)
 
 		leftSeq, err := ctx.IterResources(ia.left, rightResourceAsSubject)
 		if err != nil {
@@ -280,7 +280,7 @@ func (ia *IntersectionArrow) IterResourcesImpl(ctx *Context, subject ObjectAndRe
 		for _, path := range leftPaths {
 			resource := path.Resource
 			key := resource.Key()
-			if notSeen := seenResources.Add(key); !notSeen {
+			if notSeen := seenResources.Add(key); notSeen {
 				leftResources = append(leftResources, path.Resource)
 			}
 		}


### PR DESCRIPTION
## Description
Turns out I got the seen/notSeen logic backwards. This fixes that issue.

## Changes
* Drive-by refactor to replace `requireSameSets` with `ElementsMatch` from testify, which gives the same behavior
* Update trace verbiage to make things a bit more clear
* Only add things to the `leftResources` list if we *haven't* seen them before (oops)
## Testing
Review. See that `TEST_QUERY_PLAN_RESOURCES=true go test ./internal/services/integrationtesting -run "TestQueryPlanConsistency/intersectionarrow.yaml/lookup_resources/validate_lookup_resources_resource_view_by_all_/user:sarah"` passes.