### PR TITLE
fix: make schemautil.ApplySchemaChangesOverExisting preserve existing stuff

### DIFF
--- a/internal/services/shared/schema.go
+++ b/internal/services/shared/schema.go
@@ -26,8 +26,10 @@ type ValidatedSchemaChanges struct {
 	validatedDefinitions map[string]*schema.ValidatedDefinition
 	newCaveatDefNames    *mapz.Set[string]
 	newObjectDefNames    *mapz.Set[string]
-	additiveOnly         bool
-	schemaText           string
+	// additiveOnly indicates whether all operations should be applied
+	// or only those operations which are additive (i.e. not changes or deletions)
+	additiveOnly bool
+	schemaText   string
 }
 
 // ValidateSchemaChanges validates the schema found in the compiled schema and returns a
@@ -120,7 +122,7 @@ func ApplySchemaChanges(ctx context.Context, rwt datastore.ReadWriteTransaction,
 // ApplySchemaChangesOverExisting applies schema changes found in the validated changes struct, against
 // existing caveat and object definitions given.
 // The idea is that the given schema will be diffed against the existing objects given, and any
-// objects not named in one of those two will be preserved.
+// objects not named in one of those two which are present in the datastore will be preserved.
 func ApplySchemaChangesOverExisting(
 	ctx context.Context,
 	rwt datastore.ReadWriteTransaction,

--- a/internal/services/shared/schema_test.go
+++ b/internal/services/shared/schema_test.go
@@ -640,7 +640,6 @@ func TestApplySchemaChangesOverExisting(t *testing.T) {
 		startingSchema               string
 		patchSchema                  string
 		expectedSchema               string
-		relationships                []string
 		expectedAppliedSchemaChanges AppliedSchemaChanges
 		expectedError                string
 	}{
@@ -673,6 +672,7 @@ func TestApplySchemaChangesOverExisting(t *testing.T) {
 			`,
 			expectedSchema: "caveat catchTwentyTwo(value int) {\n\tvalue == 22\n}\n\ndefinition organization {\n\trelation member: user\n\tpermission admin = member\n}\n\ndefinition user {}",
 			expectedAppliedSchemaChanges: AppliedSchemaChanges{
+				// NOTE: this is 5 because the `user` definition is written even though it's unchanged
 				TotalOperationCount:   5,
 				NewObjectDefNames:     []string{"organization"},
 				RemovedObjectDefNames: []string{"document"},
@@ -712,6 +712,7 @@ func TestApplySchemaChangesOverExisting(t *testing.T) {
 			expectedSchema: "caveat catchTwentyTwo(value int) {\n\tvalue == 22\n}\n\ndefinition admin {}\n\ndefinition organization {\n\trelation member: user\n\tpermission admin = member\n}\n\ndefinition user {}",
 			// NOTE: we're expecting that the `admin` part of the schema stays there.
 			expectedAppliedSchemaChanges: AppliedSchemaChanges{
+				// NOTE: this is 5 because the `user` definition is written even though it's unchanged
 				TotalOperationCount:   5,
 				NewObjectDefNames:     []string{"organization"},
 				RemovedObjectDefNames: []string{"document"},
@@ -726,12 +727,11 @@ func TestApplySchemaChangesOverExisting(t *testing.T) {
 			rawDS, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, 0, memdb.DisableGC)
 			require.NoError(err)
 
-			// Write the initial schema.
-			relationships := make([]tuple.Relationship, 0, len(tc.relationships))
-			for _, rel := range tc.relationships {
-				relationships = append(relationships, tuple.MustParse(rel))
-			}
-
+			// NOTE: the schema that we start with in the DB is the concatenation of the
+			// static part of the schema and the written part of the schema because
+			// the function under tests takes the "starting" schema (i.e. the part of the schema
+			// that's expected to be modified by the written schema) as one of its arguments.
+			// It ignores what's already in the database that isn't explicitly named.
 			schemaInDB := tc.staticSchema + "\n\n" + tc.startingSchema
 
 			compiledStartingSchema, err := compiler.Compile(compiler.InputSchema{
@@ -740,7 +740,7 @@ func TestApplySchemaChangesOverExisting(t *testing.T) {
 			}, compiler.AllowUnprefixedObjectType())
 			require.NoError(err)
 
-			ds, _ := testfixtures.DatastoreFromSchemaAndTestRelationships(rawDS, schemaInDB, relationships, require)
+			ds, _ := testfixtures.DatastoreFromSchemaAndTestRelationships(rawDS, schemaInDB, nil, require)
 
 			// Update the schema and ensure it works.
 			compiled, err := compiler.Compile(compiler.InputSchema{
@@ -750,14 +750,22 @@ func TestApplySchemaChangesOverExisting(t *testing.T) {
 			require.NoError(err)
 
 			validated, err := ValidateSchemaChanges(t.Context(), compiled, caveattypes.Default.TypeSet, false, tc.patchSchema)
-			if tc.expectedError != "" && err != nil && tc.expectedError == err.Error() {
+			if tc.expectedError != "" {
+				require.ErrorContains(err, tc.expectedError)
 				return
 			}
 
 			require.NoError(err)
 
 			_, err = ds.ReadWriteTx(t.Context(), func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-				applied, err := ApplySchemaChangesOverExisting(t.Context(), rwt, caveattypes.Default.TypeSet, validated, compiledStartingSchema.CaveatDefinitions, compiledStartingSchema.ObjectDefinitions)
+				applied, err := ApplySchemaChangesOverExisting(
+					t.Context(),
+					rwt,
+					caveattypes.Default.TypeSet,
+					validated,
+					compiledStartingSchema.CaveatDefinitions,
+					compiledStartingSchema.ObjectDefinitions,
+				)
 				if tc.expectedError != "" {
 					require.EqualError(err, tc.expectedError)
 					return nil


### PR DESCRIPTION
## Description
`ApplySchemaChangesOverExisting` was intended to allow you to patch a subset of a schema. When we refactored the `WriteSchema` logic in #2805, we didn't account for definitions in the datastore that remained unchanged - the new schema and its patch were treated as the entirety of the schema that we were operating on.

This changes the logic so that it accounts for the unchanged portion of the schema and writes it along with the rest of the changes into the written schema.

## Changes
* Add a failing test
* Fix that failing test by reading out what's in the datastore
## Testing
Review. Tell me things that don't make sense so that I can clarify them.