### PR TITLE
ci: compare Go benchmarks properly

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   benchmarks:
     name: "Run Go benchmarks on Main"
-    runs-on: "depot-ubuntu-24.04-4"
+    runs-on: "depot-ubuntu-24.04-arm-8" # same as build-test.yaml
     timeout-minutes: 15
     steps:
       - uses: "actions/checkout@v6"
@@ -43,14 +43,9 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           comment-on-alert: true
 
-      - name: "Get CPU information"
-        uses: "kenchan0130/actions-system-info@master"
-        id: "system-info"
-
       - name: "Save benchmark JSON"
         uses: "actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb" # v5.0.1
         with:
           path: "./cache/benchmark-data.json"
           # Save with commit hash to avoid "cache already exists"
-          # Save with OS & CPU info to prevent comparing against results from different CPUs
-          key: "${{ github.sha }}-${{ runner.os }}-${{ steps.system-info.outputs.cpu-model }}-go-benchmark"
+          key: "${{ github.sha }}-${{ runner.os }}-go-benchmark"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -417,7 +417,7 @@ jobs:
 
   benchmarks:
     name: "Run Go benchmarks"
-    runs-on: "depot-ubuntu-24.04-arm-8"
+    runs-on: "depot-ubuntu-24.04-arm-8" # same as benchmark.yaml
     timeout-minutes: 30
     needs: "paths-filter"
     # Benchmarks on Main are ran through a different workflow
@@ -441,10 +441,6 @@ jobs:
           set -o pipefail
           go run mage.go benchmark:all | tee ${{ github.sha }}_bench_output.txt
 
-      - name: "Get CPU information"
-        uses: "kenchan0130/actions-system-info@master"
-        id: "system-info"
-
       - name: "Get Main branch SHA"
         id: "get-main-branch-sha"
         run: |
@@ -456,7 +452,7 @@ jobs:
         id: "downloadbenchmark"
         with:
           path: "./cache/benchmark-data.json"
-          key: "${{ steps.get-main-branch-sha.outputs.sha }}-${{ runner.os }}-${{ steps.system-info.outputs.cpu-model }}-go-benchmark"
+          key: "${{ steps.get-main-branch-sha.outputs.sha }}-${{ runner.os }}-go-benchmark"
 
       - name: "Compare benchmarks with Main"
         uses: "benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b" # v1.20.7


### PR DESCRIPTION
Fixing an issue where PR's are not comparing against `main`.