### PR TITLE
ci: add concurrency settings to workflows

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "Main"
 on: # yamllint disable-line rule:truthy
@@ -5,6 +6,10 @@ on: # yamllint disable-line rule:truthy
   push:
     branches:
       - "main"
+
+concurrency:
+  group: "spicedb-benchmark-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
 
 permissions:
   # permission to update benchmark contents in gh-pages branch

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "Build & Test"
 on: # yamllint disable-line rule:truthy
@@ -12,6 +13,9 @@ on: # yamllint disable-line rule:truthy
       - "checks_requested"
 permissions:
   contents: "read"
+concurrency:
+  group: "spicedb-test-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
 env:
   DOCKERHUB_PUBLIC_ACCESS_TOKEN: "dckr_pat_8AEETZWxu8f7FvJUk9NrpyX_ZEQ"
   DOCKERHUB_PUBLIC_USER: "spicedbgithubactions"

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "CLA"
 on: # yamllint disable-line rule:truthy
@@ -17,6 +18,9 @@ permissions:
   contents: "read" # CLA signatures are stored in https://github.com/authzed/cla
   pull-requests: "write"
   statuses: "write"
+concurrency:
+  group: "spicedb-cla-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
 jobs:
   cla:
     name: "Check Signature"

--- a/.github/workflows/commit-messages.yaml
+++ b/.github/workflows/commit-messages.yaml
@@ -9,6 +9,9 @@ on: # yamllint disable-line rule:truthy
       - "reopened"
 permissions:
   contents: "read"
+concurrency:
+  group: "spicedb-commit-message-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
 jobs:
   conventional-commits:
     name: "Lint Commit Messages"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "Update Docs Repo"
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/keep-a-changelog.yaml
+++ b/.github/workflows/keep-a-changelog.yaml
@@ -15,6 +15,9 @@ on: # yamllint disable-line rule:truthy
 
 permissions:
   contents: "read"
+concurrency:
+  group: "spicedb-changelog-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
 
 jobs:
   changelog:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "Pull Request Labeler"
 on: # yamllint disable-line rule:truthy
@@ -7,6 +8,9 @@ on: # yamllint disable-line rule:truthy
       - "checks_requested"
 permissions:
   contents: "read"
+concurrency:
+  group: "spicedb-pr-labeler-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
 jobs:
   triage:
     runs-on: "depot-ubuntu-24.04-small"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "Lint"
 on: # yamllint disable-line rule:truthy
@@ -12,6 +13,9 @@ on: # yamllint disable-line rule:truthy
       - "checks_requested"
 permissions:
   contents: "read"
+concurrency:
+  group: "spicedb-lint-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
 jobs:
   go-license-check:
     name: "License Check"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "Devel (nightly) Release"
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "Release for Windows"
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "Release"
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "Security"
 on: # yamllint disable-line rule:truthy
@@ -15,6 +16,9 @@ permissions:
 env:
   DOCKERHUB_PUBLIC_ACCESS_TOKEN: "dckr_pat_8AEETZWxu8f7FvJUk9NrpyX_ZEQ"
   DOCKERHUB_PUBLIC_USER: "spicedbgithubactions"
+concurrency:
+  group: "spicedb-security-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
 jobs:
   codeql:
     name: "CodeQL Analyze"

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
 name: "Build WASM"
 on: # yamllint disable-line rule:truthy


### PR DESCRIPTION
Fixes #2944 

## Description
We're kicking off lots and lots of runs and github doesn't cancel existing runs by default. This changes that behavior.

## Changes
* Add `concurrency` settings
* Add schema tags to the top of each of these files
## Testing
Review.