### PR TITLE
chore: revert release append behavior in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -208,7 +208,11 @@ nightly:
 release:
   draft: false
   prerelease: "auto"
-  mode: "append"
+  # NOTE: this replaces the contents of the existing release with the same contents + the
+  # table of release artifacts. This means that if you edit the release while goreleaser
+  # is running, you'll lose the edits; the awkwardness here reflects that goreleaser
+  # expects that it's creating the release, rather than us creating the release manually.
+  mode: "replace"
   footer: |
     ## Docker Images
     This release is available at `authzed/spicedb:v{{ .Version }}`, `quay.io/authzed/spicedb:v{{ .Version }}`, `ghcr.io/authzed/spicedb:v{{ .Version }}`


### PR DESCRIPTION
## Description
This is what append does in practice:
<img width="1627" height="1263" alt="image" src="https://github.com/user-attachments/assets/63cb2940-01d8-4808-95a6-19140a5f2f09" />

replacing and then modifying makes more sense.

## Changes
* Revert back to `replace`
* Add a note
## Testing
Review.