### PR TITLE
chore(datastore): Change the DatastoreTester interface to take a testing.TB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Begin deprecation of library "github.com/dlmiddlecote/sqlstats" (https://github.com/authzed/spicedb/pull/2904).
   NOTE: in a future release, MySQL metrics will change.
 - Add support for imports and partials to the schemadsl package that drives the LSP and development server (https://github.com/authzed/spicedb/pull/2919).
+- `DatastoreTester.New` now takes a `testing.TB` as its first argument, allowing per-test cleanup in datastore test suites (https://github.com/authzed/spicedb/pull/2925).
 
 ### Fixed
 - enforce graceful shutdown on serve and serve-testing (https://github.com/authzed/spicedb/pull/2888)

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -74,7 +74,7 @@ func crdbTestVersion() string {
 func TestCRDBDatastoreWithoutIntegrity(t *testing.T) {
 	t.Parallel()
 	b := testdatastore.RunCRDBForTesting(t, "", crdbTestVersion())
-	test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	test.All(t, test.DatastoreTesterFunc(func(_ testing.TB, revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ctx := context.Background()
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 			ds, err := NewCRDBDatastore(
@@ -202,7 +202,7 @@ func TestCRDBDatastoreWithIntegrity(t *testing.T) { //nolint:tparallel
 	t.Parallel()
 	b := testdatastore.RunCRDBForTesting(t, "", crdbTestVersion())
 
-	test.All(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	test.All(t, test.DatastoreTesterFunc(func(_ testing.TB, revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ctx := context.Background()
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 			ds, err := NewCRDBDatastore(
@@ -229,7 +229,7 @@ func TestCRDBDatastoreWithIntegrity(t *testing.T) { //nolint:tparallel
 		return ds, nil
 	}), false)
 
-	unwrappedTester := test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	unwrappedTester := test.DatastoreTesterFunc(func(_ testing.TB, revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ctx := context.Background()
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 			ds, err := NewCRDBDatastore(
@@ -505,7 +505,7 @@ func newCRDBWithUser(t *testing.T, pool *dockertest.Pool) (adminConn *pgx.Conn, 
 func RelationshipIntegrityInfoTest(t *testing.T, tester test.DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -568,7 +568,7 @@ func (f *fakeSource) Next(ctx context.Context) (*tuple.Relationship, error) {
 func BulkRelationshipIntegrityInfoTest(t *testing.T, tester test.DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -617,7 +617,7 @@ func BulkRelationshipIntegrityInfoTest(t *testing.T, tester test.DatastoreTester
 func RelationshipIntegrityWatchTest(t *testing.T, tester test.DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, rev := testfixtures.StandardDatastoreWithSchema(rawDS, require)

--- a/internal/datastore/memdb/memdb_test.go
+++ b/internal/datastore/memdb/memdb_test.go
@@ -21,7 +21,7 @@ import (
 
 type memDBTest struct{}
 
-func (mdbt memDBTest) New(revisionQuantization, _, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+func (mdbt memDBTest) New(_ testing.TB, revisionQuantization, _, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 	return NewMemdbDatastore(watchBufferLength, revisionQuantization, gcWindow)
 }
 

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -82,7 +82,7 @@ func testPostgresDatastore(t *testing.T, config postgresTestConfig) {
 		ctx := context.Background()
 
 		// NOTE: gc tests take exclusive locks, so they are run under non-parallel.
-		test.OnlyGCTests(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+		test.OnlyGCTests(t, test.DatastoreTesterFunc(func(_ testing.TB, revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 			ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 				ds, err := newPostgresDatastore(ctx, uri, primaryInstanceID,
 					RevisionQuantization(revisionQuantization),
@@ -119,7 +119,7 @@ func testPostgresDatastore(t *testing.T, config postgresTestConfig) {
 		b := testdatastore.RunPostgresForTesting(t, "", config.targetMigration, config.pgVersion, config.pgbouncer)
 		ctx := context.Background()
 
-		test.AllWithExceptions(t, test.DatastoreTesterFunc(func(revisionQuantization, _, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+		test.AllWithExceptions(t, test.DatastoreTesterFunc(func(_ testing.TB, revisionQuantization, _, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 			ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 				ds, err := newPostgresDatastore(ctx, uri, primaryInstanceID,
 					RevisionQuantization(revisionQuantization),
@@ -318,7 +318,7 @@ func testPostgresDatastoreWithoutCommitTimestamps(t *testing.T, config postgresT
 
 		// NOTE: watch API requires the commit timestamps, so we skip those tests here.
 		// NOTE: gc tests take exclusive locks, so they are run under non-parallel.
-		test.AllWithExceptions(t, test.DatastoreTesterFunc(func(revisionQuantization, _, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+		test.AllWithExceptions(t, test.DatastoreTesterFunc(func(_ testing.TB, revisionQuantization, _, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 			ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 				ds, err := newPostgresDatastore(ctx, uri, primaryInstanceID,
 					RevisionQuantization(revisionQuantization),
@@ -338,7 +338,7 @@ func testPostgresDatastoreWithoutCommitTimestamps(t *testing.T, config postgresT
 	t.Run(fmt.Sprintf("postgres-%s-gc", pgVersion), func(t *testing.T) {
 		ctx := context.Background()
 		b := testdatastore.RunPostgresForTestingWithCommitTimestamps(t, "", "head", false, pgVersion, enablePgbouncer)
-		test.OnlyGCTests(t, test.DatastoreTesterFunc(func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+		test.OnlyGCTests(t, test.DatastoreTesterFunc(func(_ testing.TB, revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 			ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 				ds, err := newPostgresDatastore(ctx, uri, primaryInstanceID,
 					RevisionQuantization(revisionQuantization),

--- a/internal/datastore/proxy/observable_test.go
+++ b/internal/datastore/proxy/observable_test.go
@@ -10,12 +10,10 @@ import (
 	"github.com/authzed/spicedb/pkg/datastore/test"
 )
 
-type observableTest struct {
-	t *testing.T
-}
+type observableTest struct{}
 
-func (obs observableTest) New(revisionQuantization, _, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
-	db, err := dsfortesting.NewMemDBDatastoreForTesting(obs.t, watchBufferLength, revisionQuantization, gcWindow)
+func (obs observableTest) New(tb testing.TB, revisionQuantization, _, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	db, err := dsfortesting.NewMemDBDatastoreForTesting(tb, watchBufferLength, revisionQuantization, gcWindow)
 	if err != nil {
 		return nil, err
 	}
@@ -23,7 +21,7 @@ func (obs observableTest) New(revisionQuantization, _, gcWindow time.Duration, w
 }
 
 func TestObservableProxy(t *testing.T) {
-	test.All(t, observableTest{t}, true)
+	test.All(t, observableTest{}, true)
 }
 
 func (p *observableProxy) ExampleRetryableError() error {

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -32,7 +32,7 @@ func TestSpannerDatastore(t *testing.T) {
 	b := testdatastore.RunSpannerForTesting(t, "", "head")
 
 	// Transaction tests are excluded because, for reasons unknown, one cannot read its own write in one transaction in the Spanner emulator.
-	test.AllWithExceptions(t, test.DatastoreTesterFunc(func(revisionQuantization, _, _ time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	test.AllWithExceptions(t, test.DatastoreTesterFunc(func(_ testing.TB, revisionQuantization, _, _ time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
 		ds := b.NewDatastore(t, func(engine, uri string) datastore.Datastore {
 			ds, err := NewSpannerDatastore(ctx, uri,
 				RevisionQuantization(revisionQuantization),

--- a/pkg/datastore/test/basic.go
+++ b/pkg/datastore/test/basic.go
@@ -15,7 +15,7 @@ func UseAfterCloseTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
 	// Create the datastore.
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	// Immediately close it.
@@ -28,7 +28,7 @@ func UseAfterCloseTest(t *testing.T, tester DatastoreTester) {
 }
 
 func DeleteAllDataTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, revision := testfixtures.StandardDatastoreWithCaveatedData(rawDS, require.New(t))
@@ -87,7 +87,7 @@ func UniqueIDTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
 	// Create the datastore.
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	// Ensure the unique ID is not empty.

--- a/pkg/datastore/test/bulk.go
+++ b/pkg/datastore/test/bulk.go
@@ -28,7 +28,7 @@ func BulkUploadTest(t *testing.T, tester DatastoreTester) {
 			require := require.New(t)
 			ctx := t.Context()
 
-			rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+			rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(err)
 
 			ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -68,7 +68,7 @@ func BulkUploadErrorsTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 	ctx := t.Context()
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -88,7 +88,7 @@ func BulkUploadAlreadyExistsSameCallErrorTest(t *testing.T, tester DatastoreTest
 	require := require.New(t)
 	ctx := t.Context()
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -127,7 +127,7 @@ func BulkUploadWithCaveats(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 	ctx := t.Context()
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -169,7 +169,7 @@ func BulkUploadWithExpiration(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 	ctx := t.Context()
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -207,7 +207,7 @@ func BulkUploadEditCaveat(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 	ctx := t.Context()
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -273,7 +273,7 @@ func BulkUploadAlreadyExistsErrorTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 	ctx := t.Context()
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)

--- a/pkg/datastore/test/caveat.go
+++ b/pkg/datastore/test/caveat.go
@@ -28,7 +28,7 @@ import (
 func CaveatNotFoundTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx := t.Context()
@@ -42,7 +42,7 @@ func CaveatNotFoundTest(t *testing.T, tester DatastoreTester) {
 
 func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
-	ds, err := tester.New(0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
 	req.NoError(err)
 
 	skipIfNotCaveatStorer(t, ds)
@@ -129,7 +129,7 @@ func WriteReadDeleteCaveatTest(t *testing.T, tester DatastoreTester) {
 
 func WriteCaveatedRelationshipTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
-	ds, err := tester.New(0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
 	req.NoError(err)
 
 	skipIfNotCaveatStorer(t, ds)
@@ -205,7 +205,7 @@ func WriteCaveatedRelationshipTest(t *testing.T, tester DatastoreTester) {
 
 func CaveatedRelationshipFilterTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
-	ds, err := tester.New(0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
 	req.NoError(err)
 
 	skipIfNotCaveatStorer(t, ds)
@@ -254,7 +254,7 @@ func CaveatedRelationshipFilterTest(t *testing.T, tester DatastoreTester) {
 
 func CaveatSnapshotReadsTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
-	ds, err := tester.New(0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 1)
 	req.NoError(err)
 
 	skipIfNotCaveatStorer(t, ds)
@@ -287,7 +287,7 @@ func CaveatSnapshotReadsTest(t *testing.T, tester DatastoreTester) {
 
 func CaveatedRelationshipWatchTest(t *testing.T, tester DatastoreTester) {
 	req := require.New(t)
-	ds, err := tester.New(0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 16)
+	ds, err := tester.New(t, 0*time.Second, veryLargeGCInterval, veryLargeGCWindow, 16)
 	req.NoError(err)
 
 	skipIfNotCaveatStorer(t, ds)

--- a/pkg/datastore/test/counters.go
+++ b/pkg/datastore/test/counters.go
@@ -18,7 +18,7 @@ import (
 )
 
 func RelationshipCounterOverExpiredTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
@@ -69,7 +69,7 @@ func RelationshipCounterOverExpiredTest(t *testing.T, tester DatastoreTester) {
 }
 
 func RegisterRelationshipCountersInParallelTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
@@ -112,7 +112,7 @@ func RegisterRelationshipCountersInParallelTest(t *testing.T, tester DatastoreTe
 }
 
 func RelationshipCountersTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, rev := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
@@ -215,7 +215,7 @@ func RelationshipCountersTest(t *testing.T, tester DatastoreTester) {
 }
 
 func RelationshipCountersWithOddFilterTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
 
@@ -257,7 +257,7 @@ func RelationshipCountersWithOddFilterTest(t *testing.T, tester DatastoreTester)
 }
 
 func UpdateRelationshipCounterTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, rev := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -23,13 +23,13 @@ const (
 // a particular datastore.
 type DatastoreTester interface {
 	// New creates a new datastore instance for a single test.
-	New(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error)
+	New(tb testing.TB, revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error)
 }
 
-type DatastoreTesterFunc func(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error)
+type DatastoreTesterFunc func(tb testing.TB, revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error)
 
-func (f DatastoreTesterFunc) New(revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
-	return f(revisionQuantization, gcInterval, gcWindow, watchBufferLength)
+func (f DatastoreTesterFunc) New(tb testing.TB, revisionQuantization, gcInterval, gcWindow time.Duration, watchBufferLength uint16) (datastore.Datastore, error) {
+	return f(tb, revisionQuantization, gcInterval, gcWindow, watchBufferLength)
 }
 
 type TestableDatastore interface {

--- a/pkg/datastore/test/namespace.go
+++ b/pkg/datastore/test/namespace.go
@@ -36,7 +36,7 @@ var (
 func NamespaceNotFoundTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx := t.Context()
@@ -53,7 +53,7 @@ func NamespaceNotFoundTest(t *testing.T, tester DatastoreTester) {
 func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx := t.Context()
@@ -144,7 +144,7 @@ func NamespaceWriteTest(t *testing.T, tester DatastoreTester) {
 func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -196,7 +196,7 @@ func NamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 func NamespaceDeleteNoRelationshipsTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, revision := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -230,7 +230,7 @@ func NamespaceDeleteNoRelationshipsTest(t *testing.T, tester DatastoreTester) {
 }
 
 func NamespaceMultiDeleteTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
@@ -258,7 +258,7 @@ func NamespaceMultiDeleteTest(t *testing.T, tester DatastoreTester) {
 func EmptyNamespaceDeleteTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, revision := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -293,7 +293,7 @@ definition document {
 	require.Len(compiled.OrderedDefinitions, 2)
 
 	// Write the namespace definition to the datastore.
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx := t.Context()
@@ -344,7 +344,7 @@ definition document {
 	require.Len(compiled.OrderedDefinitions, 2)
 
 	// Write the namespace definition to the datastore.
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx := t.Context()

--- a/pkg/datastore/test/pagination.go
+++ b/pkg/datastore/test/pagination.go
@@ -32,7 +32,7 @@ func OrderingTest(t *testing.T, tester DatastoreTester) {
 		{testfixtures.UserNS.Name, options.BySubject},
 	}
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, rev := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
@@ -74,7 +74,7 @@ func LimitTest(t *testing.T, tester DatastoreTester) {
 		testfixtures.FolderNS.Name,
 	}
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, rev := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
@@ -171,7 +171,7 @@ var orderedTestCases = []struct {
 }
 
 func OrderedLimitTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, rev := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
@@ -209,7 +209,7 @@ func OrderedLimitTest(t *testing.T, tester DatastoreTester) {
 }
 
 func ResumeTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	ds, rev := testfixtures.StandardDatastoreWithData(rawDS, require.New(t))
@@ -254,7 +254,7 @@ func ResumeTest(t *testing.T, tester DatastoreTester) {
 }
 
 func ReverseQueryFilteredOverMultipleValuesCursorTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	// Create a datastore with the standard schema but no data.
@@ -321,7 +321,7 @@ func ReverseQueryFilteredOverMultipleValuesCursorTest(t *testing.T, tester Datas
 }
 
 func ReverseQueryCursorTest(t *testing.T, tester DatastoreTester) {
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(t, err)
 
 	// Create a datastore with the standard schema but no data.

--- a/pkg/datastore/test/relationships.go
+++ b/pkg/datastore/test/relationships.go
@@ -43,7 +43,7 @@ func SimpleTest(t *testing.T, tester DatastoreTester) {
 
 	for _, numRels := range testCases {
 		t.Run(strconv.Itoa(numRels), func(t *testing.T) {
-			ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+			ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(t, err)
 			defer ds.Close()
 
@@ -270,7 +270,7 @@ func ObjectIDsTest(t *testing.T, tester DatastoreTester) {
 			ctx := t.Context()
 			require := require.New(t)
 
-			ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+			ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(err)
 			defer ds.Close()
 
@@ -399,7 +399,7 @@ func DeleteRelationshipsTest(t *testing.T, tester DatastoreTester) {
 			require := require.New(t)
 			ctx := t.Context()
 
-			ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+			ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(err)
 			defer ds.Close()
 
@@ -443,7 +443,7 @@ func InvalidReadsTest(t *testing.T, tester DatastoreTester) {
 
 		require := require.New(t)
 
-		ds, err := tester.New(0, veryLargeGCInterval, testGCDuration, 1)
+		ds, err := tester.New(t, 0, veryLargeGCInterval, testGCDuration, 1)
 		require.NoError(err)
 		defer ds.Close()
 
@@ -487,7 +487,7 @@ func InvalidReadsTest(t *testing.T, tester DatastoreTester) {
 func DeleteNotExistantTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -508,7 +508,7 @@ func DeleteNotExistantTest(t *testing.T, tester DatastoreTester) {
 func DeleteAlreadyDeletedTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -543,7 +543,7 @@ func DeleteAlreadyDeletedTest(t *testing.T, tester DatastoreTester) {
 func WriteDeleteWriteTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -570,7 +570,7 @@ func WriteDeleteWriteTest(t *testing.T, tester DatastoreTester) {
 func CreateAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -600,7 +600,7 @@ func CreateAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 func TouchAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -630,7 +630,7 @@ func TouchAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 func CreateDeleteTouchTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -659,7 +659,7 @@ func CreateDeleteTouchTest(t *testing.T, tester DatastoreTester) {
 func DeleteOneThousandIndividualInOneCallTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -694,7 +694,7 @@ func DeleteOneThousandIndividualInOneCallTest(t *testing.T, tester DatastoreTest
 func DeleteWithInvalidPrefixTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -714,7 +714,7 @@ func DeleteWithInvalidPrefixTest(t *testing.T, tester DatastoreTester) {
 func DeleteWithPrefixTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -825,7 +825,7 @@ func DeleteWithPrefixTest(t *testing.T, tester DatastoreTester) {
 func MixedWriteOperationsTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -915,7 +915,7 @@ func MixedWriteOperationsTest(t *testing.T, tester DatastoreTester) {
 func DeleteWithLimitTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -969,7 +969,7 @@ func DeleteWithLimitTest(t *testing.T, tester DatastoreTester) {
 func DeleteCaveatedTupleTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -1089,7 +1089,7 @@ func DeleteRelationshipsWithVariousFiltersTest(t *testing.T, tester DatastoreTes
 				t.Run(fmt.Sprintf("withLimit=%v", withLimit), func(t *testing.T) {
 					require := require.New(t)
 
-					rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+					rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 					require.NoError(err)
 
 					// Write the initial relationships.
@@ -1184,7 +1184,7 @@ func DeleteRelationshipsWithVariousFiltersTest(t *testing.T, tester DatastoreTes
 func RecreateRelationshipsAfterDeleteWithFilter(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -1759,7 +1759,7 @@ func QueryRelationshipsWithVariousFiltersTest(t *testing.T, tester DatastoreTest
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
-			rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+			rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(err)
 
 			ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)
@@ -1793,7 +1793,7 @@ func QueryRelationshipsWithVariousFiltersTest(t *testing.T, tester DatastoreTest
 func RelationshipCaveatFilteringTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -1874,7 +1874,7 @@ func RelationshipCaveatFilteringTest(t *testing.T, tester DatastoreTester) {
 func RelationshipExpirationTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -1938,7 +1938,7 @@ func RelationshipExpirationTest(t *testing.T, tester DatastoreTester) {
 func TypedTouchAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -1960,7 +1960,7 @@ func TypedTouchAlreadyExistingTest(t *testing.T, tester DatastoreTester) {
 func TypedTouchAlreadyExistingWithCaveatTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -1985,7 +1985,7 @@ func TypedTouchAlreadyExistingWithCaveatTest(t *testing.T, tester DatastoreTeste
 func CreateTouchDeleteTouchTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -2019,7 +2019,7 @@ func CreateTouchDeleteTouchTest(t *testing.T, tester DatastoreTester) {
 func TouchAlreadyExistingCaveatedTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -2044,7 +2044,7 @@ func TouchAlreadyExistingCaveatedTest(t *testing.T, tester DatastoreTester) {
 func MultipleReadsInRWTTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -2077,7 +2077,7 @@ func MultipleReadsInRWTTest(t *testing.T, tester DatastoreTester) {
 func WriteAndReadInRWT(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -2109,7 +2109,7 @@ func WriteAndReadInRWT(t *testing.T, tester DatastoreTester) {
 func ConcurrentWriteSerializationTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithData(rawDS, require)
@@ -2169,7 +2169,7 @@ func ConcurrentWriteSerializationTest(t *testing.T, tester DatastoreTester) {
 func BulkDeleteRelationshipsTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ := testfixtures.StandardDatastoreWithSchema(rawDS, require)

--- a/pkg/datastore/test/revisions.go
+++ b/pkg/datastore/test/revisions.go
@@ -34,7 +34,7 @@ func RevisionQuantizationTest(t *testing.T, tester DatastoreTester) {
 		t.Run(fmt.Sprintf("quantization%s", tc.quantizationRange), func(t *testing.T) {
 			require := require.New(t)
 
-			ds, err := tester.New(tc.quantizationRange, veryLargeGCInterval, veryLargeGCWindow, 1)
+			ds, err := tester.New(t, tc.quantizationRange, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(err)
 
 			ctx := t.Context()
@@ -75,7 +75,7 @@ func RevisionQuantizationTest(t *testing.T, tester DatastoreTester) {
 func RevisionSerializationTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
@@ -101,7 +101,7 @@ func GCProcessRunTest(t *testing.T, tester DatastoreTester) {
 	gcWindow := 300 * time.Millisecond
 	gcInterval := 500 * time.Millisecond
 
-	ds, err := tester.New(0, gcInterval, gcWindow, 1)
+	ds, err := tester.New(t, 0, gcInterval, gcWindow, 1)
 	require.NoError(err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -146,7 +146,7 @@ func RevisionGCTest(t *testing.T, tester DatastoreTester) {
 	gcWindow := 300 * time.Millisecond
 
 	// NOTE: we disable the background GC process here and instead manually run it below.
-	ds, err := tester.New(0, veryLargeGCInterval, gcWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, gcWindow, 1)
 	require.NoError(err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -228,7 +228,7 @@ func RevisionGCTest(t *testing.T, tester DatastoreTester) {
 func CheckRevisionsTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, 1000*time.Second, 300*time.Minute, 1)
+	ds, err := tester.New(t, 0, 1000*time.Second, 300*time.Minute, 1)
 	require.NoError(err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -268,7 +268,7 @@ func CheckRevisionsTest(t *testing.T, tester DatastoreTester) {
 func SequentialRevisionsTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, 10*time.Second, 300*time.Minute, 1)
+	ds, err := tester.New(t, 0, 10*time.Second, 300*time.Minute, 1)
 	require.NoError(err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -291,7 +291,7 @@ func SequentialRevisionsTest(t *testing.T, tester DatastoreTester) {
 func ConcurrentRevisionsTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, 10*time.Second, 300*time.Minute, 1)
+	ds, err := tester.New(t, 0, 10*time.Second, 300*time.Minute, 1)
 	require.NoError(err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)

--- a/pkg/datastore/test/stats.go
+++ b/pkg/datastore/test/stats.go
@@ -16,7 +16,7 @@ func StatsTest(t *testing.T, tester DatastoreTester) {
 	ctx := t.Context()
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	ds, _ = testfixtures.StandardDatastoreWithData(ds, require)

--- a/pkg/datastore/test/transactions.go
+++ b/pkg/datastore/test/transactions.go
@@ -31,7 +31,7 @@ func RetryTest(t *testing.T, tester DatastoreTester) {
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
-			rawDS, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+			rawDS, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 			require.NoError(err)
 
 			var ds TestableDatastore

--- a/pkg/datastore/test/watch.go
+++ b/pkg/datastore/test/watch.go
@@ -60,7 +60,7 @@ func WatchTest(t *testing.T, tester DatastoreTester) {
 		t.Run(fmt.Sprintf("%d-%v", tc.numTuples, tc.expectFallBehind), func(t *testing.T) {
 			require := require.New(t)
 
-			ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 16)
+			ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
 			require.NoError(err)
 
 			setupDatastore(ds, require)
@@ -235,7 +235,7 @@ func setOfChanges(changes []tuple.RelationshipUpdate) *mapz.Set[string] {
 func WatchCancelTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 1)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 1)
 	require.NoError(err)
 
 	startWatchRevision := setupDatastore(ds, require)
@@ -281,7 +281,7 @@ func WatchCancelTest(t *testing.T, tester DatastoreTester) {
 func WatchWithTouchTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 16)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
 	require.NoError(err)
 
 	setupDatastore(ds, require)
@@ -386,7 +386,7 @@ func WatchWithTouchTest(t *testing.T, tester DatastoreTester) {
 func WatchWithExpirationTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 16)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
 	require.NoError(err)
 
 	setupDatastore(ds, require)
@@ -431,7 +431,7 @@ func WatchWithMetadataTest(t *testing.T, tester DatastoreTester) {
 
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 16)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
 	require.NoError(err)
 
 	setupDatastore(ds, require)
@@ -470,7 +470,7 @@ func WatchWithMetadataTest(t *testing.T, tester DatastoreTester) {
 func WatchWithDeleteTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 16)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
 	require.NoError(err)
 
 	setupDatastore(ds, require)
@@ -562,7 +562,7 @@ func verifyNoUpdates(
 func WatchSchemaTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 16)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
 	require.NoError(err)
 
 	setupDatastore(ds, require)
@@ -654,7 +654,7 @@ func WatchSchemaTest(t *testing.T, tester DatastoreTester) {
 func WatchAllTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 16)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
 	require.NoError(err)
 
 	setupDatastore(ds, require)
@@ -786,7 +786,7 @@ func verifyMixedUpdates(
 func WatchCheckpointsTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 16)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
 	require.NoError(err)
 
 	setupDatastore(ds, require)
@@ -821,7 +821,7 @@ func WatchCheckpointsTest(t *testing.T, tester DatastoreTester) {
 func WatchEmissionStrategyTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
-	ds, err := tester.New(0, veryLargeGCInterval, veryLargeGCWindow, 16)
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
 	require.NoError(err)
 
 	setupDatastore(ds, require)


### PR DESCRIPTION
## Description

This change allows us to (optionally) cleanup datastore instances on a per-test basis, rather than waiting for the whole test suite to finish.
