### PR TITLE
chore: walk postgres versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -227,7 +227,7 @@ jobs:
       fail-fast: false
       matrix:
         datastore: ["postgres"]
-        pgversion: ["13.8", "14", "15", "16", "17"]
+        pgversion: ["14", "15", "16", "17", "18"]
     steps:
       - uses: "actions/checkout@v6"
         if: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- Updated CI so that Postgres tests run against v18 which is GA and not against v13 which is EOL (https://github.com/authzed/spicedb/pull/2926)
 
 ## [1.49.2] - 2026-03-02
 ### Added


### PR DESCRIPTION
## Description
Version 18 is general release, version 13 is EOL. This updates our CI matrix to reflect that.

## Changes
* Remove 13, add 18
## Testing
Review.