### PR TITLE
chore: add mustcallcheck analyzer

### DIFF
--- a/magefiles/lint.go
+++ b/magefiles/lint.go
@@ -93,6 +93,8 @@ func (Lint) Analyzers() error {
 		"-exprstatementcheck.disallowed-expr-statement-types=*github.com/rs/zerolog.Event:MarshalZerologObject:missing Send or Msg on zerolog log Event",
 		"-paniccheck",
 		"-paniccheck.skip-files=_test,zz_,migrations/index.go",
+		"-mustcallcheck",
+		"-mustcallcheck.skip-files=_test,zz_",
 		"-zerologmarshalcheck",
 		"-zerologmarshalcheck.skip-files=_test,zz_",
 		"-protomarshalcheck",

--- a/tools/analyzers/cmd/analyzers/main.go
+++ b/tools/analyzers/cmd/analyzers/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/authzed/spicedb/tools/analyzers/exprstatementcheck"
 	"github.com/authzed/spicedb/tools/analyzers/iferrafterrowclosecheck"
 	"github.com/authzed/spicedb/tools/analyzers/lendowncastcheck"
+	"github.com/authzed/spicedb/tools/analyzers/mustcallcheck"
 	"github.com/authzed/spicedb/tools/analyzers/mutexcheck"
 	"github.com/authzed/spicedb/tools/analyzers/nilvaluecheck"
 	"github.com/authzed/spicedb/tools/analyzers/paniccheck"
@@ -23,6 +24,7 @@ func main() {
 		closeafterusagecheck.Analyzer(),
 		iferrafterrowclosecheck.Analyzer(),
 		paniccheck.Analyzer(),
+		mustcallcheck.Analyzer(),
 		lendowncastcheck.Analyzer(),
 		protomarshalcheck.Analyzer(),
 		zerologmarshalcheck.Analyzer(),

--- a/tools/analyzers/mustcallcheck/mustcallcheck.go
+++ b/tools/analyzers/mustcallcheck/mustcallcheck.go
@@ -1,0 +1,146 @@
+package mustcallcheck
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"regexp"
+	"strings"
+
+	"github.com/samber/lo"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+func Analyzer() *analysis.Analyzer {
+	flagSet := flag.NewFlagSet("mustcallcheck", flag.ExitOnError)
+	skipPkg := flagSet.String("skip-pkg", "", "package(s) to skip for linting")
+	skipFiles := flagSet.String("skip-files", "", "patterns of files to skip for linting")
+
+	return &analysis.Analyzer{
+		Name: "mustcallcheck",
+		Doc:  "reports Must* method calls in error-returning functions",
+		Run: func(pass *analysis.Pass) (any, error) {
+			// Check for a skipped package.
+			if len(*skipPkg) > 0 {
+				skipped := lo.Map(strings.Split(*skipPkg, ","), func(skipped string, _ int) string { return strings.TrimSpace(skipped) })
+				for _, s := range skipped {
+					if strings.Contains(pass.Pkg.Path(), s) {
+						return nil, nil
+					}
+				}
+			}
+
+			// Check for a skipped file.
+			skipFilePatterns := make([]string, 0)
+			if len(*skipFiles) > 0 {
+				skipFilePatterns = lo.Map(strings.Split(*skipFiles, ","), func(skipped string, _ int) string { return strings.TrimSpace(skipped) })
+			}
+			for _, pattern := range skipFilePatterns {
+				_, err := regexp.Compile(pattern)
+				if err != nil {
+					return nil, fmt.Errorf("invalid skip-files pattern `%s`: %w", pattern, err)
+				}
+			}
+
+			inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+			nodeFilter := []ast.Node{
+				(*ast.File)(nil),
+				(*ast.CallExpr)(nil),
+			}
+
+			inspect.WithStack(nodeFilter, func(n ast.Node, push bool, stack []ast.Node) bool {
+				switch s := n.(type) {
+				case *ast.File:
+					for _, pattern := range skipFilePatterns {
+						isMatch, _ := regexp.MatchString(pattern, pass.Fset.Position(s.Package).Filename)
+						if isMatch {
+							return false
+						}
+					}
+					return true
+
+				case *ast.CallExpr:
+					// Extract the method name from the call expression
+					var methodName string
+					switch fun := s.Fun.(type) {
+					case *ast.Ident:
+						// Direct function call: MustParse()
+						methodName = fun.Name
+					case *ast.SelectorExpr:
+						// Method call: obj.MustParse() or pkg.MustParse()
+						methodName = fun.Sel.Name
+					default:
+						return false
+					}
+
+					// Check if the method name starts with "Must"
+					if !strings.HasPrefix(methodName, "Must") {
+						return false
+					}
+
+					// Skip special Must* methods that are designed to return errors (not panic)
+					// MustBugf returns an error in production, only panics in tests
+					// MustPanicf is explicitly for violating the linter when necessary
+					if methodName == "MustBugf" || methodName == "MustPanicf" {
+						return false
+					}
+
+					// Find the parent function declaration or function literal
+					var parentFuncType *ast.FuncType
+					for i := len(stack) - 1; i >= 0; i-- {
+						parent := stack[i]
+						if funcDecl, ok := parent.(*ast.FuncDecl); ok {
+							parentFuncType = funcDecl.Type
+							break
+						}
+						if funcLit, ok := parent.(*ast.FuncLit); ok {
+							parentFuncType = funcLit.Type
+							break
+						}
+					}
+
+					// If we couldn't find a parent function, skip
+					if parentFuncType == nil {
+						return false
+					}
+
+					// Check if the parent function returns an error
+					hasErrorReturn := false
+					if parentFuncType.Results != nil {
+						for _, result := range parentFuncType.Results.List {
+							resultType := result.Type
+							foundType := pass.TypesInfo.TypeOf(resultType)
+							if foundType == nil {
+								continue
+							}
+
+							if foundType.String() == "error" {
+								hasErrorReturn = true
+								break
+							}
+						}
+					}
+
+					// If the parent function returns an error, report the Must* call
+					if hasErrorReturn {
+						// Suggest the non-Must version by removing "Must" prefix
+						suggestedMethod := strings.TrimPrefix(methodName, "Must")
+						pass.Reportf(n.Pos(), "In package %s: found call to %s in error-returning function; use %s instead to properly handle errors", pass.Pkg.Path(), methodName, suggestedMethod)
+					}
+
+					return false
+
+				default:
+					return true
+				}
+			})
+
+			return nil, nil
+		},
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+		Flags:    *flagSet,
+	}
+}

--- a/tools/analyzers/mustcallcheck/mustcallcheck_test.go
+++ b/tools/analyzers/mustcallcheck/mustcallcheck_test.go
@@ -1,0 +1,15 @@
+package mustcallcheck
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analyzer := Analyzer()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, analyzer, "badmustcalls")
+	analysistest.Run(t, testdata, analyzer, "goodmustcalls")
+}

