### PR TITLE
build: refactor mage targets and build tags to prevent silent skipping of tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,16 +3,16 @@ version: "2"
 run:
   allow-parallel-runners: true
   build-tags:
-    - "ci"
-    - "datastoreconsistency"
-    - "docker"
-    - "image"
-    - "mage"
-    - "memoryprotection"
-    - "!skipintegrationtests"
-    - "steelthread"
-    - "pgbouncer"
-    - "postgres"
+    - "ci" # enables runtime debug assertions (swaps assert_off.go for assert_on.go); not a test category
+    - "datastore" # datastore tests that run against real databases (crdb, postgres, spanner, mysql); needs Docker
+    - "datastoreconsistency" # cross-datastore consistency tests; needs Docker
+    - "image" # tests that run against the built SpiceDB Docker image; needs the image to be built
+    - "integration" # integration tests; explicit opt-in so they don't run during unit tests
+    - "mage" # marks files as belonging to the mage build system (magefiles/)
+    - "memoryprotection" # feature flag: swaps no-op for go-rtml memory usage provider (needs -ldflags=-checklinkname=0)
+    - "steelthread" # steel thread / golden-file tests against a real SpiceDB instance
+    - "pgbouncer"  # pgbouncer-specific postgres datastore tests (subset of datastore)
+    - "postgres" # postgres-specific datastore tests (subset of datastore, excludes pgbouncer)
 #    - wasm
 linters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,7 @@ run:
     - "mage" # marks files as belonging to the mage build system (magefiles/)
     - "memoryprotection" # feature flag: swaps no-op for go-rtml memory usage provider (needs -ldflags=-checklinkname=0)
     - "steelthread" # steel thread / golden-file tests against a real SpiceDB instance
-    - "pgbouncer"  # pgbouncer-specific postgres datastore tests (subset of datastore)
+    - "pgbouncer" # pgbouncer-specific postgres datastore tests (subset of datastore)
     - "postgres" # postgres-specific datastore tests (subset of datastore, excludes pgbouncer)
 #    - wasm
 linters:

--- a/cmd/spicedb/integration/migrate_integration_test.go
+++ b/cmd/spicedb/integration/migrate_integration_test.go
@@ -1,4 +1,4 @@
-//go:build docker && image
+//go:build image
 
 package integration_test
 

--- a/cmd/spicedb/integration/restgateway_integration_test.go
+++ b/cmd/spicedb/integration/restgateway_integration_test.go
@@ -1,4 +1,4 @@
-//go:build docker && image
+//go:build image
 
 package integration_test
 

--- a/cmd/spicedb/integration/schemawatch_integration_test.go
+++ b/cmd/spicedb/integration/schemawatch_integration_test.go
@@ -1,4 +1,4 @@
-//go:build docker && image
+//go:build image
 
 package integration_test
 

--- a/cmd/spicedb/integration/serve_integration_test.go
+++ b/cmd/spicedb/integration/serve_integration_test.go
@@ -1,4 +1,4 @@
-//go:build docker && image
+//go:build image
 
 package integration_test
 

--- a/cmd/spicedb/integration/servetesting_integration_test.go
+++ b/cmd/spicedb/integration/servetesting_integration_test.go
@@ -1,4 +1,4 @@
-//go:build docker && image
+//go:build image
 
 package integration_test
 

--- a/cmd/spicedb/integration/servetesting_race_test.go
+++ b/cmd/spicedb/integration/servetesting_race_test.go
@@ -1,4 +1,4 @@
-//go:build docker && image
+//go:build image
 
 package integration_test
 

--- a/cmd/spicedb/memoryprotection/memory_protection_integration_test.go
+++ b/cmd/spicedb/memoryprotection/memory_protection_integration_test.go
@@ -1,4 +1,4 @@
-//go:build docker && image && memoryprotection
+//go:build image && memoryprotection
 
 package memoryprotection
 

--- a/internal/datastore/crdb/crdb_test.go
+++ b/internal/datastore/crdb/crdb_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker
+//go:build datastore
 
 package crdb
 

--- a/internal/datastore/crdb/partitioner_integration_test.go
+++ b/internal/datastore/crdb/partitioner_integration_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker
+//go:build datastore
 
 package crdb
 

--- a/internal/datastore/crdb/partitioner_test.go
+++ b/internal/datastore/crdb/partitioner_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker
+//go:build datastore
 
 package crdb
 

