### PR TITLE
chore: fix trace logging of non-checks

### DIFF
--- a/pkg/query/context_test.go
+++ b/pkg/query/context_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestTraceLogger(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
 	t.Run("NewTraceLogger", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		require.NotNil(logger)
 		require.Empty(logger.traces)
@@ -23,6 +23,7 @@ func TestTraceLogger(t *testing.T) {
 
 	t.Run("EnterIterator", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		resources := []Object{NewObject("document", "doc1")}
 		subject := NewObject("user", "alice").WithEllipses()
@@ -31,18 +32,19 @@ func TestTraceLogger(t *testing.T) {
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
 
-		logger.EnterIterator(iterator, resources, subject)
+		logger.EnterIterator(iterator, checkTraceString(resources, subject))
 
 		require.Len(logger.traces, 1)
 		require.Equal(1, logger.depth)
 		require.Len(logger.stack, 1)
 		require.Contains(logger.traces[0], "-> ")
 		require.Contains(logger.traces[0], "Fixed")
-		require.Contains(logger.traces[0], "check(document:doc1, user:alice)")
+		require.Contains(logger.traces[0], "check(document:doc1, user:alice#...)")
 	})
 
 	t.Run("ExitIterator", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -63,6 +65,7 @@ func TestTraceLogger(t *testing.T) {
 
 	t.Run("LogStep", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		testPath := MustPathFromString("document:doc1#view@user:alice")
 		iterator := NewFixedIterator(testPath)
@@ -79,6 +82,7 @@ func TestTraceLogger(t *testing.T) {
 
 	t.Run("LogStep_IteratorNotInStack", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		logger.depth = 3
 		testPath := MustPathFromString("document:doc1#view@user:alice")
@@ -94,6 +98,7 @@ func TestTraceLogger(t *testing.T) {
 
 	t.Run("DumpTrace", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		logger.traces = []string{"line1", "line2", "line3"}
 
@@ -104,10 +109,10 @@ func TestTraceLogger(t *testing.T) {
 
 func TestContext(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
 	t.Run("TraceStep", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		ctx := NewLocalContext(context.Background(),
 			WithTraceLogger(logger))
@@ -124,6 +129,7 @@ func TestContext(t *testing.T) {
 
 	t.Run("TraceStep_NoLogger", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		ctx := NewLocalContext(context.Background())
 		// No TraceLogger set
 
@@ -138,6 +144,7 @@ func TestContext(t *testing.T) {
 
 	t.Run("TraceEnter", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		ctx := NewLocalContext(context.Background(),
 			WithTraceLogger(logger))
@@ -147,7 +154,7 @@ func TestContext(t *testing.T) {
 		resources := []Object{NewObject("document", "doc1")}
 		subject := NewObject("user", "alice").WithEllipses()
 
-		ctx.TraceEnter(iterator, resources, subject)
+		ctx.TraceEnter(iterator, checkTraceString(resources, subject))
 
 		require.Equal(1, logger.depth)
 		require.Len(logger.stack, 1)
@@ -155,6 +162,7 @@ func TestContext(t *testing.T) {
 
 	t.Run("TraceExit", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		ctx := NewLocalContext(context.Background(),
 			WithTraceLogger(logger))
@@ -174,6 +182,7 @@ func TestContext(t *testing.T) {
 
 	t.Run("shouldTrace", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		// With logger
 		ctx := NewLocalContext(context.Background(),
 			WithTraceLogger(NewTraceLogger()))
@@ -186,6 +195,7 @@ func TestContext(t *testing.T) {
 
 	t.Run("Check_NoExecutor", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		ctx := NewLocalContext(context.Background())
 		// No Executor set - but NewLocalContext always sets LocalExecutor
 		// This test won't actually panic anymore, so we need to modify it
@@ -201,6 +211,7 @@ func TestContext(t *testing.T) {
 
 	t.Run("IterSubjects_NoExecutor", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		ctx := NewLocalContext(context.Background())
 		// No Executor set - but NewLocalContext always sets LocalExecutor
 		// This test won't actually panic anymore, so we need to modify it
@@ -216,6 +227,7 @@ func TestContext(t *testing.T) {
 
 	t.Run("IterResources_NoExecutor", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		ctx := NewLocalContext(context.Background())
 		// No Executor set - but NewLocalContext always sets LocalExecutor
 		// This test won't actually panic anymore, so we need to modify it
@@ -231,6 +243,7 @@ func TestContext(t *testing.T) {
 
 	t.Run("wrapPathSeqForTracing_NoTracing", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		ctx := NewLocalContext(context.Background())
 		// No TraceLogger
 
@@ -255,6 +268,7 @@ func TestContext(t *testing.T) {
 
 	t.Run("wrapPathSeqForTracing_WithTracing", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		ctx := NewLocalContext(context.Background(),
 			WithTraceLogger(logger))
@@ -288,6 +302,7 @@ func TestContext(t *testing.T) {
 
 	t.Run("wrapPathSeqForTracing_WithError", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
 		logger := NewTraceLogger()
 		ctx := NewLocalContext(context.Background(),
 			WithTraceLogger(logger))

--- a/pkg/query/tracing_test.go
+++ b/pkg/query/tracing_test.go
@@ -72,7 +72,7 @@ func TestIteratorTracing(t *testing.T) {
 		trace := traceLogger.DumpTrace()
 		require.Contains(t, trace, "-> ")
 		require.Contains(t, trace, "Fixed")
-		require.Contains(t, trace, "check(document:doc1, :)")
+		require.Contains(t, trace, "iterSubjects(document:doc1)")
 		require.Contains(t, trace, "<- ")
 		require.Contains(t, trace, "returned 1 paths")
 		require.Contains(t, trace, "iterating subjects for resource document:doc1 from 2 paths")


### PR DESCRIPTION
## Description
This is something that's been hard to track in looking at traces - the traces are always called "check" even if they're doing a different operation. This fixes that by plumbing in the operation. It also gets rid of the resources clause if there are no resources for the input.

## Changes
* change how trace strings are constructed and passed
* update tests accordingly
## Testing
Review, see that a trace has the correct annotations now.