### PR TITLE
test: more tweaks to certwatcher tests

### DIFF
--- a/pkg/x509util/certwatcher_test.go
+++ b/pkg/x509util/certwatcher_test.go
@@ -112,7 +112,7 @@ func TestCertWatcherStart(t *testing.T) {
 		called := atomic.Int64{}
 		watcher.RegisterCallback(func(crt tls.Certificate) {
 			called.Add(1)
-			require.NotEmpty(t, crt.Certificate)
+			assert.NotEmpty(t, crt.Certificate)
 		})
 
 		firstcert, _ := watcher.GetCertificate(nil)
@@ -136,7 +136,7 @@ func TestCertWatcherStart(t *testing.T) {
 		called := atomic.Int64{}
 		watcher.RegisterCallback(func(crt tls.Certificate) {
 			called.Add(1)
-			require.NotEmpty(t, crt.Certificate)
+			assert.NotEmpty(t, crt.Certificate)
 		})
 
 		firstcert, _ := watcher.GetCertificate(nil)
@@ -166,7 +166,7 @@ func TestCertWatcherStart(t *testing.T) {
 		called := atomic.Int64{}
 		watcher.RegisterCallback(func(crt tls.Certificate) {
 			called.Add(1)
-			require.NotEmpty(t, crt.Certificate)
+			assert.NotEmpty(t, crt.Certificate)
 		})
 
 		firstcert, err := watcher.GetCertificate(nil)


### PR DESCRIPTION
## Description
`require.NoError` calls `t.Fatalf`, which kills the goroutine from which it's called. For this reason you're not supposed to use it inside of goroutines, but the callback in `RegisterCallback` is invoked inside of a goroutine.

I'm not entirely sure that this is the fix, but it probably isn't helping.

## Changes
* Use assert instead of require
## Testing
Review.