--- a/internal/datastore/crdb/pool_test.go
+++ b/internal/datastore/crdb/pool_test.go
@@ -1,4 +1,4 @@
-//go:build docker
+//go:build datastore
 
 package crdb
 

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker
+//go:build datastore
 
 package mysql
 

--- a/internal/datastore/mysql/migrations/migrations_test.go
+++ b/internal/datastore/mysql/migrations/migrations_test.go
@@ -1,4 +1,4 @@
-//go:build ci
+//go:build datastore
 
 package migrations
 

--- a/internal/datastore/postgres/pgbouncer_test.go
+++ b/internal/datastore/postgres/pgbouncer_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker && pgbouncer
+//go:build datastore && pgbouncer
 
 package postgres
 

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker
+//go:build datastore
 
 package postgres
 

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker && postgres
+//go:build datastore && postgres
 
 package postgres
 

--- a/internal/datastore/postgres/testutil.go
+++ b/internal/datastore/postgres/testutil.go
@@ -1,4 +1,4 @@
-//go:build ci && docker
+//go:build datastore
 
 package postgres
 

--- a/internal/datastore/spanner/spanner_test.go
+++ b/internal/datastore/spanner/spanner_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker
+//go:build datastore
 
 package spanner
 

--- a/internal/fdw/pgserver.go
+++ b/internal/fdw/pgserver.go
@@ -22,9 +22,9 @@ type PgBackend struct {
 	server   *wire.Server // GUARDED_BY(mu)
 	username string
 	password string
-	mu       sync.RWMutex
-	wg       sync.WaitGroup
-	closed   bool // GUARDED_BY(mu)
+
+	mu     sync.RWMutex
+	closed bool // GUARDED_BY(mu)
 }
 
 // NewPgBackend creates a new Postgres FDW backend server.
@@ -35,45 +35,31 @@ func NewPgBackend(client *authzed.Client, username, password string) *PgBackend 
 }
 
 // Run starts the Postgres wire protocol server on the specified endpoint.
-// It blocks until the context is cancelled or an error occurs.
+// It blocks until the context is cancelled, an error occurs, or Close is called.
 func (p *PgBackend) Run(ctx context.Context, endpoint string) error {
 	server, err := wire.NewServer(p.handler, wire.SessionMiddleware(sessionMiddleware))
 	if err != nil {
 		return err
 	}
-
 	server.Auth = wire.ClearTextPassword(p.validateAuth)
 
 	// NOTE: uncomment to enable debug logging of the actual Postgres protocol.
 	// slog.SetLogLoggerLevel(slog.LevelDebug)
 
 	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return errors.New("PgBackend already closed")
+	}
 	p.server = server
 	p.mu.Unlock()
 
-	p.wg.Add(1)
-	defer p.wg.Done()
-
-	// Monitor context cancellation in a separate goroutine
 	go func() {
 		<-ctx.Done()
-		// Don't call p.Close() here to avoid deadlock (Close waits on wg)
-		// Just close the server directly, which will cause ListenAndServe to return
-		// Use the closed flag to ensure we only close once
-		p.mu.Lock()
-		if !p.closed {
-			p.closed = true
-			srv := p.server
-			p.mu.Unlock()
-			if srv != nil {
-				srv.Close()
-			}
-		} else {
-			p.mu.Unlock()
-		}
+		_ = p.Close()
 	}()
 
-	return p.server.ListenAndServe(endpoint)
+	return server.ListenAndServe(endpoint)
 }
 
 func (p *PgBackend) validateAuth(ctx context.Context, database, username, password string) (context.Context, bool, error) {
@@ -102,14 +88,7 @@ func (p *PgBackend) Close() error {
 	if server == nil {
 		return nil
 	}
-
-	// Close the server (this will cause ListenAndServe to return)
-	err := server.Close()
-
-	// Wait for the Run goroutine to complete
-	p.wg.Wait()
-
-	return err
+	return server.Close()
 }
 
 func (p *PgBackend) handler(ctx context.Context, query string) (wire.PreparedStatements, error) {

--- a/internal/fdw/pgserver_e2e_test.go
+++ b/internal/fdw/pgserver_e2e_test.go
@@ -690,11 +690,21 @@ func runPGServer(t *testing.T, client *authzed.Client) int {
 	})
 
 	go func() {
-		_ = pgserver.Run(ctx, fmt.Sprintf("localhost:%d", port))
+		// Bind to all interfaces so the Postgres container can reach us via
+		// host.docker.internal. "localhost" binds to 127.0.0.1 only, which the
+		// container cannot reach (its packets arrive from the docker bridge IP).
+		_ = pgserver.Run(ctx, fmt.Sprintf("0.0.0.0:%d", port))
 	}()
 
-	// Give PGServer time to start
-	time.Sleep(50 * time.Millisecond)
+	// Wait until the server is actually accepting connections.
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 100*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
+	}, 10*time.Second, 20*time.Millisecond, "PGServer did not start accepting connections")
 
 	return port
 }
