### PR TITLE
Fix duplicate diagnostics in LSP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Fix duplicate diagnostics in LSP server when VS Code pulls diagnostics (https://github.com/authzed/spicedb/pull/2977)
 
 ## [1.50.0] - 2026-03-19
 ### Added

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -335,7 +335,7 @@ func (s *Server) initialize(_ context.Context, r *jsonrpc2.Request) (any, error)
 		return nil, err
 	}
 
-	s.requestsDiagnostics = ip.Capabilities.Diagnostics.RefreshSupport
+	s.requestsDiagnostics = ip.Capabilities.SupportsPullDiagnostics()
 	log.Debug().
 		Bool("requestsDiagnostics", s.requestsDiagnostics).
 		Msg("initialize")

--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -287,13 +287,12 @@ func TestRequestAfterShutdown(t *testing.T) {
 }
 
 func TestDiagnosticsRefreshSupport(t *testing.T) {
+	// Initialize with textDocument diagnostic support enabled
 	tester := newLSPTester(t)
-
-	// Initialize with diagnostic refresh support enabled
 	resp, serverState := sendAndReceive[lsp.InitializeResult](tester, "initialize", InitializeParams{
 		Capabilities: ClientCapabilities{
-			Diagnostics: DiagnosticWorkspaceClientCapabilities{
-				RefreshSupport: true,
+			TextDocument: &TextDocumentClientCapabilities{
+				Diagnostic: &DiagnosticClientCapabilities{},
 			},
 		},
 	})
@@ -301,18 +300,29 @@ func TestDiagnosticsRefreshSupport(t *testing.T) {
 	require.True(t, resp.Capabilities.DocumentFormattingProvider)
 	require.True(t, tester.server.requestsDiagnostics)
 
-	// Initialize without diagnostic refresh support
+	// Initialize with only workspace diagnostic refresh support (not pull diagnostics)
 	tester2 := newLSPTester(t)
 	resp2, serverState2 := sendAndReceive[lsp.InitializeResult](tester2, "initialize", InitializeParams{
 		Capabilities: ClientCapabilities{
-			Diagnostics: DiagnosticWorkspaceClientCapabilities{
-				RefreshSupport: false,
+			Workspace: &WorkspaceClientCapabilities{
+				Diagnostics: &DiagnosticWorkspaceClientCapabilities{
+					RefreshSupport: true,
+				},
 			},
 		},
 	})
 	require.Equal(t, serverStateInitialized, serverState2)
 	require.True(t, resp2.Capabilities.DocumentFormattingProvider)
 	require.False(t, tester2.server.requestsDiagnostics)
+
+	// Initialize without any diagnostic support
+	tester3 := newLSPTester(t)
+	resp3, serverState3 := sendAndReceive[lsp.InitializeResult](tester3, "initialize", InitializeParams{
+		Capabilities: ClientCapabilities{},
+	})
+	require.Equal(t, serverStateInitialized, serverState3)
+	require.True(t, resp3.Capabilities.DocumentFormattingProvider)
+	require.False(t, tester3.server.requestsDiagnostics)
 }
 
 func TestLogJSONPtr(t *testing.T) {

--- a/internal/lsp/lspdefs.go
+++ b/internal/lsp/lspdefs.go
@@ -53,13 +53,30 @@ type InitializeParams struct {
 }
 
 type ClientCapabilities struct {
-	Diagnostics DiagnosticWorkspaceClientCapabilities `json:"diagnostics"`
+	TextDocument *TextDocumentClientCapabilities `json:"textDocument,omitempty"`
+	Workspace    *WorkspaceClientCapabilities    `json:"workspace,omitempty"`
+}
+
+type TextDocumentClientCapabilities struct {
+	Diagnostic *DiagnosticClientCapabilities `json:"diagnostic,omitempty"`
+}
+
+type DiagnosticClientCapabilities struct {
+	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
+}
+
+type WorkspaceClientCapabilities struct {
+	Diagnostics *DiagnosticWorkspaceClientCapabilities `json:"diagnostics,omitempty"`
 }
 
 type DiagnosticWorkspaceClientCapabilities struct {
-	// RefreshSupport indicates whether the client supports the new
-	// `textDocument/diagnostic` request.
 	RefreshSupport bool `json:"refreshSupport,omitempty"`
+}
+
+// SupportsPullDiagnostics returns true if the client indicated support for
+// pull-based diagnostics by including the textDocument.diagnostic capability.
+func (c ClientCapabilities) SupportsPullDiagnostics() bool {
+	return c.TextDocument != nil && c.TextDocument.Diagnostic != nil
 }
 
 type Hover struct {

--- a/internal/lsp/testutil.go
+++ b/internal/lsp/testutil.go
@@ -48,8 +48,15 @@ type lspTester struct {
 func (lt *lspTester) initialize() {
 	resp, serverState := sendAndReceive[lsp.InitializeResult](lt, "initialize", InitializeParams{
 		Capabilities: ClientCapabilities{
-			Diagnostics: DiagnosticWorkspaceClientCapabilities{
-				RefreshSupport: true,
+			TextDocument: &TextDocumentClientCapabilities{
+				Diagnostic: &DiagnosticClientCapabilities{
+					DynamicRegistration: true,
+				},
+			},
+			Workspace: &WorkspaceClientCapabilities{
+				Diagnostics: &DiagnosticWorkspaceClientCapabilities{
+					RefreshSupport: true,
+				},
 			},
 		},
 	})


### PR DESCRIPTION
Fixes authzed/spicedb-vscode#41

The LSP server's `ClientCapabilities` struct mapped diagnostics at a non-standard JSON path, so pull diagnostics support was never detected. The server always pushed `publishDiagnostics` even when the client was already pulling via `textDocument/diagnostic`, causing duplicate errors.

Fixed by restructuring `ClientCapabilities` to match the LSP spec and detecting pull support via `textDocument.diagnostic` presence.

**Tested manually** — confirmed duplicates in VS Code before the fix and single errors after.