### PR TITLE
chore: disable imports in wasm

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -24,7 +24,6 @@ jobs:
     name: "CodeQL Analyze"
     if: "${{ github.event_name == 'pull_request' }}" # workaround to https://github.com/github/codeql-action/issues/1537
     runs-on: "depot-ubuntu-24.04-8"
-    timeout-minutes: "${{ (matrix.language == 'swift' && 120) || 360 }}"
     permissions:
       # required for all workflows
       security-events: "write"
@@ -33,15 +32,10 @@ jobs:
       actions: "read"
       contents: "read"
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ["go"]
-
     steps:
       - uses: "actions/checkout@v6"
       - uses: "authzed/actions/setup-go@main"
-      - uses: "authzed/actions/codeql@11667c9b2e8b3649ad2af4d788e57d18f8e8eaf1" # main"
+      - uses: "authzed/actions/codeql@main"
 
   trivy:
     name: "Analyze Code and Docker Image with Trivvy"

--- a/pkg/development/schema.go
+++ b/pkg/development/schema.go
@@ -16,8 +16,9 @@ import (
 type CompileOption func(*compileConfig)
 
 type compileConfig struct {
-	fsys         fs.FS
-	rootFileName string
+	fsys           fs.FS
+	rootFileName   string
+	disableImports bool
 }
 
 // WithSourceFS enables import resolution using the given filesystem.
@@ -32,6 +33,12 @@ func WithRootFileName(name string) CompileOption {
 	return func(cfg *compileConfig) { cfg.rootFileName = name }
 }
 
+// WithDisableImports lets a caller disable imports in a given
+// development context.
+func WithDisableImports() CompileOption {
+	return func(cfg *compileConfig) { cfg.disableImports = true }
+}
+
 // CompileSchema compiles a schema into its caveat and namespace definition(s), returning a developer
 // error if the schema could not be compiled. The non-developer error is returned only if an
 // internal errors occurred.
@@ -44,6 +51,10 @@ func CompileSchema(schema string, opts ...CompileOption) (*compiler.CompiledSche
 	var compilerOpts []compiler.Option
 	if cfg.fsys != nil {
 		compilerOpts = append(compilerOpts, compiler.SourceFS(cfg.fsys))
+	}
+
+	if cfg.disableImports {
+		compilerOpts = append(compilerOpts, compiler.DisallowImportFlag())
 	}
 
 	sourceFileName := "schema"

--- a/pkg/development/wasm/main_test.go
+++ b/pkg/development/wasm/main_test.go
@@ -49,6 +49,21 @@ func TestInvalidSchema(t *testing.T) {
 	require.Equal(t, "Unexpected token at root level: TokenTypeIdentifier", response.GetDeveloperErrors().InputErrors[0].Message)
 }
 
+func TestSchemaWithImportsGetsError(t *testing.T) {
+	response := run(t, &devinterface.DeveloperRequest{
+		Context: &devinterface.RequestContext{
+			Schema: `
+			use import
+
+			import "foo.zed"
+			`,
+		},
+	})
+	require.NotNil(t, response.GetDeveloperErrors())
+	require.Equal(t, 1, len(response.GetDeveloperErrors().InputErrors))
+	require.Equal(t, "import statements are not allowed in this context", response.GetDeveloperErrors().InputErrors[0].Message)
+}
+
 func TestInvalidRelationship(t *testing.T) {
 	response := run(t, &devinterface.DeveloperRequest{
 		Context: &devinterface.RequestContext{

--- a/pkg/development/wasm/request.go
+++ b/pkg/development/wasm/request.go
@@ -46,7 +46,7 @@ func runDeveloperRequest(this js.Value, args []js.Value) any {
 	}
 
 	// Construct the developer context.
-	devContext, devErrors, err := development.NewDevContext(context.Background(), devRequest.Context)
+	devContext, devErrors, err := development.NewDevContext(context.Background(), devRequest.Context, development.WithDisableImports())
 	if err != nil {
 		return respErr(err)
 	}


### PR DESCRIPTION
## Description
Imports don't make sense in a wasm context where you don't have access to a filesystem. This plumbs in an option to disable them.

## Changes
* Add development option to disable imports
* Add test
* Plumb in option

## Testing
Review. See that test passes.