@@ -796,6 +806,12 @@ func runPostgres(t *testing.T) (conn *pgx.Conn) {
 		// set AutoRemove to true so that stopped container goes away by itself
 		config.AutoRemove = true
 		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
+		// Unlike every other dockertest-based test in the repo (which only flows
+		// host → container), TestEndToEnd requires the reverse: the Postgres container
+		// connects back to the FDW PGServer running on the host via postgres_fdw.
+		// Docker Desktop auto-resolves host.docker.internal, but Linux (e.g. CI
+		// runners) does not without this extra host mapping.
+		config.ExtraHosts = append(config.ExtraHosts, "host.docker.internal:host-gateway")
 	})
 	require.NoError(t, err)
 

--- a/internal/fdw/pgserver_e2e_test.go
+++ b/internal/fdw/pgserver_e2e_test.go
@@ -697,13 +697,12 @@ func runPGServer(t *testing.T, client *authzed.Client) int {
 	}()
 
 	// Wait until the server is actually accepting connections.
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 100*time.Millisecond)
-		if err != nil {
-			return false
+		if !assert.NoError(collect, err) {
+			return
 		}
 		_ = conn.Close()
-		return true
 	}, 10*time.Second, 20*time.Millisecond, "PGServer did not start accepting connections")
 
 	return port

--- a/internal/fdw/pgserver_e2e_test.go
+++ b/internal/fdw/pgserver_e2e_test.go
@@ -1,4 +1,4 @@
-//go:build ci && !skipintegrationtests
+//go:build integration
 
 package fdw_test
 

--- a/internal/services/integrationtesting/benchmark_test.go
+++ b/internal/services/integrationtesting/benchmark_test.go
@@ -1,4 +1,4 @@
-//go:build !skipintegrationtests
+//go:build integration
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/certtest/cert_test.go
+++ b/internal/services/integrationtesting/certtest/cert_test.go
@@ -1,4 +1,4 @@
-//go:build !skipintegrationtests
+//go:build integration
 
 package certtest_test
 

--- a/internal/services/integrationtesting/consistency_datastore_test.go
+++ b/internal/services/integrationtesting/consistency_datastore_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker && datastoreconsistency
+//go:build datastoreconsistency
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -1,4 +1,4 @@
-//go:build !skipintegrationtests
+//go:build integration || datastoreconsistency
 
 package integrationtesting_test
 

--- a/internal/services/integrationtesting/dockertests/dispatch_test.go
+++ b/internal/services/integrationtesting/dockertests/dispatch_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker && !skipintegrationtests
+//go:build integration
 
 package dockertests_test
 

--- a/internal/services/integrationtesting/dockertests/healthcheck_test.go
+++ b/internal/services/integrationtesting/dockertests/healthcheck_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker && !skipintegrationtests
+//go:build integration
 
 package dockertests_test
 

--- a/internal/services/integrationtesting/dockertests/perf_test.go
+++ b/internal/services/integrationtesting/dockertests/perf_test.go
@@ -1,4 +1,4 @@
-//go:build ci && docker && !skipintegrationtests
+//go:build integration
 
 package dockertests_test
 

--- a/internal/services/integrationtesting/opstest/ops_test.go
+++ b/internal/services/integrationtesting/opstest/ops_test.go
@@ -1,4 +1,4 @@
-//go:build !skipintegrationtests
+//go:build integration
 
 package opstest_test
 

--- a/internal/services/integrationtesting/queryconsistency/query_plan_consistency_test.go
+++ b/internal/services/integrationtesting/queryconsistency/query_plan_consistency_test.go
@@ -1,4 +1,4 @@
-//go:build !skipintegrationtests
+//go:build integration
 
 package queryconsistency_test
 

