### PR TITLE
chore: reduce flakiness of repair unit test

### DIFF
--- a/pkg/cmd/datastore_test.go
+++ b/pkg/cmd/datastore_test.go
@@ -43,7 +43,8 @@ func TestExecuteGC(t *testing.T) {
 }
 
 func TestExecuteRepair(t *testing.T) {
-	t.Parallel()
+	// NOTE: we don't run these in parallel because the datastore implementations
+	// share enough internals that you end up with duplicate metric registration errors otherwise.
 
 	tests := []struct {
 		name          string
@@ -78,7 +79,6 @@ func TestExecuteRepair(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 
 			cfg := tt.cfgBuilder(t)
 			err := executeRepair(cfg, []string{})


### PR DESCRIPTION
## Description
These tests regularly flaked: https://github.com/authzed/spicedb/actions/runs/21076336536/job/60626682426?pr=2805#step:4:213

Keeping them from running in parallel should help by preventing them from interacting with other tests.

## Changes
* Remove t.Parallels
* Add a comment
## Testing
Review.