### PR TITLE
chore: go through other proxies

### DIFF
--- a/internal/datastore/proxy/checkingreplicated.go
+++ b/internal/datastore/proxy/checkingreplicated.go
@@ -212,6 +212,8 @@ func (rr *checkingStableReader) LookupCounters(ctx context.Context) ([]datastore
 	return rr.chosenReader.LookupCounters(ctx)
 }
 
+// SchemaReader chooses the appropriate reader and then returns a reference to the
+// SchemaReader associated with that reader.
 func (rr *checkingStableReader) SchemaReader() (datastore.SchemaReader, error) {
 	if err := rr.determineSource(context.Background()); err != nil {
 		return nil, err

--- a/internal/datastore/proxy/counting.go
+++ b/internal/datastore/proxy/counting.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	schemautil "github.com/authzed/spicedb/internal/datastore/schema"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -262,8 +263,10 @@ func (r *countingReader) LookupCounters(ctx context.Context) ([]datastore.Relati
 	return r.delegate.LookupCounters(ctx)
 }
 
+// SchemaReader returns a wrapped version of the countingReader that exercises
+// the legacy methods when the new methods are invoked.
 func (r *countingReader) SchemaReader() (datastore.SchemaReader, error) {
-	return r.delegate.SchemaReader()
+	return schemautil.NewLegacySchemaReaderAdapter(r), nil
 }
 
 // Type assertions

--- a/internal/datastore/proxy/indexcheck/indexcheck.go
+++ b/internal/datastore/proxy/indexcheck/indexcheck.go
@@ -181,6 +181,8 @@ func (r *indexcheckingReader) ReverseQueryRelationships(ctx context.Context, sub
 	return r.delegate.ReverseQueryRelationships(ctx, subjectsFilter, opts...)
 }
 
+// SchemaReader returns a reference to the wrapped reader, since this
+// proxy does not interact with schema methods.
 func (r *indexcheckingReader) SchemaReader() (datastore.SchemaReader, error) {
 	return r.delegate.SchemaReader()
 }

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
 	"github.com/authzed/spicedb/internal/datastore/common"
+	schemautil "github.com/authzed/spicedb/internal/datastore/schema"
 	"github.com/authzed/spicedb/internal/telemetry/otelconv"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
@@ -277,8 +278,10 @@ func (r *observableReader) ReverseQueryRelationships(ctx context.Context, subjec
 	}, nil
 }
 
+// SchemaReader returns a wrapped version of the proxy that exercises the
+// legacy methods to implement the new methods.
 func (r *observableReader) SchemaReader() (datastore.SchemaReader, error) {
-	return r.delegate.SchemaReader()
+	return schemautil.NewLegacySchemaReaderAdapter(r), nil
 }
 
 type observableRWT struct {

--- a/internal/datastore/proxy/relationshipintegrity.go
+++ b/internal/datastore/proxy/relationshipintegrity.go
@@ -385,6 +385,8 @@ func (r relationshipIntegrityReader) LegacyReadNamespaceByName(ctx context.Conte
 	return r.wrapped.LegacyReadNamespaceByName(ctx, nsName)
 }
 
+// SchemaReader returns a handle to the wrapped reader's SchemaReader, as this
+// proxy does not interact with schema methods.
 func (r relationshipIntegrityReader) SchemaReader() (datastore.SchemaReader, error) {
 	return r.wrapped.SchemaReader()
 }

--- a/internal/datastore/proxy/strictreplicated.go
+++ b/internal/datastore/proxy/strictreplicated.go
@@ -261,6 +261,8 @@ func (rr *strictReadReplicatedReader) LookupCounters(ctx context.Context) ([]dat
 	return counters, err
 }
 
+// SchemaReader returns the SchemaReader instance of the replica's SchemaReader at the
+// associated revision.
 func (rr *strictReadReplicatedReader) SchemaReader() (datastore.SchemaReader, error) {
 	return rr.replica.SnapshotReader(rr.rev).SchemaReader()
 }


### PR DESCRIPTION
## Description
Sibling PR to #2868. That one just does the changes and tests for the schema caches; this one goes through the rest of them.

Note that I'm not updating the tests here; I'm going to leave that for a future refactor where we're cutting off of the legacy methods.

## Changes
* Add wrappers were necessary
* Add docstrings that explain what `SchemaReader` does in each case
## Testing
Review.