### PR TITLE
fix: small fixes to benchmarking and correctly using the once variable

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -482,8 +482,9 @@ jobs:
           external-data-json-path: "./cache/benchmark-data.json"
           # Do not save the data
           save-data-file: false
-          # Workflow will fail when an alert happens
-          fail-on-alert: true
+          # Workflow will comment, but not fail, when an alert happens
+          fail-on-alert: false
+          comment-on-alert: true
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           # Enable Job Summary for PRs
           summary-always: true

--- a/pkg/benchmarks/wide_arrow.go
+++ b/pkg/benchmarks/wide_arrow.go
@@ -98,7 +98,7 @@ func setupWideArrow(ctx context.Context, ds datastore.Datastore) (*QuerySets, er
 				ResourceID:      "file0",
 				Permission:      "viewer",
 				SubjectType:     "user",
-				SubjectID:       "user15",
+				SubjectID:       "user570",
 				SubjectRelation: tuple.Ellipsis,
 			},
 		},

--- a/pkg/query/context.go
+++ b/pkg/query/context.go
@@ -219,9 +219,10 @@ func (ctx *Context) Check(it Iterator, resource Object, subject ObjectAndRelatio
 		return nil, spiceerrors.MustBugf("no executor has been set")
 	}
 
-	if ctx.TopLevelOperation == OperationUnset {
+	ctx.topLevelOnce.Do(func() {
+		ctx.topLevelIterator = it
 		ctx.TopLevelOperation = OperationCheck
-	}
+	})
 
 	var tracedIterator Iterator
 	if ctx.shouldTrace() {


### PR DESCRIPTION
## Description
- Benchmarks weren't exercising the arrow reversal because the arrow was cheap -- it was right at the top of the iteration set, so either direction worked the same by chance
- query.Context keeps track of why it's being run. Except that was being overwritten by internal calls to IterSubjects/IterResources.