--- a/tools/analyzers/mustcallcheck/testdata/src/badmustcalls/badmustcalls.go
+++ b/tools/analyzers/mustcallcheck/testdata/src/badmustcalls/badmustcalls.go
@@ -1,0 +1,73 @@
+package badmustcalls
+
+import (
+	"regexp"
+)
+
+// Example 1: MustCompile in error-returning function
+func CompilePattern(pattern string) (*regexp.Regexp, error) {
+	re := regexp.MustCompile(pattern) // want "found call to MustCompile in error-returning function"
+	return re, nil
+}
+
+// Example 2: Custom Must method in error-returning function
+func ParseData(data string) (Result, error) {
+	result := MustParse(data) // want "found call to MustParse in error-returning function"
+	return result, nil
+}
+
+// Example 3: Must method call on object in error-returning function
+func ProcessItem(item string) error {
+	parser := &Parser{}
+	_ = parser.MustValidate(item) // want "found call to MustValidate in error-returning function"
+	return nil
+}
+
+// Example 4: Multiple return values including error
+func ConvertValue(value string) (int, string, error) {
+	result := MustConvert(value) // want "found call to MustConvert in error-returning function"
+	return result, "success", nil
+}
+
+// Example 5: Must call in nested function (closure) that returns error
+func OuterFunction() {
+	innerFunc := func(pattern string) error {
+		_ = regexp.MustCompile(pattern) // want "found call to MustCompile in error-returning function"
+		return nil
+	}
+	_ = innerFunc
+}
+
+// Helper types and functions for testing
+type Result struct {
+	Value string
+}
+
+type Parser struct{}
+
+func (p *Parser) MustValidate(s string) bool {
+	if s == "" {
+		panic("invalid input")
+	}
+	return true
+}
+
+func MustParse(data string) Result {
+	if data == "" {
+		panic("empty data")
+	}
+	return Result{Value: data}
+}
+
+func MustConvert(value string) int {
+	if value == "" {
+		panic("empty value")
+	}
+	return 42
+}
+
+// Example 6: Should catch Must* even when error is not the last return value
+func AnotherPattern() (error, string) {
+	_ = regexp.MustCompile("test") // want "found call to MustCompile in error-returning function"
+	return nil, "ok"
+}

