### PR TITLE
fix: make sure that use self comes out of formatter when self is used

### DIFF
--- a/pkg/schemadsl/generator/generator.go
+++ b/pkg/schemadsl/generator/generator.go
@@ -347,6 +347,7 @@ func (sg *sourceGenerator) mustEmitSetOpChild(setOpChild *core.SetOperation_Chil
 
 	case *core.SetOperation_Child_XSelf:
 		sg.append("self")
+		sg.flags.Add("self")
 
 	case *core.SetOperation_Child_ComputedUserset:
 		sg.append(child.ComputedUserset.Relation)

--- a/pkg/schemadsl/generator/generator_test.go
+++ b/pkg/schemadsl/generator/generator_test.go
@@ -244,6 +244,7 @@ definition foos/document {
 	}
 }
 
+// TestFormatting asserts that the input schema gets turned into the output schema
 func TestFormatting(t *testing.T) {
 	type formattingTest struct {
 		name     string
@@ -413,6 +414,34 @@ definition document {
 		}`,
 			`definition document {
 	relation viewer: user
+}`,
+		},
+		{
+			"use self happy path",
+			`use self
+
+			definition user {
+				relation viewer: user
+				permission view = viewer + self
+			}`,
+			`use self
+
+definition user {
+	relation viewer: user
+	permission view = viewer + self
+}`,
+		},
+		{
+			"use self unused",
+			`use self
+
+			definition user {
+				relation viewer: user
+				permission view = viewer
+			}`,
+			`definition user {
+	relation viewer: user
+	permission view = viewer
 }`,
 		},
 	}


### PR DESCRIPTION
## Description
When I went to test authzed/playground#103, I realized that we weren't properly handling `self` as far as generating the flag went.

## Changes
* Add a test
* Fix the test

## Testing
Review.