### PR TITLE
style: run new go fix with modernizers

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,10 +1,10 @@
 ---
 name: "Main"
 on: # yamllint disable-line rule:truthy
+  # NOTE! Do NOT add any other "on", because this workflow has permission to write to the repo!
   push:
     branches:
       - "main"
-  # NOTE! Do NOT add any other "on", because this workflow has permission to write to the repo!
 
 permissions:
   # permission to update benchmark contents in gh-pages branch

--- a/docker-compose.postgres.yaml
+++ b/docker-compose.postgres.yaml
@@ -58,7 +58,7 @@ services:
     container_name: "migrate"
     environment:
       - "SPICEDB_DATASTORE_ENGINE=postgres"
-        # Run migrations on primary
+      # Run migrations on primary
       - "SPICEDB_DATASTORE_CONN_URI=postgres://spicedb:spicedb@postgres-primary:5432/spicedb?sslmode=disable"
     command: "datastore migrate head"
     networks:

--- a/internal/auth/presharedkey_test.go
+++ b/internal/auth/presharedkey_test.go
@@ -30,7 +30,6 @@ func TestPresharedKeys(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			f := MustRequirePresharedKey(testcase.presharedkeys)
 			ctx := t.Context()
@@ -84,7 +83,6 @@ func TestPresharedKeyEdgeCases(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			f := MustRequirePresharedKey(testcase.presharedkeys)
 			ctx := withTokenMetadata("bearer " + testcase.token)

--- a/internal/caveats/builder_test.go
+++ b/internal/caveats/builder_test.go
@@ -39,7 +39,6 @@ func TestShortcircuitedOr(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("%v-%v", tc.first, tc.second), func(t *testing.T) {
 			testutil.RequireProtoEqual(t, tc.expected, ShortcircuitedOr(tc.first, tc.second), "mismatch")
 		})
@@ -87,7 +86,6 @@ func TestOr(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("%v-%v", tc.first, tc.second), func(t *testing.T) {
 			testutil.RequireProtoEqual(t, tc.expected, Or(tc.first, tc.second), "mismatch")
 		})
@@ -135,7 +133,6 @@ func TestAnd(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("%v-%v", tc.first, tc.second), func(t *testing.T) {
 			testutil.RequireProtoEqual(t, tc.expected, And(tc.first, tc.second), "mismatch")
 		})
@@ -165,7 +162,6 @@ func TestInvert(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("%v", tc.first), func(t *testing.T) {
 			testutil.RequireProtoEqual(t, tc.expected, Invert(tc.first), "mismatch")
 		})
@@ -199,7 +195,6 @@ func TestCaveatAsExpr(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			testutil.RequireProtoEqual(t, tc.expected, CaveatAsExpr(tc.caveat), "mismatch")
 		})
@@ -284,7 +279,6 @@ func TestSubtract(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result := Subtract(tc.caveat, tc.subtracted)
 			testutil.RequireProtoEqual(t, tc.expected, result, "mismatch")

--- a/internal/caveats/run_test.go
+++ b/internal/caveats/run_test.go
@@ -447,7 +447,6 @@ func TestRunCaveatExpressions(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			req := require.New(t)
 
@@ -476,7 +475,6 @@ func TestRunCaveatExpressions(t *testing.T) {
 				RunCaveatExpressionNoDebugging,
 				RunCaveatExpressionWithDebugInformation,
 			} {
-				debugOption := debugOption
 				t.Run(fmt.Sprintf("%v", debugOption), func(t *testing.T) {
 					req := require.New(t)
 

--- a/internal/cursorediterator/blocks.go
+++ b/internal/cursorediterator/blocks.go
@@ -241,8 +241,6 @@ func CursoredParallelIterators[I any](
 	tr := taskrunner.NewPreloadedTaskRunner(ctx, concurrency, len(itersToRun))
 	collectors := make([]chan item[I], len(itersToRun))
 	for i, iter := range itersToRun {
-		i := i
-		iter := iter
 		collector := make(chan item[I], parallelIteratorResultsBufferSize)
 		collectors[i] = collector
 

--- a/internal/cursorediterator/primitives_test.go
+++ b/internal/cursorediterator/primitives_test.go
@@ -610,7 +610,7 @@ func TestSpanned(t *testing.T) {
 		defer cleanup()
 
 		source := func(yield func(string, error) bool) {
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				if !yield("item", nil) {
 					return
 				}

--- a/internal/datasets/basesubjectset.go
+++ b/internal/datasets/basesubjectset.go
@@ -126,7 +126,6 @@ func (bss BaseSubjectSet[T]) Subtract(toRemove T) {
 		updatedWildcard, concretesToAdd := subtractWildcardFromWildcard(existing, toRemove, bss.constructor)
 		bss.wildcard.setOrNil(updatedWildcard)
 		for _, concrete := range concretesToAdd {
-			concrete := concrete
 			bss.setConcrete(concrete.GetSubjectId(), &concrete)
 		}
 		return

--- a/internal/datasets/subjectset_test.go
+++ b/internal/datasets/subjectset_test.go
@@ -228,8 +228,6 @@ func TestSubjectSetAdd(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			existingSet := NewSubjectSet()
 			for _, existing := range tc.existing {
@@ -597,8 +595,6 @@ func TestSubjectSetSubtract(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			existingSet := NewSubjectSet()
 			for _, existing := range tc.existing {
@@ -933,8 +929,6 @@ func TestSubjectSetIntersection(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			existingSet := NewSubjectSet()
 			for _, existing := range tc.existing {
@@ -1308,8 +1302,6 @@ func TestMultipleOperations(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			set := NewSubjectSet()
 			tc.runOps(set)
@@ -1355,8 +1347,6 @@ func TestSubtractAll(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			set := NewSubjectSet()
 
@@ -1464,7 +1454,6 @@ var testSets = [][]*v1.FoundSubject{
 
 func TestUnionCommutativity(t *testing.T) {
 	for _, pair := range allSubsets(testSets, 2) {
-		pair := pair
 		t.Run(fmt.Sprintf("%v", pair), func(t *testing.T) {
 			left1, left2 := NewSubjectSet(), NewSubjectSet()
 			for _, l := range pair[0] {
@@ -1491,7 +1480,6 @@ func TestUnionCommutativity(t *testing.T) {
 
 func TestUnionAssociativity(t *testing.T) {
 	for _, triple := range allSubsets(testSets, 3) {
-		triple := triple
 		t.Run(fmt.Sprintf("%s U %s U %s", testutil.FormatSubjects(triple[0]), testutil.FormatSubjects(triple[1]), testutil.FormatSubjects(triple[2])), func(t *testing.T) {
 			// A U (B U C) == (A U B) U C
 
@@ -1528,7 +1516,6 @@ func TestUnionAssociativity(t *testing.T) {
 
 func TestIntersectionCommutativity(t *testing.T) {
 	for _, pair := range allSubsets(testSets, 2) {
-		pair := pair
 		t.Run(fmt.Sprintf("%v", pair), func(t *testing.T) {
 			left1, left2 := NewSubjectSet(), NewSubjectSet()
 			for _, l := range pair[0] {
@@ -1554,7 +1541,6 @@ func TestIntersectionCommutativity(t *testing.T) {
 
 func TestIntersectionAssociativity(t *testing.T) {
 	for _, triple := range allSubsets(testSets, 3) {
-		triple := triple
 		t.Run(fmt.Sprintf("%s ∩ %s ∩ %s", testutil.FormatSubjects(triple[0]), testutil.FormatSubjects(triple[1]), testutil.FormatSubjects(triple[2])), func(t *testing.T) {
 			// A ∩ (B ∩ C) == (A ∩ B) ∩ C
 
@@ -1591,7 +1577,6 @@ func TestIntersectionAssociativity(t *testing.T) {
 
 func TestIdempotentUnion(t *testing.T) {
 	for _, set := range testSets {
-		set := set
 		t.Run(fmt.Sprintf("%v", set), func(t *testing.T) {
 			// A U A == A
 			A1, A2 := NewSubjectSet(), NewSubjectSet()
@@ -1610,7 +1595,6 @@ func TestIdempotentUnion(t *testing.T) {
 
 func TestIdempotentIntersection(t *testing.T) {
 	for _, set := range testSets {
-		set := set
 		t.Run(fmt.Sprintf("%v", set), func(t *testing.T) {
 			// A ∩ A == A
 			A1, A2 := NewSubjectSet(), NewSubjectSet()
@@ -1725,8 +1709,6 @@ func TestUnionWildcardWithWildcard(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s U %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toUnion)), func(t *testing.T) {
 			existing := wrap(tc.existing)
 			produced, err := unionWildcardWithWildcard(existing, tc.toUnion, subjectSetConstructor)
@@ -1845,8 +1827,6 @@ func TestUnionWildcardWithConcrete(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s U %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toUnion)), func(t *testing.T) {
 			existing := wrap(tc.existing)
 			produced := unionWildcardWithConcrete(existing, tc.toUnion, subjectSetConstructor)
@@ -1905,8 +1885,6 @@ func TestUnionConcreteWithConcrete(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s U %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toUnion)), func(t *testing.T) {
 			existing := wrap(tc.existing)
 			toUnion := wrap(tc.toUnion)
@@ -2048,8 +2026,6 @@ func TestSubtractWildcardFromWildcard(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s - %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toSubtract)), func(t *testing.T) {
 			existing := wrap(tc.existing)
 
@@ -2157,8 +2133,6 @@ func TestSubtractWildcardFromConcrete(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%v - %v", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toSubtract)), func(t *testing.T) {
 			produced := subtractWildcardFromConcrete(tc.existing, tc.toSubtract, subjectSetConstructor)
 			testutil.RequireExpectedSubject(t, tc.expected, produced)
@@ -2208,8 +2182,6 @@ func TestSubtractConcreteFromConcrete(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s - %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toSubtract)), func(t *testing.T) {
 			produced := subtractConcreteFromConcrete(tc.existing, tc.toSubtract, subjectSetConstructor)
 			testutil.RequireExpectedSubject(t, tc.expected, produced)
@@ -2283,8 +2255,6 @@ func TestSubtractConcreteFromWildcard(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s - %s", testutil.FormatSubject(tc.existing), testutil.FormatSubject(tc.toSubtract)), func(t *testing.T) {
 			produced := subtractConcreteFromWildcard(tc.existing, tc.toSubtract, subjectSetConstructor)
 			testutil.RequireExpectedSubject(t, tc.expected, produced)
@@ -2341,8 +2311,6 @@ func TestIntersectConcreteWithConcrete(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s ∩ %s", testutil.FormatSubject(tc.first), testutil.FormatSubject(tc.second)), func(t *testing.T) {
 			second := wrap(tc.second)
 
@@ -2453,8 +2421,6 @@ func TestIntersectWildcardWithWildcard(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s ∩ %s", testutil.FormatSubject(tc.first), testutil.FormatSubject(tc.second)), func(t *testing.T) {
 			first := wrap(tc.first)
 			second := wrap(tc.second)
@@ -2582,8 +2548,6 @@ func TestIntersectConcreteWithWildcard(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s ∩ %s", testutil.FormatSubject(tc.concrete), testutil.FormatSubject(tc.wildcard)), func(t *testing.T) {
 			wildcard := wrap(tc.wildcard)
 
@@ -2601,7 +2565,7 @@ func allSubsets[T any](objs []T, n int) [][]T {
 	maxInt := uint64(math.Exp2(float64(len(objs)))) - 1
 	all := make([][]T, 0)
 
-	for i := uint64(0); i < maxInt; i++ {
+	for i := range maxInt {
 		set := make([]T, 0, n)
 		for digit := uint64(0); digit < uint64(len(objs)); digit++ {
 			mask := uint64(1) << digit

--- a/internal/datastore/benchmark/driver_bench_test.go
+++ b/internal/datastore/benchmark/driver_bench_test.go
@@ -80,10 +80,10 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 			ds, _ = testfixtures.StandardDatastoreWithSchema(ds, require.New(b))
 
 			// Write a fair amount of data, much more than a functional test
-			for docNum := 0; docNum < numDocuments; docNum++ {
+			for docNum := range numDocuments {
 				_, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 					var updates []tuple.RelationshipUpdate
-					for userNum := 0; userNum < usersPerDoc; userNum++ {
+					for userNum := range usersPerDoc {
 						updates = append(updates, tuple.Create(docViewer(strconv.Itoa(docNum), strconv.Itoa(userNum))))
 					}
 
@@ -133,7 +133,6 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 				})
 				b.Run("SortedSnapshotReadOnlyNamespace", func(b *testing.B) {
 					for orderName, order := range sortOrders {
-						order := order
 						b.Run(orderName, func(b *testing.B) {
 							for n := 0; n < b.N; n++ {
 								iter, err := ds.SnapshotReader(headRev).QueryRelationships(ctx, datastore.RelationshipsFilter{
@@ -151,7 +150,6 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 				})
 				b.Run("SortedSnapshotReadWithRelation", func(b *testing.B) {
 					for orderName, order := range sortOrders {
-						order := order
 						b.Run(orderName, func(b *testing.B) {
 							for n := 0; n < b.N; n++ {
 								iter, err := ds.SnapshotReader(headRev).QueryRelationships(ctx, datastore.RelationshipsFilter{
@@ -170,7 +168,6 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 				})
 				b.Run("SortedSnapshotReadAllResourceFields", func(b *testing.B) {
 					for orderName, order := range sortOrders {
-						order := order
 						b.Run(orderName, func(b *testing.B) {
 							for n := 0; n < b.N; n++ {
 								randDocNum := rand.Intn(numDocuments) //nolint:gosec
@@ -207,12 +204,11 @@ func BenchmarkDatastoreDriver(b *testing.B) {
 				b.Run("CreateAndTouch", func(b *testing.B) {
 					const totalRelationships = 1000
 					for _, portionCreate := range []float64{0, 0.10, 0.25, 0.50, 1} {
-						portionCreate := portionCreate
 						b.Run(fmt.Sprintf("%v_", portionCreate), func(b *testing.B) {
 							for n := 0; n < b.N; n++ {
 								portionCreateIndex := int(math.Floor(portionCreate * totalRelationships))
 								mutations := make([]tuple.RelationshipUpdate, 0, totalRelationships)
-								for index := 0; index < totalRelationships; index++ {
+								for index := range totalRelationships {
 									if index >= portionCreateIndex {
 										stableID := fmt.Sprintf("id-%d", index)
 										rel := docViewer(stableID, stableID)

--- a/internal/datastore/common/changes_test.go
+++ b/internal/datastore/common/changes_test.go
@@ -308,7 +308,6 @@ func TestChanges(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -903,7 +902,6 @@ func TestCanonicalize(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			require.Equal(tc.expected, canonicalize(tc.input))
@@ -978,7 +976,7 @@ func TestThreadSafe(t *testing.T) {
 	ch := NewChanges(revisions.TransactionIDKeyFunc, datastore.WatchRelationships|datastore.WatchSchema, math.MaxInt64)
 
 	var wg errgroup.Group
-	for i := 0; i < 1_000; i++ {
+	for i := range 1_000 {
 		wg.Go(func() error {
 			rel := tuple.MustParse("document:" + strconv.Itoa(i) + "#reader@user:anne")
 			return ch.AddRelationshipChange(t.Context(), revisions.NewForTransactionID(1), rel, tuple.UpdateOperationTouch)

--- a/internal/datastore/common/chunkbytes.go
+++ b/internal/datastore/common/chunkbytes.go
@@ -338,10 +338,7 @@ func (c *SQLByteChunker[T]) chunkData(data []byte) [][]byte {
 	chunks := make([][]byte, 0, numChunks)
 
 	for i := 0; i < len(data); i += c.config.MaxChunkSize {
-		end := i + c.config.MaxChunkSize
-		if end > len(data) {
-			end = len(data)
-		}
+		end := min(i+c.config.MaxChunkSize, len(data))
 		chunks = append(chunks, data[i:end])
 	}
 

--- a/internal/datastore/common/index.go
+++ b/internal/datastore/common/index.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"slices"
+
 	"github.com/authzed/spicedb/pkg/datastore/options"
 	"github.com/authzed/spicedb/pkg/datastore/queryshape"
 )
@@ -25,10 +27,5 @@ type IndexDefinition struct {
 
 // matchesShape returns true if the index matches the given shape.
 func (id IndexDefinition) matchesShape(shape queryshape.Shape) bool {
-	for _, s := range id.Shapes {
-		if s == shape {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(id.Shapes, shape)
 }

--- a/internal/datastore/common/sql_test.go
+++ b/internal/datastore/common/sql_test.go
@@ -794,7 +794,6 @@ func TestSchemaQueryFilterer(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			for _, filterType := range []PaginationFilterType{TupleComparison, ExpandedLogicComparison} {
 				t.Run(fmt.Sprintf("filter type: %v", filterType), func(t *testing.T) {

--- a/internal/datastore/crdb/keys.go
+++ b/internal/datastore/crdb/keys.go
@@ -67,7 +67,7 @@ func overlapKeysFromContext(ctx context.Context) keySet {
 	}
 
 	for _, keyList := range md[string(requestmeta.RequestOverlapKey)] {
-		for _, key := range strings.Split(keyList, ",") {
+		for key := range strings.SplitSeq(keyList, ",") {
 			key = strings.TrimSpace(key)
 			if len(key) > 0 {
 				keys[key] = struct{}{}

--- a/internal/datastore/crdb/keys_test.go
+++ b/internal/datastore/crdb/keys_test.go
@@ -60,7 +60,6 @@ func TestOverlapKeyAddition(t *testing.T) {
 		},
 	}
 	for _, tt := range cases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			set := newKeySet(t.Context())
 			for _, n := range tt.namespaces {

--- a/internal/datastore/crdb/pool/balancer_test.go
+++ b/internal/datastore/crdb/pool/balancer_test.go
@@ -138,7 +138,6 @@ func TestNodeConnectionBalancerPrune(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tracker, err := NewNodeHealthChecker("")
 			require.NoError(t, err)

--- a/internal/datastore/crdb/version_test.go
+++ b/internal/datastore/crdb/version_test.go
@@ -40,7 +40,6 @@ func TestParseVersionString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.versionStr, func(t *testing.T) {
 			var version crdbVersion
 			err := parseVersionStringInto(tc.versionStr, &version)

--- a/internal/datastore/crdb/watch.go
+++ b/internal/datastore/crdb/watch.go
@@ -385,8 +385,6 @@ func (cds *crdbDatastore) processChanges(ctx context.Context, changes pgx.Rows, 
 			}
 
 			for _, revChange := range filtered {
-				revChange := revChange
-
 				// TODO(jschorr): Change this to a new event type if/when we decide to report these
 				// row GCs.
 

--- a/internal/datastore/memdb/memdb_test.go
+++ b/internal/datastore/memdb/memdb_test.go
@@ -42,7 +42,7 @@ func TestConcurrentWritePanic(t *testing.T) {
 
 	// Make the namespace very large to increase the likelihood of overlapping
 	relationList := make([]*corev1.Relation, 0, 1000)
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		relationList = append(relationList, ns.MustRelation(fmt.Sprintf("reader%d", i), nil))
 	}
 
@@ -94,12 +94,11 @@ func TestConcurrentWriteRelsError(t *testing.T) {
 	// Kick off a number of writes to ensure at least one hits an error.
 	g := errgroup.Group{}
 
-	for i := 0; i < 50; i++ {
-		i := i
+	for i := range 50 {
 		g.Go(func() error {
 			_, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 				updates := []tuple.RelationshipUpdate{}
-				for j := 0; j < 500; j++ {
+				for j := range 500 {
 					updates = append(updates, tuple.Touch(tuple.MustParse(fmt.Sprintf("document:doc-%d-%d#viewer@user:tom", i, j))))
 				}
 
@@ -160,7 +159,7 @@ func BenchmarkQueryRelationships(b *testing.B) {
 	ctx := b.Context()
 	rev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 		updates := []tuple.RelationshipUpdate{}
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			updates = append(updates, tuple.Touch(tuple.MustParse(fmt.Sprintf("document:doc-%d#viewer@user:tom", i))))
 		}
 

--- a/internal/datastore/memdb/readonly.go
+++ b/internal/datastore/memdb/readonly.go
@@ -446,13 +446,7 @@ func filterFuncForFilters(
 		}
 
 		if len(optionalSubjectsSelectors) > 0 {
-			hasMatchingSelector := false
-			for _, selector := range optionalSubjectsSelectors {
-				if applySubjectSelector(selector) {
-					hasMatchingSelector = true
-					break
-				}
-			}
+			hasMatchingSelector := slices.ContainsFunc(optionalSubjectsSelectors, applySubjectSelector)
 
 			if !hasMatchingSelector {
 				return true

--- a/internal/datastore/mysql/datastore.go
+++ b/internal/datastore/mysql/datastore.go
@@ -207,15 +207,9 @@ func newMySQLDatastore(ctx context.Context, uri string, replicaIndex int, option
 	maxRevisionStaleness := time.Duration(float64(config.revisionQuantization.Nanoseconds())*
 		config.maxRevisionStalenessPercent) * time.Nanosecond
 
-	quantizationPeriodNanos := config.revisionQuantization.Nanoseconds()
-	if quantizationPeriodNanos < 1 {
-		quantizationPeriodNanos = 1
-	}
+	quantizationPeriodNanos := max(config.revisionQuantization.Nanoseconds(), 1)
 
-	followerReadDelayNanos := config.followerReadDelay.Nanoseconds()
-	if followerReadDelayNanos < 0 {
-		followerReadDelayNanos = 0
-	}
+	followerReadDelayNanos := max(config.followerReadDelay.Nanoseconds(), 0)
 
 	revisionQuery := fmt.Sprintf(
 		querySelectRevision,

--- a/internal/datastore/mysql/revisions_test.go
+++ b/internal/datastore/mysql/revisions_test.go
@@ -21,7 +21,6 @@ func TestRevisionFromTransaction(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			got := revisions.NewForTransactionID(tt.txID)

--- a/internal/datastore/mysql/watch.go
+++ b/internal/datastore/mysql/watch.go
@@ -100,7 +100,6 @@ func (mds *mysqlDatastore) Watch(ctx context.Context, afterRevisionRaw datastore
 
 			// Write the staged updates to the channel
 			for _, changeToWrite := range stagedUpdates {
-				changeToWrite := changeToWrite
 				if !sendChange(changeToWrite) {
 					return
 				}

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -253,15 +253,9 @@ func newPostgresDatastore(
 
 	gcCtx, cancelGc := context.WithCancel(context.Background())
 
-	quantizationPeriodNanos := config.revisionQuantization.Nanoseconds()
-	if quantizationPeriodNanos < 1 {
-		quantizationPeriodNanos = 1
-	}
+	quantizationPeriodNanos := max(config.revisionQuantization.Nanoseconds(), 1)
 
-	followerReadDelayNanos := config.followerReadDelay.Nanoseconds()
-	if followerReadDelayNanos < 0 {
-		followerReadDelayNanos = 0
-	}
+	followerReadDelayNanos := max(config.followerReadDelay.Nanoseconds(), 0)
 
 	revisionQuery := fmt.Sprintf(
 		querySelectRevision,

--- a/internal/datastore/postgres/revisions_test.go
+++ b/internal/datastore/postgres/revisions_test.go
@@ -30,7 +30,6 @@ func TestRevisionOrdering(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s:%s", tc.lhsSnapshot, tc.rhsSnapshot), func(t *testing.T) {
 			require := require.New(t)
 
@@ -76,7 +75,6 @@ func TestRevisionSerDe(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.snapshot.String(), func(t *testing.T) {
 			require := require.New(t)
 
@@ -138,7 +136,6 @@ func TestRevisionParseOldDecimalFormat(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.snapshot.String(), func(t *testing.T) {
 			require := require.New(t)
 
@@ -180,7 +177,6 @@ func TestCombinedRevisionParsing(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.snapshot.String(), func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/datastore/postgres/snapshot.go
+++ b/internal/datastore/postgres/snapshot.go
@@ -190,13 +190,7 @@ func (s pgSnapshot) anyTXVisible(first uint64, others []uint64) bool {
 	if s.txVisible(first) {
 		return true
 	}
-	for _, txid := range others {
-		if s.txVisible(txid) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(others, s.txVisible)
 }
 
 // markComplete will create a new snapshot where the specified transaction will be marked as

--- a/internal/datastore/postgres/snapshot_test.go
+++ b/internal/datastore/postgres/snapshot_test.go
@@ -25,7 +25,6 @@ func TestSnapshotDecodeEncode(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.snapshot, func(t *testing.T) {
 			require := require.New(t)
 
@@ -60,7 +59,6 @@ func TestMarkComplete(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s+%d=>%s", tc.snapshot, tc.toMark, tc.expected), func(t *testing.T) {
 			require := require.New(t)
 			completed := tc.snapshot.markComplete(tc.toMark)
@@ -89,8 +87,6 @@ func TestVisible(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%d %s %s", tc.txID, f(tc.visible)+" in", tc.snapshot), func(t *testing.T) {
 			require := require.New(t)
 			result := tc.snapshot.txVisible(tc.txID)
@@ -109,7 +105,6 @@ func TestCompare(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s %s %s", tc.snapshot, tc.result, tc.compareWith), func(t *testing.T) {
 			require := require.New(t)
 			result := tc.snapshot.compare(tc.compareWith)
@@ -133,7 +128,6 @@ func TestMarkInProgress(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s-%d=>%s", tc.snapshot, tc.toMark, tc.expected), func(t *testing.T) {
 			require := require.New(t)
 			withInProgress := tc.snapshot.markInProgress(tc.toMark)

--- a/internal/datastore/postgres/watch.go
+++ b/internal/datastore/postgres/watch.go
@@ -88,10 +88,7 @@ func (pgd *pgDatastore) Watch(
 	}
 
 	afterRevision := afterRevisionRaw.(postgresRevision)
-	watchSleep := options.CheckpointInterval
-	if watchSleep < minimumWatchSleep {
-		watchSleep = minimumWatchSleep
-	}
+	watchSleep := max(options.CheckpointInterval, minimumWatchSleep)
 
 	watchBufferWriteTimeout := options.WatchBufferWriteTimeout
 	if watchBufferWriteTimeout <= 0 {
@@ -159,7 +156,6 @@ func (pgd *pgDatastore) Watch(
 				}
 
 				for _, changeToWrite := range changesToWrite {
-					changeToWrite := changeToWrite
 					if !sendChange(changeToWrite) {
 						return
 					}

--- a/internal/datastore/proxy/counting_test.go
+++ b/internal/datastore/proxy/counting_test.go
@@ -169,16 +169,14 @@ func TestCountingProxyThreadSafety(t *testing.T) {
 	callsPerGoroutine := uint64(100)
 
 	var wg sync.WaitGroup
-	for i := uint64(0); i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
 			r := ds.SnapshotReader(datastore.NoRevision)
 			for range callsPerGoroutine {
 				_, err := r.QueryRelationships(ctx, datastore.RelationshipsFilter{})
 				assert.NoError(t, err)
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/datastore/proxy/relationshipintegrity_test.go
+++ b/internal/datastore/proxy/relationshipintegrity_test.go
@@ -297,7 +297,7 @@ func BenchmarkQueryRelsWithIntegrity(b *testing.B) {
 			require.NoError(b, err)
 
 			_, err = pds.ReadWriteTx(b.Context(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
-				for i := 0; i < 1000; i++ {
+				for i := range 1000 {
 					rel := tuple.MustParse(fmt.Sprintf("resource:foo#viewer@user:user-%d", i))
 					if err := tx.WriteRelationships(b.Context(), []tuple.RelationshipUpdate{
 						tuple.Create(rel),

--- a/internal/datastore/proxy/schemacaching/estimatedsize_test.go
+++ b/internal/datastore/proxy/schemacaching/estimatedsize_test.go
@@ -44,7 +44,6 @@ func TestEstimatedDefinitionSizes(t *testing.T) {
 	require.NotEmpty(t, consistencyTestFiles)
 
 	for _, filePath := range consistencyTestFiles {
-		filePath := filePath
 		t.Run(path.Base(filePath), func(t *testing.T) {
 			require := require.New(t)
 			ds, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, 1*time.Second, memdb.DisableGC)
@@ -54,7 +53,6 @@ func TestEstimatedDefinitionSizes(t *testing.T) {
 			require.NoError(err)
 
 			for _, nsDef := range fullyResolved.NamespaceDefinitions {
-				nsDef := nsDef
 				t.Run("namespace "+nsDef.Name, func(t *testing.T) {
 					serialized, _ := nsDef.MarshalVT()
 					sizevt := nsDef.SizeVT()
@@ -62,7 +60,7 @@ func TestEstimatedDefinitionSizes(t *testing.T) {
 
 					succeeded := false
 					var used uint64
-					for i := 0; i < retryCount; i++ {
+					for range retryCount {
 						runtime.GC()
 						debug.FreeOSMemory()
 
@@ -90,7 +88,6 @@ func TestEstimatedDefinitionSizes(t *testing.T) {
 			}
 
 			for _, caveatDef := range fullyResolved.CaveatDefinitions {
-				caveatDef := caveatDef
 				t.Run("caveat "+caveatDef.Name, func(t *testing.T) {
 					t.Parallel()
 
@@ -100,7 +97,7 @@ func TestEstimatedDefinitionSizes(t *testing.T) {
 
 					succeeded := false
 					var used uint64
-					for i := 0; i < retryCount; i++ {
+					for range retryCount {
 						runtime.GC()
 						debug.FreeOSMemory()
 

--- a/internal/datastore/proxy/schemacaching/standardcaching_test.go
+++ b/internal/datastore/proxy/schemacaching/standardcaching_test.go
@@ -151,7 +151,6 @@ var oldtesters = []oldTesterDef{
 
 func TestOldSnapshotCaching(t *testing.T) {
 	for _, tester := range oldtesters {
-		tester := tester
 		t.Run(tester.name, func(t *testing.T) {
 			dsMock := &proxy_test.MockDatastore{}
 
@@ -368,7 +367,6 @@ func TestSnapshotCaching(t *testing.T) {
 
 func TestOldRWTCaching(t *testing.T) {
 	for _, tester := range oldtesters {
-		tester := tester
 		t.Run(tester.name, func(t *testing.T) {
 			dsMock := &proxy_test.MockDatastore{}
 			rwtMock := &proxy_test.MockReadWriteTransaction{}
@@ -458,7 +456,6 @@ func TestRWTCaching(t *testing.T) {
 
 func TestOldRWTCacheWithWrites(t *testing.T) {
 	for _, tester := range oldtesters {
-		tester := tester
 		t.Run(tester.name, func(t *testing.T) {
 			dsMock := &proxy_test.MockDatastore{}
 			rwtMock := &proxy_test.MockReadWriteTransaction{}
@@ -507,7 +504,6 @@ func TestOldRWTCacheWithWrites(t *testing.T) {
 
 func TestOldSingleFlight(t *testing.T) {
 	for _, tester := range oldtesters {
-		tester := tester
 		t.Run(tester.name, func(t *testing.T) {
 			dsMock := &proxy_test.MockDatastore{}
 
@@ -642,7 +638,6 @@ func TestOldSnapshotCachingRealDatastore(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			rawDS, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, 0, memdb.DisableGC)
 			require.NoError(t, err)
@@ -720,7 +715,6 @@ func TestSnapshotCachingRealDatastore(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			rawDS, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, 0, memdb.DisableGC)
 			require.NoError(t, err)
@@ -813,7 +807,6 @@ func (r *singleflightReader) LookupTypeDefByName(ctx context.Context, name strin
 
 func TestOldSingleFlightCancelled(t *testing.T) {
 	for _, tester := range oldtesters {
-		tester := tester
 		t.Run(tester.name, func(t *testing.T) {
 			dsMock := &proxy_test.MockDatastore{}
 			ctx1, cancel1 := context.WithCancel(t.Context())
@@ -897,7 +890,6 @@ func TestSingleFlightCancelled(t *testing.T) {
 
 func TestOldMixedCaching(t *testing.T) {
 	for _, tester := range oldtesters {
-		tester := tester
 		t.Run(tester.name, func(t *testing.T) {
 			dsMock := &proxy_test.MockDatastore{}
 

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -469,7 +469,7 @@ func TestWatchingCacheParallelReaderWriter(t *testing.T) {
 
 	go (func() {
 		// Start a loop to write a namespace a bunch of times.
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			// Write somenamespace.
 			fakeDS.updateNamespace("somenamespace", &corev1.NamespaceDefinition{Name: "somenamespace"}, rev(fmt.Sprintf("%d", i+1)))
 		}
@@ -479,7 +479,7 @@ func TestWatchingCacheParallelReaderWriter(t *testing.T) {
 
 	go func() {
 		// Start a loop to read a namespace a bunch of times.
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			headRevision, err := fakeDS.HeadRevision(t.Context())
 			assert.NoError(t, err)
 
@@ -524,7 +524,7 @@ func TestOldWatchingCacheParallelReaderWriter(t *testing.T) {
 
 	go (func() {
 		// Start a loop to write a namespace a bunch of times.
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			// Write somenamespace.
 			fakeDS.updateNamespace("somenamespace", &corev1.NamespaceDefinition{Name: "somenamespace"}, rev(fmt.Sprintf("%d", i+1)))
 		}
@@ -538,7 +538,7 @@ func TestOldWatchingCacheParallelReaderWriter(t *testing.T) {
 
 	go (func() {
 		// Start a loop to read a namespace a bunch of times.
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			headRevision, err := fakeDS.HeadRevision(t.Context())
 			headRevisionErrors <- err
 

--- a/internal/datastore/revisions/optimized_test.go
+++ b/internal/datastore/revisions/optimized_test.go
@@ -104,7 +104,6 @@ func TestOptimizedRevisionCache(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -164,7 +163,7 @@ func TestOptimizedRevisionCacheSingleFlight(t *testing.T) {
 	defer cancel()
 
 	g := errgroup.Group{}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		g.Go(func() error {
 			revision, err := or.OptimizedRevision(ctx)
 			if err != nil {

--- a/internal/datastore/revisions/remoteclock_test.go
+++ b/internal/datastore/revisions/remoteclock_test.go
@@ -71,7 +71,6 @@ func TestRemoteClockOptimizedRevisions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -118,7 +117,6 @@ func TestRemoteClockCheckRevisions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/datastore/spanner/watch.go
+++ b/internal/datastore/spanner/watch.go
@@ -84,10 +84,7 @@ func (sd *spannerDatastore) watch(
 	defer close(errs)
 
 	// NOTE: 100ms is the minimum allowed.
-	heartbeatInterval := opts.CheckpointInterval
-	if heartbeatInterval < 100*time.Millisecond {
-		heartbeatInterval = 100 * time.Millisecond
-	}
+	heartbeatInterval := max(opts.CheckpointInterval, 100*time.Millisecond)
 
 	sendError := func(err error) {
 		if errors.Is(ctx.Err(), context.Canceled) || common.IsCancellationError(err) {

--- a/internal/developmentmembership/foundsubject_test.go
+++ b/internal/developmentmembership/foundsubject_test.go
@@ -68,7 +68,6 @@ func TestToValidationString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			require.Equal(tc.expected, tc.fs.ToValidationString())

--- a/internal/developmentmembership/trackingsubjectset_test.go
+++ b/internal/developmentmembership/trackingsubjectset_test.go
@@ -326,7 +326,6 @@ func TestTrackingSubjectSet(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			for _, fs := range tc.expected {

--- a/internal/digests/digestmap_test.go
+++ b/internal/digests/digestmap_test.go
@@ -86,22 +86,22 @@ func TestDigestMap_ConcurrentAccess(t *testing.T) {
 	wg.Add(numGoroutines * 2) // writers and readers
 
 	// Concurrent writers
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		go func(id int) {
 			defer wg.Done()
 			key := "key-" + string(rune('0'+id))
-			for j := 0; j < numOperations; j++ {
+			for j := range numOperations {
 				dm.Add(key, float64(j))
 			}
 		}(i)
 	}
 
 	// Concurrent readers
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		go func(id int) {
 			defer wg.Done()
 			key := "key-" + string(rune('0'+id))
-			for j := 0; j < numOperations; j++ {
+			for range numOperations {
 				dm.CDF(key, 50.0)
 			}
 		}(i)
@@ -110,7 +110,7 @@ func TestDigestMap_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 
 	// Verify all keys have data
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		key := "key-" + string(rune('0'+i))
 		cdf, ok := dm.CDF(key, 50.0)
 		require.True(t, ok)

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -88,7 +88,6 @@ func TestMaxDepthCaching(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -185,7 +184,7 @@ func TestConcurrentDebugInfoAccess(t *testing.T) {
 	errors := make(chan error, numGoroutines)
 
 	var wg sync.WaitGroup
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(goroutineID int) {
 			defer wg.Done()

--- a/internal/dispatch/graph/check_test.go
+++ b/internal/dispatch/graph/check_test.go
@@ -1416,7 +1416,6 @@ func TestCheckPermissionOverSchema(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1925,7 +1924,6 @@ func TestCheckWithHints(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/dispatch/graph/dispatch_test.go
+++ b/internal/dispatch/graph/dispatch_test.go
@@ -29,7 +29,7 @@ func TestDispatchChunking(t *testing.T) {
 
 	resources := make([]tuple.Relationship, 0, math.MaxUint16+1)
 	enabled := make([]tuple.Relationship, 0, math.MaxUint16+1)
-	for i := 0; i < math.MaxUint16+1; i++ {
+	for i := range math.MaxUint16 + 1 {
 		resources = append(resources, tuple.MustParse(fmt.Sprintf("res:res1#owner@user:user%d", i)))
 		enabled = append(enabled, tuple.MustParse(fmt.Sprintf("user:user%d#its_a_me@user:user%d", i, i)))
 	}

--- a/internal/dispatch/graph/expand_test.go
+++ b/internal/dispatch/graph/expand_test.go
@@ -164,7 +164,6 @@ func TestExpand(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s-%s", tuple.StringONR(tc.start), tc.expansionMode), func(t *testing.T) {
 			t.Parallel()
 
@@ -903,7 +902,6 @@ func TestExpandOverSchema(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/dispatch/graph/lookupresources2_test.go
+++ b/internal/dispatch/graph/lookupresources2_test.go
@@ -181,7 +181,6 @@ func TestSimpleLookupResourcesWithCursor2(t *testing.T) {
 			expectedSecond: []string{"companyplan", "masterplan"},
 		},
 	} {
-		tc := tc
 		t.Run(tc.subject, func(t *testing.T) {
 			t.Parallel()
 
@@ -748,11 +747,9 @@ func TestLookupResources2OverSchemaWithCursors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			for _, pageSize := range []int{0, 104, 1023} {
-				pageSize := pageSize
 				t.Run(fmt.Sprintf("ps-%d_", pageSize), func(t *testing.T) {
 					t.Parallel()
 					require := require.New(t)
@@ -1348,7 +1345,6 @@ func TestLookupResources2EnsureCheckHints(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1460,7 +1456,7 @@ func genRels(resourceName string, relation string, subjectName string, subjectID
 
 func genSubjectRels(resourceName string, relation string, subjectName string, subjectRelation string, number int) []tuple.Relationship {
 	rels := make([]tuple.Relationship, 0, number)
-	for i := 0; i < number; i++ {
+	for i := range number {
 		rel := tuple.Relationship{
 			RelationshipReference: tuple.RelationshipReference{
 				Resource: ONR(resourceName, fmt.Sprintf("%s-%d", resourceName, i), relation),
@@ -1479,7 +1475,7 @@ func genRelsWithCaveat(resourceName string, relation string, subjectName string,
 
 func genRelsWithCaveatAndSubjectRelation(resourceName string, relation string, subjectName string, subjectID string, subjectRelation string, caveatName string, context map[string]any, offset int, number int) []tuple.Relationship {
 	rels := make([]tuple.Relationship, 0, number)
-	for i := 0; i < number; i++ {
+	for i := range number {
 		rel := tuple.Relationship{
 			RelationshipReference: tuple.RelationshipReference{
 				Resource: ONR(resourceName, fmt.Sprintf("%s-%d", resourceName, i+offset), relation),
@@ -1497,7 +1493,7 @@ func genRelsWithCaveatAndSubjectRelation(resourceName string, relation string, s
 
 func genResourceIds(resourceName string, number int) []string {
 	resourceIDs := make([]string, 0, number)
-	for i := 0; i < number; i++ {
+	for i := range number {
 		resourceIDs = append(resourceIDs, fmt.Sprintf("%s-%d", resourceName, i))
 	}
 	return resourceIDs

--- a/internal/dispatch/graph/lookupresources3_test.go
+++ b/internal/dispatch/graph/lookupresources3_test.go
@@ -174,7 +174,6 @@ func TestSimpleLookupResourcesWithCursor3(t *testing.T) {
 			expectedSecond: []string{"companyplan", "masterplan"},
 		},
 	} {
-		tc := tc
 		t.Run(tc.subject, func(t *testing.T) {
 			t.Parallel()
 
@@ -689,11 +688,9 @@ func TestLookupResources3OverSchemaWithCursors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			for _, pageSize := range []int{0, 104, 1023} {
-				pageSize := pageSize
 				t.Run(fmt.Sprintf("ps-%d_", pageSize), func(t *testing.T) {
 					t.Parallel()
 					require := require.New(t)
@@ -1259,7 +1256,6 @@ func TestLookupResources3EnsureCheckHints(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/dispatch/graph/lookupsubjects_test.go
+++ b/internal/dispatch/graph/lookupsubjects_test.go
@@ -130,7 +130,6 @@ func TestSimpleLookupSubjects(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("simple-lookup-subjects:%s:%s:%s:%s:%s", tc.resourceType, tc.resourceID, tc.permission, tc.subjectType, tc.subjectRelation), func(t *testing.T) {
 			t.Parallel()
 
@@ -256,7 +255,6 @@ func TestLookupSubjectsDispatchCount(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("dispatch-count-lookup-subjects:%s:%s:%s:%s:%s", tc.resourceType, tc.resourceID, tc.permission, tc.subjectType, tc.subjectRelation), func(t *testing.T) {
 			t.Parallel()
 
@@ -999,7 +997,6 @@ func TestLookupSubjectsOverSchema(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/dispatch/keys/computed_test.go
+++ b/internal/dispatch/keys/computed_test.go
@@ -405,7 +405,6 @@ func TestStableCacheKeys(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			key := tc.createKey()
 			require.Equal(t, tc.expected, hex.EncodeToString(key.StableSumAsBytes()))
@@ -568,27 +567,20 @@ func TestCacheKeyNoOverlap(t *testing.T) {
 	require.Len(t, cachePrefixes, len(generatorFuncs))
 
 	for _, resourceIds := range allResourceIds {
-		resourceIds := resourceIds
 		t.Run(strings.Join(resourceIds, ","), func(t *testing.T) {
 			for _, subjectIds := range allSubjectIds {
-				subjectIds := subjectIds
 				t.Run(strings.Join(subjectIds, ","), func(t *testing.T) {
 					for _, resourceRelation := range resourceRelations {
-						resourceRelation := resourceRelation
 						t.Run(tuple.StringCoreRR(resourceRelation), func(t *testing.T) {
 							for _, subjectRelation := range subjectRelations {
-								subjectRelation := subjectRelation
 								t.Run(tuple.StringCoreRR(subjectRelation), func(t *testing.T) {
 									for _, revision := range revisions {
-										revision := revision
 										t.Run(revision, func(t *testing.T) {
 											metadata := &v1.ResolverMeta{
 												AtRevision: revision,
 											}
 
 											for prefix, f := range generatorFuncs {
-												prefix := prefix
-												f := f
 												t.Run(prefix, func(t *testing.T) {
 													generated, usedData := f(resourceIds, subjectIds, resourceRelation, subjectRelation, metadata)
 													usedDataString := fmt.Sprintf("%s:%s", prefix, strings.Join(usedData, ","))

--- a/internal/dispatch/remote/cluster.go
+++ b/internal/dispatch/remote/cluster.go
@@ -188,10 +188,7 @@ func (dal *digestAndLock) getWaitTime(maximumHedgingDelay time.Duration) time.Du
 		return dal.startingPrimaryHedgingDelay
 	}
 
-	waitTime := time.Duration(milliseconds) * time.Millisecond
-	if waitTime > maximumHedgingDelay {
-		waitTime = maximumHedgingDelay
-	}
+	waitTime := min(time.Duration(milliseconds)*time.Millisecond, maximumHedgingDelay)
 	return waitTime
 }
 
@@ -501,8 +498,8 @@ func dispatchStreamingRequest[Q streamingRequestMessage, R any](
 	if cursorSupports, ok := any(req).(requestMessageWithCursor); ok {
 		cursor := cursorSupports.GetOptionalCursor()
 		if cursor != nil && len(cursor.Sections) > 0 {
-			if strings.HasPrefix(cursor.Sections[0], secondaryCursorPrefix) {
-				cursorLockedSecondaryName = strings.TrimPrefix(cursor.Sections[0], secondaryCursorPrefix)
+			if after, ok0 := strings.CutPrefix(cursor.Sections[0], secondaryCursorPrefix); ok0 {
+				cursorLockedSecondaryName = after
 				cursor.Sections = cursor.Sections[1:]
 			}
 		}

--- a/internal/dispatch/remote/cluster_test.go
+++ b/internal/dispatch/remote/cluster_test.go
@@ -165,7 +165,6 @@ func TestDispatchTimeout(t *testing.T) {
 			20 * time.Millisecond,
 		},
 	} {
-		tc := tc
 		t.Run(fmt.Sprintf("%v", tc.timeout > tc.sleepTime), func(t *testing.T) {
 			// Configure a fake dispatcher service and an associated buffconn-based
 			// connection to it.
@@ -326,7 +325,6 @@ func TestCheckSecondaryDispatch(t *testing.T) {
 			1,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			conn := connectionForDispatching(t, &fakeDispatchSvc{dispatchCount: 1, sleepTime: tc.primarySleepTime})
@@ -899,7 +897,7 @@ func TestGetPrimaryWaitTime(t *testing.T) {
 	dispatcher := d.(*clusterDispatcher)
 
 	// Add a bunch of times to the secondary.
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		dispatcher.secondaryInitialResponseDigests["check"].addResultTime(2 * time.Millisecond)
 	}
 
@@ -1038,7 +1036,7 @@ func TestSupportedResourceSubjectTrackerParallelUpdates(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			tracker.updateForError(testResourceRelationError{fmt.Errorf("foo"), "document", "viewer"})
 		}
 	}()
@@ -1046,7 +1044,7 @@ func TestSupportedResourceSubjectTrackerParallelUpdates(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			tracker.updateForSuccess(tuple.RR("document", "editor"), tuple.RR("user", "..."))
 		}
 	}()
@@ -1159,7 +1157,7 @@ func TestDALCount(t *testing.T) {
 		lock:   sync.RWMutex{},
 	}
 
-	for i := 0; i < minimumDigestCount-1; i++ {
+	for i := range minimumDigestCount - 1 {
 		uintValue, err := safecast.Convert[uint64](i + 1)
 		require.NoError(t, err)
 

--- a/internal/dispatch/remote/expr_test.go
+++ b/internal/dispatch/remote/expr_test.go
@@ -43,7 +43,6 @@ func TestParseDispatchExpression(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := ParseDispatchExpression("somemethod", tc.expr)
 			if tc.expectedError != "" {
@@ -139,7 +138,6 @@ func TestRunCheckDispatchExpr(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			parsed, err := ParseDispatchExpression("check", tc.expr)
 			require.NoError(t, err)

--- a/internal/dispatch/remote/primarysleeper_test.go
+++ b/internal/dispatch/remote/primarysleeper_test.go
@@ -199,13 +199,11 @@ func TestPrimarySleeper_ConcurrentCancelSleep(t *testing.T) {
 		start := time.Now()
 		var wg sync.WaitGroup
 
-		for i := 0; i < 10; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+		for range 10 {
+			wg.Go(func() {
 				time.Sleep(5 * time.Millisecond)
 				sleeper.cancelSleep()
-			}()
+			})
 		}
 
 		go func() {
@@ -262,7 +260,7 @@ func TestPrimarySleeper_SleepConcurrently(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()

--- a/internal/fdw/stats/stats_test.go
+++ b/internal/fdw/stats/stats_test.go
@@ -319,21 +319,21 @@ func TestConcurrentAccess(t *testing.T) {
 	done := make(chan bool, 3)
 
 	go func() {
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			pkg.AddSample(float32(i), safecast.MustConvert[uint](i*10))
 		}
 		done <- true
 	}()
 
 	go func() {
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			pkg.AddWidthSample(safecast.MustConvert[uint](i * 5))
 		}
 		done <- true
 	}()
 
 	go func() {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			_ = pkg.Explain()
 		}
 		done <- true

--- a/internal/fdw/tables/consistency.go
+++ b/internal/fdw/tables/consistency.go
@@ -57,8 +57,8 @@ func consistencyFromFields(fields fieldMap[string], parameters []wire.Parameter)
 
 	default:
 		isAtExactSnapshot := false
-		if strings.HasPrefix(consistencyFieldValue, consistencyExactPrefix) {
-			consistencyFieldValue = strings.TrimPrefix(consistencyFieldValue, consistencyExactPrefix)
+		if after, ok := strings.CutPrefix(consistencyFieldValue, consistencyExactPrefix); ok {
+			consistencyFieldValue = after
 			isAtExactSnapshot = true
 		}
 

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1066,7 +1066,7 @@ func run[T any, R withError](
 	defer cancelFn()
 
 	results := make([]R, 0, len(children))
-	for i := 0; i < len(children); i++ {
+	for range children {
 		select {
 		case result := <-resultChan:
 			results = append(results, result)
@@ -1104,7 +1104,7 @@ func union[T any](
 	responseMetadata := emptyMetadata
 	membershipSet := NewMembershipSet()
 
-	for i := 0; i < len(children); i++ {
+	for range children {
 		select {
 		case result := <-resultChan:
 			log.Ctx(ctx).Trace().Object("anyResult", result.Resp).Send()
@@ -1156,7 +1156,7 @@ func all[T any](
 	defer cancelFn()
 
 	var membershipSet *MembershipSet
-	for i := 0; i < len(children); i++ {
+	for range children {
 		select {
 		case result := <-resultChan:
 			responseMetadata = combineResponseMetadata(ctx, responseMetadata, result.Resp.Metadata)
@@ -1278,7 +1278,6 @@ func dispatchAllAsync[T any, R withError](
 ) {
 	tr := taskrunner.NewPreloadedTaskRunner(ctx, concurrencyLimit, len(children))
 	for _, currentChild := range children {
-		currentChild := currentChild
 		tr.Add(func(ctx context.Context) error {
 			result := handler(ctx, crc, currentChild)
 			resultChan <- result

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -23,7 +23,6 @@ func TestAsyncDispatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%d/%d", tc.numRequests, tc.concurrencyLimit), func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/graph/computed/computecheck_test.go
+++ b/internal/graph/computed/computecheck_test.go
@@ -803,7 +803,6 @@ func TestComputeCheckWithCaveats(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ds, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, 0, memdb.DisableGC)
 			require.NoError(t, err)
@@ -817,7 +816,6 @@ func TestComputeCheckWithCaveats(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, r := range tt.checks {
-				r := r
 				t.Run(fmt.Sprintf("%s::%v", r.check, r.context), func(t *testing.T) {
 					rel := tuple.MustParse(r.check)
 

--- a/internal/graph/cursors.go
+++ b/internal/graph/cursors.go
@@ -368,8 +368,6 @@ func withInternalParallelizedStreamingIterableInCursor[T any, Q any](
 
 	// Schedule a task to be invoked for each item to be run.
 	for taskIndex, item := range itemsToRun {
-		taskIndex := taskIndex
-		item := item
 		tr.Add(func(ctx context.Context) error {
 			stream.lock.Lock()
 			if ci.limits.hasExhaustedLimit() {

--- a/internal/graph/cursors_test.go
+++ b/internal/graph/cursors_test.go
@@ -273,7 +273,7 @@ func TestWithParallelizedStreamingIterableInCursorEnsureParallelism(t *testing.T
 
 	items := []int{}
 	expected := []int{}
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		items = append(items, i)
 		expected = append(expected, i*10)
 	}

--- a/internal/graph/limits_test.go
+++ b/internal/graph/limits_test.go
@@ -9,7 +9,7 @@ import (
 func TestLimitsPrepareForPublishing(t *testing.T) {
 	limits := newLimitTracker(10)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		result := limits.prepareForPublishing()
 		require.True(t, result)
 	}

--- a/internal/graph/lr3stats_test.go
+++ b/internal/graph/lr3stats_test.go
@@ -146,7 +146,7 @@ func TestEstimatedConcurrencyLimit_CDFBelowThreshold(t *testing.T) {
 
 	// Pre-populate digest map with data that will result in CDF <= 0.1
 	// Add many high values so that the CDF for limit 100 is low
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		crr.digestMap.Add("test-key", 200.0) // Values much higher than limit
 	}
 
@@ -188,7 +188,7 @@ func TestEstimatedConcurrencyLimit_CDFAboveThreshold(t *testing.T) {
 
 	// Pre-populate digest map with data that will result in CDF > 0.1
 	// Add many low values so that the CDF for limit 100 is high
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		crr.digestMap.Add("test-key", 50.0) // Values lower than limit
 	}
 
@@ -232,7 +232,7 @@ func TestEstimatedConcurrencyLimit_CountingIteratorTracksResults(t *testing.T) {
 	fn := func(computedConcurrencyLimit uint16) iter.Seq2[result, error] {
 		return func(yield func(result, error) bool) {
 			// Yield 3 results
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				pramItem := possibleResource{
 					resourceID:    fmt.Sprintf("obj%d", i),
 					forSubjectIDs: []string{"user1"},

--- a/internal/graph/membershipset_test.go
+++ b/internal/graph/membershipset_test.go
@@ -129,7 +129,6 @@ func TestMembershipSetAddDirectMember(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ms := membershipSetFromMap(tc.existingMembers)
 			ms.AddDirectMember(tc.directMemberID, unwrapCaveat(tc.directMemberCaveat))
@@ -232,7 +231,6 @@ func TestMembershipSetAddMemberViaRelationship(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ms := membershipSetFromMap(tc.existingMembers)
 			ms.AddMemberViaRelationship(tc.resourceID, tc.resourceCaveatExpression, tc.parentRelationship)
@@ -374,7 +372,6 @@ func TestMembershipSetUnionWith(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ms1 := membershipSetFromMap(tc.set1)
 			ms2 := membershipSetFromMap(tc.set2)
@@ -551,7 +548,6 @@ func TestMembershipSetIntersectWith(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ms1 := membershipSetFromMap(tc.set1)
 			ms2 := membershipSetFromMap(tc.set2)
@@ -740,7 +736,6 @@ func TestMembershipSetSubtract(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ms1 := membershipSetFromMap(tc.set1)
 			ms2 := membershipSetFromMap(tc.set2)

--- a/internal/graph/resourcesubjectsmap2_test.go
+++ b/internal/graph/resourcesubjectsmap2_test.go
@@ -142,7 +142,6 @@ func TestResourcesSubjectsMap2MapFoundResources(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			rsm := newResourcesSubjectMap2(&core.RelationReference{
 				Namespace: "group",

--- a/internal/lsp/lspdefs.go
+++ b/internal/lsp/lspdefs.go
@@ -5,7 +5,7 @@ import (
 )
 
 type InitializeResult struct {
-	Capabilities ServerCapabilities `json:"capabilities,omitempty"`
+	Capabilities ServerCapabilities `json:"capabilities"`
 }
 
 type ServerCapabilities struct {
@@ -44,7 +44,7 @@ type InitializeParams struct {
 	RootPath string `json:"rootPath,omitempty"`
 
 	RootURI               baselsp.DocumentURI `json:"rootUri,omitempty"`
-	ClientInfo            baselsp.ClientInfo  `json:"clientInfo,omitempty"`
+	ClientInfo            baselsp.ClientInfo  `json:"clientInfo"`
 	Trace                 baselsp.Trace       `json:"trace,omitempty"`
 	InitializationOptions any                 `json:"initializationOptions,omitempty"`
 	Capabilities          ClientCapabilities  `json:"capabilities"`
@@ -53,7 +53,7 @@ type InitializeParams struct {
 }
 
 type ClientCapabilities struct {
-	Diagnostics DiagnosticWorkspaceClientCapabilities `json:"diagnostics,omitempty"`
+	Diagnostics DiagnosticWorkspaceClientCapabilities `json:"diagnostics"`
 }
 
 type DiagnosticWorkspaceClientCapabilities struct {

--- a/internal/namespace/aliasing_test.go
+++ b/internal/namespace/aliasing_test.go
@@ -190,7 +190,6 @@ func TestAliasing(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/namespace/canonicalization_test.go
+++ b/internal/namespace/canonicalization_test.go
@@ -518,7 +518,6 @@ func TestCanonicalization(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -647,7 +646,6 @@ func TestCanonicalizationComparison(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/namespace/caveats_test.go
+++ b/internal/namespace/caveats_test.go
@@ -47,7 +47,6 @@ func TestValidateCaveatDefinition(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.caveat.Name, func(t *testing.T) {
 			err := ValidateCaveatDefinition(caveattypes.Default.TypeSet, tc.caveat)
 			if tc.expectedError != "" {

--- a/internal/namespace/test/serialization_test.go
+++ b/internal/namespace/test/serialization_test.go
@@ -79,7 +79,6 @@ func assertParity(t *testing.T, filenames []string, emptyProto definitionInterfa
 
 func TestSerialization(t *testing.T) {
 	for _, test := range serializationTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/namespace/util_test.go
+++ b/internal/namespace/util_test.go
@@ -58,7 +58,6 @@ func TestListReferencedNamespaces(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/relationships/validation_test.go
+++ b/internal/relationships/validation_test.go
@@ -326,7 +326,6 @@ func TestValidateRelationshipOperations(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			req := require.New(t)

--- a/internal/services/integrationtesting/cert_test.go
+++ b/internal/services/integrationtesting/cert_test.go
@@ -266,7 +266,7 @@ func TestCertRotation(t *testing.T) {
 	require.NoError(t, certFile.Close())
 
 	// check for waitFactor*initialValidDuration seconds
-	for i := 0; i < waitFactor; i++ {
+	for range waitFactor {
 		_, err = client.CheckPermission(ctx, &v1.CheckPermissionRequest{
 			Consistency: &v1.Consistency{
 				Requirement: &v1.Consistency_AtLeastAsFresh{

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -52,13 +52,9 @@ func TestConsistency(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, filePath := range consistencyTestFiles {
-		filePath := filePath
-
 		t.Run(path.Base(filePath), func(t *testing.T) {
 			t.Parallel()
 			for _, dispatcherKind := range []string{"local", "caching"} {
-				dispatcherKind := dispatcherKind
-
 				t.Run(dispatcherKind, func(t *testing.T) {
 					for _, chunkSize := range []uint16{5, 10} {
 						t.Run(fmt.Sprintf("chunk-size-%d", chunkSize), func(t *testing.T) {
@@ -267,8 +263,6 @@ func runConsistencyTestSuiteForFile(t *testing.T, filePath string, useCachingDis
 	// Run consistency tests.
 	testers := consistencytestutil.ServiceTesters(cad.Conn)
 	for _, tester := range testers {
-		tester := tester
-
 		t.Run(tester.Name(), func(t *testing.T) {
 			runConsistencyTestsWithServiceTester(t, cad, tester, headRevision, useCachingDispatcher)
 		})
@@ -342,7 +336,6 @@ func testForEachRelationship(
 	t.Helper()
 
 	for _, relationship := range vctx.clusterAndData.Populated.Relationships {
-		relationship := relationship
 		t.Run(fmt.Sprintf("%s_%s", prefix, tuple.MustString(relationship)),
 			func(t *testing.T) {
 				handler(t, relationship)
@@ -367,9 +360,7 @@ func testForEachResource(
 
 		resourceType := resourceType
 		for _, relation := range resourceType.Relation {
-			relation := relation
 			for _, resource := range resources {
-				resource := resource
 				t.Run(fmt.Sprintf("%s_%s_%s_%s", prefix, resourceType.Name, resource.ObjectID, relation.Name),
 					func(t *testing.T) {
 						handler(t, tuple.ObjectAndRelation{
@@ -391,9 +382,7 @@ func testForEachResourceType(
 	handler func(t *testing.T, resourceType tuple.RelationReference),
 ) {
 	for _, resourceType := range vctx.clusterAndData.Populated.NamespaceDefinitions {
-		resourceType := resourceType
 		for _, relation := range resourceType.Relation {
-			relation := relation
 			t.Run(fmt.Sprintf("%s_%s_%s_", prefix, resourceType.Name, relation.Name),
 				func(t *testing.T) {
 					handler(t, tuple.RelationReference{
@@ -523,10 +512,8 @@ func validateLookupResources(t *testing.T, vctx validationContext) {
 	testForEachResourceType(t, vctx, "validate_lookup_resources",
 		func(t *testing.T, resourceRelation tuple.RelationReference) {
 			for _, subject := range vctx.accessibilitySet.AllSubjectsNoWildcards() {
-				subject := subject
 				t.Run(tuple.StringONR(subject), func(t *testing.T) {
 					for _, pageSize := range []uint32{0, 2} {
-						pageSize := pageSize
 						t.Run(fmt.Sprintf("pagesize-%d", pageSize), func(t *testing.T) {
 							accessibleResources := vctx.accessibilitySet.LookupAccessibleResources(resourceRelation, subject)
 
@@ -534,7 +521,7 @@ func validateLookupResources(t *testing.T, vctx validationContext) {
 							// Loop until all resources have been found or we've hit max iterations.
 							var currentCursor *v1.Cursor
 							resolvedResources := map[string]*v1.LookupResourcesResponse{}
-							for i := 0; i < 100; i++ {
+							for range 100 {
 								foundResources, lastCursor, err := vctx.serviceTester.LookupResources(t.Context(), resourceRelation, subject, vctx.revision, currentCursor, pageSize, nil)
 								require.NoError(t, err)
 
@@ -632,7 +619,6 @@ func validateLookupSubjects(t *testing.T, vctx validationContext) {
 	testForEachResource(t, vctx, "validate_lookup_subjects",
 		func(t *testing.T, resource tuple.ObjectAndRelation) {
 			for _, subjectType := range vctx.accessibilitySet.SubjectTypes() {
-				subjectType := subjectType
 				t.Run(fmt.Sprintf("%s#%s", subjectType.ObjectType, subjectType.Relation),
 					func(t *testing.T) {
 						resolvedSubjects, err := vctx.serviceTester.LookupSubjects(t.Context(), resource, subjectType, vctx.revision, nil)
@@ -816,7 +802,6 @@ func runAssertions(t *testing.T, vctx validationContext) {
 					v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION,
 				},
 			} {
-				entry := entry
 				t.Run(entry.name, func(t *testing.T) {
 					bulkCheckItems := make([]*v1.BulkCheckPermissionRequestItem, 0, len(entry.assertions))
 
@@ -967,7 +952,6 @@ func validateDevelopmentChecks(t *testing.T, devContext *development.DevContext,
 	testForEachResource(t, vctx, "validate_check_watch",
 		func(t *testing.T, resource tuple.ObjectAndRelation) {
 			for _, subject := range vctx.accessibilitySet.AllSubjectsNoWildcards() {
-				subject := subject
 				t.Run(tuple.StringONR(subject), func(t *testing.T) {
 					require.NotNil(t, devContext)
 					cr, err := development.RunCheck(devContext, resource, subject, nil)

--- a/internal/services/integrationtesting/ops_test.go
+++ b/internal/services/integrationtesting/ops_test.go
@@ -751,11 +751,9 @@ func TestSchemaAndRelationshipsOperations(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			for _, testerName := range []string{"v1"} {
-				testerName := testerName
 				t.Run(testerName, func(t *testing.T) {
 					conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, false, tf.EmptyDatastore)
 					t.Cleanup(cleanup)

--- a/internal/services/integrationtesting/query_plan_consistency_test.go
+++ b/internal/services/integrationtesting/query_plan_consistency_test.go
@@ -197,7 +197,6 @@ func runQueryPlanLookupResources(t *testing.T, handle *queryPlanConsistencyHandl
 		func(t *testing.T, resourceRelation tuple.RelationReference) {
 			t.Parallel()
 			for _, subject := range accessibilitySet.AllSubjectsNoWildcards() {
-				subject := subject
 				t.Run(tuple.StringONR(subject), func(t *testing.T) {
 					accessibleResources := accessibilitySet.LookupAccessibleResources(resourceRelation, subject)
 					queryCtx := handle.buildContext(t)
@@ -248,7 +247,6 @@ func runQueryPlanLookupSubjects(t *testing.T, handle *queryPlanConsistencyHandle
 		func(t *testing.T, resourceRelation tuple.RelationReference) {
 			t.Parallel()
 			for _, resource := range accessibilitySet.AllResourcesNoWildcards() {
-				resource := resource
 				// Only test resources that match the current resource type
 				if resource.ObjectType != resourceRelation.ObjectType || resource.Relation != resourceRelation.Relation {
 					continue

--- a/internal/services/v1/bulkcheck.go
+++ b/internal/services/v1/bulkcheck.go
@@ -242,8 +242,6 @@ func (bc *bulkChecker) checkBulkPermissions(ctx context.Context, req *v1.CheckBu
 	}
 
 	for _, group := range groupedItems {
-		group := group
-
 		slicez.ForEachChunk(group.resourceIDs, bc.dispatchChunkSize, func(resourceIDs []string) {
 			tr.Add(func(ctx context.Context) error {
 				startTime := time.Now()

--- a/internal/services/v1/debug_test.go
+++ b/internal/services/v1/debug_test.go
@@ -482,7 +482,6 @@ func TestCheckPermissionWithDebug(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			req := require.New(t)
 			conn, cleanup, _, revision := testserver.NewTestServer(req, 5*time.Second, memdb.DisableGC, true,
@@ -497,7 +496,6 @@ func TestCheckPermissionWithDebug(t *testing.T) {
 			ctx = requestmeta.AddRequestHeaders(ctx, requestmeta.RequestDebugInformation)
 
 			for _, stc := range tc.toTest {
-				stc := stc
 				t.Run(stc.name, func(t *testing.T) {
 					req := require.New(t)
 
@@ -738,7 +736,7 @@ func TestBulkCheckPermissionWithDebug(t *testing.T) {
 				// 100 IDs is the default batch size, so 99 + `first`.
 				docsSlice := make([]string, 0, 99)
 				docsSlice = append(docsSlice, "first")
-				for i := 0; i < 99; i++ {
+				for i := range 99 {
 					docsSlice = append(docsSlice, fmt.Sprintf("doc-%d", i))
 				}
 
@@ -770,7 +768,7 @@ func TestBulkCheckPermissionWithDebug(t *testing.T) {
 					},
 				}
 
-				for i := 0; i < 500; i++ {
+				for i := range 500 {
 					items = append(items, bulkCheckItem{
 						toCheck: fmt.Sprintf("document:doc-%d#view@user:tom", i),
 						rda:     nil,
@@ -879,7 +877,6 @@ func TestBulkCheckPermissionWithDebug(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			req := require.New(t)
 			conn, cleanup, _, revision := testserver.NewTestServer(req, 5*time.Second, memdb.DisableGC, true,

--- a/internal/services/v1/experimental_test.go
+++ b/internal/services/v1/experimental_test.go
@@ -50,10 +50,8 @@ func TestBulkImportRelationships(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			for _, withCaveats := range []bool{true, false} {
-				withCaveats := withCaveats
 				t.Run(fmt.Sprintf("withCaveats=%t", withCaveats), func(t *testing.T) {
 					require := require.New(t)
 
@@ -71,7 +69,7 @@ func TestBulkImportRelationships(t *testing.T) {
 						batchSize := tc.batchSize()
 						batch := make([]*v1.Relationship, 0, batchSize)
 
-						for i := uint64(0); i < batchSize; i++ {
+						for i := range batchSize {
 							if withCaveats {
 								batch = append(batch, mustRelWithCaveatAndContext(
 									tf.DocumentNS.Name,
@@ -313,7 +311,6 @@ func TestBulkExportRelationshipsWithFilter(t *testing.T) {
 	batchSize := uint32(14)
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)
@@ -526,7 +523,7 @@ func TestBulkCheckPermission(t *testing.T) {
 			name: "chunking test",
 			requests: (func() []string {
 				toReturn := make([]string, 0, defaultFilterMaximumIDCountForTest+5)
-				for i := 0; i < int(defaultFilterMaximumIDCountForTest+5); i++ {
+				for i := range int(defaultFilterMaximumIDCountForTest + 5) {
 					toReturn = append(toReturn, fmt.Sprintf(`document:masterplan-%d#view@user:eng_lead`, i))
 				}
 
@@ -534,7 +531,7 @@ func TestBulkCheckPermission(t *testing.T) {
 			})(),
 			response: (func() []bulkCheckTest {
 				toReturn := make([]bulkCheckTest, 0, defaultFilterMaximumIDCountForTest+5)
-				for i := 0; i < int(defaultFilterMaximumIDCountForTest+5); i++ {
+				for i := range int(defaultFilterMaximumIDCountForTest + 5) {
 					toReturn = append(toReturn, bulkCheckTest{
 						req:  fmt.Sprintf(`document:masterplan-%d#view@user:eng_lead`, i),
 						resp: v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION,
@@ -550,7 +547,7 @@ func TestBulkCheckPermission(t *testing.T) {
 				toReturn := make([]string, 0, defaultFilterMaximumIDCountForTest+6)
 				toReturn = append(toReturn, `nondoc:masterplan#view@user:eng_lead`)
 
-				for i := 0; i < int(defaultFilterMaximumIDCountForTest+5); i++ {
+				for i := range int(defaultFilterMaximumIDCountForTest + 5) {
 					toReturn = append(toReturn, fmt.Sprintf(`document:masterplan-%d#view@user:eng_lead`, i))
 				}
 
@@ -563,7 +560,7 @@ func TestBulkCheckPermission(t *testing.T) {
 					err: namespace.NewNamespaceNotFoundErr("nondoc"),
 				})
 
-				for i := 0; i < int(defaultFilterMaximumIDCountForTest+5); i++ {
+				for i := range int(defaultFilterMaximumIDCountForTest + 5) {
 					toReturn = append(toReturn, bulkCheckTest{
 						req:  fmt.Sprintf(`document:masterplan-%d#view@user:eng_lead`, i),
 						resp: v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION,
@@ -593,7 +590,6 @@ func TestBulkCheckPermission(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			req := v1.BulkCheckPermissionRequest{
 				Consistency: &v1.Consistency{
@@ -750,7 +746,6 @@ func TestExperimentalSchemaDiff(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Write the existing schema.
 			_, err := schemaClient.WriteSchema(t.Context(), &v1.WriteSchemaRequest{
@@ -1164,7 +1159,6 @@ definition user {}`,
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Write the schema.
 			_, err := schemaClient.WriteSchema(t.Context(), &v1.WriteSchemaRequest{
@@ -1391,7 +1385,6 @@ func TestExperimentalDependentRelations(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 			expClient := v1.NewExperimentalServiceClient(conn)
@@ -1591,7 +1584,6 @@ func TestExperimentalComputablePermissions(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 			expClient := v1.NewExperimentalServiceClient(conn)

--- a/internal/services/v1/expreflection_test.go
+++ b/internal/services/v1/expreflection_test.go
@@ -779,7 +779,6 @@ func TestExpSchemaFiltering(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			sf, err := newexpSchemaFilters(tc.filters)
 			require.NoError(t, err)
@@ -896,7 +895,6 @@ func TestExpNewexpSchemaFilters(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := newexpSchemaFilters(tc.filters)
 			if tc.err == "" {

--- a/internal/services/v1/hash_test.go
+++ b/internal/services/v1/hash_test.go
@@ -191,7 +191,6 @@ func TestReadRelationshipsHashStability(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			verr := tc.request.Validate()
 			require.NoError(t, verr)
@@ -386,7 +385,6 @@ func TestLRHashStability(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			verr := tc.request.Validate()
 			require.NoError(t, verr)
@@ -594,7 +592,6 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			verr := tc.request.Validate()
 			require.NoError(t, verr)
@@ -802,7 +799,6 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			verr := tc.request.Validate()
 			require.NoError(t, verr)

--- a/internal/services/v1/metadata_test.go
+++ b/internal/services/v1/metadata_test.go
@@ -238,7 +238,7 @@ func checkServiceMethods[T any](
 	client T,
 	handlers map[string]func(t *testing.T, client T) metadata.MD,
 ) {
-	et := reflect.TypeOf(new(T)).Elem()
+	et := reflect.TypeFor[T]()
 	for i := 0; i < et.NumMethod(); i++ {
 		methodName := et.Method(i).Name
 		t.Run(methodName, func(t *testing.T) {

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -250,13 +250,10 @@ func TestCheckPermissions(t *testing.T) {
 	}
 
 	for _, delta := range testTimedeltas {
-		delta := delta
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 			for _, debug := range []bool{false, true} {
-				debug := debug
 				t.Run(fmt.Sprintf("debug%v", debug), func(t *testing.T) {
 					for _, tc := range testCases {
-						tc := tc
 						t.Run(fmt.Sprintf(
 							"%s:%s#%s@%s:%s#%s",
 							tc.resource.ObjectType,
@@ -623,13 +620,10 @@ func TestLookupResources(t *testing.T) {
 	}
 
 	for _, delta := range testTimedeltas {
-		delta := delta
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 			for _, tc := range testCases {
-				tc := tc
 				t.Run(fmt.Sprintf("%s::%s from %s:%s#%s", tc.objectType, tc.permission, tc.subject.Object.ObjectType, tc.subject.Object.ObjectId, tc.subject.OptionalRelation), func(t *testing.T) {
 					for _, useV2 := range []bool{false, true} {
-						useV2 := useV2
 						t.Run(fmt.Sprintf("v2:%v", useV2), func(t *testing.T) {
 							require := require.New(t)
 							conn, cleanup, _, revision := testserver.NewTestServerWithConfig(
@@ -714,10 +708,8 @@ func TestExpand(t *testing.T) {
 	}
 
 	for _, delta := range testTimedeltas {
-		delta := delta
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 			for _, tc := range testCases {
-				tc := tc
 				t.Run(fmt.Sprintf("%s:%s#%s", tc.startObjectType, tc.startObjectID, tc.startPermission), func(t *testing.T) {
 					require := require.New(t)
 					conn, cleanup, _, revision := testserver.NewTestServer(require, delta, memdb.DisableGC, true, tf.StandardDatastoreWithData)
@@ -845,7 +837,6 @@ func TestTranslateExpansionTree(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			out := v1svc.TranslateRelationshipTree(v1svc.TranslateExpansionTree(tt.input))
 			require.Equal(t, tt.input, out)
@@ -984,10 +975,8 @@ func TestLookupSubjects(t *testing.T) {
 	}
 
 	for _, delta := range testTimedeltas {
-		delta := delta
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 			for _, tc := range testCases {
-				tc := tc
 				t.Run(fmt.Sprintf("%s:%s#%s for %s#%s", tc.resource.ObjectType, tc.resource.ObjectId, tc.permission, tc.subjectType, tc.subjectRelation), func(t *testing.T) {
 					require := require.New(t)
 					conn, cleanup, _, revision := testserver.NewTestServer(require, delta, memdb.DisableGC, true, tf.StandardDatastoreWithData)
@@ -1158,7 +1147,6 @@ func TestCheckWithCaveatErrors(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			request := &v1.CheckPermissionRequest{
 				Consistency: &v1.Consistency{
@@ -1577,7 +1565,7 @@ func bySubjectID(a, b expectedSubject) int {
 
 func generateMap(length int) map[string]any {
 	output := make(map[string]any, length)
-	for i := 0; i < length; i++ {
+	for range length {
 		random := randString(32)
 		output[random] = random
 	}
@@ -1655,13 +1643,10 @@ func TestLookupResourcesWithCursors(t *testing.T) {
 	}
 
 	for _, delta := range testTimedeltas {
-		delta := delta
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 			for _, limit := range []int{1, 2, 5, 10, 100} {
-				limit := limit
 				t.Run(fmt.Sprintf("limit%d", limit), func(t *testing.T) {
 					for _, tc := range testCases {
-						tc := tc
 						t.Run(fmt.Sprintf("%s::%s from %s:%s#%s", tc.objectType, tc.permission, tc.subject.Object.ObjectType, tc.subject.Object.ObjectId, tc.subject.OptionalRelation), func(t *testing.T) {
 							require := require.New(t)
 							conn, cleanup, _, revision := testserver.NewTestServer(require, delta, memdb.DisableGC, true, tf.StandardDatastoreWithData)
@@ -1672,7 +1657,7 @@ func TestLookupResourcesWithCursors(t *testing.T) {
 							var currentCursor *v1.Cursor
 							foundObjectIds := mapz.NewSet[string]()
 
-							for i := 0; i < 5; i++ {
+							for range 5 {
 								var trailer metadata.MD
 								uintLimit, err := safecast.Convert[uint32](limit)
 								require.NoError(err)
@@ -1913,7 +1898,7 @@ func TestCheckBulkPermissions(t *testing.T) {
 			name: "chunking test",
 			requests: (func() []string {
 				toReturn := make([]string, 0, defaultFilterMaximumIDCountForTest+5)
-				for i := 0; i < int(defaultFilterMaximumIDCountForTest+5); i++ {
+				for i := range int(defaultFilterMaximumIDCountForTest + 5) {
 					toReturn = append(toReturn, fmt.Sprintf(`document:masterplan-%d#view@user:eng_lead`, i))
 				}
 
@@ -1921,7 +1906,7 @@ func TestCheckBulkPermissions(t *testing.T) {
 			})(),
 			response: (func() []bulkCheckTest {
 				toReturn := make([]bulkCheckTest, 0, defaultFilterMaximumIDCountForTest+5)
-				for i := 0; i < int(defaultFilterMaximumIDCountForTest+5); i++ {
+				for i := range int(defaultFilterMaximumIDCountForTest + 5) {
 					toReturn = append(toReturn, bulkCheckTest{
 						req:  fmt.Sprintf(`document:masterplan-%d#view@user:eng_lead`, i),
 						resp: v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION,
@@ -1937,7 +1922,7 @@ func TestCheckBulkPermissions(t *testing.T) {
 				toReturn := make([]string, 0, defaultFilterMaximumIDCountForTest+6)
 				toReturn = append(toReturn, `nondoc:masterplan#view@user:eng_lead`)
 
-				for i := 0; i < int(defaultFilterMaximumIDCountForTest+5); i++ {
+				for i := range int(defaultFilterMaximumIDCountForTest + 5) {
 					toReturn = append(toReturn, fmt.Sprintf(`document:masterplan-%d#view@user:eng_lead`, i))
 				}
 
@@ -1950,7 +1935,7 @@ func TestCheckBulkPermissions(t *testing.T) {
 					err: namespace.NewNamespaceNotFoundErr("nondoc"),
 				})
 
-				for i := 0; i < int(defaultFilterMaximumIDCountForTest+5); i++ {
+				for i := range int(defaultFilterMaximumIDCountForTest + 5) {
 					toReturn = append(toReturn, bulkCheckTest{
 						req:  fmt.Sprintf(`document:masterplan-%d#view@user:eng_lead`, i),
 						resp: v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION,
@@ -1980,7 +1965,6 @@ func TestCheckBulkPermissions(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			for _, withTracing := range []bool{true, false} {
 				t.Run(fmt.Sprintf("withTracing=%t", withTracing), func(t *testing.T) {
@@ -2092,7 +2076,6 @@ func TestImportBulkRelationships(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, withTrait := range []string{"", "caveated_viewer", "expiring_viewer"} {
-				withTrait := withTrait
 				t.Run(fmt.Sprintf("withTrait=%s", withTrait), func(t *testing.T) {
 					require := require.New(t)
 
@@ -2110,7 +2093,7 @@ func TestImportBulkRelationships(t *testing.T) {
 						batchSize := tc.batchSize()
 						batch := make([]*v1.Relationship, 0, batchSize)
 
-						for i := uint64(0); i < batchSize; i++ {
+						for i := range batchSize {
 							switch withTrait {
 							case "caveated_viewer":
 								batch = append(batch, mustRelWithCaveatAndContext(
@@ -2359,7 +2342,6 @@ func TestExportBulkRelationshipsWithFilter(t *testing.T) {
 	batchSize := uint32(14)
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/services/v1/reflectionapi_test.go
+++ b/internal/services/v1/reflectionapi_test.go
@@ -781,7 +781,6 @@ func TestSchemaFiltering(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			sf, err := newSchemaFilters(tc.filters)
 			require.NoError(t, err)
@@ -898,7 +897,6 @@ func TestNewSchemaFilters(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := newSchemaFilters(tc.filters)
 			if tc.err == "" {

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -276,13 +276,10 @@ func TestReadRelationships(t *testing.T) {
 	}
 
 	for _, pageSize := range []int{0, 1, 5, 10} {
-		pageSize := pageSize
 		t.Run(fmt.Sprintf("page%d_", pageSize), func(t *testing.T) {
 			for _, delta := range testTimedeltas {
-				delta := delta
 				t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 					for _, tc := range testCases {
-						tc := tc
 						t.Run(tc.name, func(t *testing.T) {
 							require := require.New(t)
 							conn, cleanup, _, revision := testserver.NewTestServer(require, delta, memdb.DisableGC, true, tf.StandardDatastoreWithData)
@@ -299,7 +296,7 @@ func TestReadRelationships(t *testing.T) {
 
 							uintPageSize, err := safecast.Convert[uint32](pageSize)
 							require.NoError(err)
-							for i := 0; i < 20; i++ {
+							for range 20 {
 								stream, err := client.ReadRelationships(t.Context(), &v1.ReadRelationshipsRequest{
 									Consistency: &v1.Consistency{
 										Requirement: &v1.Consistency_AtLeastAsFresh{
@@ -876,10 +873,8 @@ func TestInvalidWriteRelationship(t *testing.T) {
 	}
 
 	for _, delta := range testTimedeltas {
-		delta := delta
 		t.Run(fmt.Sprintf("fuzz%d", delta/time.Millisecond), func(t *testing.T) {
 			for _, tc := range testCases {
-				tc := tc
 				t.Run(tc.name, func(t *testing.T) {
 					require := require.New(t)
 					conn, cleanup, _, _ := testserver.NewTestServer(require, 0, memdb.DisableGC, true, tf.StandardDatastoreWithData)
@@ -1248,9 +1243,7 @@ func TestDeleteRelationships(t *testing.T) {
 		},
 	}
 	for _, delta := range testTimedeltas {
-		delta := delta
 		for _, tc := range testCases {
-			tc := tc
 			t.Run(fmt.Sprintf("fuzz%d/%s", delta/time.Millisecond, tc.name), func(t *testing.T) {
 				require := require.New(t)
 				conn, cleanup, ds, revision := testserver.NewTestServer(require, delta, memdb.DisableGC, true, tf.StandardDatastoreWithData)
@@ -1350,7 +1343,6 @@ func TestDeleteRelationshipsBeyondLimitPartial(t *testing.T) {
 	}
 
 	for _, batchSize := range []int{5, 6, 7, 10} {
-		batchSize := batchSize
 		require.Greater(t, len(expected), batchSize)
 
 		t.Run(fmt.Sprintf("batchsize-%d", batchSize), func(t *testing.T) {
@@ -1362,7 +1354,7 @@ func TestDeleteRelationshipsBeyondLimitPartial(t *testing.T) {
 			iterations := 0
 			uintBatchSize, err := safecast.Convert[uint32](batchSize)
 			require.NoError(err)
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				iterations++
 
 				headRev, err := ds.HeadRevision(t.Context())
@@ -1710,9 +1702,9 @@ func TestReadRelationshipsWithTimeout(t *testing.T) {
 
 	// Write additional test data.
 	counter := 0
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		updates := make([]*v1.RelationshipUpdate, 0, 100)
-		for j := 0; j < 1000; j++ {
+		for range 1000 {
 			counter++
 			updates = append(updates, &v1.RelationshipUpdate{
 				Operation:    v1.RelationshipUpdate_OPERATION_CREATE,
@@ -1727,7 +1719,7 @@ func TestReadRelationshipsWithTimeout(t *testing.T) {
 	}
 
 	retryCount := 5
-	for i := 0; i < retryCount; i++ {
+	for range retryCount {
 		// Perform a read and ensures it times out.
 		stream, err := client.ReadRelationships(t.Context(), &v1.ReadRelationshipsRequest{
 			Consistency: &v1.Consistency{
@@ -1842,11 +1834,10 @@ func TestManyConcurrentWriteRelationshipsReturnsSerializationErrorOnMemdb(t *tes
 	// is limited.
 	g := errgroup.Group{}
 
-	for i := 0; i < 50; i++ {
-		i := i
+	for i := range 50 {
 		g.Go(func() error {
 			updates := []*v1.RelationshipUpdate{}
-			for j := 0; j < 500; j++ {
+			for j := range 500 {
 				updates = append(updates, &v1.RelationshipUpdate{
 					Operation:    v1.RelationshipUpdate_OPERATION_CREATE,
 					Relationship: tuple.ToV1Relationship(tuple.MustParse(fmt.Sprintf("document:doc-%d-%d#viewer@user:tom", i, j))),

--- a/internal/services/v1/schema_test.go
+++ b/internal/services/v1/schema_test.go
@@ -766,7 +766,6 @@ func TestSchemaDiff(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Write the existing schema.
 			_, err := schemaClient.WriteSchema(t.Context(), &v1.WriteSchemaRequest{
@@ -1179,7 +1178,6 @@ definition user {}`,
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Write the schema.
 			_, err := schemaClient.WriteSchema(t.Context(), &v1.WriteSchemaRequest{
@@ -1406,7 +1404,6 @@ func TestDependentRelations(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 			schemaClient := v1.NewSchemaServiceClient(conn)
@@ -1605,7 +1602,6 @@ func TestComputablePermissions(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, tf.EmptyDatastore)
 			schemaClient := v1.NewSchemaServiceClient(conn)

--- a/internal/services/v1/watch_test.go
+++ b/internal/services/v1/watch_test.go
@@ -343,7 +343,6 @@ definition document {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/taskrunner/preloadedtaskrunner_test.go
+++ b/internal/taskrunner/preloadedtaskrunner_test.go
@@ -24,7 +24,7 @@ func TestPreloadedTaskRunnerCompletesAllTasks(t *testing.T) {
 	tr := NewPreloadedTaskRunner(t.Context(), 2, 5)
 	wg := sync.WaitGroup{}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		wg.Add(1)
 		i := i
 		tr.Add(func(ctx context.Context) error {
@@ -51,8 +51,7 @@ func TestPreloadedTaskRunnerCancelsEarlyDueToError(t *testing.T) {
 	tr := NewPreloadedTaskRunner(ctx, 3, 10)
 	completed := sync.Map{}
 
-	for i := 0; i < 10; i++ {
-		i := i
+	for i := range 10 {
 		tr.Add(func(ctx context.Context) error {
 			if i == 1 {
 				return fmt.Errorf("some error")
@@ -69,7 +68,7 @@ func TestPreloadedTaskRunnerCancelsEarlyDueToError(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	count := 0
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if _, ok := completed.Load(i); ok {
 			count++
 		}
@@ -89,8 +88,7 @@ func TestPreloadedTaskRunnerCancelsEarlyDueToCancel(t *testing.T) {
 	tr := NewPreloadedTaskRunner(ctx, 3, 10)
 	completed := sync.Map{}
 
-	for i := 0; i < 10; i++ {
-		i := i
+	for i := range 10 {
 		tr.Add(func(ctx context.Context) error {
 			if i == 1 {
 				cancel()
@@ -108,7 +106,7 @@ func TestPreloadedTaskRunnerCancelsEarlyDueToCancel(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	count := 0
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if _, ok := completed.Load(i); ok {
 			count++
 		}
@@ -128,8 +126,7 @@ func TestPreloadedTaskRunnerReturnsError(t *testing.T) {
 	tr := NewPreloadedTaskRunner(ctx, 3, 10)
 	completed := sync.Map{}
 
-	for i := 0; i < 10; i++ {
-		i := i
+	for i := range 10 {
 		tr.Add(func(ctx context.Context) error {
 			if i == 1 {
 				return fmt.Errorf("some error")
@@ -147,7 +144,7 @@ func TestPreloadedTaskRunnerReturnsError(t *testing.T) {
 	require.ErrorContains(t, err, "some error")
 
 	count := 0
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if _, ok := completed.Load(i); ok {
 			count++
 		}

--- a/internal/taskrunner/taskrunner_test.go
+++ b/internal/taskrunner/taskrunner_test.go
@@ -19,8 +19,7 @@ func TestTaskRunnerCompletesAllTasks(t *testing.T) {
 	tr := NewTaskRunner(t.Context(), 2)
 	completed := sync.Map{}
 
-	for i := 0; i < 5; i++ {
-		i := i
+	for i := range 5 {
 		tr.Schedule(func(ctx context.Context) error {
 			time.Sleep(time.Duration(i*10) * time.Millisecond)
 			completed.Store(i, true)
@@ -33,7 +32,7 @@ func TestTaskRunnerCompletesAllTasks(t *testing.T) {
 		require.NoError(t, err)
 	}, 5*time.Second)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		vle, ok := completed.Load(i)
 		require.True(t, ok)
 		require.True(t, vle.(bool))
@@ -50,8 +49,7 @@ func TestTaskRunnerCancelsEarlyDueToError(t *testing.T) {
 	tr := NewTaskRunner(ctx, 3)
 	completed := sync.Map{}
 
-	for i := 0; i < 10; i++ {
-		i := i
+	for i := range 10 {
 		tr.Schedule(func(ctx context.Context) error {
 			if i == 1 {
 				return fmt.Errorf("some error")
@@ -70,7 +68,7 @@ func TestTaskRunnerCancelsEarlyDueToError(t *testing.T) {
 	}, 5*time.Second)
 
 	count := 0
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if _, ok := completed.Load(i); ok {
 			count++
 		}
@@ -89,8 +87,7 @@ func TestTaskRunnerCancelsEarlyDueToCancel(t *testing.T) {
 	tr := NewTaskRunner(ctx, 3)
 	completed := sync.Map{}
 
-	for i := 0; i < 10; i++ {
-		i := i
+	for i := range 10 {
 		tr.Schedule(func(ctx context.Context) error {
 			if i == 1 {
 				cancel()
@@ -110,7 +107,7 @@ func TestTaskRunnerCancelsEarlyDueToCancel(t *testing.T) {
 	}, 5*time.Second)
 
 	count := 0
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if _, ok := completed.Load(i); ok {
 			count++
 		}

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -150,7 +150,7 @@ func TestClusterWithDispatchAndCacheConfig(t testing.TB, size uint, ds datastore
 
 	// make placeholder resolved addresses, 1 per node
 	addresses := make([]resolver.Address, 0, size)
-	for i := uint(0); i < size; i++ {
+	for i := range size {
 		addresses = append(addresses, resolver.Address{
 			Addr:       fmt.Sprintf("%s_%d", prefix, i),
 			ServerName: "",
@@ -162,7 +162,7 @@ func TestClusterWithDispatchAndCacheConfig(t testing.TB, size uint, ds datastore
 	conns := make([]*grpc.ClientConn, 0, size)
 	cancelFuncs := make([]func(), 0, size)
 
-	for i := uint(0); i < size; i++ {
+	for i := range size {
 		dispatcherOptions := []combineddispatch.Option{
 			combineddispatch.UpstreamAddr("test://" + prefix),
 			combineddispatch.PrometheusSubsystem(fmt.Sprintf("%s_%d_client_dispatch", prefix, i)),

--- a/internal/testutil/subjects_test.go
+++ b/internal/testutil/subjects_test.go
@@ -149,7 +149,6 @@ func TestCompareSubjects(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("%s vs %s", FormatSubject(tc.first), FormatSubject(tc.second)), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -98,7 +98,7 @@ func testCacheImplementation(t *testing.T, factory func() (Cache[StringKey, stri
 		cache, err := factory()
 		require.NoError(t, err)
 
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			cache.Close()
 		}
 	})

--- a/pkg/caveats/compile_test.go
+++ b/pkg/caveats/compile_test.go
@@ -189,7 +189,6 @@ func TestCompile(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			compiled, err := compileCaveat(tc.env, tc.exprString)
 			if len(tc.expectedErrors) == 0 {
@@ -219,7 +218,6 @@ func TestSerialization(t *testing.T) {
 	exprs := []string{"a == 1", "a + b == 2", "b - a == 4", "l.all(i, i > 42)"}
 
 	for _, expr := range exprs {
-		expr := expr
 		t.Run(expr, func(t *testing.T) {
 			vars := map[string]types.VariableType{
 				"a": types.Default.IntType,
@@ -368,7 +366,6 @@ func TestRewriteVariable(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("%s::%s->%s", tc.expr, tc.oldVarName, tc.newVarName), func(t *testing.T) {
 			env := MustEnvForVariablesWithDefaultTypeSet(tc.vars)
 

--- a/pkg/caveats/context_test.go
+++ b/pkg/caveats/context_test.go
@@ -110,7 +110,6 @@ func TestConvertContextToStruct(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := ConvertContextToStruct(tc.input)
 			require.NoError(t, err)

--- a/pkg/caveats/eval_test.go
+++ b/pkg/caveats/eval_test.go
@@ -356,7 +356,6 @@ func TestEvaluateCaveat(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			compiled, err := compileCaveat(tc.env, tc.exprString)
 			require.NoError(t, err)

--- a/pkg/caveats/replacer/replacer_test.go
+++ b/pkg/caveats/replacer/replacer_test.go
@@ -62,7 +62,6 @@ func TestReplaceVariable(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env, err := cel.NewEnv(
 				cel.Variable("x", cel.IntType),

--- a/pkg/caveats/structure_test.go
+++ b/pkg/caveats/structure_test.go
@@ -89,7 +89,6 @@ func TestReferencedParameters(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.expr, func(t *testing.T) {
 			compiled, err := compileCaveat(tc.env, tc.expr)
 			require.NoError(t, err)

--- a/pkg/caveats/types/encoded_test.go
+++ b/pkg/caveats/types/encoded_test.go
@@ -45,7 +45,6 @@ func TestEncodeDecodeTypes(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.vtype.String(), func(t *testing.T) {
 			encoded := EncodeParameterType(tc.vtype)
 			decoded, err := DecodeParameterType(Default.TypeSet, encoded)

--- a/pkg/caveats/types/ipaddress.go
+++ b/pkg/caveats/types/ipaddress.go
@@ -37,7 +37,7 @@ func (ipa IPAddress) SerializedString() string {
 }
 
 func (ipa IPAddress) ConvertToNative(typeDesc reflect.Type) (any, error) {
-	if typeDesc == reflect.TypeOf("") {
+	if typeDesc == reflect.TypeFor[string]() {
 		return ipa.ip.String(), nil
 	}
 	return nil, fmt.Errorf("type conversion error from 'IPAddress' to '%v'", typeDesc)

--- a/pkg/caveats/types/map_test.go
+++ b/pkg/caveats/types/map_test.go
@@ -54,7 +54,6 @@ func TestMapSubtree(t *testing.T) {
 		},
 	}
 	for _, tt := range tcs {
-		tt := tt
 		t.Run("", func(t *testing.T) {
 			require.Equal(t, tt.subtree, subtree(tt.map1, tt.map2))
 		})

--- a/pkg/caveats/types/types_test.go
+++ b/pkg/caveats/types/types_test.go
@@ -281,7 +281,6 @@ func TestConversion(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := tc.vtype.ConvertValue(tc.inputValue)
 			if err != nil {

--- a/pkg/cmd/server/middleware_test.go
+++ b/pkg/cmd/server/middleware_test.go
@@ -78,7 +78,6 @@ func TestInvalidModification(t *testing.T) {
 			err: "duplicate names in middleware modification",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.mod.validate()
 			if tt.err != "" {
@@ -183,7 +182,6 @@ func TestChainValidate(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := mc.validate(tt.mod)
 			if tt.err != "" {

--- a/pkg/cmd/termination/termination_test.go
+++ b/pkg/cmd/termination/termination_test.go
@@ -43,7 +43,7 @@ func TestPublishError(t *testing.T) {
 
 	// test error metadata is truncated when too large
 	var builder strings.Builder
-	for i := 0; i < kubeTerminationLogLimit; i++ {
+	for range kubeTerminationLogLimit {
 		builder.WriteString("a")
 	}
 	publishedError.Metadata["large_value"] = builder.String()

--- a/pkg/composableschemadsl/compiler/compiler_test.go
+++ b/pkg/composableschemadsl/compiler/compiler_test.go
@@ -1414,7 +1414,6 @@ func TestCompile(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)

--- a/pkg/composableschemadsl/compiler/development_test.go
+++ b/pkg/composableschemadsl/compiler/development_test.go
@@ -217,7 +217,6 @@ func TestPositionToAstNode(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -389,7 +388,6 @@ func TestNodeChainString(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/composableschemadsl/generator/generator.go
+++ b/pkg/composableschemadsl/generator/generator.go
@@ -395,8 +395,8 @@ func (sg *sourceGenerator) appendComment(comment string) {
 	case strings.HasPrefix(comment, "/*"):
 		stripped := strings.TrimSpace(comment)
 
-		if strings.HasPrefix(stripped, "/**") {
-			stripped = strings.TrimPrefix(stripped, "/**")
+		if after, ok := strings.CutPrefix(stripped, "/**"); ok {
+			stripped = after
 			sg.append("/**")
 		} else {
 			stripped = strings.TrimPrefix(stripped, "/*")

--- a/pkg/composableschemadsl/generator/generator_test.go
+++ b/pkg/composableschemadsl/generator/generator_test.go
@@ -66,7 +66,6 @@ caveat somecaveat(someParam int) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 			source, ok, err := GenerateCaveatSource(test.input, caveattypes.Default.TypeSet)
@@ -233,7 +232,6 @@ definition foos/document {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 			source, ok, err := GenerateSource(test.input, caveattypes.Default.TypeSet)
@@ -409,7 +407,6 @@ definition document {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 			compiled, err := compiler.Compile(compiler.InputSchema{

--- a/pkg/composableschemadsl/lexer/lex_test.go
+++ b/pkg/composableschemadsl/lexer/lex_test.go
@@ -282,7 +282,6 @@ var lexerTests = []lexerTest{
 
 func TestLexer(t *testing.T) {
 	for _, test := range lexerTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			test := test // Close over test and not the pointer that is reused.
 			tokens := performLex(&test)

--- a/pkg/composableschemadsl/parser/parser_impl.go
+++ b/pkg/composableschemadsl/parser/parser_impl.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/authzed/spicedb/pkg/composableschemadsl/dslshape"
@@ -155,13 +156,7 @@ func (p *sourceParser) consumeToken() commentedLexeme {
 
 // isToken returns true if the current token matches one of the types given.
 func (p *sourceParser) isToken(types ...lexer.TokenType) bool {
-	for _, kind := range types {
-		if p.currentToken.Kind == kind {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(types, p.currentToken.Kind)
 }
 
 // isKeyword returns true if the current token is a keyword matching that given.

--- a/pkg/composableschemadsl/parser/parser_test.go
+++ b/pkg/composableschemadsl/parser/parser_test.go
@@ -149,7 +149,6 @@ func TestParser(t *testing.T) {
 	}
 
 	for _, test := range parserTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			root := Parse(createAstNode, input.Source(test.name), test.input())
@@ -171,10 +170,10 @@ func TestParser(t *testing.T) {
 }
 
 func getParseTree(currentNode *testNode, indentation int) string {
-	parseTree := ""
-	parseTree += strings.Repeat(" ", indentation)
-	parseTree += fmt.Sprintf("%v", currentNode.nodeType)
-	parseTree += "\n"
+	var parseTree strings.Builder
+	parseTree.WriteString(strings.Repeat(" ", indentation))
+	parseTree.WriteString(fmt.Sprintf("%v", currentNode.nodeType))
+	parseTree.WriteString("\n")
 
 	keys := make([]string, 0, len(currentNode.properties))
 
@@ -185,9 +184,9 @@ func getParseTree(currentNode *testNode, indentation int) string {
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		parseTree += strings.Repeat(" ", indentation+2)
-		parseTree += fmt.Sprintf("%s = %v", key, currentNode.properties[key])
-		parseTree += "\n"
+		parseTree.WriteString(strings.Repeat(" ", indentation+2))
+		parseTree.WriteString(fmt.Sprintf("%s = %v", key, currentNode.properties[key]))
+		parseTree.WriteString("\n")
 	}
 
 	keys = make([]string, 0, len(currentNode.children))
@@ -200,13 +199,13 @@ func getParseTree(currentNode *testNode, indentation int) string {
 
 	for _, key := range keys {
 		value := currentNode.children[key]
-		parseTree += fmt.Sprintf("%s%v =>", strings.Repeat(" ", indentation+2), key)
-		parseTree += "\n"
+		parseTree.WriteString(fmt.Sprintf("%s%v =>", strings.Repeat(" ", indentation+2), key))
+		parseTree.WriteString("\n")
 
 		for e := value.Front(); e != nil; e = e.Next() {
-			parseTree += getParseTree(e.Value.(*testNode), indentation+4)
+			parseTree.WriteString(getParseTree(e.Value.(*testNode), indentation+4))
 		}
 	}
 
-	return parseTree
+	return parseTree.String()
 }

--- a/pkg/cursor/cursor_test.go
+++ b/pkg/cursor/cursor_test.go
@@ -45,7 +45,6 @@ func TestEncodeDecode(t *testing.T) {
 			"another",
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			encoded, err := EncodeFromDispatchCursor(&dispatch.Cursor{
@@ -121,7 +120,6 @@ func TestDecode(t *testing.T) {
 			expectError:      false,
 		},
 	} {
-		testCase := testCase
 		testName := fmt.Sprintf("%s(%s)=>%s", testCase.name, testCase.token, testCase.expectedRevision)
 		t.Run(testName, func(t *testing.T) {
 			require := require.New(t)

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -134,7 +134,6 @@ func TestRelationshipsFilterFromPublicFilter(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			computed, err := RelationshipsFilterFromPublicFilter(test.input)
 			if test.expectedError != "" {
@@ -296,7 +295,6 @@ func TestConvertedRelationshipFilterTest(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			filter, err := RelationshipsFilterFromPublicFilter(tc.filter)
 			require.NoError(t, err)
@@ -570,7 +568,6 @@ func TestRelationshipsFilterTest(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			relationship := tuple.MustParse(tc.relationshipString)
 			require.Equal(t, tc.expected, tc.filter.Test(relationship))

--- a/pkg/datastore/pagination/iterator_test.go
+++ b/pkg/datastore/pagination/iterator_test.go
@@ -38,7 +38,6 @@ func TestPaginatedIterator(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%d/%d-%d", tc.pageSize, tc.totalRelationships, tc.order), func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)
@@ -88,10 +87,7 @@ func generateMock(t *testing.T, rels []tuple.Relationship, pageSize int, order o
 
 	var last options.Cursor
 	for i := 0; i <= relsLen; i += pageSize {
-		pastLastIndex := i + pageSize
-		if pastLastIndex > relsLen {
-			pastLastIndex = relsLen
-		}
+		pastLastIndex := min(i+pageSize, relsLen)
 
 		pageSize64, err := safecast.Convert[uint64](pageSize)
 		require.NoError(t, err)

--- a/pkg/datastore/test/counters.go
+++ b/pkg/datastore/test/counters.go
@@ -79,10 +79,8 @@ func RegisterRelationshipCountersInParallelTest(t *testing.T, tester DatastoreTe
 	var numSucceeded, numFailed atomic.Int32
 	failures := make(chan error, 10)
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 10 {
+		wg.Go(func() {
 			_, err := ds.ReadWriteTx(t.Context(), func(ctx context.Context, tx datastore.ReadWriteTransaction) error {
 				return tx.RegisterCounter(ctx, "document", &core.RelationshipFilter{
 					ResourceType: testfixtures.DocumentNS.Name,
@@ -94,7 +92,7 @@ func RegisterRelationshipCountersInParallelTest(t *testing.T, tester DatastoreTe
 			} else {
 				numSucceeded.Add(1)
 			}
-		}()
+		})
 	}
 
 	// Wait for all goroutines to finish.

--- a/pkg/datastore/test/pagination.go
+++ b/pkg/datastore/test/pagination.go
@@ -39,8 +39,6 @@ func OrderingTest(t *testing.T, tester DatastoreTester) {
 	tRequire := testfixtures.RelationshipChecker{Require: require.New(t), DS: ds}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s-%d", tc.resourceType, tc.ordering), func(t *testing.T) {
 			require := require.New(t)
 			ctx := t.Context()
@@ -97,10 +95,7 @@ func LimitTest(t *testing.T, tester DatastoreTester) {
 
 					require.NoError(err)
 
-					expectedCount := limit
-					if expectedCount > len(expected) {
-						expectedCount = len(expected)
-					}
+					expectedCount := min(limit, len(expected))
 
 					tRequire.VerifyIteratorCount(iter, expectedCount)
 				})
@@ -248,10 +243,7 @@ func ResumeTest(t *testing.T, tester DatastoreTester) {
 
 						require.NoError(err)
 
-						upperBound := offset + batchSize
-						if upperBound > len(expected) {
-							upperBound = len(expected)
-						}
+						upperBound := min(offset+batchSize, len(expected))
 
 						cursor = tRequire.VerifyOrderedIteratorResults(iter, expected[offset:upperBound]...)
 					}
@@ -291,7 +283,7 @@ func ReverseQueryFilteredOverMultipleValuesCursorTest(t *testing.T, tester Datas
 
 			foundTuples := mapz.NewSet[string]()
 
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				iter, err := reader.ReverseQueryRelationships(
 					t.Context(),
 					datastore.SubjectsFilter{
@@ -358,7 +350,7 @@ func ReverseQueryCursorTest(t *testing.T, tester DatastoreTester) {
 
 			foundTuples := mapz.NewSet[string]()
 
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				iter, err := reader.ReverseQueryRelationships(
 					t.Context(),
 					datastore.SubjectsFilter{

--- a/pkg/datastore/test/relationships.go
+++ b/pkg/datastore/test/relationships.go
@@ -42,7 +42,6 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 	testCases := []int{1, 2, 4, 32, 256}
 
 	for _, numRels := range testCases {
-		numRels := numRels
 		t.Run(strconv.Itoa(numRels), func(t *testing.T) {
 			ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(t, err)
@@ -61,7 +60,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 			tRequire := testfixtures.RelationshipChecker{Require: require.New(t), DS: ds}
 
 			var testRels []tuple.Relationship
-			for i := 0; i < numRels; i++ {
+			for i := range numRels {
 				resourceName := fmt.Sprintf("resource%d", i)
 				userName := fmt.Sprintf("user%d", i)
 
@@ -312,8 +311,8 @@ func ObjectIDsTest(t *testing.T, tester DatastoreTester) {
 // DeleteRelationshipsTest tests whether or not the requirements for deleting
 // relationships hold for a particular datastore.
 func DeleteRelationshipsTest(t *testing.T, tester DatastoreTester) {
-	var testRels []tuple.Relationship
-	for i := 0; i < 10; i++ {
+	testRels := make([]tuple.Relationship, 0, 10)
+	for i := range 10 {
 		newRel := makeTestRel(fmt.Sprintf("resource%d", i), fmt.Sprintf("user%d", i%2))
 		testRels = append(testRels, newRel)
 	}
@@ -396,7 +395,6 @@ func DeleteRelationshipsTest(t *testing.T, tester DatastoreTester) {
 	}
 
 	for _, tt := range table {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctx := t.Context()
@@ -669,7 +667,7 @@ func DeleteOneThousandIndividualInOneCallTest(t *testing.T, tester DatastoreTest
 
 	// Write the 1000 relationships.
 	relationships := make([]tuple.Relationship, 0, 1000)
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		tpl := makeTestRel("foo", fmt.Sprintf("user%d", i))
 		relationships = append(relationships, tpl)
 	}
@@ -835,7 +833,7 @@ func MixedWriteOperationsTest(t *testing.T, tester DatastoreTester) {
 
 	// Write the 100 relationships.
 	rels := make([]tuple.Relationship, 0, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		rels = append(rels, tuple.Relationship{
 			RelationshipReference: tuple.RelationshipReference{
 				Resource: tuple.ONR("document", "somedoc", "viewer"),
@@ -853,7 +851,7 @@ func MixedWriteOperationsTest(t *testing.T, tester DatastoreTester) {
 	expectedRels := make([]tuple.Relationship, 0, 105)
 
 	// Add a CREATE for 10 new relationships.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		newRel := tuple.Relationship{
 			RelationshipReference: tuple.RelationshipReference{
 				Resource: tuple.ONR("document", "somedoc", "viewer"),
@@ -865,7 +863,7 @@ func MixedWriteOperationsTest(t *testing.T, tester DatastoreTester) {
 	}
 
 	// Add a TOUCH for 5 existing relationships.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		updates = append(updates, tuple.Touch(tuple.Relationship{
 			RelationshipReference: tuple.RelationshipReference{
 				Resource: tuple.ONR("document", "somedoc", "viewer"),
@@ -875,7 +873,7 @@ func MixedWriteOperationsTest(t *testing.T, tester DatastoreTester) {
 	}
 
 	// Add a TOUCH for 5 new relationships.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		newRel := tuple.Relationship{
 			RelationshipReference: tuple.RelationshipReference{
 				Resource: tuple.ONR("document", "somedoc", "viewer"),
@@ -888,7 +886,7 @@ func MixedWriteOperationsTest(t *testing.T, tester DatastoreTester) {
 
 	// DELETE the first 10 relationships.
 	deletedRels := make([]tuple.Relationship, 0, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		rel := tuple.Relationship{
 			RelationshipReference: tuple.RelationshipReference{
 				Resource: tuple.ONR("document", "somedoc", "viewer"),
@@ -925,7 +923,7 @@ func DeleteWithLimitTest(t *testing.T, tester DatastoreTester) {
 
 	// Write the 1000 relationships.
 	rels := make([]tuple.Relationship, 0, 1000)
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		rels = append(rels, makeTestRel("foo", fmt.Sprintf("user%d", i)))
 	}
 
@@ -1086,7 +1084,6 @@ func DeleteRelationshipsWithVariousFiltersTest(t *testing.T, tester DatastoreTes
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			for _, withLimit := range []bool{false, true} {
 				t.Run(fmt.Sprintf("withLimit=%v", withLimit), func(t *testing.T) {
@@ -1194,7 +1191,7 @@ func RecreateRelationshipsAfterDeleteWithFilter(t *testing.T, tester DatastoreTe
 	ctx := t.Context()
 
 	relationships := make([]tuple.Relationship, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		relationships[i] = tuple.MustParse(fmt.Sprintf("document:%d#owner@user:first", i))
 	}
 
@@ -1759,7 +1756,6 @@ func QueryRelationshipsWithVariousFiltersTest(t *testing.T, tester DatastoreTest
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/pkg/datastore/test/revisions.go
+++ b/pkg/datastore/test/revisions.go
@@ -31,7 +31,6 @@ func RevisionQuantizationTest(t *testing.T, tester DatastoreTester) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("quantization%s", tc.quantizationRange), func(t *testing.T) {
 			require := require.New(t)
 
@@ -306,11 +305,11 @@ func ConcurrentRevisionsTest(t *testing.T, tester DatastoreTester) {
 
 	errCh := make(chan error, 10*5)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			defer wg.Done()
 
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				head, err := ds.HeadRevision(ctx)
 				if err != nil {
 					errCh <- fmt.Errorf("HeadRevision error: %w", err)

--- a/pkg/datastore/test/watch.go
+++ b/pkg/datastore/test/watch.go
@@ -57,7 +57,6 @@ func WatchTest(t *testing.T, tester DatastoreTester) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%d-%v", tc.numTuples, tc.expectFallBehind), func(t *testing.T) {
 			require := require.New(t)
 

--- a/pkg/development/schema_position_mapper_test.go
+++ b/pkg/development/schema_position_mapper_test.go
@@ -402,7 +402,6 @@ definition document {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			compiled, err := compiler.Compile(compiler.InputSchema{
 				Source:       input.Source("test"),

--- a/pkg/development/warnings.go
+++ b/pkg/development/warnings.go
@@ -3,6 +3,7 @@ package development
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/ccoveille/go-safecast/v2"
 
@@ -123,13 +124,7 @@ func shouldSkipCheck(metadata *corev1.Metadata, name string) bool {
 	}
 
 	comments := namespace.GetComments(metadata)
-	for _, comment := range comments {
-		if comment == "// spicedb-ignore-warning: "+name {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(comments, "// spicedb-ignore-warning: "+name)
 }
 
 type tupleset interface {

--- a/pkg/diff/caveats/diff_test.go
+++ b/pkg/diff/caveats/diff_test.go
@@ -269,7 +269,6 @@ func TestCaveatDiff(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			diff, err := DiffCaveats(tc.existing, tc.updated, caveattypes.Default.TypeSet)

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -239,7 +239,6 @@ func TestDiffableSchema(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			schema, err := compiler.Compile(compiler.InputSchema{
 				Source:       input.Source("schema"),
@@ -249,7 +248,6 @@ func TestDiffableSchema(t *testing.T) {
 
 			diffableSchema := NewDiffableSchemaFromCompiledSchema(schema)
 			for index, check := range tc.checkers {
-				check := check
 				t.Run(fmt.Sprintf("check-%d", index), func(t *testing.T) {
 					check(t, &diffableSchema)
 				})

--- a/pkg/diff/namespace/diff_test.go
+++ b/pkg/diff/namespace/diff_test.go
@@ -574,7 +574,6 @@ func TestNamespaceDiff(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			diff, err := DiffNamespaces(tc.existing, tc.updated)

--- a/pkg/genutil/mapz/set_test.go
+++ b/pkg/genutil/mapz/set_test.go
@@ -324,7 +324,6 @@ func TestSetIntersectionDifference(t *testing.T) {
 	}
 
 	for index, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("%d", index), func(t *testing.T) {
 			firstSet := NewSet[int]()
 			firstSet.Extend(tc.first)

--- a/pkg/genutil/slicez/chunking_test.go
+++ b/pkg/genutil/slicez/chunking_test.go
@@ -80,7 +80,7 @@ func TestForEachChunkOverflowPanic(t *testing.T) {
 	datasize := math.MaxUint16
 	chunksize := uint16(50)
 	data := make([]int, 0, datasize)
-	for i := 0; i < datasize; i++ {
+	for i := range datasize {
 		data = append(data, i)
 	}
 
@@ -99,12 +99,11 @@ func TestForEachChunkOverflowIncorrect(t *testing.T) {
 
 	chunksize := uint16(50)
 	for _, datasize := range []int{math.MaxUint16 + int(chunksize), 10_000_000} {
-		datasize := datasize
 		t.Run(fmt.Sprintf("test-%d-%d", datasize, chunksize), func(t *testing.T) {
 			t.Parallel()
 
 			data := make([]int, 0, datasize)
-			for i := 0; i < datasize; i++ {
+			for i := range datasize {
 				data = append(data, i)
 			}
 

--- a/pkg/middleware/requestid/requestid_test.go
+++ b/pkg/middleware/requestid/requestid_test.go
@@ -35,7 +35,7 @@ func (t *testServer) Ping(ctx context.Context, req *testpb.PingRequest) (*testpb
 
 func (t *testServer) PingList(_ *testpb.PingListRequest, server testpb.TestService_PingListServer) error {
 	// Send a few responses to test server streaming
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		if err := server.Send(&testpb.PingListResponse{Value: "ping"}); err != nil {
 			return err
 		}

--- a/pkg/query/datastore_test.go
+++ b/pkg/query/datastore_test.go
@@ -183,7 +183,6 @@ func TestDatastoreIteratorSubjectTypeMismatchScenarios(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -326,7 +325,6 @@ func TestDatastoreIteratorWildcardSubjectTypeMismatchScenarios(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/query/intersection_test.go
+++ b/pkg/query/intersection_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -218,13 +219,7 @@ func TestIntersectionIteratorClone(t *testing.T) {
 	// Both iterators should produce identical results (order may vary)
 	require.Len(clonedResults, len(originalResults), "cloned iterator should produce same number of results")
 	for _, expectedPath := range originalResults {
-		found := false
-		for _, actualPath := range clonedResults {
-			if expectedPath.Equals(actualPath) {
-				found = true
-				break
-			}
-		}
+		found := slices.ContainsFunc(clonedResults, expectedPath.Equals)
 		require.True(found, "Expected path %v should be found in cloned results", expectedPath)
 	}
 }

--- a/pkg/releases/versions_test.go
+++ b/pkg/releases/versions_test.go
@@ -30,7 +30,6 @@ func TestCheckIsLatestVersion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			state, _, release, _ := CheckIsLatestVersion(t.Context(), func() (string, error) {
 				return tc.version, nil

--- a/pkg/schema/definition_test.go
+++ b/pkg/schema/definition_test.go
@@ -444,7 +444,6 @@ func TestDefinition(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -603,7 +602,6 @@ func TestTraitsUnion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			result := tc.traits1.union(tc.traits2)
@@ -1518,7 +1516,6 @@ func TestTypeSystemAccessors(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/pkg/schema/full_reachability.go
+++ b/pkg/schema/full_reachability.go
@@ -118,7 +118,6 @@ func relationsReferencing(ctx context.Context, arrowSet *ArrowSet, res FullSchem
 	key := namespaceName + "#" + relationName
 	foundArrows, _ := arrowSet.arrowsByFullTuplesetRelation.Get(key)
 	for _, arrow := range foundArrows {
-		arrow := arrow
 		foundReferences = append(foundReferences, RelationReferenceInfo{
 			Relation: &core.RelationReference{
 				Namespace: namespaceName,

--- a/pkg/schema/reachabilitygraph_test.go
+++ b/pkg/schema/reachabilitygraph_test.go
@@ -198,7 +198,6 @@ func TestRelationsEncounteredForSubject(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -549,7 +548,6 @@ func TestRelationsEncounteredForResource(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -1228,7 +1226,6 @@ func TestReachabilityGraph(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/pkg/schema/typesystem_test.go
+++ b/pkg/schema/typesystem_test.go
@@ -44,16 +44,14 @@ func TestTypeSystemConcurrency(t *testing.T) {
 	errs := make(chan error, 600)
 
 	for range 10 {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			for range 20 {
 				for _, n := range []string{"document", "user", "team"} {
 					_, err := ts.GetValidatedDefinition(ctx, n)
 					errs <- err
 				}
 			}
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 	close(errs)
@@ -164,7 +162,6 @@ func TestApplyExpirationFilter(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -344,7 +341,6 @@ func TestDirectPossibleTraitsForFilter(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -667,7 +663,6 @@ func TestPossibleTraitsForFilter(t *testing.T) {
 
 	// Run expiration filter tests for PossibleTraitsForFilter
 	for _, tc := range expirationTestCases {
-		tc := tc
 		t.Run("PossibleTraitsForFilter with expiration: "+tc.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -688,7 +683,6 @@ func TestPossibleTraitsForFilter(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/pkg/schema/v2/testing/generator.go
+++ b/pkg/schema/v2/testing/generator.go
@@ -182,7 +182,7 @@ func mustGenerateOperation(t *rapid.T, relationNames []string, subjectRelationNa
 		// Union
 		numChildren := rapid.IntRange(1, 3).Draw(t, path+"::unionNumChildren")
 		unionBuilder := schema.NewUnion()
-		for i := 0; i < numChildren; i++ {
+		for i := range numChildren {
 			childOp := mustGenerateOperation(t, relationNames, subjectRelationNames, depthRemaining-1, path+"::unionChild#"+strconv.Itoa(i))
 			unionBuilder = unionBuilder.Add(childOp)
 		}
@@ -192,7 +192,7 @@ func mustGenerateOperation(t *rapid.T, relationNames []string, subjectRelationNa
 		// Intersection
 		numChildren := rapid.IntRange(1, 3).Draw(t, "intersectionNumChildren")
 		intersectionBuilder := schema.NewIntersection()
-		for i := 0; i < numChildren; i++ {
+		for i := range numChildren {
 			childOp := mustGenerateOperation(t, relationNames, subjectRelationNames, depthRemaining-1, path+"::intersectionChild#"+strconv.Itoa(i))
 			intersectionBuilder = intersectionBuilder.Add(childOp)
 		}

--- a/pkg/schemadsl/compiler/compiler_test.go
+++ b/pkg/schemadsl/compiler/compiler_test.go
@@ -1457,7 +1457,6 @@ func TestCompile(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)

--- a/pkg/schemadsl/compiler/development_test.go
+++ b/pkg/schemadsl/compiler/development_test.go
@@ -217,7 +217,6 @@ func TestPositionToAstNode(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/schemadsl/generator/generator.go
+++ b/pkg/schemadsl/generator/generator.go
@@ -396,8 +396,8 @@ func (sg *sourceGenerator) appendComment(comment string) {
 	case strings.HasPrefix(comment, "/*"):
 		stripped := strings.TrimSpace(comment)
 
-		if strings.HasPrefix(stripped, "/**") {
-			stripped = strings.TrimPrefix(stripped, "/**")
+		if after, ok := strings.CutPrefix(stripped, "/**"); ok {
+			stripped = after
 			sg.append("/**")
 		} else {
 			stripped = strings.TrimPrefix(stripped, "/*")

--- a/pkg/schemadsl/generator/generator_test.go
+++ b/pkg/schemadsl/generator/generator_test.go
@@ -66,7 +66,6 @@ caveat somecaveat(someParam int) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 			source, ok, err := GenerateCaveatSource(test.input, caveattypes.Default.TypeSet)
@@ -233,7 +232,6 @@ definition foos/document {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 			source, ok, err := GenerateSource(test.input, caveattypes.Default.TypeSet)
@@ -447,7 +445,6 @@ definition user {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 			compiled, err := compiler.Compile(compiler.InputSchema{

--- a/pkg/schemadsl/lexer/lex_test.go
+++ b/pkg/schemadsl/lexer/lex_test.go
@@ -284,7 +284,6 @@ var lexerTests = []lexerTest{
 
 func TestLexer(t *testing.T) {
 	for _, test := range lexerTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			test := test // Close over test and not the pointer that is reused.
 			tokens := performLex(&test)

--- a/pkg/schemadsl/parser/parser_impl.go
+++ b/pkg/schemadsl/parser/parser_impl.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/authzed/spicedb/pkg/schemadsl/dslshape"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
@@ -154,13 +155,7 @@ func (p *sourceParser) consumeToken() commentedLexeme {
 
 // isToken returns true if the current token matches one of the types given.
 func (p *sourceParser) isToken(types ...lexer.TokenType) bool {
-	for _, kind := range types {
-		if p.currentToken.Kind == kind {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(types, p.currentToken.Kind)
 }
 
 // isIdentifier returns true if the current token is an identifier matching that given.

--- a/pkg/schemadsl/parser/parser_test.go
+++ b/pkg/schemadsl/parser/parser_test.go
@@ -152,7 +152,6 @@ func TestParser(t *testing.T) {
 	}
 
 	for _, test := range parserTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			root := Parse(createAstNode, input.Source(test.name), test.input())
@@ -174,10 +173,10 @@ func TestParser(t *testing.T) {
 }
 
 func getParseTree(currentNode *testNode, indentation int) string {
-	parseTree := ""
-	parseTree += strings.Repeat(" ", indentation)
-	parseTree += fmt.Sprintf("%v", currentNode.nodeType)
-	parseTree += "\n"
+	var parseTree strings.Builder
+	parseTree.WriteString(strings.Repeat(" ", indentation))
+	parseTree.WriteString(fmt.Sprintf("%v", currentNode.nodeType))
+	parseTree.WriteString("\n")
 
 	keys := make([]string, 0, len(currentNode.properties))
 
@@ -188,9 +187,9 @@ func getParseTree(currentNode *testNode, indentation int) string {
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		parseTree += strings.Repeat(" ", indentation+2)
-		parseTree += fmt.Sprintf("%s = %v", key, currentNode.properties[key])
-		parseTree += "\n"
+		parseTree.WriteString(strings.Repeat(" ", indentation+2))
+		parseTree.WriteString(fmt.Sprintf("%s = %v", key, currentNode.properties[key]))
+		parseTree.WriteString("\n")
 	}
 
 	keys = make([]string, 0, len(currentNode.children))
@@ -203,13 +202,13 @@ func getParseTree(currentNode *testNode, indentation int) string {
 
 	for _, key := range keys {
 		value := currentNode.children[key]
-		parseTree += fmt.Sprintf("%s%v =>", strings.Repeat(" ", indentation+2), key)
-		parseTree += "\n"
+		parseTree.WriteString(fmt.Sprintf("%s%v =>", strings.Repeat(" ", indentation+2), key))
+		parseTree.WriteString("\n")
 
 		for e := value.Front(); e != nil; e = e.Next() {
-			parseTree += getParseTree(e.Value.(*testNode), indentation+4)
+			parseTree.WriteString(getParseTree(e.Value.(*testNode), indentation+4))
 		}
 	}
 
-	return parseTree
+	return parseTree.String()
 }

--- a/pkg/spiceerrors/util.go
+++ b/pkg/spiceerrors/util.go
@@ -11,8 +11,6 @@ type WithMetadata interface {
 // CombineMetadata combines the metadata found on an existing error with that given.
 func CombineMetadata(withMetadata WithMetadata, metadata map[string]string) map[string]string {
 	clone := maps.Clone(withMetadata.DetailsMetadata())
-	for key, value := range metadata {
-		clone[key] = value
-	}
+	maps.Copy(clone, metadata)
 	return clone
 }

--- a/pkg/testutil/proto_test.go
+++ b/pkg/testutil/proto_test.go
@@ -96,7 +96,6 @@ func TestAreProtoEqual(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := AreProtoEqual(tc.first, tc.second, "something went wrong")
 			require.Equal(t, tc.expectedEqual, err == nil)
@@ -151,7 +150,6 @@ func TestRequireProtoEqual(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			RequireProtoEqual(t, tc.first, tc.second, "something went wrong")
 		})
@@ -219,7 +217,6 @@ func TestAreProtoSlicesEqual(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := AreProtoSlicesEqual(tc.first, tc.second, func(first, second *core.ObjectAndRelation) int {
 				return strings.Compare(first.ObjectId, second.ObjectId)
@@ -265,7 +262,6 @@ func TestRequireProtoSlicesEqual(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			RequireProtoSlicesEqual(t, tc.first, tc.second, func(first *core.ObjectAndRelation, second *core.ObjectAndRelation) int {
 				return strings.Compare(first.ObjectId, second.ObjectId)

--- a/pkg/tuple/hashing_test.go
+++ b/pkg/tuple/hashing_test.go
@@ -11,7 +11,6 @@ func TestCanonicalBytes(t *testing.T) {
 	foundBytes := make(map[string]string)
 
 	for _, tc := range testCases {
-		tc := tc
 		if tc.relFormat.Resource.ObjectType == "" {
 			continue
 		}

--- a/pkg/tuple/onr_test.go
+++ b/pkg/tuple/onr_test.go
@@ -38,7 +38,6 @@ var onrTestCases = []struct {
 
 func TestSerializeONR(t *testing.T) {
 	for _, tc := range onrTestCases {
-		tc := tc
 		if tc.objectFormat.ObjectType == "" && tc.objectFormat.ObjectID == "" && tc.objectFormat.Relation == "" {
 			continue
 		}
@@ -53,7 +52,6 @@ func TestSerializeONR(t *testing.T) {
 
 func TestParseONR(t *testing.T) {
 	for _, tc := range onrTestCases {
-		tc := tc
 		t.Run(tc.serialized, func(t *testing.T) {
 			require := require.New(t)
 
@@ -110,7 +108,6 @@ var subjectOnrTestCases = []struct {
 
 func TestParseSubjectONR(t *testing.T) {
 	for _, tc := range subjectOnrTestCases {
-		tc := tc
 		t.Run(tc.serialized, func(t *testing.T) {
 			require := require.New(t)
 

--- a/pkg/tuple/parsing_test.go
+++ b/pkg/tuple/parsing_test.go
@@ -578,7 +578,6 @@ var testCases = []struct {
 
 func TestSerialize(t *testing.T) {
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("tuple/"+tc.input, func(t *testing.T) {
 			if tc.relFormat.Resource.ObjectType == "" {
 				return
@@ -594,7 +593,6 @@ func TestSerialize(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("relationship/"+tc.input, func(t *testing.T) {
 			if tc.v1Format == nil {
 				return
@@ -617,7 +615,6 @@ func TestSerialize(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("relationship/"+tc.input, func(t *testing.T) {
 			parsed, err := Parse(tc.input)
 			if tc.relFormat.Resource.ObjectType == "" {
@@ -631,7 +628,6 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("v1/"+tc.input, func(t *testing.T) {
 			parsed, err := ParseV1Rel(tc.input)
 			if tc.relFormat.Resource.ObjectType == "" {
@@ -647,7 +643,6 @@ func TestParse(t *testing.T) {
 
 func TestConvert(t *testing.T) {
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			require := require.New(t)
 
@@ -674,7 +669,6 @@ func TestConvert(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("validate/"+tc.input, func(t *testing.T) {
 			parsed, err := ParseV1Rel(tc.input)
 			if err == nil {

--- a/pkg/tuple/updates_test.go
+++ b/pkg/tuple/updates_test.go
@@ -36,7 +36,6 @@ func TestUpdateMethods(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("%d", tc.expected.Operation), func(t *testing.T) {
 			if tc.input != tc.expected {
 				t.Errorf("expected %v, got %v", tc.expected, tc.input)

--- a/pkg/tuple/v1_test.go
+++ b/pkg/tuple/v1_test.go
@@ -50,7 +50,6 @@ func TestJoinSubjectRef(t *testing.T) {
 
 func TestBackAndForth(t *testing.T) {
 	for _, tc := range testCases {
-		tc := tc
 		if tc.stableCanonicalization == "" {
 			continue
 		}

--- a/pkg/validationfile/blocks/assertions_test.go
+++ b/pkg/validationfile/blocks/assertions_test.go
@@ -142,7 +142,6 @@ assertFalse: garbage
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			a := Assertions{}

--- a/pkg/validationfile/blocks/expectedrelations.go
+++ b/pkg/validationfile/blocks/expectedrelations.go
@@ -209,8 +209,8 @@ func (vs ValidationString) Subject() (*SubjectWithExceptions, *spiceerrors.WithS
 		exceptions = make([]SubjectAndCaveat, 0, len(exceptionsStringsSlice))
 		for _, exceptionString := range exceptionsStringsSlice {
 			isCaveated := false
-			if strings.HasSuffix(exceptionString, "[...]") {
-				exceptionString = strings.TrimSuffix(exceptionString, "[...]")
+			if before, ok0 := strings.CutSuffix(exceptionString, "[...]"); ok0 {
+				exceptionString = before
 				isCaveated = true
 			}
 

--- a/pkg/validationfile/blocks/expectedrelations_test.go
+++ b/pkg/validationfile/blocks/expectedrelations_test.go
@@ -112,7 +112,6 @@ func TestValidationString(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			vs := ValidationString(tc.input)
@@ -251,7 +250,6 @@ document:seconddoc#view:
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			per := ParsedExpectedRelations{}

--- a/pkg/validationfile/blocks/relationships_test.go
+++ b/pkg/validationfile/blocks/relationships_test.go
@@ -45,7 +45,6 @@ document:second#viewer@user:1`,
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			pr := ParsedRelationships{}
 			err := yamlv3.Unmarshal([]byte(tt.contents), &pr)

--- a/pkg/validationfile/fileformat_test.go
+++ b/pkg/validationfile/fileformat_test.go
@@ -81,7 +81,6 @@ validation:
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			decoded, err := DecodeValidationFile([]byte(tt.contents))
 			if tt.expectedError != "" {

--- a/pkg/validationfile/loader_test.go
+++ b/pkg/validationfile/loader_test.go
@@ -177,7 +177,6 @@ func TestPopulateFromFiles(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ds, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, 0, 0)

--- a/pkg/validationfile/schema_test.go
+++ b/pkg/validationfile/schema_test.go
@@ -44,7 +44,6 @@ func TestParseSchema(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			inputSchema := compiler.InputSchema{
 				Source:       input.Source("schema"),

--- a/pkg/zedtoken/zedtoken_test.go
+++ b/pkg/zedtoken/zedtoken_test.go
@@ -39,7 +39,6 @@ var encodeHLCRevisionTests = []datastore.Revision{
 
 func TestZedTokenEncode(t *testing.T) {
 	for _, rev := range encodeRevisionTests {
-		rev := rev
 		t.Run(rev.String(), func(t *testing.T) {
 			require := require.New(t)
 			encoded := MustNewFromRevisionForTesting(rev)
@@ -55,7 +54,6 @@ func TestZedTokenEncode(t *testing.T) {
 
 func TestZedTokenEncodeHLC(t *testing.T) {
 	for _, rev := range encodeHLCRevisionTests {
-		rev := rev
 		t.Run(rev.String(), func(t *testing.T) {
 			require := require.New(t)
 			encoded := MustNewFromRevisionForTesting(rev)
@@ -160,7 +158,6 @@ var decodeTests = []struct {
 
 func TestDecode(t *testing.T) {
 	for _, testCase := range decodeTests {
-		testCase := testCase
 		testName := fmt.Sprintf("%s(%s)=>%s", testCase.format, testCase.token, testCase.expectedRevision)
 		t.Run(testName, func(t *testing.T) {
 			require := require.New(t)
@@ -266,7 +263,6 @@ var hlcDecodeTests = []struct {
 
 func TestHLCDecode(t *testing.T) {
 	for _, testCase := range hlcDecodeTests {
-		testCase := testCase
 		testName := fmt.Sprintf("%s(%s)=>%s", testCase.format, testCase.token, testCase.expectedRevision)
 		t.Run(testName, func(t *testing.T) {
 			require := require.New(t)


### PR DESCRIPTION
## Description

This change modernizes the Go codebase with newer idioms that we might have missed updating ourselves.

## Testing

These should all be equivalent in behavior. The only thing to be careful about is the functionality and the minimum Go version SpiceDB is built with (in our go.mod).

## References

https://go.dev/blog/gofix