--- a/tools/analyzers/mustcallcheck/testdata/src/goodmustcalls/goodmustcalls.go
+++ b/tools/analyzers/mustcallcheck/testdata/src/goodmustcalls/goodmustcalls.go
@@ -1,0 +1,71 @@
+package goodmustcalls
+
+import (
+	"regexp"
+)
+
+// Example 1: MustCompile in non-error-returning function (OK)
+func GetPattern() *regexp.Regexp {
+	return regexp.MustCompile("test")
+}
+
+// Example 2: MustCompile at package level (OK)
+var packageLevelRegex = regexp.MustCompile("^test$")
+
+// Example 3: Must method in init function (OK)
+func init() {
+	_ = regexp.MustCompile("init pattern")
+}
+
+// Example 4: Must method in function that doesn't return error (OK)
+func ParseWithoutError(data string) Result {
+	return MustParse(data)
+}
+
+// Example 5: Must method in function that returns only values, no error (OK)
+func ConvertToInt(value string) int {
+	return MustConvert(value)
+}
+
+// Example 6: Must method in closure without error return (OK)
+func OuterWithNonErrorClosure() {
+	innerFunc := func(pattern string) *regexp.Regexp {
+		return regexp.MustCompile(pattern)
+	}
+	_ = innerFunc
+}
+
+// Example 7: Function that returns something named "error" but isn't the error interface (OK)
+type ErrorCode struct {
+	Code int
+}
+
+func GetErrorCode() ErrorCode {
+	_ = regexp.MustCompile("pattern")
+	return ErrorCode{Code: 42}
+}
+
+// Example 8: Must method in a function that panics anyway (OK - no error return)
+func MustDoSomething() {
+	_ = regexp.MustCompile("test")
+	panic("intentional panic")
+}
+
+// Helper types and functions for testing
+type Result struct {
+	Value string
+}
+
+func MustParse(data string) Result {
+	if data == "" {
+		panic("empty data")
+	}
+	return Result{Value: data}
+}
+
+func MustConvert(value string) int {
+	if value == "" {
+		panic("empty value")
+	}
+	return 42
+}


### PR DESCRIPTION
## Description
In #2878 we fixed an issue where we were using a `Must*` function inside a function that returned an error, which meant we were risking a panic when we didn't have reason to. This PR adds an analyzer for similar issues and adds fixes for those issues.

## Note
This analyzer was created with the help of AI tooling.

## Changes
* Add analyzer
* Add tests for analyzer
* Add analyzer to analyzer list
* Fix analyzer findings
## Testing
Review.