### PR TITLE
chore: pre-warm validator caches

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -70,7 +70,7 @@ jobs:
 
   unit:
     name: "Unit"
-    runs-on: "depot-ubuntu-24.04-arm-4"
+    runs-on: "depot-ubuntu-24.04-arm-8"
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'

--- a/internal/services/v1/experimental.go
+++ b/internal/services/v1/experimental.go
@@ -99,7 +99,7 @@ func NewExperimentalServer(dispatch dispatch.Dispatcher, permServerConfig Permis
 	validator := genutil.MustNewProtoValidator(
 		// NOTE: using `WithMessages` here allows us to pre-warm the validator cache
 		protovalidate.WithMessages(
-			inputMessagesForService(v1.RegisterExperimentalServiceServer, *new(v1.ExperimentalServiceServer))...
+			inputMessagesForService(v1.RegisterExperimentalServiceServer, v1.ExperimentalServiceServer(nil))...,
 		))
 
 	return &experimentalServer{

--- a/internal/services/v1/genutil.go
+++ b/internal/services/v1/genutil.go
@@ -7,35 +7,49 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 )
 
-type descCapture struct {
+// fakeServiceRegistrar implements the grpc.ServiceRegistrar interface
+// so that we can interrogate the registered methods.
+type fakeServiceRegistrar struct {
+	// desc is a Service Description which we can interrogate
 	desc *grpc.ServiceDesc
 }
 
-func (d *descCapture) RegisterService(desc *grpc.ServiceDesc, impl any) {
+func (d *fakeServiceRegistrar) RegisterService(desc *grpc.ServiceDesc, impl any) {
 	d.desc = desc
 }
 
 // inputMessagesForService takes a registration function for a service
 // and the unimplemented service struct and returns a list of instantiated
-// messages for those services. Used to pre-warm protovalidator caches.
+// messages for those services. returns nil if it's unable to unpack the service.
+// Used to pre-warm protovalidator caches.
 func inputMessagesForService[S any](
 	registerFn func(grpc.ServiceRegistrar, S),
 	impl S,
-) ([]proto.Message) {
-	cap := &descCapture{}
-	registerFn(cap, impl)
+) []proto.Message {
+	registrar := &fakeServiceRegistrar{}
+	registerFn(registrar, impl)
 
 	desc, err := protoregistry.GlobalFiles.FindDescriptorByName(
-		protoreflect.FullName(cap.desc.ServiceName),
+		protoreflect.FullName(registrar.desc.ServiceName),
 	)
 	if err != nil {
 		return nil
 	}
 	svcDesc := desc.(protoreflect.ServiceDescriptor)
 
-	var msgs []proto.Message
-	for _, md := range cap.desc.Methods {
+	var msgs []proto.Message //nolint:prealloc  // we don't have any foreknowledge and also this isn't perf sensitive
+	// iterate over Methods to capture unary services
+	for _, md := range registrar.desc.Methods {
 		methodDesc := svcDesc.Methods().ByName(protoreflect.Name(md.MethodName))
+		msgType, err := protoregistry.GlobalTypes.FindMessageByName(methodDesc.Input().FullName())
+		if err != nil {
+			return nil
+		}
+		msgs = append(msgs, msgType.New().Interface())
+	}
+	// iterate over Streams to capture streaming services
+	for _, sd := range registrar.desc.Streams {
+		methodDesc := svcDesc.Methods().ByName(protoreflect.Name(sd.StreamName))
 		msgType, err := protoregistry.GlobalTypes.FindMessageByName(methodDesc.Input().FullName())
 		if err != nil {
 			return nil

--- a/internal/services/v1/genutil_test.go
+++ b/internal/services/v1/genutil_test.go
@@ -3,12 +3,13 @@ package v1
 import (
 	"testing"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/stretchr/testify/require"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 )
 
 func TestInputMessagesForService(t *testing.T) {
-	messages := inputMessagesForService(v1.RegisterPermissionsServiceServer, *new(v1.PermissionsServiceServer))
+	messages := inputMessagesForService(v1.RegisterPermissionsServiceServer, v1.PermissionsServiceServer(nil))
 	require.NotEmpty(t, messages)
 	// Ensure that a CheckPermissionsRequest is in the list
 	checkPermRequestFound := false
@@ -27,4 +28,17 @@ func TestInputMessagesForService(t *testing.T) {
 		}
 	}
 	require.True(t, lrRequestFound, "did not find a LookupResourcesRequest in the list")
+}
+
+func TestInputMessagesForServiceOnWatch(t *testing.T) {
+	messages := inputMessagesForService(v1.RegisterWatchServiceServer, v1.WatchServiceServer(nil))
+	require.NotEmpty(t, messages)
+	// Ensure that a CheckPermissionsRequest is in the list
+	watchRequestFound := false
+	for _, message := range messages {
+		if _, ok := message.(*v1.WatchRequest); ok {
+			watchRequestFound = true
+		}
+	}
+	require.True(t, watchRequestFound, "did not find a CheckPermissionRequest in the list")
 }

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	// "reflect"
 	"time"
 
 	"buf.build/go/protovalidate"
@@ -152,7 +151,7 @@ func NewPermissionsServer(
 	validator := genutil.MustNewProtoValidator(
 		// NOTE: using `WithMessages` here allows us to pre-warm the validator cache
 		protovalidate.WithMessages(
-			inputMessagesForService(v1.RegisterPermissionsServiceServer, *new(v1.PermissionsServiceServer))...
+			inputMessagesForService(v1.RegisterPermissionsServiceServer, v1.PermissionsServiceServer(nil))...,
 		))
 
 	return &permissionServer{

--- a/internal/services/v1/schema.go
+++ b/internal/services/v1/schema.go
@@ -50,13 +50,9 @@ func NewSchemaServer(config SchemaServerConfig) v1.SchemaServiceServer {
 	validator := genutil.MustNewProtoValidator(
 		// NOTE: using `WithMessages` here allows us to pre-warm the validator cache. As new
 		// methods are added to this service, you'll need to add new messages to this method.
+		// NOTE: using `WithMessages` here allows us to pre-warm the validator cache
 		protovalidate.WithMessages(
-			&v1.ReadSchemaRequest{},
-			&v1.WriteSchemaRequest{},
-			&v1.ReflectSchemaRequest{},
-			&v1.ComputablePermissionsRequest{},
-			&v1.DependentRelationsRequest{},
-			&v1.DiffSchemaRequest{},
+			inputMessagesForService(v1.RegisterSchemaServiceServer, v1.SchemaServiceServer(nil))...,
 		))
 
 	return &schemaServer{

--- a/internal/services/v1/watch.go
+++ b/internal/services/v1/watch.go
@@ -34,10 +34,9 @@ type watchServer struct {
 // NewWatchServer creates an instance of the watch server.
 func NewWatchServer(heartbeatDuration time.Duration) v1.WatchServiceServer {
 	validator := genutil.MustNewProtoValidator(
-		// NOTE: using `WithMessages` here allows us to pre-warm the validator cache. As new
-		// methods are added to this service, you'll need to add new messages to this method.
+		// NOTE: using `WithMessages` here allows us to pre-warm the validator cache
 		protovalidate.WithMessages(
-			&v1.WatchRequest{},
+			inputMessagesForService(v1.RegisterWatchServiceServer, v1.WatchServiceServer(nil))...,
 		))
 
 	s := &watchServer{


### PR DESCRIPTION
## Description
In #2863 we added the protovalidate interceptor. Protovalidate works by reflecting messages and reading validation metadata, rather than using autogenerated code in the old way of doing things. This means that the reflection has to happen at some point, and if the cache isn't prewarmed it happens the first time that a `Validator` encounters a new message.

That meant that we were seeing cold-start validation taking on the order of tens of milliseconds, rather than the microseconds that we'd expect validation to take otherwise.

This fixes that by prewarming the validator's caches with the messages it's going to encounter according to which service it's attached to.

## Changes
* Add `WithMessages` option to each of the validators
## Testing
Review. See that cold-start latency isn't present anymore.