### PR TITLE
feat(schema): add support for parent namespace in arrow information

### DIFF
--- a/pkg/schema/arrows_test.go
+++ b/pkg/schema/arrows_test.go
@@ -271,3 +271,275 @@ func TestAllReachableRelations(t *testing.T) {
 		})
 	}
 }
+
+func TestLookupArrowsWithComputedUserset(t *testing.T) {
+	t.Parallel()
+
+	type expectedArrow struct {
+		parentNamespace string
+		parentRelation  string
+		arrowExpression string
+	}
+
+	type testcase struct {
+		name       string
+		schemaText string
+
+		targetNamespace string
+		targetRelation  string
+		expected        []expectedArrow
+	}
+
+	tcs := []testcase{
+		{
+			name: "basic arrow",
+			schemaText: `
+			definition user {}
+
+			definition organization {
+				relation member: user
+			}
+
+			definition resource {
+				relation org: organization
+				permission view = org->member
+			}
+		`,
+			targetNamespace: "organization",
+			targetRelation:  "member",
+			expected: []expectedArrow{
+				{
+					parentNamespace: "resource",
+					parentRelation:  "view",
+					arrowExpression: "org->member",
+				},
+			},
+		},
+		{
+			name: "multiple arrows to same relation",
+			schemaText: `
+			definition user {}
+
+			definition organization {
+				relation member: user
+			}
+
+			definition resource {
+				relation org: organization
+				permission view = org->member
+				permission another_view = org->member
+			}
+
+			definition another_resource {
+				relation org: organization
+				permission view = org->member
+			}
+		`,
+			targetNamespace: "organization",
+			targetRelation:  "member",
+			expected: []expectedArrow{
+				{
+					parentNamespace: "resource",
+					parentRelation:  "view",
+					arrowExpression: "org->member",
+				},
+				{
+					parentNamespace: "resource",
+					parentRelation:  "another_view",
+					arrowExpression: "org->member",
+				},
+				{
+					parentNamespace: "another_resource",
+					parentRelation:  "view",
+					arrowExpression: "org->member",
+				},
+			},
+		},
+		{
+			name: "arrows across different namespaces",
+			schemaText: `
+			definition user {}
+
+			definition organization {
+				relation member: user
+			}
+
+			definition project {
+				relation org: organization
+				permission view = org->member
+			}
+
+			definition document {
+				relation org: organization
+				permission view = org->member
+			}
+		`,
+			targetNamespace: "organization",
+			targetRelation:  "member",
+			expected: []expectedArrow{
+				{
+					parentNamespace: "project",
+					parentRelation:  "view",
+					arrowExpression: "org->member",
+				},
+				{
+					parentNamespace: "document",
+					parentRelation:  "view",
+					arrowExpression: "org->member",
+				},
+			},
+		},
+		{
+			name: "arrow in union and exclusion expression",
+			schemaText: `
+			definition user {}
+
+			definition organization {
+				relation member: user
+			}
+
+			definition resource {
+				relation reader: user
+				relation writer: user
+				relation banned: user
+				relation org: organization
+				permission view = reader + writer - banned + org->member
+			}
+		`,
+			targetNamespace: "organization",
+			targetRelation:  "member",
+			expected: []expectedArrow{
+				{
+					parentNamespace: "resource",
+					parentRelation:  "view",
+					arrowExpression: "org->member",
+				},
+			},
+		},
+		{
+			name: "chained arrow through intermediate type",
+			schemaText: `
+			definition user {}
+
+			definition team {
+				relation member: user
+			}
+
+			definition organization {
+				relation team: team
+				permission member = team->member
+			}
+
+			definition resource {
+				relation org: organization
+				permission view = org->member
+			}
+		`,
+			targetNamespace: "team",
+			targetRelation:  "member",
+			expected: []expectedArrow{
+				{
+					parentNamespace: "organization",
+					parentRelation:  "member",
+					arrowExpression: "team->member",
+				},
+			},
+		},
+		{
+			name: "multiple arrows in nested expression",
+			schemaText: `
+			definition user {}
+
+			definition team {
+				relation member: user
+			}
+
+			definition organization {
+				relation admin: user
+				relation team: team
+				permission member = admin + team->member
+			}
+
+			definition resource {
+				relation org: organization
+				relation team: team
+				permission view = org->member + team->member
+			}
+		`,
+			targetNamespace: "team",
+			targetRelation:  "member",
+			expected: []expectedArrow{
+				{
+					parentNamespace: "organization",
+					parentRelation:  "member",
+					arrowExpression: "team->member",
+				},
+				{
+					parentNamespace: "resource",
+					parentRelation:  "view",
+					arrowExpression: "team->member",
+				},
+			},
+		},
+		{
+			name: "arrow with intersection and exclusion",
+			schemaText: `
+			definition user {}
+
+			definition organization {
+				relation member: user
+				relation admin: user
+			}
+
+			definition resource {
+				relation org: organization
+				relation blocked: user
+				permission view = org->member & org->admin - blocked
+			}
+		`,
+			targetNamespace: "organization",
+			targetRelation:  "member",
+			expected: []expectedArrow{
+				{
+					parentNamespace: "resource",
+					parentRelation:  "view",
+					arrowExpression: "org->member",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+
+			schema, err := compiler.Compile(compiler.InputSchema{
+				Source:       "",
+				SchemaString: tc.schemaText,
+			}, compiler.AllowUnprefixedObjectType())
+			require.NoError(t, err)
+
+			res := ResolverForCompiledSchema(*schema)
+			arrowSet, err := buildArrowSet(t.Context(), res)
+			require.NoError(t, err)
+
+			arrows := arrowSet.LookupArrowsWithComputedUserset(tc.targetNamespace, tc.targetRelation)
+			require.Len(t, arrows, len(tc.expected))
+
+			for _, expected := range tc.expected {
+				found := false
+				for _, actual := range arrows {
+					actualExpression := actual.Arrow.Tupleset.Relation + "->" + actual.Arrow.ComputedUserset.Relation
+					if actual.ParentNamespace == expected.parentNamespace &&
+						actual.ParentRelationName == expected.parentRelation &&
+						actualExpression == expected.arrowExpression {
+						found = true
+						break
+					}
+				}
+				require.True(t, found, "expected arrow %v not found in %v", expected, arrows)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enhance the `ArrowSet` utility in `pkg/schema` to provide more granular information about arrows `TupleToUserset`s defined in a schema. It adds parent namespace to `ArrowInformation` and a new lookup method to retrieve arrows by their computed userset.

### Changes
- Added a `ParentNamespace` field to `ArrowInformation`. This allows each arrow reference to be fully qualified by its parent relation's location (namepace + relation name).
- Added `LookupArrowsWithComputedUserset` on `ArrowSet` that returns all `ArrowInformation` objects pointing to a specific namespace and relation.

### Why
Currently, `ArrowSet` only provides a boolean check (`HasPossibleArrowWithComputedUserset`) to see if any arrow points to a relation. This forces consumers who need to perform filtered analysis i.e., checking if an arrow is reachable from a specific set of entry points, to manually walk the schema (using `graph.WalkRewrite`) or parse userset rewrites.
By including the parent context and providing a direct lookup, consumers can now efficiently retrieve and filter arrows without duplicating the traversal logic already performed by `ArrowSet`.