### PR TITLE
fix(postgres): some requests may silently swallow errors of sort "revision not found in replica"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed MySQL metrics prefixed with `go_sql_stats_connections_*` in favor of those prefixed with `go_sql_*` (https://github.com/authzed/spicedb/pull/2980)
 - Removed support for Spanner flag value `--datastore-spanner-metrics=deprecated-prometheus`; please use values `otel` or `native` (https://github.com/authzed/spicedb/pull/2980)
 
+### Fixed
+- On a Postgres setup with read replicas, some requests may silently swallow errors of sort "revision not found in replica" (https://github.com/authzed/spicedb/pull/2979)
+
 ## [1.51.0] - 2026-03-24
 ### Changed
 - Updated DevContext and LSP to support composable schemas (https://github.com/authzed/spicedb/pull/2965)

--- a/internal/datastore/crdb/pool/pool.go
+++ b/internal/datastore/crdb/pool/pool.go
@@ -177,8 +177,7 @@ func (p *RetryPool) MinConns() uint32 {
 // connection on error, or retrying on a retryable error.
 func (p *RetryPool) ExecFunc(ctx context.Context, tagFunc func(ctx context.Context, tag pgconn.CommandTag, err error) error, sql string, arguments ...any) error {
 	return p.withRetries(ctx, 0, func(conn *pgxpool.Conn) error {
-		tag, err := conn.Conn().Exec(ctx, sql, arguments...)
-		return tagFunc(ctx, tag, err)
+		return common.QuerierFuncsFor(conn.Conn()).ExecFunc(ctx, tagFunc, sql, arguments...)
 	})
 }
 
@@ -186,16 +185,7 @@ func (p *RetryPool) ExecFunc(ctx context.Context, tagFunc func(ctx context.Conte
 // connection on error, or retrying on a retryable error.
 func (p *RetryPool) QueryFunc(ctx context.Context, rowsFunc func(ctx context.Context, rows pgx.Rows) error, sql string, optionsAndArgs ...any) error {
 	return p.withRetries(ctx, 0, func(conn *pgxpool.Conn) error {
-		rows, err := conn.Conn().Query(ctx, sql, optionsAndArgs...)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		err = rowsFunc(ctx, rows)
-		if err != nil {
-			return err
-		}
-		return rows.Err()
+		return common.QuerierFuncsFor(conn.Conn()).QueryFunc(ctx, rowsFunc, sql, optionsAndArgs...)
 	})
 }
 
@@ -203,7 +193,7 @@ func (p *RetryPool) QueryFunc(ctx context.Context, rowsFunc func(ctx context.Con
 // the connection on error, or retrying on a retryable error.
 func (p *RetryPool) QueryRowFunc(ctx context.Context, rowFunc func(ctx context.Context, row pgx.Row) error, sql string, optionsAndArgs ...any) error {
 	return p.withRetries(ctx, 0, func(conn *pgxpool.Conn) error {
-		return rowFunc(ctx, conn.Conn().QueryRow(ctx, sql, optionsAndArgs...))
+		return common.QuerierFuncsFor(conn.Conn()).QueryRowFunc(ctx, rowFunc, sql, optionsAndArgs...)
 	})
 }
 

--- a/internal/datastore/postgres/common/pgx.go
+++ b/internal/datastore/postgres/common/pgx.go
@@ -283,7 +283,11 @@ func (t *QuerierFuncs) QueryFunc(ctx context.Context, rowsFunc func(ctx context.
 	if err != nil {
 		return err
 	}
-	return rows.Err()
+	rows.Close() // drain all results sets in case it was a multi-statementy query
+	if rows.Err() != nil {
+		return rows.Err()
+	}
+	return nil
 }
 
 func (t *QuerierFuncs) QueryRowFunc(ctx context.Context, rowFunc func(ctx context.Context, row pgx.Row) error, sql string, optionsAndArgs ...any) error {

--- a/internal/datastore/postgres/common/pgx_test.go
+++ b/internal/datastore/postgres/common/pgx_test.go
@@ -1,0 +1,76 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+// multiStatementRows simulates pgx.Rows behavior for a two-statement simple-protocol query
+// where the first statement (SELECT) returns 0 rows successfully, and the second statement
+// (DO ASSERT) produces an error.
+type multiStatementRows struct {
+	closed          bool
+	secondStmtError error
+}
+
+func (r *multiStatementRows) Next() bool                                   { return false }
+func (r *multiStatementRows) Scan(...any) error                            { return fmt.Errorf("no rows") }
+func (r *multiStatementRows) Values() ([]any, error)                       { return nil, nil }
+func (r *multiStatementRows) RawValues() [][]byte                          { return nil }
+func (r *multiStatementRows) Conn() *pgx.Conn                              { return nil }
+func (r *multiStatementRows) CommandTag() pgconn.CommandTag                { return pgconn.NewCommandTag("SELECT 0") }
+func (r *multiStatementRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+
+func (r *multiStatementRows) Err() error {
+	if r.closed {
+		return r.secondStmtError
+	}
+	// Before Close(), first result set had no error
+	return nil
+}
+
+func (r *multiStatementRows) Close() {
+	r.closed = true
+}
+
+// fakeMultiStatementQuerier returns multiStatementRows from Query to simulate a
+// two-statement batch where the SELECT succeeds and the ASSERT fails.
+type fakeMultiStatementQuerier struct {
+	secondStmtError error
+}
+
+func (q *fakeMultiStatementQuerier) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.NewCommandTag(""), nil
+}
+
+func (q *fakeMultiStatementQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return &multiStatementRows{secondStmtError: q.secondStmtError}, nil
+}
+
+func (q *fakeMultiStatementQuerier) QueryRow(context.Context, string, ...any) pgx.Row {
+	return nil
+}
+
+// TestQueryFuncSurfacesErrorFromSecondStatement verifies that QueryFunc returns
+// an error produced by the second statement in a multi-statement batch (e.g. a
+// DO ASSERT used by strict read mode). The second statement's error only becomes
+// visible on pgx.Rows after Close() drains all result sets.
+func TestQueryFuncSurfacesErrorFromSecondStatement(t *testing.T) {
+	assertErr := &pgconn.PgError{Code: "P0004", Message: "replica missing revision"}
+	querier := QuerierFuncsFor(&fakeMultiStatementQuerier{secondStmtError: assertErr})
+
+	err := querier.QueryFunc(t.Context(), func(_ context.Context, rows pgx.Rows) error {
+		// Simulate reading: no rows returned
+		for rows.Next() {
+			t.Fatal("expected no rows")
+		}
+		return rows.Err()
+	}, "SELECT 1")
+
+	require.ErrorIs(t, err, assertErr)
+}


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

Fixing this bug mentioned in https://github.com/authzed/spicedb/issues/2525#issuecomment-4094529592

> **Bug 2: Strict read assertion error is silently lost**
> The WHERE clause filters out all rows → 0 results (valid namespace data is dropped)
> The DO block's ASSERT fails → produces an error
> QuerierFuncs.QueryFunc in pgx.go calls rows.Err() before the deferred rows.Close() has drained the second statement's result set, so the ASSERT error is never propagated

```
6:01PM WRN error calling script step error="rpc error: code = Unknown desc = object definition `auth/organisation` not found" consistency=FullyConsistent op=CheckPermission script="spam user#view checks" step=1 worker=89
```

## Testing

[script.yaml](https://github.com/user-attachments/files/25392706/script.yaml)

1. `docker-compose -f docker-compose.postgres.yaml up --build` (with REPLICA_APPLY_DELAY=25ms)
2. `thumper migrate --insecure --no-verify-ca --endpoint localhost:50051 --token foobar ./script.yaml && thumper run --insecure --no-verify-ca --qps 100 --endpoint localhost:50051 --token foobar ./script.yaml`

wait 1 hour; you should see no errors