### PR TITLE
fix: server not dying when streaming api is still running

### DIFF
--- a/internal/services/shared/errors.go
+++ b/internal/services/shared/errors.go
@@ -176,7 +176,7 @@ func rewriteError(ctx context.Context, err error, config *ConfigForErrors) error
 	case errors.As(err, &datastore.WatchDisabledError{}):
 		return status.Errorf(codes.FailedPrecondition, "%s", err)
 	case errors.As(err, &datastore.WatchCanceledError{}):
-		return status.Errorf(codes.Canceled, "watch canceled by user: %s", err)
+		return status.Errorf(codes.Canceled, "watch canceled: %s", err)
 	case errors.As(err, &datastore.WatchDisconnectedError{}):
 		return status.Errorf(codes.ResourceExhausted, "watch disconnected: %s", err)
 	case errors.As(err, &datastore.WatchRetryableError{}):

--- a/internal/services/shared/errors_test.go
+++ b/internal/services/shared/errors_test.go
@@ -109,7 +109,7 @@ func TestRewriteError(t *testing.T) {
 			inputError:       datastore.NewWatchCanceledErr(),
 			config:           nil,
 			expectedCode:     codes.Canceled,
-			expectedContains: "watch canceled by user: watch was canceled by the caller",
+			expectedContains: "watch canceled: watch was canceled",
 		},
 		{
 			name:             "watch disabled",

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -703,7 +703,7 @@ type ReadOnlyDatastore interface {
 	//
 	// Errors returned will fall into a few classes:
 	// - WatchDisconnectedError - the watch has fallen too far behind and has been disconnected.
-	// - WatchCanceledError     - the watch was canceled by the caller.
+	// - WatchCanceledError     - the watch was canceled.
 	// - WatchDisabledError     - the watch is disabled by being unsupported by the datastore.
 	// - WatchRetryableError    - the watch is retryable, and the caller may retry after some backoff time.
 	// - InvalidRevisionError   - the revision specified has passed the datastore's watch history window and

--- a/pkg/datastore/errors.go
+++ b/pkg/datastore/errors.go
@@ -47,7 +47,7 @@ func (err NamespaceNotFoundError) DetailsMetadata() map[string]string {
 // as a result.
 type WatchDisconnectedError struct{ error }
 
-// WatchCanceledError occurs when a watch was canceled by the caller.
+// WatchCanceledError occurs when a watch was canceled.
 type WatchCanceledError struct{ error }
 
 // WatchDisabledError occurs when watch is disabled by being unsupported by the datastore.
@@ -149,7 +149,7 @@ func NewWatchDisconnectedErr() error {
 // NewWatchCanceledErr constructs a new watch was canceled error.
 func NewWatchCanceledErr() error {
 	return WatchCanceledError{
-		error: errors.New("watch was canceled by the caller"),
+		error: errors.New("watch was canceled"),
 	}
 }
 


### PR DESCRIPTION
## Description

Have the server die when you kill it when a streaming api (e.g. Watch) is still running.

## Testing

1. On tab 1, run `go run ./cmd/spicedb/main.go serve --grpc-preshared-key foobar`
2. On tab 2, run `zed watch`
3. On tab 1, ctrl+c the server. The server should die.
