### PR TITLE
chore: use correct logger in import logic

### DIFF
--- a/pkg/composableschemadsl/compiler/importer.go
+++ b/pkg/composableschemadsl/compiler/importer.go
@@ -6,8 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/rs/zerolog/log"
-
+	"github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/input"
 )
 
@@ -21,7 +20,7 @@ func importFile(fsys fs.FS, filePath string) (*dslNode, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read import in schema file: %w", err)
 	}
-	log.Trace().Str("schema", string(schemaBytes)).Str("file", filePath).Msg("read schema from file")
+	logging.Trace().Str("schema", string(schemaBytes)).Str("file", filePath).Msg("read schema from file")
 
 	parsedSchema, _, err := parseSchema(InputSchema{
 		Source:       input.Source(filePath),

--- a/pkg/composableschemadsl/compiler/translator.go
+++ b/pkg/composableschemadsl/compiler/translator.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/ccoveille/go-safecast/v2"
 	"github.com/jzelinskie/stringz"
-	"github.com/rs/zerolog/log"
 
+	"github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/caveats"
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/composableschemadsl/dslshape"
@@ -85,7 +85,7 @@ func translate(tctx *translationContext, root *dslNode) (*CompiledSchema, error)
 			}
 
 		case dslshape.NodeTypeCaveatDefinition:
-			log.Trace().Msg("adding caveat definition")
+			logging.Trace().Msg("adding caveat definition")
 			// TODO: Maybe refactor these in terms of a generic function?
 			def, err := translateCaveatDefinition(tctx, topLevelNode)
 			if err != nil {
@@ -106,7 +106,7 @@ func translate(tctx *translationContext, root *dslNode) (*CompiledSchema, error)
 			orderedDefinitions = append(orderedDefinitions, def)
 
 		case dslshape.NodeTypeDefinition:
-			log.Trace().Msg("adding object definition")
+			logging.Trace().Msg("adding object definition")
 			def, err := translateObjectDefinition(tctx, topLevelNode)
 			if err != nil {
 				return nil, err
@@ -817,7 +817,7 @@ func translateImports(itctx importResolutionContext, root *dslNode) error {
 				// by not reading the schema file in and compiling a schema with an empty string.
 				// This prevents duplicate definitions from ending up in the output, as well
 				// as preventing circular imports.
-				log.Debug().Str("filepath", filePath).Msg("file has already been visited in another part of the walk")
+				logging.Debug().Str("filepath", filePath).Msg("file has already been visited in another part of the walk")
 				continue
 			}
 

--- a/pkg/schemadsl/compiler/importer.go
+++ b/pkg/schemadsl/compiler/importer.go
@@ -6,8 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/rs/zerolog/log"
-
+	"github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
 )
 
@@ -21,7 +20,7 @@ func importFile(fsys fs.FS, filePath string) (*dslNode, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read import in schema file %q: %w", filePath, err)
 	}
-	log.Trace().Str("schema", string(schemaBytes)).Str("file", filePath).Msg("read schema from file")
+	logging.Trace().Str("schema", string(schemaBytes)).Str("file", filePath).Msg("read schema from file")
 
 	parsedSchema, _, err := parseSchema(InputSchema{
 		Source:       input.Source(filePath),

--- a/pkg/schemadsl/compiler/translator.go
+++ b/pkg/schemadsl/compiler/translator.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/ccoveille/go-safecast/v2"
 	"github.com/jzelinskie/stringz"
-	"github.com/rs/zerolog/log"
 
+	"github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/caveats"
 	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
@@ -105,7 +105,7 @@ func translate(tctx *translationContext, root *dslNode) (*CompiledSchema, error)
 			orderedDefinitions = append(orderedDefinitions, def)
 
 		case dslshape.NodeTypeDefinition:
-			log.Trace().Msg("adding object definition")
+			logging.Trace().Msg("adding object definition")
 			def, err := translateObjectDefinition(tctx, topLevelNode)
 			if err != nil {
 				return nil, err
@@ -859,7 +859,7 @@ func translateImports(itctx importResolutionContext, root *dslNode) error {
 				// by not reading the schema file in and compiling a schema with an empty string.
 				// This prevents duplicate definitions from ending up in the output, as well
 				// as preventing circular imports.
-				log.Debug().Str("filepath", filePath).Msg("file has already been visited in another part of the walk")
+				logging.Debug().Str("filepath", filePath).Msg("file has already been visited in another part of the walk")
 				continue
 			}
 


### PR DESCRIPTION
## Description
I used the incorrect logger when I originally wrote this, and then I copied it when I moved import logic into `schemadsl`. This fixes it.

## Changes
* Use our internal `logging` package instead of a bare reference to zerolog
## Testing
Review.