### PR TITLE
chore: take glibc cve fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 # use `docker buildx imagetools inspect <image>` to get the multi-platform sha256
 # Note: Using glibc-dynamic base instead of static because the postgres-fdw command requires libc
-FROM cgr.dev/chainguard/glibc-dynamic@sha256:530fc40b687b95f6c5e8a9b62da03306754da5ef45178e632b7486603bfb7096
+FROM cgr.dev/chainguard/glibc-dynamic@sha256:3f5dc064fa077619b186d21a426c07fb3868668ffe104db8ba3e46347a80a1d3
 COPY --from=health-probe-builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 COPY --from=spicedb-builder /go/src/app/spicedb /usr/local/bin/spicedb
 ENV PATH="$PATH:/usr/local/bin"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,7 +1,7 @@
 # vim: syntax=dockerfile
 # use `docker buildx imagetools inspect <image>` to get the multi-platform sha256
 # Note: Using glibc-dynamic base instead of static because the postgres-fdw command requires libc
-ARG BASE=cgr.dev/chainguard/glibc-dynamic@sha256:530fc40b687b95f6c5e8a9b62da03306754da5ef45178e632b7486603bfb7096
+ARG BASE=cgr.dev/chainguard/glibc-dynamic@sha256:3f5dc064fa077619b186d21a426c07fb3868668ffe104db8ba3e46347a80a1d3
 FROM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS health-probe-builder
 WORKDIR /go/src/app
 RUN apk update && apk add --no-cache git


### PR DESCRIPTION
## Description
Fixes this problem: https://github.com/authzed/spicedb/actions/runs/21416538278/job/61666365612?pr=2852

## Changes
* Bump chainguard version

## Testing
See that security lint passes