### PR TITLE
test: prevent duplicate metrics collector registration attempted

### DIFF
--- a/pkg/cmd/datastore_test.go
+++ b/pkg/cmd/datastore_test.go
@@ -21,6 +21,7 @@ func TestExecuteGC(t *testing.T) {
 			name: "cockroachdb does not support garbage collection",
 			cfgBuilder: func(t *testing.T) *datastore.Config {
 				cfg := datastore.DefaultDatastoreConfig()
+				cfg.EnableDatastoreMetrics = false // avoid "duplicate metrics collector registration attempted"
 				cfg.Engine = "cockroachdb"
 				runningDatastore := datastoreTest.RunDatastoreEngine(t, cfg.Engine)
 				db := runningDatastore.NewDatabase(t)
@@ -54,6 +55,7 @@ func TestExecuteRepair(t *testing.T) {
 			name: "cockroachdb does not support repair",
 			cfgBuilder: func(t *testing.T) *datastore.Config {
 				cfg := datastore.DefaultDatastoreConfig()
+				cfg.EnableDatastoreMetrics = false // avoid "duplicate metrics collector registration attempted"
 				cfg.Engine = "cockroachdb"
 				runningDatastore := datastoreTest.RunDatastoreEngine(t, cfg.Engine)
 				db := runningDatastore.NewDatabase(t)
@@ -66,6 +68,7 @@ func TestExecuteRepair(t *testing.T) {
 			name: "postgres supports repair",
 			cfgBuilder: func(t *testing.T) *datastore.Config {
 				cfg := datastore.DefaultDatastoreConfig()
+				cfg.EnableDatastoreMetrics = false // avoid "duplicate metrics collector registration attempted"
 				cfg.Engine = "postgres"
 				runningDatastore := datastoreTest.RunDatastoreEngine(t, cfg.Engine)
 				db := runningDatastore.NewDatabase(t)


### PR DESCRIPTION
This PR fixes a test flake.

The other way to prevent this flake is to do what https://github.com/authzed/spicedb/issues/2829 says, but this is more work and riskier.