### PR TITLE
chore: add ctx to RevisionedReader.ReadSchema()

### DIFF
--- a/internal/caveats/run_test.go
+++ b/internal/caveats/run_test.go
@@ -471,7 +471,7 @@ func TestRunCaveatExpressions(t *testing.T) {
 			req.NoError(err)
 
 			dl := datalayer.NewDataLayer(ds)
-			sr, err := dl.SnapshotReader(headRevision).ReadSchema()
+			sr, err := dl.SnapshotReader(headRevision).ReadSchema(t.Context())
 			req.NoError(err)
 
 			for _, debugOption := range []RunCaveatExpressionDebugOption{
@@ -524,7 +524,7 @@ func TestRunCaveatWithMissingMap(t *testing.T) {
 	req.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, err := dl.SnapshotReader(headRevision).ReadSchema()
+	sr, err := dl.SnapshotReader(headRevision).ReadSchema(t.Context())
 	req.NoError(err)
 
 	result, err := RunSingleCaveatExpression(
@@ -556,7 +556,7 @@ func TestRunCaveatWithEmptyMap(t *testing.T) {
 	req.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, err := dl.SnapshotReader(headRevision).ReadSchema()
+	sr, err := dl.SnapshotReader(headRevision).ReadSchema(t.Context())
 	req.NoError(err)
 
 	_, err = RunSingleCaveatExpression(
@@ -594,7 +594,7 @@ func TestRunCaveatMultipleTimes(t *testing.T) {
 	req.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, err := dl.SnapshotReader(headRevision).ReadSchema()
+	sr, err := dl.SnapshotReader(headRevision).ReadSchema(t.Context())
 	req.NoError(err)
 
 	runner := NewCaveatRunner(types.Default.TypeSet)
@@ -662,7 +662,7 @@ func TestRunCaveatWithMissingDefinition(t *testing.T) {
 	req.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, err := dl.SnapshotReader(headRevision).ReadSchema()
+	sr, err := dl.SnapshotReader(headRevision).ReadSchema(t.Context())
 	req.NoError(err)
 
 	// Try to run a caveat that doesn't exist
@@ -697,7 +697,7 @@ func TestCaveatRunnerPopulateCaveatDefinitionsForExpr(t *testing.T) {
 	req.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, err := dl.SnapshotReader(headRevision).ReadSchema()
+	sr, err := dl.SnapshotReader(headRevision).ReadSchema(t.Context())
 	req.NoError(err)
 
 	runner := NewCaveatRunner(types.Default.TypeSet)
@@ -742,7 +742,7 @@ func TestCaveatRunnerEmptyExpression(t *testing.T) {
 	req.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, err := dl.SnapshotReader(headRevision).ReadSchema()
+	sr, err := dl.SnapshotReader(headRevision).ReadSchema(t.Context())
 	req.NoError(err)
 
 	runner := NewCaveatRunner(types.Default.TypeSet)
@@ -823,7 +823,7 @@ func TestUnknownCaveatOperation(t *testing.T) {
 	req.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, err := dl.SnapshotReader(headRevision).ReadSchema()
+	sr, err := dl.SnapshotReader(headRevision).ReadSchema(t.Context())
 	req.NoError(err)
 
 	runner := NewCaveatRunner(types.Default.TypeSet)

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -207,7 +207,7 @@ func (ld *localDispatcher) loadNamespace(ctx context.Context, nsName string, rev
 	reader := datalayer.MustFromContext(ctx).SnapshotReader(revision)
 
 	// Load namespace and relation from the datastore
-	schemaReader, err := reader.ReadSchema()
+	schemaReader, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return nil, rewriteNamespaceError(err)
 	}

--- a/internal/dispatch/keys/keys.go
+++ b/internal/dispatch/keys/keys.go
@@ -108,7 +108,7 @@ func (c *CanonicalKeyHandler) CheckCacheKey(ctx context.Context, req *v1.Dispatc
 		}
 		r := dl.SnapshotReader(revision)
 
-		sr, err := r.ReadSchema()
+		sr, err := r.ReadSchema(ctx)
 		if err != nil {
 			return emptyDispatchCacheKey, err
 		}

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -659,7 +659,7 @@ func (cc *ConcurrentChecker) checkComputedUserset(ctx context.Context, crc curre
 	// the same namespace as the caller, and thus must be fully typed checked.
 	if cu.Object == core.ComputedUserset_TUPLE_USERSET_OBJECT {
 		dl := datalayer.MustFromContext(ctx).SnapshotReader(crc.parentReq.Revision)
-		sr, err := dl.ReadSchema()
+		sr, err := dl.ReadSchema(ctx)
 		if err != nil {
 			return checkResultError(err, emptyMetadata)
 		}
@@ -698,7 +698,7 @@ type Traits struct {
 // types of the given relation support caveats or expiration.
 func TraitsForArrowRelation(ctx context.Context, reader datalayer.RevisionedReader, namespaceName string, relationName string) (Traits, error) {
 	// TODO(jschorr): Change to use the type system once we wire it through Check dispatch.
-	schemaReader, err := reader.ReadSchema()
+	schemaReader, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return Traits{}, err
 	}

--- a/internal/graph/computed/computecheck.go
+++ b/internal/graph/computed/computecheck.go
@@ -179,7 +179,7 @@ func computeCaveatedCheckResult(ctx context.Context, runner *cexpr.CaveatRunner,
 
 	dl := datalayer.MustFromContext(ctx)
 	reader := dl.SnapshotReader(params.AtRevision)
-	sr, err := reader.ReadSchema()
+	sr, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/graph/expand.go
+++ b/internal/graph/expand.go
@@ -244,7 +244,7 @@ func (ce *ConcurrentExpander) expandComputedUserset(ctx context.Context, req Val
 
 	// Check if the target relation exists. If not, return nothing.
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(req.Revision)
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return expandError(err)
 	}

--- a/internal/graph/lookupresources2.go
+++ b/internal/graph/lookupresources2.go
@@ -128,7 +128,7 @@ func (crr *CursoredLookupResources2) afterSameType(
 	// Load the type system and reachability graph to find the entrypoints for the reachability.
 	dl := datalayer.MustFromContext(ctx)
 	reader := dl.SnapshotReader(req.Revision)
-	sr, err := reader.ReadSchema()
+	sr, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return err
 	}
@@ -363,7 +363,7 @@ func (crr *CursoredLookupResources2) redispatchOrReportOverDatabaseQuery(
 			toBeHandled := make([]itemAndPostCursor[dispatchableResourcesSubjectMap2], 0)
 			currentCursor := queryCursor
 			caveatRunner := caveats.NewCaveatRunner(crr.caveatTypeSet)
-			caveatSR, err := config.reader.ReadSchema()
+			caveatSR, err := config.reader.ReadSchema(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/graph/lookupresources3.go
+++ b/internal/graph/lookupresources3.go
@@ -268,7 +268,7 @@ func (crr *CursoredLookupResources3) LookupResources3(req ValidatedLookupResourc
 	// interfaces used by various suboperations of the lookup resources operation.
 	dl := datalayer.MustFromContext(stream.Context())
 	reader := dl.SnapshotReader(req.Revision)
-	sr, err := reader.ReadSchema()
+	sr, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return err
 	}
@@ -813,7 +813,7 @@ func (crr *CursoredLookupResources3) relationshipsIter(
 
 					// Start the new relationships chunk that we will fill as we iterate over the results.
 					// It starts at the given dbCursor, which may be nil/empty if this is the first chunk.
-					caveatSR, err := refs.reader.ReadSchema()
+					caveatSR, err := refs.reader.ReadSchema(ctx)
 					if err != nil {
 						yieldError(err)
 						return

--- a/internal/graph/lookupsubjects.go
+++ b/internal/graph/lookupsubjects.go
@@ -69,7 +69,7 @@ func (cl *ConcurrentLookupSubjects) LookupSubjects(
 
 	dl := datalayer.MustFromContext(ctx)
 	reader := dl.SnapshotReader(req.Revision)
-	sr, err := reader.ReadSchema()
+	sr, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (cl *ConcurrentLookupSubjects) lookupViaComputed(
 	cu *core.ComputedUserset,
 ) error {
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(parentRequest.Revision)
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return err
 	}
@@ -259,7 +259,7 @@ func lookupViaIntersectionTupleToUserset(
 	ttu *core.FunctionedTupleToUserset,
 ) error {
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(parentRequest.Revision)
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return err
 	}
@@ -438,7 +438,7 @@ func lookupViaTupleToUserset[T relation](
 	relationshipsBySubjectONR := mapz.NewMultiMap[tuple.ObjectAndRelation, tuple.Relationship]()
 
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(parentRequest.Revision)
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/namespace/util_test.go
+++ b/internal/namespace/util_test.go
@@ -171,7 +171,7 @@ func TestCheckNamespaceAndRelations(t *testing.T) {
 			require.NoError(t, err)
 
 			dl := datalayer.NewDataLayer(ds)
-			sr, err := dl.SnapshotReader(rev).ReadSchema()
+			sr, err := dl.SnapshotReader(rev).ReadSchema(t.Context())
 			require.NoError(t, err)
 
 			err = namespace.CheckNamespaceAndRelations(t.Context(), tc.checks, sr)

--- a/internal/relationships/validation_test.go
+++ b/internal/relationships/validation_test.go
@@ -336,7 +336,7 @@ func TestValidateRelationshipOperations(t *testing.T) {
 
 			uds, rev := testfixtures.DatastoreFromSchemaAndTestRelationships(ds, tc.schema, nil, req)
 			dl := datalayer.NewDataLayer(uds)
-			sr, err := dl.SnapshotReader(rev).ReadSchema()
+			sr, err := dl.SnapshotReader(rev).ReadSchema(t.Context())
 			req.NoError(err)
 
 			op := tuple.Create

--- a/internal/services/shared/schema.go
+++ b/internal/services/shared/schema.go
@@ -94,7 +94,7 @@ type AppliedSchemaChanges struct {
 // ApplySchemaChanges applies schema changes found in the validated changes struct, via the specified
 // ReadWriteTransaction.
 func ApplySchemaChanges(ctx context.Context, rwt datalayer.ReadWriteTransaction, caveatTypeSet *caveattypes.TypeSet, validated *ValidatedSchemaChanges) (*AppliedSchemaChanges, error) {
-	sr, err := rwt.ReadSchema()
+	sr, err := rwt.ReadSchema(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func ApplySchemaChangesOverExisting(
 
 		// Get the list of extant definitions so that we can add them to the
 		// list of definitions that should be written in the single shot
-		sr, err := rwt.ReadSchema()
+		sr, err := rwt.ReadSchema(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/services/shared/schema_test.go
+++ b/internal/services/shared/schema_test.go
@@ -776,7 +776,7 @@ func TestApplySchemaChangesOverExisting(t *testing.T) {
 				require.NoError(err)
 				require.Equal(tc.expectedAppliedSchemaChanges, *applied)
 
-				sr, err := rwt.ReadSchema()
+				sr, err := rwt.ReadSchema(ctx)
 				require.NoError(err)
 				schemaText, err := sr.SchemaText(t.Context())
 				require.NoError(err)

--- a/internal/services/v1/bulkcheck.go
+++ b/internal/services/v1/bulkcheck.go
@@ -165,7 +165,7 @@ func (bc *bulkChecker) checkBulkPermissions(ctx context.Context, req *v1.CheckBu
 
 		dl := datalayer.MustFromContext(ctx).SnapshotReader(atRevision)
 
-		sr, err := dl.ReadSchema()
+		sr, err := dl.ReadSchema(ctx)
 		if err != nil {
 			return err
 		}
@@ -253,7 +253,7 @@ func (bc *bulkChecker) checkBulkPermissions(ctx context.Context, req *v1.CheckBu
 
 				dl := datalayer.MustFromContext(ctx).SnapshotReader(atRevision)
 
-				sr, err := dl.ReadSchema()
+				sr, err := dl.ReadSchema(ctx)
 				if err != nil {
 					return appendResultsForError(group.params, resourceIDs, err)
 				}

--- a/internal/services/v1/experimental.go
+++ b/internal/services/v1/experimental.go
@@ -259,7 +259,7 @@ func (es *experimentalServer) BulkImportRelationships(stream v1.ExperimentalServ
 			caveat:                 core.ContextualizedCaveat{},
 			caveatTypeSet:          es.caveatTypeSet,
 		}
-		sr, err := rwt.ReadSchema()
+		sr, err := rwt.ReadSchema(ctx)
 		if err != nil {
 			return err
 		}
@@ -352,7 +352,7 @@ func BulkExport(ctx context.Context, dl datalayer.DataLayer, batchSize uint64, r
 
 	reader := dl.SnapshotReader(atRevision)
 
-	sr, err := reader.ReadSchema()
+	sr, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return shared.RewriteErrorWithoutConfig(ctx, err)
 	}
@@ -603,7 +603,7 @@ func (es *experimentalServer) ExperimentalComputablePermissions(ctx context.Cont
 	}
 
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(atRevision)
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return nil, shared.RewriteErrorWithoutConfig(ctx, err)
 	}
@@ -690,7 +690,7 @@ func (es *experimentalServer) ExperimentalDependentRelations(ctx context.Context
 	}
 
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(atRevision)
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return nil, shared.RewriteErrorWithoutConfig(ctx, err)
 	}
@@ -764,7 +764,7 @@ func (es *experimentalServer) ExperimentalRegisterRelationshipCounter(ctx contex
 	}
 
 	_, err := dl.ReadWriteTx(ctx, func(ctx context.Context, rwt datalayer.ReadWriteTransaction) error {
-		sr, err := rwt.ReadSchema()
+		sr, err := rwt.ReadSchema(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/services/v1/permissions.go
+++ b/internal/services/v1/permissions.go
@@ -86,7 +86,7 @@ func (ps *permissionServer) CheckPermission(ctx context.Context, req *v1.CheckPe
 		return nil, ps.rewriteError(ctx, err)
 	}
 
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return nil, ps.rewriteError(ctx, err)
 	}
@@ -253,7 +253,7 @@ func (ps *permissionServer) ExpandPermissionTree(ctx context.Context, req *v1.Ex
 
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(atRevision)
 
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return nil, ps.rewriteError(ctx, err)
 	}
@@ -496,7 +496,7 @@ func (ps *permissionServer) lookupResources3(req *v1.LookupResourcesRequest, res
 
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(atRevision)
 
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return ps.rewriteError(ctx, err)
 	}
@@ -647,7 +647,7 @@ func (ps *permissionServer) lookupResources2(req *v1.LookupResourcesRequest, res
 
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(atRevision)
 
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return ps.rewriteError(ctx, err)
 	}
@@ -808,7 +808,7 @@ func (ps *permissionServer) LookupSubjects(req *v1.LookupSubjectsRequest, resp v
 		return ps.rewriteError(ctx, err)
 	}
 
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return ps.rewriteError(ctx, err)
 	}
@@ -1096,7 +1096,7 @@ func (ps *permissionServer) ImportBulkRelationships(stream grpc.ClientStreamingS
 			numWritten += streamWritten
 
 			// The stream has terminated because we're awaiting namespace and/or caveat information
-			schemaReader, err := rwt.ReadSchema()
+			schemaReader, err := rwt.ReadSchema(ctx)
 			if err != nil {
 				return err
 			}
@@ -1184,7 +1184,7 @@ func ExportBulk(ctx context.Context, dl datalayer.DataLayer, batchSize uint64, r
 
 	reader := dl.SnapshotReader(atRevision)
 
-	readerSchema, err := reader.ReadSchema()
+	readerSchema, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return shared.RewriteErrorWithoutConfig(ctx, err)
 	}

--- a/internal/services/v1/permissions_queryplan.go
+++ b/internal/services/v1/permissions_queryplan.go
@@ -26,7 +26,7 @@ func (ps *permissionServer) checkPermissionWithQueryPlan(ctx context.Context, re
 
 	// Load all namespace and caveat definitions to build the schema
 	// TODO: Better schema caching
-	sr, err := reader.ReadSchema()
+	sr, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return nil, ps.rewriteError(ctx, err)
 	}

--- a/internal/services/v1/reflectionutil.go
+++ b/internal/services/v1/reflectionutil.go
@@ -23,7 +23,7 @@ func loadCurrentSchema(ctx context.Context) (*diff.DiffableSchema, datastore.Rev
 
 	reader := dl.SnapshotReader(atRevision)
 
-	sr, err := reader.ReadSchema()
+	sr, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return nil, atRevision, err
 	}

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -203,7 +203,7 @@ func (ps *permissionServer) ReadRelationships(req *v1.ReadRelationshipsRequest, 
 	}
 
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(atRevision)
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return ps.rewriteError(ctx, err)
 	}
@@ -387,7 +387,7 @@ func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.Writ
 
 	revision, err := dl.ReadWriteTx(ctx, func(ctx context.Context, rwt datalayer.ReadWriteTransaction) error {
 		// Extract schema reader for validation.
-		sr, err := rwt.ReadSchema()
+		sr, err := rwt.ReadSchema(ctx)
 		if err != nil {
 			return err
 		}
@@ -494,7 +494,7 @@ func (ps *permissionServer) DeleteRelationships(ctx context.Context, req *v1.Del
 	var deletedRelationshipCount uint64
 	revision, err := dl.ReadWriteTx(ctx, func(ctx context.Context, rwt datalayer.ReadWriteTransaction) error {
 		// Extract schema reader for validation.
-		sr, err := rwt.ReadSchema()
+		sr, err := rwt.ReadSchema(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/services/v1/schema.go
+++ b/internal/services/v1/schema.go
@@ -91,7 +91,7 @@ func (ss *schemaServer) ReadSchema(ctx context.Context, _ *v1.ReadSchemaRequest)
 
 	reader := dl.SnapshotReader(headRevision)
 
-	sr, err := reader.ReadSchema()
+	sr, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return nil, ss.rewriteError(ctx, err)
 	}
@@ -270,7 +270,7 @@ func (ss *schemaServer) ComputablePermissions(ctx context.Context, req *v1.Compu
 	}
 
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(atRevision)
-	sr, err := dl.ReadSchema()
+	sr, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return nil, shared.RewriteErrorWithoutConfig(ctx, err)
 	}
@@ -357,7 +357,7 @@ func (ss *schemaServer) DependentRelations(ctx context.Context, req *v1.Dependen
 	}
 
 	dl := datalayer.MustFromContext(ctx).SnapshotReader(atRevision)
-	sr2, err := dl.ReadSchema()
+	sr2, err := dl.ReadSchema(ctx)
 	if err != nil {
 		return nil, shared.RewriteErrorWithoutConfig(ctx, err)
 	}

--- a/internal/services/v1/watch.go
+++ b/internal/services/v1/watch.go
@@ -83,7 +83,7 @@ func (ws *watchServer) Watch(req *v1.WatchRequest, stream v1.WatchService_WatchS
 	}
 
 	reader := dl.SnapshotReader(afterRevision)
-	sr, err := reader.ReadSchema()
+	sr, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to read schema: %s", err)
 	}

--- a/pkg/datalayer/counting.go
+++ b/pkg/datalayer/counting.go
@@ -121,8 +121,8 @@ type countingRevisionedReader struct {
 	counts   *MethodCounts
 }
 
-func (r *countingRevisionedReader) ReadSchema() (SchemaReader, error) {
-	return r.delegate.ReadSchema()
+func (r *countingRevisionedReader) ReadSchema(ctx context.Context) (SchemaReader, error) {
+	return r.delegate.ReadSchema(ctx)
 }
 
 func (r *countingRevisionedReader) QueryRelationships(ctx context.Context, filter datastore.RelationshipsFilter, opts ...options.QueryOptionsOption) (datastore.RelationshipIterator, error) {

--- a/pkg/datalayer/datalayer.go
+++ b/pkg/datalayer/datalayer.go
@@ -81,7 +81,7 @@ type SchemaReader interface {
 // RevisionedReader reads data at a specific revision.
 type RevisionedReader interface {
 	// ReadSchema returns a SchemaReader for organized schema operations.
-	ReadSchema() (SchemaReader, error)
+	ReadSchema(ctx context.Context) (SchemaReader, error)
 
 	// QueryRelationships reads relationships, starting from the resource side.
 	QueryRelationships(

--- a/pkg/datalayer/impl.go
+++ b/pkg/datalayer/impl.go
@@ -85,7 +85,7 @@ type revisionedReader struct {
 	reader datastore.Reader
 }
 
-func (r *revisionedReader) ReadSchema() (SchemaReader, error) {
+func (r *revisionedReader) ReadSchema(ctx context.Context) (SchemaReader, error) {
 	return &legacySchemaReaderAdapter{legacyReader: r.reader}, nil
 }
 
@@ -110,7 +110,7 @@ type readWriteTransaction struct {
 	rwt datastore.ReadWriteTransaction
 }
 
-func (t *readWriteTransaction) ReadSchema() (SchemaReader, error) {
+func (t *readWriteTransaction) ReadSchema(_ context.Context) (SchemaReader, error) {
 	return &legacySchemaReaderAdapter{legacyReader: t.rwt}, nil
 }
 

--- a/pkg/datastore/pagination/iterator_test.go
+++ b/pkg/datastore/pagination/iterator_test.go
@@ -109,7 +109,7 @@ type mockedReader struct {
 
 var _ datalayer.RevisionedReader = &mockedReader{}
 
-func (m *mockedReader) ReadSchema() (datalayer.SchemaReader, error) {
+func (m *mockedReader) ReadSchema(_ context.Context) (datalayer.SchemaReader, error) {
 	panic("not implemented")
 }
 

--- a/pkg/development/check.go
+++ b/pkg/development/check.go
@@ -44,7 +44,7 @@ func RunCheck(devContext *DevContext, resource tuple.ObjectAndRelation, subject 
 	}
 
 	reader := devContext.DataLayer.SnapshotReader(devContext.Revision)
-	sr, srErr := reader.ReadSchema()
+	sr, srErr := reader.ReadSchema(ctx)
 	if srErr != nil {
 		return CheckResult{v1dispatch.ResourceCheckResult_NOT_MEMBER, nil, nil, nil}, srErr
 	}

--- a/pkg/development/devcontext.go
+++ b/pkg/development/devcontext.go
@@ -240,7 +240,7 @@ func (dc *DevContext) Dispose() {
 func loadsRels(ctx context.Context, rels []tuple.Relationship, rwt datalayer.ReadWriteTransaction) ([]*devinterface.DeveloperError, error) {
 	devErrors := make([]*devinterface.DeveloperError, 0, len(rels))
 	updates := make([]tuple.RelationshipUpdate, 0, len(rels))
-	sr, srErr := rwt.ReadSchema()
+	sr, srErr := rwt.ReadSchema(ctx)
 	if srErr != nil {
 		return nil, srErr
 	}

--- a/pkg/query/caveat.go
+++ b/pkg/query/caveat.go
@@ -127,7 +127,7 @@ func (c *CaveatIterator) simplifyCaveat(ctx *Context, path Path) (*core.CaveatEx
 	}
 
 	// Use the SimplifyCaveatExpression function to properly handle AND/OR logic
-	sr, err := ctx.Reader.ReadSchema()
+	sr, err := ctx.Reader.ReadSchema(ctx)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get schema reader: %w", err)
 	}

--- a/pkg/query/simplify_caveat_test.go
+++ b/pkg/query/simplify_caveat_test.go
@@ -48,7 +48,7 @@ func TestSimplifyLeafCaveat(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 
@@ -137,7 +137,7 @@ func TestSimplifyAndOperation(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 
@@ -243,7 +243,7 @@ func TestSimplifyOrOperation(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 
@@ -361,7 +361,7 @@ func TestSimplifyNestedOperations(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 
@@ -448,7 +448,7 @@ func TestSimplifyOrWithSameCaveatDifferentContexts(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 
@@ -536,7 +536,7 @@ func TestSimplifyAndWithSameCaveatDifferentContexts(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 
@@ -634,7 +634,7 @@ func TestSimplifyNotWithSameCaveatDifferentContexts(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 
@@ -718,7 +718,7 @@ func TestSimplifyComplexNestedExpressions(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 
@@ -1187,7 +1187,7 @@ func TestSimplifyWithEmptyContext(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 
@@ -1271,7 +1271,7 @@ func TestSimplifyNotConditional(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 
@@ -1359,7 +1359,7 @@ func TestSimplifyDeeplyNestedCaveats(t *testing.T) {
 	require.NoError(err)
 
 	dl := datalayer.NewDataLayer(ds)
-	sr, srErr := dl.SnapshotReader(revision).ReadSchema()
+	sr, srErr := dl.SnapshotReader(revision).ReadSchema(ctx)
 	require.NoError(srErr)
 	runner := internalcaveats.NewCaveatRunner(caveattypes.Default.TypeSet)
 

--- a/pkg/schema/resolver.go
+++ b/pkg/schema/resolver.go
@@ -28,8 +28,8 @@ func ResolverFor(sr datalayer.SchemaReader) *DatastoreResolver {
 
 // ResolverForSchemaReader returns a TypeSystemResolver for a datalayer reader.
 // The reader's ReadSchema() method is called eagerly to resolve definitions.
-func ResolverForSchemaReader(reader datalayer.RevisionedReader) (*DatastoreResolver, error) {
-	sr, err := reader.ReadSchema()
+func ResolverForSchemaReader(ctx context.Context, reader datalayer.RevisionedReader) (*DatastoreResolver, error) {
+	sr, err := reader.ReadSchema(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -166,7 +166,7 @@ func PopulateFromFilesContents(ctx context.Context, dl datalayer.DataLayer, cave
 
 	// Load the definitions and relationships into the datastore.
 	revision, err := dl.ReadWriteTx(ctx, func(ctx context.Context, rwt datalayer.ReadWriteTransaction) error {
-		resolver, err := schema.ResolverForSchemaReader(rwt)
+		resolver, err := schema.ResolverForSchemaReader(ctx, rwt)
 		if err != nil {
 			return err
 		}
@@ -214,7 +214,7 @@ func PopulateFromFilesContents(ctx context.Context, dl datalayer.DataLayer, cave
 			chunkedRels = append(chunkedRels, update.Relationship)
 		}
 		revision, err = dl.ReadWriteTx(ctx, func(ctx context.Context, rwt datalayer.ReadWriteTransaction) error {
-			sr, srErr := rwt.ReadSchema()
+			sr, srErr := rwt.ReadSchema(ctx)
 			if srErr != nil {
 				return srErr
 			}


### PR DESCRIPTION
## Description

Noticed in https://github.com/authzed/spicedb/pull/2924 that spans were getting disconnected when `experimental-schema-mode=read-new-write-new`.

After this PR in merged, in https://github.com/josephschorr/spicedb/blob/3272cce5849c019a7df9f5d4241669f9d48df4b5/pkg/datalayer/schema_adapter.go#L340 we must remove the `context.Background()`.

