### PR TITLE
chore: work around ghcr limitations and update goreleaser config

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: "goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29" # v7.0.0
         with:
           distribution: "goreleaser-pro"
-          version: "2.11.1"
+          version: "2.15.2"
           args: "release -f .goreleaser.nightly.yml --clean --nightly"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -32,7 +32,7 @@ jobs:
           distribution: "goreleaser-pro"
           # NOTE: keep in sync with goreleaser version in other job.
           # github actions don't allow yaml anchors.
-          version: "v2.3.2"
+          version: "v2.15.2"
           args: "release --clean --config=.goreleaser.windows.yml"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
           distribution: "goreleaser-pro"
           # NOTE: keep in sync with goreleaser version in other job.
           # github actions don't allow yaml anchors.
-          version: "v2.3.2"
+          version: "v2.15.2"
           args: "release --clean"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -75,11 +75,11 @@ jobs:
         id: "goreleaser"
         with:
           distribution: "goreleaser-pro"
-          version: "2.3.2"
-          args: "release --clean --split --snapshot --single-target"
+          version: "2.15.2"
+          args: "release --clean --split --snapshot --single-target --skip archive,nfpm,snapcraft"
         env:
           GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"
       - name: "Obtain container image to scan"
-        run: 'echo "IMAGE_VERSION=$(jq .version dist/linux_amd64_v1/metadata.json --raw-output)" >> $GITHUB_ENV'
+        run: 'echo "IMAGE_VERSION=$(jq .version dist/linux_amd64/metadata.json --raw-output)" >> $GITHUB_ENV'
       - name: "run trivy on release image"
         run: "docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.69.3 image --format table --exit-code 1 --ignore-unfixed --vuln-type os,library --no-progress --severity CRITICAL,HIGH,MEDIUM authzed/spicedb:v${{ env.IMAGE_VERSION }}-amd64 --db-repository public.ecr.aws/aquasecurity/trivy-db --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db"

--- a/.goreleaser.windows.yml
+++ b/.goreleaser.windows.yml
@@ -28,7 +28,7 @@ archives:
       - "completions/*"
     format_overrides:
       - goos: "windows"
-        format: "zip"
+        formats: "zip"
 
 chocolateys:
   - name: "spicedb"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,7 +58,7 @@ nfpms:
         dst: "/usr/share/man/man1/spicedb.1"
         file_info:
           mode: 0644
-furies:
+gemfury:
   - account: "authzed"
     secret_name: "GEMFURY_PUSH_TOKEN"
     disable: "{{ gt (len .Prerelease) 0 }}"
@@ -81,121 +81,57 @@ snapcrafts:
         plugs:
           - "network-bind"
           - "network"
