### PR TITLE
chore: add partial support to schemadsl

### DIFF
--- a/pkg/query/recursive_strategies_test.go
+++ b/pkg/query/recursive_strategies_test.go
@@ -178,7 +178,7 @@ func TestRecursiveCheckStrategiesMultipleResources(t *testing.T) {
 	}
 	subject := ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}
 
-	allResults := make([][]Path, 0)
+	allResults := make([][]Path, 0, len(strategies))
 
 	for _, strategy := range strategies {
 		recursive := NewRecursiveIterator(union, "folder", "view")

--- a/pkg/schemadsl/dslshape/dslshape.go
+++ b/pkg/schemadsl/dslshape/dslshape.go
@@ -38,6 +38,10 @@ const (
 	NodeTypeSelfExpression // A self keyword
 
 	NodeTypeCaveatTypeReference // A type reference for a caveat parameter.
+
+	NodeTypeImport
+	NodeTypePartial
+	NodeTypePartialReference // A location where a partial is referenced
 )
 
 const (
@@ -218,4 +222,19 @@ const (
 	//
 	NodeExpressionPredicateLeftExpr  = "left-expr"
 	NodeExpressionPredicateRightExpr = "right-expr"
+
+	//
+	// NodeTypeImport
+	//
+	NodeImportPredicatePath = "import-path"
+
+	//
+	// NodeTypePartial
+	//
+	NodePartialPredicateName = "partial-name"
+
+	//
+	// NodeTypePartialReference
+	//
+	NodePartialReferencePredicateName = "partial-reference-name"
 )

--- a/pkg/schemadsl/dslshape/zz_generated.nodetype_string.go
+++ b/pkg/schemadsl/dslshape/zz_generated.nodetype_string.go
@@ -31,11 +31,14 @@ func _() {
 	_ = x[NodeTypeNilExpression-20]
 	_ = x[NodeTypeSelfExpression-21]
 	_ = x[NodeTypeCaveatTypeReference-22]
+	_ = x[NodeTypeImport-23]
+	_ = x[NodeTypePartial-24]
+	_ = x[NodeTypePartialReference-25]
 }
 
-const _NodeType_name = "NodeTypeErrorNodeTypeFileNodeTypeCommentNodeTypeUseFlagNodeTypeDefinitionNodeTypeCaveatDefinitionNodeTypeCaveatParameterNodeTypeCaveatExpressionNodeTypeRelationNodeTypePermissionNodeTypeTypeAnnotationNodeTypeTypeReferenceNodeTypeSpecificTypeReferenceNodeTypeCaveatReferenceNodeTypeTraitReferenceNodeTypeUnionExpressionNodeTypeIntersectExpressionNodeTypeExclusionExpressionNodeTypeArrowExpressionNodeTypeIdentifierNodeTypeNilExpressionNodeTypeSelfExpressionNodeTypeCaveatTypeReference"
+const _NodeType_name = "NodeTypeErrorNodeTypeFileNodeTypeCommentNodeTypeUseFlagNodeTypeDefinitionNodeTypeCaveatDefinitionNodeTypeCaveatParameterNodeTypeCaveatExpressionNodeTypeRelationNodeTypePermissionNodeTypeTypeAnnotationNodeTypeTypeReferenceNodeTypeSpecificTypeReferenceNodeTypeCaveatReferenceNodeTypeTraitReferenceNodeTypeUnionExpressionNodeTypeIntersectExpressionNodeTypeExclusionExpressionNodeTypeArrowExpressionNodeTypeIdentifierNodeTypeNilExpressionNodeTypeSelfExpressionNodeTypeCaveatTypeReferenceNodeTypeImportNodeTypePartialNodeTypePartialReference"
 
-var _NodeType_index = [...]uint16{0, 13, 25, 40, 55, 73, 97, 120, 144, 160, 178, 200, 221, 250, 273, 295, 318, 345, 372, 395, 413, 434, 456, 483}
+var _NodeType_index = [...]uint16{0, 13, 25, 40, 55, 73, 97, 120, 144, 160, 178, 200, 221, 250, 273, 295, 318, 345, 372, 395, 413, 434, 456, 483, 497, 512, 536}
 
 func (i NodeType) String() string {
 	idx := int(i) - 0

--- a/pkg/schemadsl/lexer/flaggablelexer_test.go
+++ b/pkg/schemadsl/lexer/flaggablelexer_test.go
@@ -60,6 +60,12 @@ var flaggableLexerTests = []lexerTest{
 		{TokenTypeIdentifier, 0, "self", ""},
 		tEOF,
 	}},
+	{"use partial", "use partial", []Lexeme{
+		{TokenTypeIdentifier, 0, "use", ""},
+		{TokenTypeWhitespace, 0, " ", ""},
+		{TokenTypeKeyword, 0, "partial", ""},
+		tEOF,
+	}},
 }
 
 func TestFlaggableLexer(t *testing.T) {

--- a/pkg/schemadsl/lexer/flags.go
+++ b/pkg/schemadsl/lexer/flags.go
@@ -17,6 +17,9 @@ const (
 	// FlagSelf indicates that `self` is supported as a first-class
 	// feature in the schema.
 	FlagSelf = "self"
+
+	// FlagPartials indicates that partials are supported in the schema.
+	FlagPartials = "partial"
 )
 
 var AllUseFlags []string
@@ -57,6 +60,15 @@ var Flags = map[string]transformer{
 	FlagSelf: func(lexeme Lexeme) (Lexeme, bool) {
 		// `self` becomes a keyword.
 		if lexeme.Kind == TokenTypeIdentifier && lexeme.Value == "self" {
+			lexeme.Kind = TokenTypeKeyword
+			return lexeme, true
+		}
+
+		return lexeme, false
+	},
+	FlagPartials: func(lexeme Lexeme) (Lexeme, bool) {
+		// `partial` becomes a keyword.
+		if lexeme.Kind == TokenTypeIdentifier && lexeme.Value == "partial" {
 			lexeme.Kind = TokenTypeKeyword
 			return lexeme, true
 		}

--- a/pkg/schemadsl/parser/parser_test.go
+++ b/pkg/schemadsl/parser/parser_test.go
@@ -144,6 +144,11 @@ func TestParser(t *testing.T) {
 		{"permission type annotation double colon test", "permission_type_annotation_double_colon"},
 		{"permission type annotation newline after colon test", "permission_type_annotation_newline_after_colon"},
 		{"permission type annotation just pipe test", "permission_type_annotation_just_pipe"},
+		{"top-level block with unrecognized keyword", "nonsense_top_level_block"},
+		{"partials happy path", "partials"},
+		{"partials with malformed partial reference", "partials_with_malformed_partial_reference"},
+		{"partials with malformed reference splat", "partials_with_malformed_reference_splat"},
+		{"partials with malformed partial block", "partials_with_malformed_partial_block"},
 	}
 
 	for _, test := range parserTests {

--- a/pkg/schemadsl/parser/tests/invaliduse.zed.expected
+++ b/pkg/schemadsl/parser/tests/invaliduse.zed.expected
@@ -10,7 +10,7 @@ NodeTypeFile
       child-node =>
         NodeTypeError
           end-rune = 12
-          error-message = Unknown use flag: `something`. Options are: expiration, self, typechecking
+          error-message = Unknown use flag: `something`. Options are: expiration, partial, self, typechecking
           error-source = 
 
           input-source = invalid use

--- a/pkg/schemadsl/parser/tests/nonsense_top_level_block.zed
+++ b/pkg/schemadsl/parser/tests/nonsense_top_level_block.zed
@@ -1,0 +1,4 @@
+nonsense thing {
+  relation: user
+  permission view = user
+}

--- a/pkg/schemadsl/parser/tests/nonsense_top_level_block.zed.expected
+++ b/pkg/schemadsl/parser/tests/nonsense_top_level_block.zed.expected
@@ -1,0 +1,11 @@
+NodeTypeFile
+  end-rune = -1
+  input-source = top-level block with unrecognized keyword
+  start-rune = 0
+  child-node =>
+    NodeTypeError
+      end-rune = -1
+      error-message = Unexpected token at root level: TokenTypeIdentifier
+      error-source = nonsense
+      input-source = top-level block with unrecognized keyword
+      start-rune = 0

--- a/pkg/schemadsl/parser/tests/partials.zed
+++ b/pkg/schemadsl/parser/tests/partials.zed
@@ -1,0 +1,12 @@
+use partial
+
+partial view_partial {
+  relation user: user
+  permission view = user
+}
+
+definition user {}
+
+definition resource {
+  ...view_partial
+}

--- a/pkg/schemadsl/parser/tests/partials.zed.expected
+++ b/pkg/schemadsl/parser/tests/partials.zed.expected
@@ -1,0 +1,59 @@
+NodeTypeFile
+  end-rune = 147
+  input-source = partials happy path
+  start-rune = 0
+  child-node =>
+    NodeTypeUseFlag
+      end-rune = 10
+      input-source = partials happy path
+      start-rune = 0
+      use-flag-name = partial
+    NodeTypePartial
+      end-rune = 83
+      input-source = partials happy path
+      partial-name = view_partial
+      start-rune = 13
+      child-node =>
+        NodeTypeRelation
+          end-rune = 56
+          input-source = partials happy path
+          relation-name = user
+          start-rune = 38
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 56
+              input-source = partials happy path
+              start-rune = 53
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 56
+                  input-source = partials happy path
+                  start-rune = 53
+                  type-name = user
+        NodeTypePermission
+          end-rune = 81
+          input-source = partials happy path
+          relation-name = view
+          start-rune = 60
+          compute-expression =>
+            NodeTypeIdentifier
+              end-rune = 81
+              identifier-value = user
+              input-source = partials happy path
+              start-rune = 78
+    NodeTypeDefinition
+      definition-name = user
+      end-rune = 103
+      input-source = partials happy path
+      start-rune = 86
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 146
+      input-source = partials happy path
+      start-rune = 106
+      child-node =>
+        NodeTypePartialReference
+          end-rune = 144
+          input-source = partials happy path
+          partial-reference-name = view_partial
+          start-rune = 130

--- a/pkg/schemadsl/parser/tests/partials_with_malformed_partial_block.zed
+++ b/pkg/schemadsl/parser/tests/partials_with_malformed_partial_block.zed
@@ -1,0 +1,12 @@
+use partial
+
+partial view_partial {
+  relation user: user
+  permission view = user
+
+
+definition user {}
+
+definition resource {
+  ...view_partial
+}

--- a/pkg/schemadsl/parser/tests/partials_with_malformed_partial_block.zed.expected
+++ b/pkg/schemadsl/parser/tests/partials_with_malformed_partial_block.zed.expected
@@ -1,0 +1,65 @@
+NodeTypeFile
+  end-rune = 146
+  input-source = partials with malformed partial block
+  start-rune = 0
+  child-node =>
+    NodeTypeUseFlag
+      end-rune = 10
+      input-source = partials with malformed partial block
+      start-rune = 0
+      use-flag-name = partial
+    NodeTypePartial
+      end-rune = 82
+      input-source = partials with malformed partial block
+      partial-name = view_partial
+      start-rune = 13
+      child-node =>
+        NodeTypeRelation
+          end-rune = 56
+          input-source = partials with malformed partial block
+          relation-name = user
+          start-rune = 38
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 56
+              input-source = partials with malformed partial block
+              start-rune = 53
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 56
+                  input-source = partials with malformed partial block
+                  start-rune = 53
+                  type-name = user
+        NodeTypePermission
+          end-rune = 81
+          input-source = partials with malformed partial block
+          relation-name = view
+          start-rune = 60
+          compute-expression =>
+            NodeTypeIdentifier
+              end-rune = 81
+              identifier-value = user
+              input-source = partials with malformed partial block
+              start-rune = 78
+        NodeTypeError
+          end-rune = 82
+          error-message = Expected end of statement or definition, found: TokenTypeKeyword
+          error-source = definition
+          input-source = partials with malformed partial block
+          start-rune = 85
+    NodeTypeDefinition
+      definition-name = user
+      end-rune = 102
+      input-source = partials with malformed partial block
+      start-rune = 85
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 145
+      input-source = partials with malformed partial block
+      start-rune = 105
+      child-node =>
+        NodeTypePartialReference
+          end-rune = 143
+          input-source = partials with malformed partial block
+          partial-reference-name = view_partial
+          start-rune = 129

--- a/pkg/schemadsl/parser/tests/partials_with_malformed_partial_reference.zed
+++ b/pkg/schemadsl/parser/tests/partials_with_malformed_partial_reference.zed
@@ -1,0 +1,12 @@
+use partial
+
+partial view_partial {
+  relation user: user
+  permission view = user
+}
+
+definition user {}
+
+definition resource {
+  ...view_partial and_something_else
+}

--- a/pkg/schemadsl/parser/tests/partials_with_malformed_partial_reference.zed.expected
+++ b/pkg/schemadsl/parser/tests/partials_with_malformed_partial_reference.zed.expected
@@ -1,0 +1,71 @@
+NodeTypeFile
+  end-rune = 144
+  input-source = partials with malformed partial reference
+  start-rune = 0
+  child-node =>
+    NodeTypeUseFlag
+      end-rune = 10
+      input-source = partials with malformed partial reference
+      start-rune = 0
+      use-flag-name = partial
+    NodeTypePartial
+      end-rune = 83
+      input-source = partials with malformed partial reference
+      partial-name = view_partial
+      start-rune = 13
+      child-node =>
+        NodeTypeRelation
+          end-rune = 56
+          input-source = partials with malformed partial reference
+          relation-name = user
+          start-rune = 38
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 56
+              input-source = partials with malformed partial reference
+              start-rune = 53
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 56
+                  input-source = partials with malformed partial reference
+                  start-rune = 53
+                  type-name = user
+        NodeTypePermission
+          end-rune = 81
+          input-source = partials with malformed partial reference
+          relation-name = view
+          start-rune = 60
+          compute-expression =>
+            NodeTypeIdentifier
+              end-rune = 81
+              identifier-value = user
+              input-source = partials with malformed partial reference
+              start-rune = 78
+    NodeTypeDefinition
+      definition-name = user
+      end-rune = 103
+      input-source = partials with malformed partial reference
+      start-rune = 86
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 144
+      input-source = partials with malformed partial reference
+      start-rune = 106
+      child-node =>
+        NodeTypePartialReference
+          end-rune = 144
+          input-source = partials with malformed partial reference
+          partial-reference-name = view_partial
+          start-rune = 130
+        NodeTypeError
+          end-rune = 144
+          error-message = Expected end of statement or definition, found: TokenTypeIdentifier
+          error-source = and_something_else
+          input-source = partials with malformed partial reference
+          start-rune = 146
+    NodeTypeError
+      end-rune = 144
+      error-message = Unexpected token at root level: TokenTypeIdentifier
+      error-source = and_something_else
+      input-source = partials with malformed partial reference
+      start-rune = 146

--- a/pkg/schemadsl/parser/tests/partials_with_malformed_reference_splat.zed
+++ b/pkg/schemadsl/parser/tests/partials_with_malformed_reference_splat.zed
@@ -1,0 +1,12 @@
+use partial
+
+partial view_partial {
+  relation user: user
+  permission view = user
+}
+
+definition user {}
+
+definition resource {
+  ..view_partial
+}

--- a/pkg/schemadsl/parser/tests/partials_with_malformed_reference_splat.zed.expected
+++ b/pkg/schemadsl/parser/tests/partials_with_malformed_reference_splat.zed.expected
@@ -1,0 +1,66 @@
+NodeTypeFile
+  end-rune = 126
+  input-source = partials with malformed reference splat
+  start-rune = 0
+  child-node =>
+    NodeTypeUseFlag
+      end-rune = 10
+      input-source = partials with malformed reference splat
+      start-rune = 0
+      use-flag-name = partial
+    NodeTypePartial
+      end-rune = 83
+      input-source = partials with malformed reference splat
+      partial-name = view_partial
+      start-rune = 13
+      child-node =>
+        NodeTypeRelation
+          end-rune = 56
+          input-source = partials with malformed reference splat
+          relation-name = user
+          start-rune = 38
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 56
+              input-source = partials with malformed reference splat
+              start-rune = 53
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 56
+                  input-source = partials with malformed reference splat
+                  start-rune = 53
+                  type-name = user
+        NodeTypePermission
+          end-rune = 81
+          input-source = partials with malformed reference splat
+          relation-name = view
+          start-rune = 60
+          compute-expression =>
+            NodeTypeIdentifier
+              end-rune = 81
+              identifier-value = user
+              input-source = partials with malformed reference splat
+              start-rune = 78
+    NodeTypeDefinition
+      definition-name = user
+      end-rune = 103
+      input-source = partials with malformed reference splat
+      start-rune = 86
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 126
+      input-source = partials with malformed reference splat
+      start-rune = 106
+      child-node =>
+        NodeTypeError
+          end-rune = 126
+          error-message = Expected end of statement or definition, found: TokenTypePeriod
+          error-source = .
+          input-source = partials with malformed reference splat
+          start-rune = 130
+    NodeTypeError
+      end-rune = 126
+      error-message = Unexpected token at root level: TokenTypePeriod
+      error-source = .
+      input-source = partials with malformed reference splat
+      start-rune = 130


### PR DESCRIPTION
## Description
Part of unifying `composableschemadsl` and `schemadsl`. This will enable us to better-support composable schema syntax in tooling, from `zed` to `spicedb-vscode` to the playground.

## Changes
Will annotate.

## Testing
Review; see that tests pass.