### PR TITLE
chore: add cockroachdb 26.1 to the matrix and modify version parsing

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -262,7 +262,11 @@ jobs:
       fail-fast: false
       matrix:
         datastore: ["crdb"]
-        crdbversion: ["25.2.0", "25.3.0"]
+        crdbversion:
+          # the version many folks are on
+          - "25.2.0"
+          # the most recent version
+          - "26.1.0"
     steps:
       - uses: "actions/checkout@v6"
         if: |
@@ -297,7 +301,11 @@ jobs:
       fail-fast: false
       matrix:
         datastore: ["crdb"]
-        crdbversion: ["25.2.0", "25.3.0"]
+        crdbversion:
+          # the version many folks are on
+          - "25.2.0"
+          # the most recent version
+          - "26.1.0"
     steps:
       - uses: "actions/checkout@v6"
         if: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   NOTE: in a future release, MySQL metrics will change.
 - Add support for imports and partials to the schemadsl package that drives the LSP and development server (https://github.com/authzed/spicedb/pull/2919).
 - `DatastoreTester.New` now takes a `testing.TB` as its first argument, allowing per-test cleanup in datastore test suites (https://github.com/authzed/spicedb/pull/2925).
+- Added support for CRDB 26.1 by fixing how version information is read from the cluster
 
 ### Fixed
 - enforce graceful shutdown on serve and serve-testing (https://github.com/authzed/spicedb/pull/2888)

--- a/internal/datastore/crdb/version/version.go
+++ b/internal/datastore/crdb/version/version.go
@@ -8,4 +8,4 @@ const MinimumSupportedCockroachDBVersion = "23.1.30"
 // LatestTestedCockroachDBVersion is the latest version of CockroachDB that has been tested with this driver.
 //
 // NOTE: must match a tag on DockerHub for the `cockroachdb/cockroach` image, without the `v` prefix.
-const LatestTestedCockroachDBVersion = "25.3.2"
+const LatestTestedCockroachDBVersion = "26.1.0"

--- a/internal/datastore/crdb/watch.go
+++ b/internal/datastore/crdb/watch.go
@@ -28,7 +28,11 @@ import (
 )
 
 const (
-	queryChangefeed       = "CREATE CHANGEFEED FOR %s WITH updated, cursor = '%s', resolved = '%s', min_checkpoint_frequency = '0';"
+	// cursor: the revision before which we want to start the changefeed
+	// resolved: the minimum duration between "resolved" checkpoint messages
+	// min_checkpoint_frequency: how frequently CRDB will attempt to produce a checkpoint. the docs say that this can be 0,
+	// but that doesn't seem to be true for 26.1, so we set it to 1ms, which is still short but seems to work.
+	queryChangefeed       = "CREATE CHANGEFEED FOR %s WITH updated, cursor = '%s', resolved = '%s', min_checkpoint_frequency = '1ms';"
 	queryChangefeedPreV25 = "EXPERIMENTAL CHANGEFEED FOR %s WITH updated, cursor = '%s', resolved = '%s', min_checkpoint_frequency = '0';"
 	queryChangefeedPreV22 = "EXPERIMENTAL CHANGEFEED FOR %s WITH updated, cursor = '%s', resolved = '%s';"
 )

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -1937,7 +1937,7 @@ func NullCaveatWatchTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Verify the relationship create was tracked by the watch.
-	test.VerifyUpdates(require, [][]tuple.RelationshipUpdate{
+	test.VerifyUpdates(t, require, [][]tuple.RelationshipUpdate{
 		{
 			tuple.Touch(tuple.MustParse("resource:someresourceid#somerelation@subject:somesubject")),
 		},
@@ -1953,7 +1953,7 @@ func NullCaveatWatchTest(t *testing.T, ds datastore.Datastore) {
 	require.NoError(err)
 
 	// Verify the delete.
-	test.VerifyUpdates(require, [][]tuple.RelationshipUpdate{
+	test.VerifyUpdates(t, require, [][]tuple.RelationshipUpdate{
 		{
 			tuple.Delete(tuple.MustParse("resource:someresourceid#somerelation@subject:somesubject")),
 		},

--- a/pkg/datastore/test/watch.go
+++ b/pkg/datastore/test/watch.go
@@ -122,22 +122,24 @@ func WatchTest(t *testing.T, tester DatastoreTester) {
 				testUpdates = append(testUpdates, bulkDeletes)
 			}
 
-			VerifyUpdates(require, testUpdates, changes, errchan, tc.expectFallBehind)
+			VerifyUpdates(t, require, testUpdates, changes, errchan, tc.expectFallBehind)
 
 			// Test the catch-up case
 			changes, errchan = ds.Watch(t.Context(), lowestRevision, opts)
-			VerifyUpdates(require, testUpdates, changes, errchan, tc.expectFallBehind)
+			VerifyUpdates(t, require, testUpdates, changes, errchan, tc.expectFallBehind)
 		})
 	}
 }
 
 func VerifyUpdates(
+	t *testing.T,
 	require *require.Assertions,
 	testUpdates [][]tuple.RelationshipUpdate,
 	changes <-chan datastore.RevisionChanges,
 	errchan <-chan error,
 	expectDisconnect bool,
 ) {
+	t.Helper()
 	for _, expected := range testUpdates {
 		changeWait := time.NewTimer(waitForChangesTimeout)
 		select {
@@ -174,12 +176,14 @@ func VerifyUpdates(
 }
 
 func VerifyUpdatesWithMetadata(
+	t *testing.T,
 	require *require.Assertions,
 	testUpdates []updateWithMetadata,
 	changes <-chan datastore.RevisionChanges,
 	errchan <-chan error,
 	expectDisconnect bool,
 ) {
+	t.Helper()
 	for _, expected := range testUpdates {
 		changeWait := time.NewTimer(waitForChangesTimeout)
 		select {
@@ -309,7 +313,7 @@ func WatchWithTouchTest(t *testing.T, tester DatastoreTester) {
 		tuple.MustParse("document:firstdoc#viewer@user:fred[thirdcaveat]"),
 	)
 
-	VerifyUpdates(require, [][]tuple.RelationshipUpdate{
+	VerifyUpdates(t, require, [][]tuple.RelationshipUpdate{
 		{
 			tuple.Touch(tuple.MustParse("document:firstdoc#viewer@user:tom")),
 			tuple.Touch(tuple.MustParse("document:firstdoc#viewer@user:sarah")),
@@ -353,7 +357,7 @@ func WatchWithTouchTest(t *testing.T, tester DatastoreTester) {
 		tuple.MustParse("document:firstdoc#viewer@user:fred[thirdcaveat]"),
 	)
 
-	VerifyUpdates(require, [][]tuple.RelationshipUpdate{
+	VerifyUpdates(t, require, [][]tuple.RelationshipUpdate{
 		{tuple.Touch(tuple.MustParse("document:firstdoc#viewer@user:tom[somecaveat]"))},
 	},
 		changes,
@@ -374,7 +378,7 @@ func WatchWithTouchTest(t *testing.T, tester DatastoreTester) {
 		tuple.MustParse("document:firstdoc#viewer@user:fred[thirdcaveat]"),
 	)
 
-	VerifyUpdates(require, [][]tuple.RelationshipUpdate{
+	VerifyUpdates(t, require, [][]tuple.RelationshipUpdate{
 		{tuple.Touch(tuple.MustParse("document:firstdoc#viewer@user:tom[somecaveat:{\"somecondition\": 42}]"))},
 	},
 		changes,
@@ -410,7 +414,7 @@ func WatchWithExpirationTest(t *testing.T, tester DatastoreTester) {
 	}, options.WithMetadata(metadata))
 	require.NoError(err)
 
-	VerifyUpdates(require, [][]tuple.RelationshipUpdate{
+	VerifyUpdates(t, require, [][]tuple.RelationshipUpdate{
 		{tuple.Touch(tuple.MustParse("document:firstdoc#viewer@user:tom[expiration:2321-01-01T00:00:00Z]"))},
 	},
 		changes,
@@ -455,7 +459,7 @@ func WatchWithMetadataTest(t *testing.T, tester DatastoreTester) {
 	}, options.WithMetadata(metadata))
 	require.NoError(err)
 
-	VerifyUpdatesWithMetadata(require, []updateWithMetadata{
+	VerifyUpdatesWithMetadata(t, require, []updateWithMetadata{
 		{
 			updates:  []tuple.RelationshipUpdate{tuple.Touch(tuple.MustParse("document:firstdoc#viewer@user:tom"))},
 			metadata: map[string]any{"somekey": "somevalue"},
@@ -498,7 +502,7 @@ func WatchWithDeleteTest(t *testing.T, tester DatastoreTester) {
 		tuple.MustParse("document:firstdoc#viewer@user:fred[thirdcaveat]"),
 	)
 
-	VerifyUpdates(require, [][]tuple.RelationshipUpdate{
+	VerifyUpdates(t, require, [][]tuple.RelationshipUpdate{
 		{
 			tuple.Touch(tuple.MustParse("document:firstdoc#viewer@user:tom")),
 			tuple.Touch(tuple.MustParse("document:firstdoc#viewer@user:sarah")),
@@ -522,7 +526,7 @@ func WatchWithDeleteTest(t *testing.T, tester DatastoreTester) {
 		tuple.MustParse("document:firstdoc#viewer@user:fred[thirdcaveat]"),
 	)
 
-	VerifyUpdates(require, [][]tuple.RelationshipUpdate{
+	VerifyUpdates(t, require, [][]tuple.RelationshipUpdate{
 		{tuple.Delete(tuple.MustParse("document:firstdoc#viewer@user:tom"))},
 	},
 		changes,


### PR DESCRIPTION
## Description
Cockroach 26.1 has been released and we want to make sure that SpiceDB plays nice with it. This moves the matrix so that we test against 26.1.

We found that Cockroach now restricts access to its internal table, so we can't grab the version object directly. This changes the logic so that we rely on string parsing. This is less safe/direct, but it also works with v26.1.

We also found that checkpointing behavior changed in 26.1, so we updated `min_checkpoint_interval`.

We also 

## Changes
* Move matrix so that we test against 26.1
* Add a test for version checking behavior
* Fix version checking behavior for 26.1
* Fix an issue with `min_checkpoint_interval` in 26.1

## Testing
Review. See that tests pass.