### PR TITLE
fix: do not register CRDB metrics in init()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed MySQL metrics prefixed with `go_sql_stats_connections_*` in favor of those prefixed with `go_sql_*` (https://github.com/authzed/spicedb/pull/2980)
 - Removed support for Spanner flag value `--datastore-spanner-metrics=deprecated-prometheus`; please use values `otel` or `native` (https://github.com/authzed/spicedb/pull/2980)
 
+### Fixed
+- Do not register CRDB metrics in `init()` functions (https://github.com/authzed/spicedb/pull/2966)
+
 ## [1.51.0] - 2026-03-24
 ### Changed
 - Updated DevContext and LSP to support composable schemas (https://github.com/authzed/spicedb/pull/2965)

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -103,7 +103,7 @@ func newCRDBDatastore(ctx context.Context, url string, options ...Option) (datas
 	// interfere with pool setup.
 	initPoolConfig := readPoolConfig.Copy()
 	initPoolConfig.MinConns = 1
-	initPool, err := pool.NewRetryPool(initCtx, "init", initPoolConfig, healthChecker, config.maxRetries, config.connectRate)
+	initPool, err := pool.NewRetryPool(initCtx, "init", initPoolConfig, healthChecker, config.maxRetries, config.connectRate, nil)
 	if err != nil {
 		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, url)
 	}
@@ -197,17 +197,18 @@ func newCRDBDatastore(ctx context.Context, url string, options ...Option) (datas
 		gcWindow:                     config.gcWindow,
 		watchEnabled:                 !config.watchDisabled,
 		schema:                       *schema.Schema(config.columnOptimizationOption, config.withIntegrity, false),
+		healthTracker:                healthChecker,
 	}
 	ds.SetNowFunc(ds.headRevisionInternal)
 
 	// this ctx and cancel is tied to the lifetime of the datastore
 	ds.ctx, ds.cancel = context.WithCancel(context.Background())
-	ds.writePool, err = pool.NewRetryPool(ds.ctx, "write", writePoolConfig, healthChecker, config.maxRetries, config.connectRate)
+	ds.writePool, err = pool.NewRetryPool(ds.ctx, "write", writePoolConfig, healthChecker, config.maxRetries, config.connectRate, nil)
 	if err != nil {
 		ds.cancel()
 		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, url)
 	}
-	ds.readPool, err = pool.NewRetryPool(ds.ctx, "read", readPoolConfig, healthChecker, config.maxRetries, config.connectRate)
+	ds.readPool, err = pool.NewRetryPool(ds.ctx, "read", readPoolConfig, healthChecker, config.maxRetries, config.connectRate, nil)
 	if err != nil {
 		ds.cancel()
 		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, url)
@@ -226,14 +227,14 @@ func newCRDBDatastore(ctx context.Context, url string, options ...Option) (datas
 	if config.enableConnectionBalancing {
 		log.Ctx(initCtx).Info().Msg("starting cockroach connection balancer")
 		ds.pruneGroup, ds.ctx = errgroup.WithContext(ds.ctx)
-		writePoolBalancer := pool.NewNodeConnectionBalancer(ds.writePool, healthChecker, 5*time.Second)
-		readPoolBalancer := pool.NewNodeConnectionBalancer(ds.readPool, healthChecker, 5*time.Second)
+		ds.writePoolBalancer = pool.NewNodeConnectionBalancer(ds.writePool, healthChecker, 5*time.Second)
+		ds.readPoolBalancer = pool.NewNodeConnectionBalancer(ds.readPool, healthChecker, 5*time.Second)
 		ds.pruneGroup.Go(func() error {
-			writePoolBalancer.Prune(ds.ctx)
+			ds.writePoolBalancer.Prune(ds.ctx)
 			return nil
 		})
 		ds.pruneGroup.Go(func() error {
-			readPoolBalancer.Prune(ds.ctx)
+			ds.readPoolBalancer.Prune(ds.ctx)
 			return nil
 		})
 		ds.pruneGroup.Go(func() error {
@@ -261,19 +262,20 @@ type crdbDatastore struct {
 	revisions.CommonDecoder
 	*common.MigrationValidator
 
-	dburl                        string
-	readPool, writePool          *pool.RetryPool
-	collectors                   []prometheus.Collector
-	watchBufferLength            uint16
-	watchChangeBufferMaximumSize uint64
-	watchBufferWriteTimeout      time.Duration
-	watchConnectTimeout          time.Duration
-	writeOverlapKeyer            overlapKeyer
-	overlapKeyInit               func(ctx context.Context) keySet
-	analyzeBeforeStatistics      bool
-	gcWindow                     time.Duration
-	schema                       common.SchemaInformation
-	acquireTimeout               time.Duration
+	dburl                               string
+	readPool, writePool                 *pool.RetryPool
+	readPoolBalancer, writePoolBalancer *pool.NodeConnectionBalancer
+	collectors                          []prometheus.Collector
+	watchBufferLength                   uint16
+	watchChangeBufferMaximumSize        uint64
+	watchBufferWriteTimeout             time.Duration
+	watchConnectTimeout                 time.Duration
+	writeOverlapKeyer                   overlapKeyer
+	overlapKeyInit                      func(ctx context.Context) keySet
+	analyzeBeforeStatistics             bool
+	gcWindow                            time.Duration
+	schema                              common.SchemaInformation
+	acquireTimeout                      time.Duration
 
 	beginChangefeedQuery string
 	transactionNowQuery  string
@@ -288,6 +290,8 @@ type crdbDatastore struct {
 	filterMaximumIDCount uint16
 	supportsIntegrity    bool
 	watchEnabled         bool
+
+	healthTracker *pool.NodeHealthTracker
 
 	uniqueID atomic.Pointer[string]
 }
@@ -481,6 +485,15 @@ func (cds *crdbDatastore) Close() error {
 	}
 	cds.readPool.Close()
 	cds.writePool.Close()
+	if cds.writePoolBalancer != nil {
+		cds.writePoolBalancer.Close()
+	}
+	if cds.readPoolBalancer != nil {
+		cds.readPoolBalancer.Close()
+	}
+	if cds.healthTracker != nil {
+		cds.healthTracker.Close()
+	}
 	for _, collector := range cds.collectors {
 		ok := prometheus.Unregister(collector)
 		if !ok {

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -890,7 +890,7 @@ func TestRegisterPrometheusCollectors(t *testing.T) {
 	// Create read & write pools
 	readPoolConfig, err := pgxpool.ParseConfig(fmt.Sprintf("postgres://db:password@pg.example.com:5432/mydb?pool_max_conns=%d", readMaxConns))
 	require.NoError(t, err)
-	readPool, err := pool.NewRetryPool(t.Context(), "read", readPoolConfig, nil, 18, 20)
+	readPool, err := pool.NewRetryPool(t.Context(), "read", readPoolConfig, nil, 18, 20, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		readPool.Close()
@@ -898,7 +898,7 @@ func TestRegisterPrometheusCollectors(t *testing.T) {
 
 	writePoolConfig, err := pgxpool.ParseConfig(fmt.Sprintf("postgres://db:password@pg.example.com:5432/mydb?pool_max_conns=%d", writeMaxConns))
 	require.NoError(t, err)
-	writePool, err := pool.NewRetryPool(t.Context(), "read", writePoolConfig, nil, 18, 20)
+	writePool, err := pool.NewRetryPool(t.Context(), "write", writePoolConfig, nil, 18, 20, nil)
 	require.NoError(t, err)
 
 	// Create datastore with those pools
@@ -973,7 +973,7 @@ func TestVersionReading(t *testing.T) {
 	require.NoError(err)
 	checker, err := pool.NewNodeHealthChecker(uri)
 	require.NoError(err)
-	initPool, err := pool.NewRetryPool(t.Context(), "pool", initPoolConfig, checker, 18, 20)
+	initPool, err := pool.NewRetryPool(t.Context(), "pool", initPoolConfig, checker, 18, 20, nil)
 	require.NoError(err)
 	t.Cleanup(func() {
 		initPool.Close()

--- a/internal/datastore/crdb/pool/balancer.go
+++ b/internal/datastore/crdb/pool/balancer.go
@@ -20,24 +20,6 @@ import (
 	"github.com/authzed/spicedb/pkg/genutil"
 )
 
-var (
-	connectionsPerCRDBNodeCountGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "crdb_connections_per_node",
-		Help: "The number of active connections SpiceDB holds to each CockroachDB node, by pool (read/write). Imbalanced values across nodes suggest the connection balancer is unable to redistribute connections evenly.",
-	}, []string{"pool", "node_id"})
-
-	pruningTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "crdb_pruning_duration",
-		Help:    "Duration in milliseconds of one iteration of the CockroachDB connection balancer pruning excess connections from over-represented nodes. Elevated values indicate the balancer is struggling to rebalance connections.",
-		Buckets: []float64{.1, .2, .5, 1, 2, 5, 10, 20, 50, 100},
-	}, []string{"pool"})
-)
-
-func init() {
-	prometheus.MustRegister(connectionsPerCRDBNodeCountGauge)
-	prometheus.MustRegister(pruningTimeHistogram)
-}
-
 type balancePoolConn[C balanceConn] interface {
 	Conn() C
 	Release()
@@ -81,6 +63,9 @@ type nodeConnectionBalancer[P balancePoolConn[C], C balanceConn] struct {
 	healthTracker *NodeHealthTracker
 	rnd           *rand.Rand
 	seed          int64
+
+	connectionsPerCRDBNodeCountGauge *prometheus.GaugeVec
+	pruningTimeHistogram             prometheus.Histogram
 }
 
 // newNodeConnectionBalancer is generic over underlying connection types for
@@ -99,18 +84,46 @@ func newNodeConnectionBalancer[P balancePoolConn[C], C balanceConn](pool balance
 			seed = 0
 		}
 	}
+	var (
+		connectionsPerCRDBNodeCountGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "crdb_connections_per_node",
+			ConstLabels: prometheus.Labels{
+				"pool": pool.ID(),
+			},
+			Help: "The number of active connections SpiceDB holds to each CockroachDB node, by pool (read/write). Imbalanced values across nodes suggest the connection balancer is unable to redistribute connections evenly.",
+		}, []string{"node_id"})
+
+		pruningTimeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name: "crdb_pruning_duration",
+			ConstLabels: prometheus.Labels{
+				"pool": pool.ID(),
+			},
+			Help:    "Duration in milliseconds of one iteration of the CockroachDB connection balancer pruning excess connections from over-represented nodes. Elevated values indicate the balancer is struggling to rebalance connections.",
+			Buckets: []float64{.1, .2, .5, 1, 2, 5, 10, 20, 50, 100},
+		})
+	)
+
+	prometheus.MustRegister(connectionsPerCRDBNodeCountGauge)
+	prometheus.MustRegister(pruningTimeHistogram)
 	return &nodeConnectionBalancer[P, C]{
-		ticker:        time.NewTicker(interval),
-		sem:           semaphore.NewWeighted(1),
-		healthTracker: healthTracker,
-		pool:          pool,
-		seed:          seed,
+		ticker:                           time.NewTicker(interval),
+		sem:                              semaphore.NewWeighted(1),
+		healthTracker:                    healthTracker,
+		pool:                             pool,
+		seed:                             seed,
+		connectionsPerCRDBNodeCountGauge: connectionsPerCRDBNodeCountGauge,
+		pruningTimeHistogram:             pruningTimeHistogram,
 		// nolint:gosec
 		// use of non cryptographically secure random number generator is not concern here,
 		// as it's used for shuffling the nodes to balance the connections when the number of
 		// connections do not divide evenly.
 		rnd: rand.New(rand.NewSource(seed)),
 	}
+}
+
+func (p *nodeConnectionBalancer[P, C]) Close() {
+	prometheus.Unregister(p.connectionsPerCRDBNodeCountGauge)
+	prometheus.Unregister(p.pruningTimeHistogram)
 }
 
 // Prune starts periodically checking idle connections and killing ones that are determined to be unbalanced.
@@ -137,7 +150,7 @@ func (p *nodeConnectionBalancer[P, C]) Prune(ctx context.Context) {
 func (p *nodeConnectionBalancer[P, C]) mustPruneConnections(ctx context.Context) {
 	start := time.Now()
 	defer func() {
-		pruningTimeHistogram.WithLabelValues(p.pool.ID()).Observe(float64(time.Since(start).Milliseconds()))
+		p.pruningTimeHistogram.Observe(float64(time.Since(start).Milliseconds()))
 	}()
 	conns := p.pool.AcquireAllIdle(ctx)
 	defer func() {
@@ -182,8 +195,7 @@ func (p *nodeConnectionBalancer[P, C]) mustPruneConnections(ctx context.Context)
 	p.healthTracker.RLock()
 	for node := range p.healthTracker.nodesEverSeen {
 		if _, ok := connectionCounts[node]; !ok {
-			connectionsPerCRDBNodeCountGauge.DeletePartialMatch(map[string]string{
-				"pool":    p.pool.ID(),
+			p.connectionsPerCRDBNodeCountGauge.DeletePartialMatch(map[string]string{
 				"node_id": strconv.FormatUint(uint64(node), 10),
 			})
 		}
@@ -205,8 +217,7 @@ func (p *nodeConnectionBalancer[P, C]) mustPruneConnections(ctx context.Context)
 	initialPerNodeMax := p.pool.MaxConns() / nodeCount
 	for i, node := range nodes {
 		count := connectionCounts[node]
-		connectionsPerCRDBNodeCountGauge.WithLabelValues(
-			p.pool.ID(),
+		p.connectionsPerCRDBNodeCountGauge.WithLabelValues(
 			strconv.FormatUint(uint64(node), 10),
 		).Set(float64(count))
 

--- a/internal/datastore/crdb/pool/balancer_test.go
+++ b/internal/datastore/crdb/pool/balancer_test.go
@@ -141,6 +141,9 @@ func TestNodeConnectionBalancerPrune(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tracker, err := NewNodeHealthChecker("")
 			require.NoError(t, err)
+			t.Cleanup(func() {
+				tracker.Close()
+			})
 			for _, n := range tt.nodes {
 				tracker.healthyNodes[n] = struct{}{}
 			}

--- a/internal/datastore/crdb/pool/health.go
+++ b/internal/datastore/crdb/pool/health.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -18,15 +19,6 @@ import (
 
 const errorBurst = 2
 
-var healthyCRDBNodeCountGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-	Name: "crdb_healthy_nodes",
-	Help: "the number of healthy crdb nodes detected by spicedb",
-})
-
-func init() {
-	prometheus.MustRegister(healthyCRDBNodeCountGauge)
-}
-
 // NodeHealthTracker detects changes in the node pool by polling the cluster periodically and recording
 // the node ids that are seen. This is used to detect new nodes that come online that have either previously
 // been marked unhealthy due to connection errors or due to scale up.
@@ -34,10 +26,11 @@ func init() {
 // Consumers can manually mark a node healthy or unhealthy as well.
 type NodeHealthTracker struct {
 	sync.RWMutex
-	connConfig    *pgx.ConnConfig
-	healthyNodes  map[uint32]struct{}      // GUARDED_BY(RWMutex)
-	nodesEverSeen map[uint32]*rate.Limiter // GUARDED_BY(RWMutex)
-	newLimiter    func() *rate.Limiter
+	connConfig                *pgx.ConnConfig
+	healthyNodes              map[uint32]struct{}      // GUARDED_BY(RWMutex)
+	nodesEverSeen             map[uint32]*rate.Limiter // GUARDED_BY(RWMutex)
+	newLimiter                func() *rate.Limiter
+	healthyCRDBNodeCountGauge prometheus.Gauge
 }
 
 // NewNodeHealthChecker builds a health checker that polls the cluster at the given url.
@@ -47,14 +40,29 @@ func NewNodeHealthChecker(url string) (*NodeHealthTracker, error) {
 		return nil, err
 	}
 
+	healthyCRDBNodeCountGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "crdb_healthy_nodes",
+		Help: "the number of healthy crdb nodes detected by spicedb",
+	})
+
+	err = prometheus.Register(healthyCRDBNodeCountGauge)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register crdb healthy nodes metric: %w", err)
+	}
+
 	return &NodeHealthTracker{
-		connConfig:    connConfig,
-		healthyNodes:  make(map[uint32]struct{}, 0),
-		nodesEverSeen: make(map[uint32]*rate.Limiter, 0),
+		healthyCRDBNodeCountGauge: healthyCRDBNodeCountGauge,
+		connConfig:                connConfig,
+		healthyNodes:              make(map[uint32]struct{}, 0),
+		nodesEverSeen:             make(map[uint32]*rate.Limiter, 0),
 		newLimiter: func() *rate.Limiter {
 			return rate.NewLimiter(rate.Every(1*time.Minute), errorBurst)
 		},
 	}, nil
+}
+
+func (t *NodeHealthTracker) Close() {
+	_ = prometheus.Unregister(t.healthyCRDBNodeCountGauge)
 }
 
 // Poll starts polling the cluster and recording the node IDs that it sees.
@@ -104,7 +112,7 @@ func (t *NodeHealthTracker) SetNodeHealth(nodeID uint32, healthy bool) {
 	t.Lock()
 	defer t.Unlock()
 	defer func() {
-		healthyCRDBNodeCountGauge.Set(float64(len(t.healthyNodes)))
+		t.healthyCRDBNodeCountGauge.Set(float64(len(t.healthyNodes)))
 	}()
 
 	if _, ok := t.nodesEverSeen[nodeID]; !ok {

--- a/internal/datastore/crdb/pool/health_test.go
+++ b/internal/datastore/crdb/pool/health_test.go
@@ -2,20 +2,16 @@ package pool
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/time/rate"
 )
 
 func TestNodeHealthTracker(t *testing.T) {
-	tracker := &NodeHealthTracker{
-		healthyNodes:  make(map[uint32]struct{}),
-		nodesEverSeen: make(map[uint32]*rate.Limiter),
-		newLimiter: func() *rate.Limiter {
-			return rate.NewLimiter(rate.Every(1*time.Minute), 2)
-		},
-	}
+	tracker, err := NewNodeHealthChecker("postgres://user:password@localhost:5432/dbname")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		tracker.Close()
+	})
 
 	tracker.SetNodeHealth(1, true)
 	require.True(t, tracker.IsHealthy(1))

--- a/internal/datastore/crdb/pool/pool.go
+++ b/internal/datastore/crdb/pool/pool.go
@@ -28,16 +28,6 @@ type pgxPool interface {
 	Stat() *pgxpool.Stat
 }
 
-var resetHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
-	Name:    "crdb_client_resets",
-	Help:    "Distribution of the number of client-side transaction restarts per transaction attempt. Restarts occur when CockroachDB returns a serialization failure (40001) and the driver retries the transaction from scratch. Sustained high values indicate transaction contention.",
-	Buckets: []float64{0, 1, 2, 5, 10, 20, 50},
-})
-
-func init() {
-	prometheus.MustRegister(resetHistogram)
-}
-
 type ctxDisableRetries struct{}
 
 var (
@@ -46,9 +36,10 @@ var (
 )
 
 type RetryPool struct {
-	pool          pgxPool
-	id            string
-	healthTracker *NodeHealthTracker
+	pool           pgxPool
+	id             string
+	healthTracker  *NodeHealthTracker
+	resetHistogram prometheus.Histogram
 
 	sync.RWMutex
 	maxRetries  uint8
@@ -56,8 +47,10 @@ type RetryPool struct {
 	gc          map[*pgx.Conn]struct{} // GUARDED_BY(RWMutex)
 }
 
-func NewRetryPool(ctx context.Context, name string, config *pgxpool.Config, healthTracker *NodeHealthTracker, maxRetries uint8, connectRate time.Duration) (*RetryPool, error) {
-	config = config.Copy()
+// NewRetryPool creates a new RetryPool that wraps a pgx connection pool with retry logic.
+// If pool is nil, a new pgxpool.Pool is created from config; otherwise the provided pool is
+// used directly, which is useful for injecting a mock in tests.
+func NewRetryPool(ctx context.Context, name string, config *pgxpool.Config, healthTracker *NodeHealthTracker, maxRetries uint8, connectRate time.Duration, pool pgxPool) (*RetryPool, error) {
 	p := &RetryPool{
 		id:            name,
 		maxRetries:    maxRetries,
@@ -66,82 +59,100 @@ func NewRetryPool(ctx context.Context, name string, config *pgxpool.Config, heal
 		gc:            make(map[*pgx.Conn]struct{}, 0),
 	}
 
-	limiter := rate.NewLimiter(rate.Every(connectRate), 1)
-	afterConnect := config.AfterConnect
-	config.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
-		if afterConnect != nil {
-			if err := afterConnect(ctx, conn); err != nil {
+	if pool == nil {
+		config = config.Copy()
+
+		limiter := rate.NewLimiter(rate.Every(connectRate), 1)
+		afterConnect := config.AfterConnect
+		config.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+			if afterConnect != nil {
+				if err := afterConnect(ctx, conn); err != nil {
+					return err
+				}
+			}
+
+			p.Lock()
+			defer p.Unlock()
+
+			delete(p.nodeForConn, conn)
+			delete(p.gc, conn)
+
+			healthTracker.SetNodeHealth(nodeID(conn), true)
+
+			if err := limiter.Wait(ctx); err != nil {
 				return err
 			}
+
+			p.nodeForConn[conn] = nodeID(conn)
+
+			return nil
 		}
 
-		p.Lock()
-		defer p.Unlock()
-
-		delete(p.nodeForConn, conn)
-		delete(p.gc, conn)
-
-		healthTracker.SetNodeHealth(nodeID(conn), true)
-
-		if err := limiter.Wait(ctx); err != nil {
-			return err
+		// if we attempt to acquire or release a connection that has been marked for
+		// GC, return false to tell the underlying pool to destroy the connection
+		gcConnection := func(conn *pgx.Conn) bool {
+			p.RLock()
+			_, ok := p.gc[conn]
+			p.RUnlock()
+			if ok {
+				p.Lock()
+				delete(p.gc, conn)
+				delete(p.nodeForConn, conn)
+				p.Unlock()
+			}
+			return !ok
 		}
 
-		p.nodeForConn[conn] = nodeID(conn)
+		beforeAcquire := config.BeforeAcquire                                   //nolint:staticcheck
+		config.BeforeAcquire = func(ctx context.Context, conn *pgx.Conn) bool { //nolint:staticcheck
+			if beforeAcquire != nil {
+				if !beforeAcquire(ctx, conn) {
+					return false
+				}
+			}
 
-		return nil
-	}
+			return gcConnection(conn)
+		}
 
-	// if we attempt to acquire or release a connection that has been marked for
-	// GC, return false to tell the underlying pool to destroy the connection
-	gcConnection := func(conn *pgx.Conn) bool {
-		p.RLock()
-		_, ok := p.gc[conn]
-		p.RUnlock()
-		if ok {
+		afterRelease := config.AfterRelease
+		config.AfterRelease = func(conn *pgx.Conn) bool {
+			if afterRelease != nil {
+				if !afterRelease(conn) {
+					return false
+				}
+			}
+			return gcConnection(conn)
+		}
+
+		beforeClose := config.BeforeClose
+		config.BeforeClose = func(conn *pgx.Conn) {
+			if beforeClose != nil {
+				beforeClose(conn)
+			}
 			p.Lock()
-			delete(p.gc, conn)
+			defer p.Unlock()
 			delete(p.nodeForConn, conn)
-			p.Unlock()
-		}
-		return !ok
-	}
-
-	beforeAcquire := config.BeforeAcquire                                   //nolint:staticcheck
-	config.BeforeAcquire = func(ctx context.Context, conn *pgx.Conn) bool { //nolint:staticcheck
-		if beforeAcquire != nil {
-			if !beforeAcquire(ctx, conn) {
-				return false
-			}
+			delete(p.gc, conn)
 		}
 
-		return gcConnection(conn)
-	}
-
-	afterRelease := config.AfterRelease
-	config.AfterRelease = func(conn *pgx.Conn) bool {
-		if afterRelease != nil {
-			if !afterRelease(conn) {
-				return false
-			}
+		var err error
+		pool, err = pgxpool.NewWithConfig(ctx, config)
+		if err != nil {
+			return nil, err
 		}
-		return gcConnection(conn)
 	}
 
-	beforeClose := config.BeforeClose
-	config.BeforeClose = func(conn *pgx.Conn) {
-		if beforeClose != nil {
-			beforeClose(conn)
-		}
-		p.Lock()
-		defer p.Unlock()
-		delete(p.nodeForConn, conn)
-		delete(p.gc, conn)
-	}
+	p.resetHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "crdb_client_resets",
+		ConstLabels: prometheus.Labels{
+			"pool_name": name, // this is needed to avoid "duplicate metrics collector registration attempted"
+		},
+		Help:    "Distribution of the number of client-side transaction restarts per transaction attempt. Restarts occur when CockroachDB returns a serialization failure (40001) and the driver retries the transaction from scratch. Sustained high values indicate transaction contention.",
+		Buckets: []float64{0, 1, 2, 5, 10, 20, 50},
+	})
 
-	pool, err := pgxpool.NewWithConfig(ctx, config)
-	if err != nil {
-		return nil, err
+	if err := prometheus.Register(p.resetHistogram); err != nil {
+		return nil, fmt.Errorf("error registering CRDB reset histogram: %w", err)
 	}
 
 	p.pool = pool
@@ -253,6 +264,7 @@ func (p *RetryPool) Config() *pgxpool.Config {
 // Close closes the underlying pgxpool.Pool
 func (p *RetryPool) Close() {
 	p.pool.Close()
+	prometheus.Unregister(p.resetHistogram)
 }
 
 // Stat returns the underlying pgxpool.Pool stats
@@ -315,7 +327,7 @@ func (p *RetryPool) withRetries(ctx context.Context, acquireTimeout time.Duratio
 
 	var retries uint8
 	defer func() {
-		resetHistogram.Observe(float64(retries))
+		p.resetHistogram.Observe(float64(retries))
 	}()
 
 	maxRetries := p.maxRetries

--- a/internal/datastore/crdb/pool/pool_test.go
+++ b/internal/datastore/crdb/pool/pool_test.go
@@ -7,11 +7,9 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/time/rate"
 )
 
 // TestPool implements pgxPool interface for testing
@@ -53,7 +51,12 @@ func NewTestPool() *TestPool {
 			return nil
 		},
 		configFunc: func() *pgxpool.Config {
-			return &pgxpool.Config{}
+			url := "postgres://jack:secret@localhost:5432/mydb?sslmode=verify-ca&pool_max_conns=10&pool_max_conn_lifetime=1h30m" //nolint:gosec this is a test
+			c, err := pgxpool.ParseConfig(url)
+			if err != nil {
+				panic(err)
+			}
+			return c
 		},
 		closeFunc: func() {},
 		statFunc: func() *pgxpool.Stat {
@@ -63,21 +66,19 @@ func NewTestPool() *TestPool {
 }
 
 // createTestRetryPool creates a RetryPool for testing with dependency injection
-func createTestRetryPool(testPool *TestPool) *RetryPool {
-	return &RetryPool{
-		pool: testPool,
-		id:   "test-pool",
-		healthTracker: &NodeHealthTracker{
-			healthyNodes:  make(map[uint32]struct{}),
-			nodesEverSeen: make(map[uint32]*rate.Limiter),
-			newLimiter: func() *rate.Limiter {
-				return rate.NewLimiter(rate.Every(1*time.Minute), 2)
-			},
-		},
-		maxRetries:  3,
-		nodeForConn: make(map[*pgx.Conn]uint32),
-		gc:          make(map[*pgx.Conn]struct{}),
-	}
+func createTestRetryPool(t *testing.T, testPool *TestPool) *RetryPool {
+	ht, err := NewNodeHealthChecker("postgres://user:password@localhost:5432/dbname")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ht.Close()
+	})
+
+	retrypool, err := NewRetryPool(t.Context(), "name", testPool.Config(), ht, 3, 0, testPool)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		retrypool.Close()
+	})
+	return retrypool
 }
 
 func TestContextCancelledDuringBlockingAcquire(t *testing.T) {
@@ -89,7 +90,7 @@ func TestContextCancelledDuringBlockingAcquire(t *testing.T) {
 			return nil, ctx.Err()
 		}
 
-		retryPool := createTestRetryPool(testPool)
+		retryPool := createTestRetryPool(t, testPool)
 		ctx, cancel := context.WithCancel(t.Context())
 
 		// Cancel the context after a short delay
@@ -123,7 +124,7 @@ func TestAcquireTimeoutReturnsErrAcquire(t *testing.T) {
 			}
 		}
 
-		retryPool := createTestRetryPool(testPool)
+		retryPool := createTestRetryPool(t, testPool)
 		ctx := t.Context()
 		acquireTimeout := 50 * time.Millisecond
 
@@ -143,7 +144,7 @@ func TestAcquireTimeoutReturnsErrAcquire(t *testing.T) {
 func TestAcquireSucceedsButTopLevelContextCancelled(t *testing.T) {
 	testPool := NewTestPool()
 
-	retryPool := createTestRetryPool(testPool)
+	retryPool := createTestRetryPool(t, testPool)
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // Cancel immediately
 
@@ -164,7 +165,7 @@ func TestAcquireErrorWithConnectionReturned(t *testing.T) {
 			return &pgxpool.Conn{}, errors.New("pool exhausted")
 		}
 
-		retryPool := createTestRetryPool(testPool)
+		retryPool := createTestRetryPool(t, testPool)
 		ctx := context.Background()
 
 		err := retryPool.withRetries(ctx, 0, func(conn *pgxpool.Conn) error {
@@ -193,7 +194,7 @@ func TestAcquireSucceedsWithinTimeout(t *testing.T) {
 			}
 		}
 
-		retryPool := createTestRetryPool(testPool)
+		retryPool := createTestRetryPool(t, testPool)
 		ctx := t.Context()
 		acquireTimeout := 50 * time.Millisecond
 		functionCalled := false
@@ -219,7 +220,7 @@ func TestNoAcquireTimeoutUsesOriginalContext(t *testing.T) {
 		return &pgxpool.Conn{}, nil
 	}
 
-	retryPool := createTestRetryPool(testPool)
+	retryPool := createTestRetryPool(t, testPool)
 	originalCtx := context.Background()
 
 	err := retryPool.withRetries(originalCtx, 0, func(conn *pgxpool.Conn) error {
@@ -240,7 +241,7 @@ func TestAcquireTimeoutCreatesSeparateContext(t *testing.T) {
 			return &pgxpool.Conn{}, nil
 		}
 
-		retryPool := createTestRetryPool(testPool)
+		retryPool := createTestRetryPool(t, testPool)
 		originalCtx := context.Background()
 		acquireTimeout := 50 * time.Millisecond
 		startTime := time.Now()
@@ -269,7 +270,7 @@ func TestAcquireTimeoutContextCausePreserved(t *testing.T) {
 			return nil, ctx.Err()
 		}
 
-		retryPool := createTestRetryPool(testPool)
+		retryPool := createTestRetryPool(t, testPool)
 		ctx := t.Context()
 		acquireTimeout := 10 * time.Millisecond
 
@@ -292,7 +293,7 @@ func TestSuccessfulFunctionExecution(t *testing.T) {
 		return &pgxpool.Conn{}, nil
 	}
 
-	retryPool := createTestRetryPool(testPool)
+	retryPool := createTestRetryPool(t, testPool)
 	ctx := t.Context()
 	functionCalled := false
 

--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -56,10 +56,6 @@ var definitionsReadTotalCounter = prometheus.NewCounterVec(prometheus.CounterOpt
 
 const maximumRetryCount = 10
 
-func init() {
-	prometheus.MustRegister(namespacesFallbackModeGauge, caveatsFallbackModeGauge, schemaCacheRevisionGauge, definitionsReadCachedCounter, definitionsReadTotalCounter)
-}
-
 // watchingCachingProxy is a datastore proxy that caches schema (namespaces and caveat definitions)
 // and updates its cache via a WatchSchema call. If the supplied datastore to be wrapped does not support
 // this API, or the data is not available in this case or an error occurs, the updating cache fallsback
@@ -74,6 +70,7 @@ type watchingCachingProxy struct {
 
 	namespaceCache *schemaWatchCache[*core.NamespaceDefinition]
 	caveatCache    *schemaWatchCache[*core.CaveatDefinition]
+	metrics        []prometheus.Collector
 }
 
 // createWatchingCacheProxy creates and returns a watching cache proxy.
@@ -83,7 +80,12 @@ func createWatchingCacheProxy(delegate datastore.Datastore, c cache.Cache[cache.
 		c:         c,
 	}
 
+	metrics := []prometheus.Collector{namespacesFallbackModeGauge, caveatsFallbackModeGauge, schemaCacheRevisionGauge, definitionsReadCachedCounter, definitionsReadTotalCounter}
+	for _, metric := range metrics {
+		_ = prometheus.Register(metric)
+	}
 	proxy := &watchingCachingProxy{
+		metrics:       metrics,
 		Datastore:     delegate,
 		fallbackCache: fallbackCache,
 
@@ -354,6 +356,9 @@ func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 // Close stops all resources.
 // The caller must have canceled the context passed to Start.
 func (p *watchingCachingProxy) Close() error {
+	for _, metric := range p.metrics {
+		prometheus.Unregister(metric)
+	}
 	p.caveatCache.setFallbackMode()
 	p.namespaceCache.setFallbackMode()
 

--- a/internal/services/integrationtesting/consistency_datastore_test.go
+++ b/internal/services/integrationtesting/consistency_datastore_test.go
@@ -39,41 +39,43 @@ func TestConsistencyPerDatastore(t *testing.T) {
 	for _, engineID := range datastore.Engines {
 		t.Run(engineID, func(t *testing.T) {
 			for _, filePath := range consistencyTestFiles {
-				rde := testdatastore.RunDatastoreEngine(t, engineID)
-				baseds := rde.NewDatastore(t, config.DatastoreConfigInitFunc(t,
-					dsconfig.WithWatchBufferLength(0),
-					dsconfig.WithGCWindow(time.Duration(90_000_000_000_000)),
-					dsconfig.WithRevisionQuantization(10),
-					dsconfig.WithMaxRetries(50),
-					dsconfig.WithWriteAcquisitionTimeout(5*time.Second)))
-				ds := indexcheck.WrapWithIndexCheckingDatastoreProxyIfApplicable(baseds)
+				t.Run(path.Base(filePath), func(t *testing.T) {
+					rde := testdatastore.RunDatastoreEngine(t, engineID)
+					baseds := rde.NewDatastore(t, config.DatastoreConfigInitFunc(t,
+						dsconfig.WithWatchBufferLength(0),
+						dsconfig.WithGCWindow(time.Duration(90_000_000_000_000)),
+						dsconfig.WithRevisionQuantization(10),
+						dsconfig.WithMaxRetries(50),
+						dsconfig.WithWriteAcquisitionTimeout(5*time.Second)))
+					ds := indexcheck.WrapWithIndexCheckingDatastoreProxyIfApplicable(baseds)
 
-				cad := consistencytestutil.BuildDataAndCreateClusterForTesting(t, filePath, ds)
-				dispatcher, err := graph.NewLocalOnlyDispatcher(graph.MustNewDefaultDispatcherParametersForTesting())
-				require.NoError(t, err)
-				t.Cleanup(func() { dispatcher.Close() })
-				accessibilitySet := consistencytestutil.BuildAccessibilitySet(t, cad.Ctx, cad.Populated, cad.DataStore)
+					cad := consistencytestutil.BuildDataAndCreateClusterForTesting(t, filePath, ds)
+					dispatcher, err := graph.NewLocalOnlyDispatcher(graph.MustNewDefaultDispatcherParametersForTesting())
+					require.NoError(t, err)
+					t.Cleanup(func() { dispatcher.Close() })
+					accessibilitySet := consistencytestutil.BuildAccessibilitySet(t, cad.Ctx, cad.Populated, cad.DataStore)
 
-				headRevision, err := cad.DataStore.HeadRevision(cad.Ctx)
-				require.NoError(t, err)
+					headRevision, err := cad.DataStore.HeadRevision(cad.Ctx)
+					require.NoError(t, err)
 
-				// Run the assertions within each file.
-				testers := consistencytestutil.ServiceTesters(cad.Conn)
-				for _, tester := range testers {
-					tester := tester
+					// Run the assertions within each file.
+					testers := consistencytestutil.ServiceTesters(cad.Conn)
+					for _, tester := range testers {
+						tester := tester
 
-					vctx := validationContext{
-						clusterAndData:   cad,
-						accessibilitySet: accessibilitySet,
-						serviceTester:    tester,
-						revision:         headRevision,
-						dispatcher:       dispatcher,
+						vctx := validationContext{
+							clusterAndData:   cad,
+							accessibilitySet: accessibilitySet,
+							serviceTester:    tester,
+							revision:         headRevision,
+							dispatcher:       dispatcher,
+						}
+
+						t.Run(tester.Name(), func(t *testing.T) {
+							runAssertions(t, vctx)
+						})
 					}
-
-					t.Run(path.Base(filePath)+"/"+tester.Name(), func(t *testing.T) {
-						runAssertions(t, vctx)
-					})
-				}
+				})
 			}
 		})
 	}

--- a/internal/services/steelthreadtesting/steelthread_test.go
+++ b/internal/services/steelthreadtesting/steelthread_test.go
@@ -56,6 +56,9 @@ func TestNonMemdbSteelThreads(t *testing.T) {
 						dsconfig.WithMaxRetries(50),
 						dsconfig.WithExperimentalColumnOptimization(true),
 						dsconfig.WithWriteAcquisitionTimeout(5*time.Second)))
+					t.Cleanup(func() {
+						_ = ds.Close()
+					})
 
 					ds = indexcheck.WrapWithIndexCheckingDatastoreProxyIfApplicable(ds)
 					runSteelThreadTest(t, tc, ds)


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

Before: if you spun up SpiceDB with a datastore OTHER THAN CRDB, you could see CRDB metrics published.

Now: you don't see them.

## Testing

- `docker-compose up --build` and then explore http://localhost:3000/. You should see CRDB metrics
- `docker-compose -f docker-compose.mysql.yaml up --build` and then explore http://localhost:3000/. You should NOT see CRDB metrics