### PR TITLE
chore: implement self in schemav2

### DIFF
--- a/pkg/schema/arrows.go
+++ b/pkg/schema/arrows.go
@@ -180,6 +180,9 @@ func (as *ArrowSet) collectArrowInformationForSetOperation(ctx context.Context, 
 		case *core.SetOperation_Child_XNil:
 			// Nothing to do
 
+		case *core.SetOperation_Child_XSelf:
+			// Nothing to do
+
 		default:
 			return fmt.Errorf("unknown set operation child `%T` in addArrowRelationsInSetOperation", child)
 		}

--- a/pkg/schema/full_reachability.go
+++ b/pkg/schema/full_reachability.go
@@ -220,6 +220,9 @@ func setOperationReferencesRelation(ctx context.Context, so *core.SetOperation, 
 		case *core.SetOperation_Child_XNil:
 			// Nothing to do
 
+		case *core.SetOperation_Child_XSelf:
+			// Nothing to do
+
 		default:
 			return false, fmt.Errorf("unknown set operation child `%T` in setOperationReferencesRelation", child)
 		}

--- a/pkg/schema/v2/flatten.go
+++ b/pkg/schema/v2/flatten.go
@@ -185,6 +185,10 @@ func flattenOperation(op Operation, def *Definition, baseName string, options Fl
 		// Nil reference is a leaf node, no flattening needed
 		return o, nil, nil
 
+	case *SelfReference:
+		// Self reference is a leaf node, no flattening needed
+		return o, nil, nil
+
 	case *UnionOperation:
 		// Flatten children first
 		flattenedChildren := make([]Operation, len(o.children))

--- a/pkg/schema/v2/flatten_test.go
+++ b/pkg/schema/v2/flatten_test.go
@@ -33,6 +33,17 @@ definition user {}`,
 definition user {}`,
 		},
 		{
+			name: "self permission",
+			schemaString: `use self
+definition user {
+	permission view = self
+			}`,
+			expectedString: `use self
+definition user {
+	permission view = self
+			}`,
+		},
+		{
 			name: "nested union in permission",
 			schemaString: `definition document {
 	relation viewer: user

--- a/pkg/schema/v2/resolved.go
+++ b/pkg/schema/v2/resolved.go
@@ -151,6 +151,10 @@ func resolveOperation(op Operation, def *Definition) (Operation, error) {
 		// NilReference is not replaced during resolution
 		return o, nil
 
+	case *SelfReference:
+		// SelfReference is not replaced during resolution
+		return o, nil
+
 	default:
 		return nil, fmt.Errorf("unknown operation type: %T", op)
 	}

--- a/pkg/schema/v2/tocorev1.go
+++ b/pkg/schema/v2/tocorev1.go
@@ -344,6 +344,19 @@ func operationToUsersetRewrite(op Operation) (*core.UsersetRewrite, error) {
 			},
 		}, nil
 
+	case *SelfReference:
+		return &core.UsersetRewrite{
+			RewriteOperation: &core.UsersetRewrite_Union{
+				Union: &core.SetOperation{
+					Child: []*core.SetOperation_Child{
+						{
+							ChildType: &core.SetOperation_Child_XSelf{},
+						},
+					},
+				},
+			},
+		}, nil
+
 	default:
 		return nil, fmt.Errorf("unknown operation type: %T", op)
 	}
@@ -460,6 +473,11 @@ func operationToChild(op Operation) (*core.SetOperation_Child, error) {
 	case *NilReference:
 		return &core.SetOperation_Child{
 			ChildType: &core.SetOperation_Child_XNil{},
+		}, nil
+
+	case *SelfReference:
+		return &core.SetOperation_Child{
+			ChildType: &core.SetOperation_Child_XSelf{},
 		}, nil
 
 	default:

--- a/pkg/schema/v2/tocorev1_test.go
+++ b/pkg/schema/v2/tocorev1_test.go
@@ -119,6 +119,21 @@ func TestAsCompiledSchema(t *testing.T) {
 			expectedDefinitionNames: []string{"user", "organization", "resource"},
 			expectedCaveatNames:     []string{},
 		},
+		{
+			name: "schema with self",
+			schemaText: `
+			use self
+
+			definition user {
+				relation viewer: user
+				permission view = viewer + self
+			}
+		`,
+			expectedNumDefinitions:  1,
+			expectedNumCaveats:      0,
+			expectedDefinitionNames: []string{"user"},
+			expectedCaveatNames:     []string{},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -172,11 +187,16 @@ func TestAsCompiledSchemaRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	schemaText := `
+		use self
+
 		caveat ip_check(ip string) {
 			ip == "192.168.1.1"
 		}
 
-		definition user {}
+		definition user {
+			relation viewer: user
+			permission view = viewer + self
+		}
 
 		definition organization {
 			relation member: user


### PR DESCRIPTION
## Description
A package that uses SpiceDB had failing tests because of this missing functionality. This fixes that.

## Changes
* Add tests for `use self`
* Fix tests
## Testing
Review. See that tests pass.