-brews:
-  - name: "{{.ProjectName}}"
-    <<: &brew-shared
-      description: "Google Zanzibar-inspired permissions database for fine-grained access control"
-      homepage: "https://github.com/authzed/spicedb"
-      license: "Apache-2.0"
-      dependencies:
-        - name: "go"
-          type: "build"
-      custom_block: |
-        head "https://github.com/authzed/spicedb.git", :branch => "main"
-      url_template: "https://github.com/authzed/spicedb/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-      install: |
-        if build.head?
-          versionVar = "github.com/jzelinskie/cobrautil/v2.Version"
-          versionCmd = "$(git describe --always --abbrev=7 --dirty --tags)"
-          system "go build -tags memoryprotection --ldflags '-s -w -checklinkname=0 -X #{versionVar}=#{versionCmd}' ./cmd/spicedb"
-        end
-        bin.install "spicedb"
-        generate_completions_from_executable(bin/"spicedb", "completion", shells: [:bash, :zsh, :fish])
-      test: |
-        system "#{bin}/spicedb version"
-      repository:
-        owner: "authzed"
-        name: "homebrew-tap"
-        token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-      commit_author:
-        name: "authzedbot"
-        email: "infrastructure@authzed.com"
-      commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-      directory: "Formula"
-      skip_upload: "auto"
-  - name: "{{.ProjectName}}@{{.Version}}"
-    <<: *brew-shared
-dockers:
-  # AMD64
-  - image_templates:
-      - &amd_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64"
-      - &amd_image_gh "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64"
-      - &amd_image_dh "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64"
-    dockerfile: &dockerfile "Dockerfile.release"
-    goos: "linux"
-    goarch: "amd64"
-    use: "buildx"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-  # AMD64 (debug)
-  - image_templates:
-      - &amd_debug_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64-debug"
-      - &amd_debug_image_gh "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64-debug"
-      - &amd_debug_image_dh "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-amd64-debug"
-    dockerfile: &dockerfile "Dockerfile.release"
-    goos: "linux"
-    goarch: "amd64"
-    use: "buildx"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--build-arg=BASE=cgr.dev/chainguard/busybox"
-  # ARM64
-  - image_templates:
-      - &arm_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64"
-      - &arm_image_gh "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64"
-      - &arm_image_dh "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64"
-    dockerfile: *dockerfile
-    goos: "linux"
-    goarch: "arm64"
-    use: "buildx"
-    build_flag_templates:
-      - "--platform=linux/arm64"
-  # ARM64 (debug)
-  - image_templates:
-      - &arm_debug_image_quay "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64-debug"
-      - &arm_debug_image_gh "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64-debug"
-      - &arm_debug_image_dh "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-arm64-debug"
-    dockerfile: *dockerfile
-    goos: "linux"
-    goarch: "arm64"
-    use: "buildx"
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--build-arg=BASE=cgr.dev/chainguard/busybox"
-docker_manifests:
-  # Quay
-  - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"
-    image_templates: [*amd_image_quay, *arm_image_quay]
-  - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest"
-    image_templates: [*amd_image_quay, *arm_image_quay]
-  # GitHub Registry
-  - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"
-    image_templates: [*amd_image_gh, *arm_image_gh]
-  - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest"
-    image_templates: [*amd_image_gh, *arm_image_gh]
-  # Docker Hub
-  - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}"
-    image_templates: [*amd_image_dh, *arm_image_dh]
-  - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest"
-    image_templates: [*amd_image_dh, *arm_image_dh]
-
-  # Debug Images:
-
-  # Quay (debug)
-  - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
-    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
-  - name_template: "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
-    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
-  # GitHub Registry
-  - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
-    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
-  - name_template: "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
-    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
-  # Docker Hub
-  - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:v{{ .Version }}-debug"
-    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
-  - name_template: "authzed/spicedb{{ if .IsNightly }}-git{{ end }}:latest-debug"
-    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
+homebrew_casks:
+  - alternative_names:
+      - "{{.ProjectName}}@{{.Version}}"
+    description: "Google Zanzibar-inspired permissions database for fine-grained access control"
+    homepage: "https://github.com/authzed/spicedb"
+    url:
+      template: "https://github.com/authzed/spicedb/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    completions:
+      bash: "completions/spicedb.bash"
+      zsh: "completions/spicedb.zsh"
+      fish: "completions/spicedb.fish"
+    manpages:
+      - "manpages/spicedb.1"
+    repository:
+      owner: "authzed"
+      name: "homebrew-tap"
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: "authzedbot"
+      email: "infrastructure@authzed.com"
+    commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
+    skip_upload: "auto"
+dockers_v2:
+  # Standard images
+  - id: "standard"
+    dockerfile: "Dockerfile.release"
+    platforms:
+      - "linux/amd64"
+      - "linux/arm64"
+    images:
+      - "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}"
+      - "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}"
+      - "authzed/spicedb{{ if .IsNightly }}-git{{ end }}"
+    tags:
+      - "v{{ .Version }}"
+      - "latest"
+  # Debug images
+  - id: "debug"
+    dockerfile: "Dockerfile.release"
+    platforms:
+      - "linux/amd64"
+      - "linux/arm64"
+    images:
+      - "quay.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}"
+      - "ghcr.io/authzed/spicedb{{ if .IsNightly }}-git{{ end }}"
+      - "authzed/spicedb{{ if .IsNightly }}-git{{ end }}"
+    tags:
+      - "v{{ .Version }}-debug"
+      - "latest-debug"
+    build_args:
+      BASE: "cgr.dev/chainguard/busybox"
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,9 +3,12 @@
 ARG BASE=cgr.dev/chainguard/static@sha256:99a5f826e71115aef9f63368120a6aa518323e052297718e9bf084fb84def93c
 
 FROM $BASE
-# NOTE: this copies in the health probe binary from the official build of the container.
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.48 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
-COPY spicedb /usr/local/bin/spicedb
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETPLATFORM
+# NOTE: downloads the health probe binary directly from the official release.
+ADD --chmod=755 https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.48/grpc_health_probe-${TARGETOS}-${TARGETARCH} /usr/local/bin/grpc_health_probe
+COPY $TARGETPLATFORM/spicedb /usr/local/bin/spicedb
 ENV PATH="$PATH:/usr/local/bin"
 EXPOSE 50051
 ENTRYPOINT ["spicedb"]


### PR DESCRIPTION
## Description
In using the `COPY` command to pull in the built version of `grpc-health-probe`, we were hitting ghcr egress limits for their organization. This changes the approach to use `ADD` and grab the binary directly.

I also ran `goreleaser check` on the configuration files and found some deprecations, so I migrated the config file.

## Changes
Will annotate

## Testing
```
  # Build the binary
  CGO_ENABLED=0 go build -tags memoryprotection -ldflags="-s -w -checklinkname=0" -o spicedb ./cmd/spicedb

  # Set up the directory structure goreleaser would create
  mkdir -p linux/amd64 && cp spicedb linux/amd64/spicedb

  # Build the image
  docker buildx build -f Dockerfile.release --platform linux/amd64 -t spicedb-release-test .
```