### PR TITLE
fix(devContext): only the first occurrence of a caveat parameter coul…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 - Fix duplicate diagnostics in LSP server when VS Code pulls diagnostics (https://github.com/authzed/spicedb/pull/2977)
+- In DevContext's schema position mapper, only the first occurrence of a caveat parameter could be found (https://github.com/authzed/spicedb/pull/2972)
 
 ## [1.50.0] - 2026-03-19
 ### Added

--- a/pkg/development/schema_position_mapper.go
+++ b/pkg/development/schema_position_mapper.go
@@ -237,8 +237,8 @@ func (r *SchemaPositionMapper) ReferenceAtPosition(source input.Source, position
 	}
 
 	// Caveat parameter used in expression.
-	if caveatParamName, caveatDef, ok := r.caveatParamChain(nodeChain, source, position); ok {
-		targetSourceCode := fmt.Sprintf("%s %s", caveatParamName, caveats.ParameterTypeString(caveatDef.ParameterTypes[caveatParamName]))
+	if caveatParamName, paramTypeString, ok := r.caveatParamChain(nodeChain, source, position); ok {
+		targetSourceCode := fmt.Sprintf("%s %s", caveatParamName, paramTypeString)
 
 		return &SchemaReference{
 			Source:   source,
@@ -279,59 +279,77 @@ func (r *SchemaPositionMapper) lookupRelation(defName, relationName string) (*co
 	return rel, ts, true
 }
 
-func (r *SchemaPositionMapper) caveatParamChain(nodeChain *compiler.NodeChain, source input.Source, position input.Position) (string, *core.CaveatDefinition, bool) {
+// caveatParamChain determines whether the given position within a caveat expression refers to a
+// caveat parameter. It walks the node chain to find the enclosing caveat definition, tokenizes the
+// CEL expression, and checks if the token at the cursor position matches a declared parameter name.
+//
+// For example, given the schema:
+//
+//	caveat my_caveat(some_param int) {
+//	    some_param > 0
+//	}
+//
+// If the cursor is on "some_param" in the expression "some_param > 0", this returns
+// ("some_param", "int", true).
+//
+// Returns ("", "", false) if the position is not within a caveat expression or does not correspond
+// to a known parameter.
+func (r *SchemaPositionMapper) caveatParamChain(nodeChain *compiler.NodeChain, source input.Source, position input.Position) (string, string, bool) {
 	if !nodeChain.HasHeadType(dslshape.NodeTypeCaveatExpression) {
-		return "", nil, false
+		return "", "", false
 	}
 
 	caveatDefNode := nodeChain.FindNodeOfType(dslshape.NodeTypeCaveatDefinition)
 	if caveatDefNode == nil {
-		return "", nil, false
+		return "", "", false
 	}
 
 	caveatName, err := caveatDefNode.GetString(dslshape.NodeCaveatDefinitionPredicateName)
 	if err != nil {
-		return "", nil, false
+		return "", "", false
 	}
 
 	caveatDef, ok := r.lookupCaveat(caveatName)
 	if !ok {
-		return "", nil, false
+		return "", "", false
 	}
 
 	runePosition, err := r.schema.SourcePositionToRunePosition(source, position)
 	if err != nil {
-		return "", nil, false
+		return "", "", false
 	}
 
 	exprRunePosition, err := nodeChain.Head().GetInt(dslshape.NodePredicateStartRune)
 	if err != nil {
-		return "", nil, false
+		return "", "", false
 	}
 
 	if exprRunePosition > runePosition {
-		return "", nil, false
+		return "", "", false
 	}
 
-	relationRunePosition := runePosition - exprRunePosition
+	relativeRunePosition := runePosition - exprRunePosition
 
 	caveatExpr, err := nodeChain.Head().GetString(dslshape.NodeCaveatExpressionPredicateExpression)
 	if err != nil {
-		return "", nil, false
+		return "", "", false
 	}
 
 	// Split the expression into tokens and find the associated token.
 	tokens := strings.FieldsFunc(caveatExpr, splitCELToken)
 	currentIndex := 0
 	for _, token := range tokens {
-		if currentIndex <= relationRunePosition && currentIndex+len(token) >= relationRunePosition {
-			if _, ok := caveatDef.ParameterTypes[token]; ok {
-				return token, caveatDef, true
+		// Find the token's actual position in the expression starting from currentIndex.
+		tokenStart := strings.Index(caveatExpr[currentIndex:], token) + currentIndex
+		if tokenStart <= relativeRunePosition && tokenStart+len(token) >= relativeRunePosition {
+			if paramType, ok := caveatDef.ParameterTypes[token]; ok {
+				return token, caveats.ParameterTypeString(paramType), true
 			}
 		}
+		currentIndex = tokenStart + len(token)
 	}
 
-	return "", caveatDef, true
+	return "", "", false
 }
 
 func splitCELToken(r rune) bool {

--- a/pkg/development/schema_position_mapper_test.go
+++ b/pkg/development/schema_position_mapper_test.go
@@ -257,6 +257,49 @@ func TestSchemaPositionMapper(t *testing.T) {
 			},
 		},
 		{
+			name: "caveat parameter reference second reference",
+			schema: `definition user {}
+
+			caveat somecaveat(someparam int) {
+				someparam < 42 || someparam > 43
+			}
+
+			definition resource {
+				relation viewer: user with somecaveat
+				permission view = viewer
+			}
+			`,
+			line:   3,
+			column: 23,
+			expectedReference: &SchemaReference{
+				Source:                   input.Source("test"),
+				Position:                 input.Position{LineNumber: 3, ColumnPosition: 23},
+				Text:                     "someparam",
+				ReferenceType:            ReferenceTypeCaveatParameter,
+				ReferenceMarkdown:        "someparam int",
+				TargetSource:             &testSource,
+				TargetSourceCode:         "someparam int",
+				TargetNamePositionOffset: 0,
+			},
+		},
+		{
+			name: "caveat expression non-parameter token",
+			schema: `definition user {}
+
+			caveat somecaveat(someparam int) {
+				someparam < 42 || someparam > 43
+			}
+
+			definition resource {
+				relation viewer: user with somecaveat
+				permission view = viewer
+			}
+			`,
+			line:              3,
+			column:            19, // space
+			expectedReference: nil,
+		},
+		{
 			name: "longer test",
 			schema: `definition user {}
 


### PR DESCRIPTION
…d be found

<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

This was found in https://github.com/authzed/spicedb/pull/2965 and I am extracting it into its own PR.

The issue is shown in the second screenshot - notice how hovering over the second `day` shows nothing:

<img width="729" height="550" alt="image" src="https://github.com/user-attachments/assets/70cb0ed2-f883-4863-a5e9-0682cde105c5" />

<img width="664" height="423" alt="image" src="https://github.com/user-attachments/assets/a112766f-b9d1-4c63-a5a4-cb89a4712d6e" />


## Testing

In VSCode:

<img width="458" height="111" alt="image" src="https://github.com/user-attachments/assets/c2c53a57-2fcd-4b66-ac3e-7f7413564e44" />


## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->