--- a/internal/services/integrationtesting/queryconsistency/query_plan_grpc_test.go
+++ b/internal/services/integrationtesting/queryconsistency/query_plan_grpc_test.go
@@ -1,4 +1,4 @@
-//go:build !skipintegrationtests
+//go:build integration
 
 package queryconsistency_test
 

--- a/internal/services/steelthreadtesting/steelthread_test.go
+++ b/internal/services/steelthreadtesting/steelthread_test.go
@@ -1,4 +1,4 @@
-//go:build steelthread && docker && image
+//go:build steelthread
 
 package steelthreadtesting
 

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/magefile/mage/mg"
@@ -41,7 +42,7 @@ func (t Test) Unit(ctx context.Context) error {
 }
 
 func (Test) unit(ctx context.Context, coverage bool) error {
-	args := []string{"-tags", "ci,skipintegrationtests,memoryprotection", "-race", "-timeout", "15m", "-count=1"}
+	args := []string{"-tags", "ci,memoryprotection", "-race", "-timeout", "15m", "-count=1"}
 	if coverage {
 		fmt.Println("running unit tests with coverage")
 		args = append(args, coverageFlags...)
@@ -54,18 +55,25 @@ func (Test) unit(ctx context.Context, coverage bool) error {
 // Image Run tests that run the built image
 func (Test) Image(ctx context.Context) error {
 	mg.Deps(Build{}.Testimage)
-	return goDirTest(ctx, "./cmd/spicedb", "./...", "-tags", "docker,image")
+	return goDirTest(ctx, "./cmd/spicedb", "./...", "-tags", "image")
 }
 
 // Integration Run integration tests
 func (Test) Integration(ctx context.Context) error {
 	mg.Deps(checkDocker)
-	if err := goTest(ctx, "./internal/services/integrationtesting/...", "-tags", "ci,docker", "-timeout", "30m"); err != nil {
+	dirs, err := findDirsWithBuildTag("integration")
+	if err != nil {
+		return err
+	}
+	if len(dirs) == 0 {
+		return fmt.Errorf("no packages found with //go:build integration")
+	}
+	if err := goDirTests(ctx, dirs, "-tags", "ci,integration", "-timeout", "30m"); err != nil {
 		return err
 	}
 
 	// This also requires SpiceDB docker image to be built, but we have it isolated because of the dependency with go-rtml
-	return goTest(ctx, "./cmd/spicedb/memoryprotection/...", "-tags", "ci,docker,memoryprotection", "-timeout", "15m")
+	return goTest(ctx, "./cmd/spicedb/memoryprotection/...", "-tags", "ci,image,memoryprotection", "-timeout", "15m")
 }
 
 // e2e Runs e2e tests (new enemy)
@@ -100,15 +108,22 @@ func (Test) E2e(ctx context.Context, crdbVersion string) error {
 // IntegrationCover Run integration tests with cover
 func (Test) IntegrationCover(ctx context.Context) error {
 	mg.Deps(checkDocker)
-	args := []string{"-tags", "ci,docker", "-timeout", "30m", "-count=1", "-v"}
+	dirs, err := findDirsWithBuildTag("integration")
+	if err != nil {
+		return err
+	}
+	if len(dirs) == 0 {
+		return fmt.Errorf("no packages found with //go:build integration")
+	}
+	args := []string{"-tags", "ci,integration", "-timeout", "30m", "-count=1", "-v"}
 	args = append(args, coverageFlags...)
-	return goTest(ctx, "./internal/services/integrationtesting/...", args...)
+	return goDirTests(ctx, dirs, args...)
 }
 
 // Steelthread Run steelthread tests
 func (Test) Steelthread(ctx context.Context) error {
 	fmt.Println("running steel thread tests")
-	return goTest(ctx, "./internal/services/steelthreadtesting/...", "-tags", "steelthread,docker,image,ci", "-timeout", "15m", "-v")
+	return goTest(ctx, "./internal/services/steelthreadtesting/...", "-tags", "ci,steelthread", "-timeout", "15m", "-v")
 }
 
 // RegenSteelthread Regenerate the steelthread tests
@@ -116,7 +131,7 @@ func (Test) RegenSteelthread() error {
 	fmt.Println("regenerating steel thread tests")
 	return RunSh("go", WithV(), WithDir("."), WithEnv(map[string]string{
 		"REGENERATE_STEEL_RESULTS": "true",
-	}), WithArgs("test", "./internal/services/steelthreadtesting/...", "-tags", "steelthread,docker,image,ci", "-timeout", "15m", "-v"))("go")
+	}), WithArgs("test", "./internal/services/steelthreadtesting/...", "-tags", "ci,steelthread", "-timeout", "15m", "-v"))("go")
 }
 
 // Analyzers Run the analyzer unit tests
@@ -195,7 +210,7 @@ func (Testds) Mysql(ctx context.Context) error {
 }
 
 func datastoreTest(ctx context.Context, datastore string, env map[string]string, tags ...string) error {
-	mergedTags := append([]string{"ci", "docker"}, tags...)
+	mergedTags := append([]string{"ci", "datastore"}, tags...)
 	tagString := strings.Join(mergedTags, ",")
 	mg.Deps(checkDocker)
 	args := []string{"-tags", tagString}
@@ -259,11 +274,39 @@ func (Testcons) Mysql(ctx context.Context) error {
 func consistencyTest(ctx context.Context, datastore string, env map[string]string) error {
 	mg.Deps(checkDocker)
 	args := []string{
-		"-tags", "ci,docker,datastoreconsistency",
+		"-tags", "ci,datastoreconsistency",
 		"-run", fmt.Sprintf("TestConsistencyPerDatastore/%s", datastore),
 	}
 	args = append(args, coverageFlags...)
 	return goDirTestWithEnv(ctx, ".", "./internal/services/integrationtesting/...",
 		env,
 		args...)
+}
+
+// findDirsWithBuildTag returns Go package paths (e.g. "./internal/fdw") containing at least
+// one _test.go file whose //go:build constraint references tag. Lets us target the right
+// packages without hard-coding folder paths that can drift.
+func findDirsWithBuildTag(tag string) ([]string, error) {
+	out, err := sh.Output("grep", "-rlE", fmt.Sprintf(`^//go:build.*\b%s\b`, tag), "--include=*_test.go", ".")
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	var result []string
+	for _, f := range strings.Split(strings.TrimSpace(out), "\n") {
+		if f == "" {
+			continue
+		}
+		dir := "./" + filepath.Dir(f)
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		result = append(result, dir)
+	}
+	fmt.Printf("found %d packages with //go:build %s:\n", len(result), tag)
+	for _, d := range result {
+		fmt.Println("  " + d)
+	}
+	return result, nil
 }

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -115,7 +115,7 @@ func (Test) IntegrationCover(ctx context.Context) error {
 	if len(dirs) == 0 {
 		return fmt.Errorf("no packages found with //go:build integration")
 	}
-	args := []string{"-tags", "ci,integration", "-timeout", "30m", "-count=1", "-v"}
+	args := []string{"-tags", "ci,integration", "-timeout", "30m", "-count=1"}
 	args = append(args, coverageFlags...)
 	return goDirTests(ctx, dirs, args...)
 }

--- a/magefiles/util.go
+++ b/magefiles/util.go
@@ -22,6 +22,15 @@ func goTest(ctx context.Context, path string, args ...string) error {
 	return goDirTest(ctx, ".", path, args...)
 }
 
+// goDirTests runs go test against multiple package paths in a single invocation.
+func goDirTests(ctx context.Context, paths []string, args ...string) error {
+	testArgs, err := testWithArgs(ctx, args...)
+	if err != nil {
+		return err
+	}
+	return RunSh("go", WithV(), WithDir("."), WithArgs(testArgs...))(paths...)
+}
+
 // goDirTest runs go test in a directory with a timeout
 func goDirTest(ctx context.Context, dir string, path string, args ...string) error {
 	testArgs, err := testWithArgs(ctx, args...)


### PR DESCRIPTION
## Description


- refactor `mage` targets to NOT list test specific dirs which is error-prone.
- remove tag `skipintegrationtests` which was confusing
- remove tag `docker` which was unnecessary

## Testing

With this PR, codecov coverage MUST go up.
If we are omitting any tests, Codecov will tell us because coverage will drop on those files.

## References

pre-requisite for https://github.com/authzed/spicedb/pull/3016
