### PR TITLE
ci: use arm runners in integration tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -256,7 +256,7 @@ jobs:
 
   crdbdatastoreinttest:
     name: "Datastore Integration Tests"
-    runs-on: "depot-ubuntu-24.04-4"
+    runs-on: "depot-ubuntu-24.04-arm-4"
     needs: "paths-filter"
     strategy:
       fail-fast: false
@@ -291,7 +291,7 @@ jobs:
 
   crdbdatastoreconstest:
     name: "Datastore Consistency Tests"
-    runs-on: "depot-ubuntu-24.04-4"
+    runs-on: "depot-ubuntu-24.04-arm-4"
     needs: "paths-filter"
     strategy:
       fail-fast: false
@@ -326,6 +326,8 @@ jobs:
 
   e2e:
     name: "E2E"
+    # NOTE: the e2e tests can't be run on ARM because chaosd (which is used in the cockroach e2e consistency tests)
+    # doesn't support ARM and it doesn't appear that it will.
     runs-on: "depot-ubuntu-24.04-8"
     needs: "paths-filter"
     strategy:


### PR DESCRIPTION
## Description
In #2818 we started using ARM runners for most of our tests. This gave some huge speedups on unit tests; I punted on integration tests because the e2e tests were failing and I thought we'd need to make a bunch of updates.

It turns out that the e2e tests probably won't be able to run on ARM while they depend on Chaosd, but ARM runners sped up our integration tests by a factor of 2 (!!)

## Changes
Use ARM runners for remaining tests where it helps

## Testing
Review