### PR TITLE
chore: fix workflow deprecations

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -51,7 +51,7 @@ jobs:
           # trivy does not flag an old SpiceDB version
           fetch-depth: 0
       - uses: "authzed/actions/setup-go@main"
-      - uses: "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9" # v3.7.0
+      - uses: "docker/login-action@v4" # v3.7.0
         with:
           username: "${{ env.DOCKERHUB_PUBLIC_USER }}"
           password: "${{ env.DOCKERHUB_PUBLIC_ACCESS_TOKEN }}"
@@ -60,8 +60,7 @@ jobs:
           sudo snap install snapcraft --channel=8.x/stable --classic
           mkdir -p $HOME/.cache/snapcraft/download
           mkdir -p $HOME/.cache/snapcraft/stage-packages
-      - uses: "aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1" # For https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23
-        #uses: "aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478" # master
+      - uses: "aquasecurity/trivy-action@v0.35.0"
         with:
           scan-type: "fs"
           ignore-unfixed: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,8 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 go build -tags memoryprotection -v -ldflags=-checklinkname=0 -o spicedb ./cmd/spicedb
 
 # use `docker buildx imagetools inspect <image>` to get the multi-platform sha256
-FROM golang:1.26.2-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS health-probe-builder
-WORKDIR /go/src/app
-RUN apk update && apk add --no-cache git
-RUN git clone https://github.com/authzed/grpc-health-probe.git
-WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout main
-RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
-
-# use `docker buildx imagetools inspect <image>` to get the multi-platform sha256
 FROM cgr.dev/chainguard/static@sha256:99a5f826e71115aef9f63368120a6aa518323e052297718e9bf084fb84def93c
-COPY --from=health-probe-builder /go/bin/grpc-health-probe /bin/grpc_health_probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.48 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY --from=spicedb-builder /go/src/app/spicedb /usr/local/bin/spicedb
 ENV PATH="$PATH:/usr/local/bin"
 EXPOSE 50051

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,16 +1,10 @@
 # vim: syntax=dockerfile
 # use `docker buildx imagetools inspect <image>` to get the multi-platform sha256
 ARG BASE=cgr.dev/chainguard/static@sha256:99a5f826e71115aef9f63368120a6aa518323e052297718e9bf084fb84def93c
-FROM golang:1.25.8-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa AS health-probe-builder
-WORKDIR /go/src/app
-RUN apk update && apk add --no-cache git
-RUN git clone https://github.com/authzed/grpc-health-probe.git
-WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout main
-RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 FROM $BASE
-COPY --from=health-probe-builder /go/bin/grpc-health-probe /usr/local/bin/grpc_health_probe
+# NOTE: this copies in the health probe binary from the official build of the container.
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.48 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY spicedb /usr/local/bin/spicedb
 ENV PATH="$PATH:/usr/local/bin"
 EXPOSE 50051


### PR DESCRIPTION
## Description
Fixing one of the warnings here and trying to get rid of trivy flaps: https://github.com/authzed/spicedb/actions/runs/24415833647?pr=3038

## Changes
* Bump version and let float
## Testing
Review.