### PR TITLE
fix: lexing utf-8 characters

### DIFF
--- a/pkg/schemadsl/lexer/lex.go
+++ b/pkg/schemadsl/lexer/lex.go
@@ -162,19 +162,20 @@ func (l *Lexer) errorf(currentRune rune, format string, args ...any) stateFn {
 
 // peekValue looks forward for the given value string. If found, returns true.
 func (l *Lexer) peekValue(value string) bool {
-	for index, runeValue := range value {
+	// NOTE: we manually track start position here because we can't count on the
+	// runes that we're next()ing over to all have the same width.
+	startPos := l.pos
+	for _, runeValue := range value {
 		r := l.next()
 		if r != runeValue {
-			for j := 0; j <= index; j++ {
-				l.backup()
-			}
+			// Restore to starting position on mismatch.
+			l.pos = startPos
 			return false
 		}
 	}
 
-	for i := 0; i < len(value); i++ {
-		l.backup()
-	}
+	// Restore to starting position after successful peek.
+	l.pos = startPos
 
 	return true
 }
@@ -188,14 +189,15 @@ func (l *Lexer) accept(valid string) bool {
 	return false
 }
 
-// acceptString consumes the full given string, if the next tokens in the stream.
+// acceptString consumes the full given string, if the next token is in the stream.
 func (l *Lexer) acceptString(value string) bool {
-	for index, runeValue := range value {
+	// NOTE: we manually track start position here because we can't count on the
+	// runes that we're next()ing over to all have the same width.
+	startPos := l.pos
+	for _, runeValue := range value {
 		if l.next() != runeValue {
-			for i := 0; i <= index; i++ {
-				l.backup()
-			}
-
+			// Restore to the starting position on mismatch.
+			l.pos = startPos
 			return false
 		}
 	}

--- a/pkg/schemadsl/lexer/lex_test.go
+++ b/pkg/schemadsl/lexer/lex_test.go
@@ -66,6 +66,10 @@ var lexerTests = []lexerTest{
 		tEOF,
 	}},
 
+	{"unicode identifier", "一级", []Lexeme{{TokenTypeIdentifier, 0, "一级", ""}, tEOF}},
+	{"unicode singlequoted string literal", "'一级'", []Lexeme{{TokenTypeString, 0, "'一级'", ""}, tEOF}},
+	{"ascii singlequoted string literal", "'foo'", []Lexeme{{TokenTypeString, 0, "'foo'", ""}, tEOF}},
+
 	{"multiple slash path", "foo/bar/baz/bang/zoom", []Lexeme{
 		{TokenTypeIdentifier, 0, "foo", ""},
 		{TokenTypeDiv, 0, "/", ""},
@@ -237,7 +241,25 @@ var lexerTests = []lexerTest{
 		},
 	},
 	{
+		"cel string literal with terminators with unicode", `"""hi "一级" """`,
+		[]Lexeme{
+			{TokenTypeString, 0, `"""hi "一级" """`, ""},
+			tEOF,
+		},
+	},
+	{
 		"unterminated cel string literal", "\"hi\nthere\"",
+		[]Lexeme{
+			{
+				Kind:     TokenTypeError,
+				Position: 0,
+				Value:    "\n",
+				Error:    "Unterminated string",
+			},
+		},
+	},
+	{
+		"unterminated cel string literal with unicode", "\"hi\n一级\"",
 		[]Lexeme{
 			{
 				Kind:     TokenTypeError,

--- a/pkg/schemadsl/parser/parser_test.go
+++ b/pkg/schemadsl/parser/parser_test.go
@@ -124,6 +124,7 @@ func TestParser(t *testing.T) {
 		{"arrow illegal operations test", "arrowillegalops"},
 		{"arrow illegal function test", "arrowillegalfunc"},
 		{"caveat with keyword parameter test", "caveatwithkeywordparam"},
+		{"caveat with unicode identifier", "caveat_unicode"},
 		{"use expiration test", "useexpiration"},
 		{"use expiration keyword test", "useexpirationkeyword"},
 		{"expiration non-keyword test", "expirationnonkeyword"},

--- a/pkg/schemadsl/parser/tests/caveat_unicode.zed
+++ b/pkg/schemadsl/parser/tests/caveat_unicode.zed
@@ -1,0 +1,3 @@
+caveat test_chinese(attr string) {
+  attr == '一级'
+}

--- a/pkg/schemadsl/parser/tests/caveat_unicode.zed.expected
+++ b/pkg/schemadsl/parser/tests/caveat_unicode.zed.expected
@@ -1,0 +1,28 @@
+NodeTypeFile
+  end-rune = 55
+  input-source = caveat with unicode identifier
+  start-rune = 0
+  child-node =>
+    NodeTypeCaveatDefinition
+      caveat-definition-name = test_chinese
+      end-rune = 54
+      input-source = caveat with unicode identifier
+      start-rune = 0
+      caveat-definition-expression =>
+        NodeTypeCaveatExpression
+          caveat-expression-expressionstr = attr == '一级'
+          end-rune = 52
+          input-source = caveat with unicode identifier
+          start-rune = 37
+      parameters =>
+        NodeTypeCaveatParameter
+          caveat-parameter-name = attr
+          end-rune = 30
+          input-source = caveat with unicode identifier
+          start-rune = 20
+          caveat-parameter-type =>
+            NodeTypeCaveatTypeReference
+              end-rune = 30
+              input-source = caveat with unicode identifier
+              start-rune = 25
+              type-name = string


### PR DESCRIPTION
Fixes #2835 

## Description
See #2835. A user encountered an issue where non-ASCII characters in string literals were causing a lexer panic. This fixes that by changing how peeks and string literal lexing work.

The issue was that the code implicitly made an assumption that all of the peeked or accepted runes were the same width, which isn't necessarily going to be the case in unicode strings; `l.backup()` will use the currently-set width, rather than the width of the rune that is being backed up over. Manually tracking the start position works around this problem.

## Changes
* Add parser test
* Add lexer test
* Change lexer logic to restore to a starting position rather than calling `backup` multiple times

## Testing
Review. See that tests pass.