### PR TITLE
chore: update glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ WORKDIR /go/src/app/grpc-health-probe
 RUN git checkout main
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
-# use `crane digest <image>` to get the multi-platform sha256
+# use `docker buildx imagetools inspect <image>` to get the multi-platform sha256
 # Note: Using glibc-dynamic base instead of static because the postgres-fdw command requires libc
-FROM cgr.dev/chainguard/glibc-dynamic@sha256:2c50486a00691ab9bf245c5e5e456777ff4bb25c8635be898bd5e2f0ab72eedb
+FROM cgr.dev/chainguard/glibc-dynamic@sha256:530fc40b687b95f6c5e8a9b62da03306754da5ef45178e632b7486603bfb7096
 COPY --from=health-probe-builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 COPY --from=spicedb-builder /go/src/app/spicedb /usr/local/bin/spicedb
 ENV PATH="$PATH:/usr/local/bin"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,7 +1,7 @@
 # vim: syntax=dockerfile
 # use `docker buildx imagetools inspect <image>` to get the multi-platform sha256
 # Note: Using glibc-dynamic base instead of static because the postgres-fdw command requires libc
-ARG BASE=cgr.dev/chainguard/glibc-dynamic@sha256:2c50486a00691ab9bf245c5e5e456777ff4bb25c8635be898bd5e2f0ab72eedb
+ARG BASE=cgr.dev/chainguard/glibc-dynamic@sha256:530fc40b687b95f6c5e8a9b62da03306754da5ef45178e632b7486603bfb7096
 FROM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS health-probe-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git


### PR DESCRIPTION
## Description
Trivy is reporting failures [here](https://github.com/authzed/spicedb/actions/runs/21227443694/job/61078017009?pr=2838) because of vulnerabilities in glibc.

## Changes
* Bump to most recent version

## Testing
Review. See that tests pass.