### PR TITLE
chore: bump memory available to integration tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -100,7 +100,8 @@ jobs:
 
   integration:
     name: "Integration Tests"
-    runs-on: "depot-ubuntu-24.04-4"
+    # TODO: make these use arm once we find a set of compatible packages
+    runs-on: "depot-ubuntu-24.04-8"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'


### PR DESCRIPTION
## Description
These are regularly failing quietly.  When running them locally I watched them consume a hilarious amount of memory, which makes me think that they're ooming. Putting them in a bigger box should help, as well as speed them up.

## Changes
* Use a bigger box
## Testing
Review.