### PR TITLE
fix: avoid hash collision in caveat context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Upgraded the spanner client, which changed the internal implementation to not use a session pool. This means that the `--datastore-spanner-max-sessions` and `--datastore-spanner-min-sessions` flags are now deprecated and no-op. We also strongly recommend using [Application Default Credentials](https://docs.cloud.google.com/docs/authentication/client-libraries#adc) in favor of a credentials file. (https://github.com/authzed/spicedb/pull/3038)
 - Query Planner: error `"ERROR: index \"pk_relation_tuple\" cannot be used for this query (SQLSTATE 42809)"` returned when using wildcards (https://github.com/authzed/spicedb/pull/3039)
 - Providing one of (`--grpc-tls-cert-path`, `--grpc-tls-key-path`) but not the other is now considered an error state, as both are necessary if you want to use TLS.
-- In a caveat context that uses nested lists of lists, the hashes generated for cache keys could collide because of an issue with the serialization logic. The serialization now uses deterministic protobuf serialization which avoids this issue.
+- In a caveat context that uses nested lists of lists, the hashes generated for cache keys could collide because of an issue with the serialization logic. The serialization now uses deterministic protobuf serialization which avoids this issue (https://github.com/authzed/spicedb/pull/3065)
 
 ## [1.51.1] - 2026-04-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Upgraded the spanner client, which changed the internal implementation to not use a session pool. This means that the `--datastore-spanner-max-sessions` and `--datastore-spanner-min-sessions` flags are now deprecated and no-op. We also strongly recommend using [Application Default Credentials](https://docs.cloud.google.com/docs/authentication/client-libraries#adc) in favor of a credentials file. (https://github.com/authzed/spicedb/pull/3038)
 - Query Planner: error `"ERROR: index \"pk_relation_tuple\" cannot be used for this query (SQLSTATE 42809)"` returned when using wildcards (https://github.com/authzed/spicedb/pull/3039)
 - Providing one of (`--grpc-tls-cert-path`, `--grpc-tls-key-path`) but not the other is now considered an error state, as both are necessary if you want to use TLS.
+- In a caveat context that uses nested lists of lists, the hashes generated for cache keys could collide because of an issue with the serialization logic. The serialization now uses deterministic protobuf serialization which avoids this issue.
 
 ## [1.51.1] - 2026-04-14
 ### Fixed

--- a/internal/dispatch/keys/computed.go
+++ b/internal/dispatch/keys/computed.go
@@ -72,29 +72,37 @@ func expandRequestToKey(req *v1.DispatchExpandRequest, option dispatchCacheKeyHa
 }
 
 // lookupResourcesRequest2ToKey converts a lookup request into a cache key
-func lookupResourcesRequest2ToKey(req *v1.DispatchLookupResources2Request, option dispatchCacheKeyHashComputeOption) DispatchCacheKey {
+func lookupResourcesRequest2ToKey(req *v1.DispatchLookupResources2Request, option dispatchCacheKeyHashComputeOption) (DispatchCacheKey, error) {
+	stableContextString, err := caveats.StableContextStringForHashing(req.Context)
+	if err != nil {
+		return DispatchCacheKey{}, err
+	}
 	return dispatchCacheKeyHash(lookupPrefix, req.Metadata.AtRevision, option,
 		hashableRelationReference{req.ResourceRelation},
 		hashableRelationReference{req.SubjectRelation},
 		hashableIds(req.SubjectIds),
 		hashableOnr{req.TerminalSubject},
-		hashableContext{HashableContext: caveats.HashableContext{Struct: req.Context}}, // NOTE: context is included here because lookup does a single dispatch
+		hashableContextString(stableContextString),
 		hashableCursor{req.OptionalCursor},
 		hashableLimit(req.OptionalLimit),
-	)
+	), nil
 }
 
 // lookupResourcesRequest3ToKey converts a lookup request into a cache key
-func lookupResourcesRequest3ToKey(req *v1.DispatchLookupResources3Request, option dispatchCacheKeyHashComputeOption) DispatchCacheKey {
+func lookupResourcesRequest3ToKey(req *v1.DispatchLookupResources3Request, option dispatchCacheKeyHashComputeOption) (DispatchCacheKey, error) {
+	stableContextString, err := caveats.StableContextStringForHashing(req.Context)
+	if err != nil {
+		return DispatchCacheKey{}, err
+	}
 	return dispatchCacheKeyHash(lookupPrefix, req.Metadata.AtRevision, option,
 		hashableRelationReference{req.ResourceRelation},
 		hashableRelationReference{req.SubjectRelation},
 		hashableIds(req.SubjectIds),
 		hashableOnr{req.TerminalSubject},
-		hashableContext{HashableContext: caveats.HashableContext{Struct: req.Context}}, // NOTE: context is included here because lookup does a single dispatch
+		hashableContextString(stableContextString), // NOTE: context is included here because lookup does a single dispatch
 		hashableCursorSections{req.OptionalCursor},
 		hashableLimit(req.OptionalLimit),
-	)
+	), nil
 }
 
 // lookupSubjectsRequestToKey converts a lookup subjects request into a cache key

--- a/internal/dispatch/keys/computed_test.go
+++ b/internal/dispatch/keys/computed_test.go
@@ -145,7 +145,7 @@ func TestStableCacheKeys(t *testing.T) {
 		{
 			"lookup resources 2",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -154,13 +154,14 @@ func TestStableCacheKeys(t *testing.T) {
 						AtRevision: "1234",
 					},
 				}, computeBothHashes)
+				return key
 			},
-			"f49fbafef9c489abe601",
+			"9884bbb3acd3b3ca1a",
 		},
 		{
 			"lookup resources 2 with zero limit",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -170,13 +171,14 @@ func TestStableCacheKeys(t *testing.T) {
 					},
 					OptionalLimit: 0,
 				}, computeBothHashes)
+				return key
 			},
-			"f49fbafef9c489abe601",
+			"9884bbb3acd3b3ca1a",
 		},
 		{
 			"lookup resources 2 with non-zero limit",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -186,13 +188,14 @@ func TestStableCacheKeys(t *testing.T) {
 					},
 					OptionalLimit: 42,
 				}, computeBothHashes)
+				return key
 			},
-			"ea88adb1c1dfa6ebab01",
+			"dba285cdd9caeef36e",
 		},
 		{
 			"lookup resources 2 with nil context",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -202,13 +205,14 @@ func TestStableCacheKeys(t *testing.T) {
 					},
 					Context: nil,
 				}, computeBothHashes)
+				return key
 			},
-			"f49fbafef9c489abe601",
+			"9884bbb3acd3b3ca1a",
 		},
 		{
 			"lookup resources 2 with empty context",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -221,13 +225,14 @@ func TestStableCacheKeys(t *testing.T) {
 						return v
 					}(),
 				}, computeBothHashes)
+				return key
 			},
-			"f49fbafef9c489abe601",
+			"9884bbb3acd3b3ca1a",
 		},
 		{
 			"lookup resources 2 with context",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -243,13 +248,14 @@ func TestStableCacheKeys(t *testing.T) {
 						return v
 					}(),
 				}, computeBothHashes)
+				return key
 			},
-			"bbd78884eff9edbebd01",
+			"a3dad09ce9d690b78401",
 		},
 		{
 			"lookup resources 2 with different context",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -265,13 +271,14 @@ func TestStableCacheKeys(t *testing.T) {
 						return v
 					}(),
 				}, computeBothHashes)
+				return key
 			},
-			"94d0faa5feaaa4dc17",
+			"f6d4bc92bae9e9d64b",
 		},
 		{
 			"lookup resources 2 with escaped string",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -286,13 +293,14 @@ func TestStableCacheKeys(t *testing.T) {
 						return v
 					}(),
 				}, computeBothHashes)
+				return key
 			},
-			"cdffc895cb9299b9da01",
+			"a0aebfb9a8abd1b802",
 		},
 		{
 			"lookup resources 2 with nested context",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -311,13 +319,14 @@ func TestStableCacheKeys(t *testing.T) {
 						return v
 					}(),
 				}, computeBothHashes)
+				return key
 			},
-			"84d8d38ff9fadbb36d",
+			"8e8ddfd8affeecc918",
 		},
 		{
 			"lookup resources 2 with empty cursor",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -327,13 +336,14 @@ func TestStableCacheKeys(t *testing.T) {
 					},
 					OptionalCursor: &v1.Cursor{},
 				}, computeBothHashes)
+				return key
 			},
-			"f49fbafef9c489abe601",
+			"9884bbb3acd3b3ca1a",
 		},
 		{
 			"lookup resources 2 with non-empty cursor",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -345,13 +355,14 @@ func TestStableCacheKeys(t *testing.T) {
 						Sections: []string{"foo"},
 					},
 				}, computeBothHashes)
+				return key
 			},
-			"f09894c0d9a0b8ff7f",
+			"9e82ddefb6ccbfd6aa01",
 		},
 		{
 			"lookup resources 2 with different cursor",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -363,13 +374,14 @@ func TestStableCacheKeys(t *testing.T) {
 						Sections: []string{"foo", "bar"},
 					},
 				}, computeBothHashes)
+				return key
 			},
-			"badfd7c59cdbcef671",
+			"e593e789a89a9acd13",
 		},
 		{
 			"lookup resources 2 with different terminal subject",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah"},
@@ -381,13 +393,14 @@ func TestStableCacheKeys(t *testing.T) {
 						Sections: []string{"foo", "bar"},
 					},
 				}, computeBothHashes)
+				return key
 			},
-			"8787b685e9cea993a901",
+			"f6cf8df7bdc7959520",
 		},
 		{
 			"lookup resources 2 with different subject IDs",
 			func() DispatchCacheKey {
-				return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+				key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 					ResourceRelation: RR("document", "view"),
 					SubjectRelation:  RR("user", "..."),
 					SubjectIds:       []string{"mariah", "tom"},
@@ -399,8 +412,9 @@ func TestStableCacheKeys(t *testing.T) {
 						Sections: []string{"foo", "bar"},
 					},
 				}, computeBothHashes)
+				return key
 			},
-			"f4d6d884eaa5e4b4ed01",
+			"de839ec8eea2f7bf19",
 		},
 	}
 
@@ -474,19 +488,20 @@ var generatorFuncs = map[string]generatorFunc{
 		subjectRelation *core.RelationReference,
 		metadata *v1.ResolverMeta,
 	) (DispatchCacheKey, []string) {
-		return lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
-				ResourceRelation: resourceRelation,
-				SubjectRelation:  subjectRelation,
-				SubjectIds:       subjectIds,
-				TerminalSubject:  ONR(subjectRelation.Namespace, subjectIds[0], subjectRelation.Relation),
-				Metadata:         metadata,
-			}, computeBothHashes), []string{
-				resourceRelation.Namespace,
-				resourceRelation.Relation,
-				subjectRelation.Namespace,
-				subjectIds[0],
-				subjectRelation.Relation,
-			}
+		key, _ := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+			ResourceRelation: resourceRelation,
+			SubjectRelation:  subjectRelation,
+			SubjectIds:       subjectIds,
+			TerminalSubject:  ONR(subjectRelation.Namespace, subjectIds[0], subjectRelation.Relation),
+			Metadata:         metadata,
+		}, computeBothHashes)
+		return key, []string{
+			resourceRelation.Namespace,
+			resourceRelation.Relation,
+			subjectRelation.Namespace,
+			subjectIds[0],
+			subjectRelation.Relation,
+		}
 	},
 
 	// Expand.
@@ -616,7 +631,7 @@ func TestComputeOnlyStableHash(t *testing.T) {
 }
 
 func TestComputeContextHash(t *testing.T) {
-	result := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
+	result, err := lookupResourcesRequest2ToKey(&v1.DispatchLookupResources2Request{
 		ResourceRelation: RR("document", "view"),
 		SubjectRelation:  RR("user", "..."),
 		SubjectIds:       []string{"mariah"},
@@ -640,5 +655,6 @@ func TestComputeContextHash(t *testing.T) {
 		}(),
 	}, computeBothHashes)
 
-	require.Equal(t, "81aab1c790f0be947d", hex.EncodeToString(result.StableSumAsBytes()))
+	require.NoError(t, err)
+	require.Equal(t, "e49efdc8e1d99daca601", hex.EncodeToString(result.StableSumAsBytes()))
 }

--- a/internal/dispatch/keys/hasher_common.go
+++ b/internal/dispatch/keys/hasher_common.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/authzed/spicedb/pkg/caveats"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -95,8 +94,8 @@ func (hc hashableCursorSections) AppendToHash(hasher hasherInterface) {
 	}
 }
 
-type hashableContext struct{ caveats.HashableContext }
+type hashableContextString string
 
-func (hc hashableContext) AppendToHash(hasher hasherInterface) {
-	hc.HashableContext.AppendToHash(hasher)
+func (hc hashableContextString) AppendToHash(hasher hasherInterface) {
+	hasher.WriteString(string(hc))
 }

--- a/internal/dispatch/keys/keys.go
+++ b/internal/dispatch/keys/keys.go
@@ -44,11 +44,11 @@ type Handler interface {
 type baseKeyHandler struct{}
 
 func (b baseKeyHandler) LookupResources2CacheKey(_ context.Context, req *v1.DispatchLookupResources2Request) (DispatchCacheKey, error) {
-	return lookupResourcesRequest2ToKey(req, computeBothHashes), nil
+	return lookupResourcesRequest2ToKey(req, computeBothHashes)
 }
 
 func (b baseKeyHandler) LookupResources3CacheKey(_ context.Context, req *v1.DispatchLookupResources3Request) (DispatchCacheKey, error) {
-	return lookupResourcesRequest3ToKey(req, computeBothHashes), nil
+	return lookupResourcesRequest3ToKey(req, computeBothHashes)
 }
 
 func (b baseKeyHandler) LookupSubjectsCacheKey(_ context.Context, req *v1.DispatchLookupSubjectsRequest) (DispatchCacheKey, error) {
@@ -64,11 +64,19 @@ func (b baseKeyHandler) CheckDispatchKey(_ context.Context, req *v1.DispatchChec
 }
 
 func (b baseKeyHandler) LookupResources2DispatchKey(_ context.Context, req *v1.DispatchLookupResources2Request) ([]byte, error) {
-	return lookupResourcesRequest2ToKey(req, computeOnlyStableHash).StableSumAsBytes(), nil
+	hash, err := lookupResourcesRequest2ToKey(req, computeOnlyStableHash)
+	if err != nil {
+		return nil, err
+	}
+	return hash.StableSumAsBytes(), nil
 }
 
 func (b baseKeyHandler) LookupResources3DispatchKey(_ context.Context, req *v1.DispatchLookupResources3Request) ([]byte, error) {
-	return lookupResourcesRequest3ToKey(req, computeOnlyStableHash).StableSumAsBytes(), nil
+	hash, err := lookupResourcesRequest3ToKey(req, computeOnlyStableHash)
+	if err != nil {
+		return nil, err
+	}
+	return hash.StableSumAsBytes(), nil
 }
 
 func (b baseKeyHandler) LookupSubjectsDispatchKey(_ context.Context, req *v1.DispatchLookupSubjectsRequest) ([]byte, error) {

--- a/internal/services/v1/hash.go
+++ b/internal/services/v1/hash.go
@@ -101,7 +101,11 @@ func computeCallHash(apiName string, consistency *v1.Consistency, arguments map[
 			stringArguments[argName] = strconv.Itoa(int(v))
 
 		case *structpb.Struct:
-			stringArguments[argName] = caveats.StableContextStringForHashing(v)
+			contextString, err := caveats.StableContextStringForHashing(v)
+			if err != nil {
+				return "", err
+			}
+			stringArguments[argName] = contextString
 
 		default:
 			return "", spiceerrors.MustBugf("unknown argument type in compute call hash")

--- a/internal/services/v1/hash_test.go
+++ b/internal/services/v1/hash_test.go
@@ -226,7 +226,7 @@ func TestLRHashStability(t *testing.T) {
 				},
 				OptionalLimit: 1000,
 			},
-			"f5c7ca6296253717",
+			"cf1d767007d04edc",
 		},
 		{
 			"different LR subject",
@@ -246,7 +246,7 @@ func TestLRHashStability(t *testing.T) {
 				},
 				OptionalLimit: 1000,
 			},
-			"aa8b67b886ecf3fd",
+			"3aecab574a273b45",
 		},
 		{
 			"different LR resource",
@@ -266,7 +266,7 @@ func TestLRHashStability(t *testing.T) {
 				},
 				OptionalLimit: 1000,
 			},
-			"fb16e4dd9395864a",
+			"67a8f4c53250f14a",
 		},
 		{
 			"different LR resource permission",
@@ -286,7 +286,7 @@ func TestLRHashStability(t *testing.T) {
 				},
 				OptionalLimit: 1000,
 			},
-			"593e60bf77f8bdb4",
+			"63d0ca03f244fc44",
 		},
 		{
 			"different limit LR",
@@ -306,7 +306,7 @@ func TestLRHashStability(t *testing.T) {
 				},
 				OptionalLimit: 999,
 			},
-			"0097cf2ee303ec31",
+			"b26e38746b7dd856",
 		},
 		{
 			"LR with different consistency",
@@ -326,7 +326,7 @@ func TestLRHashStability(t *testing.T) {
 				},
 				OptionalLimit: 1000,
 			},
-			"d8b707db35cb7043",
+			"77f27e2d566ebfbe",
 		},
 		{
 			"basic LR with caveat context",
@@ -353,7 +353,7 @@ func TestLRHashStability(t *testing.T) {
 					return s
 				}(),
 			},
-			"d40193c84ec59e6f",
+			"cbaa1004df7bd467",
 		},
 		{
 			"basic LR with different caveat context",
@@ -380,7 +380,7 @@ func TestLRHashStability(t *testing.T) {
 					return s
 				}(),
 			},
-			"a5af756163998c88",
+			"1afac87f34a901c4",
 		},
 	}
 
@@ -417,7 +417,7 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"f518629690bd9dc0",
+			"1bb4418571995a32",
 		},
 		{
 			"different resource ID, should still be the same hash",
@@ -434,7 +434,7 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"f518629690bd9dc0",
+			"1bb4418571995a32",
 		},
 		{
 			"basic bulk check item - transcribed letter",
@@ -451,7 +451,7 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"60f1e177297e915e",
+			"aa035599b6525b1d",
 		},
 		{
 			"different resource type",
@@ -468,7 +468,7 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"5117abaee3adf638",
+			"3cedf7fb7805705d",
 		},
 		{
 			"different permission",
@@ -485,7 +485,7 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"716f7be27e600292",
+			"4497a1419274b340",
 		},
 		{
 			"different subject type",
@@ -502,7 +502,7 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"7cb5945314ccbdce",
+			"89c6106d825c579a",
 		},
 		{
 			"different subject id",
@@ -519,7 +519,7 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"b24ecacf87fd0bb8",
+			"af0b171b98c325aa",
 		},
 		{
 			"different subject relation",
@@ -537,7 +537,7 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 					OptionalRelation: "foo",
 				},
 			},
-			"ee8c34ab206c80d7",
+			"624b6989fcd41287",
 		},
 		{
 			"with context",
@@ -562,7 +562,7 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 					return s
 				}(),
 			},
-			"7a5b1fec3cbed446",
+			"b52787f4dcfda909",
 		},
 		{
 			"with different context",
@@ -587,7 +587,7 @@ func TestCheckBulkPermissionsItemWithoutResourceIDHashStability(t *testing.T) {
 					return s
 				}(),
 			},
-			"f17da513a6207c30",
+			"01890cb311887418",
 		},
 	}
 
@@ -624,7 +624,7 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"5edbb3bbb8079754",
+			"afdf81991b9fea82",
 		},
 		{
 			"different resource ID, should be a different hash",
@@ -641,7 +641,7 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"e6711064500e65ba",
+			"aef33bb5fef05e09",
 		},
 		{
 			"basic bulk check item - transcribed letter",
@@ -658,7 +658,7 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"8cda00b7188572b7",
+			"b46fcb0d87f7878a",
 		},
 		{
 			"different resource type",
@@ -675,7 +675,7 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"51df43a69e51d3b0",
+			"eeec3e95226dc10b",
 		},
 		{
 			"different permission",
@@ -692,7 +692,7 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"62aaa50b2821130d",
+			"4470347cbcd50f28",
 		},
 		{
 			"different subject type",
@@ -709,7 +709,7 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"82a445d3ffc0823a",
+			"4c8a61948de1f861",
 		},
 		{
 			"different subject id",
@@ -726,7 +726,7 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 					},
 				},
 			},
-			"d3d624a310fa7781",
+			"15390b3ad12e998a",
 		},
 		{
 			"different subject relation",
@@ -744,7 +744,7 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 					OptionalRelation: "foo",
 				},
 			},
-			"a9d96f0572caef89",
+			"beeba065b897035f",
 		},
 		{
 			"with context",
@@ -769,7 +769,7 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 					return s
 				}(),
 			},
-			"94dea3fccff039ed",
+			"a2379564a6a20756",
 		},
 		{
 			"with different context",
@@ -794,7 +794,7 @@ func TestCheckBulkPermissionsItemWIDHashStability(t *testing.T) {
 					return s
 				}(),
 			},
-			"7ffdedbe12d578ee",
+			"779beae0e00a7427",
 		},
 	}
 

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -2472,26 +2472,26 @@ func TestBulkCheckCaveatContextCollision(t *testing.T) {
 	goodStruct, err := structpb.NewStruct(map[string]any{"x": []any{[]any{"a"}, "b"}})
 	require.NoError(t, err)
 	good := &v1.CheckBulkPermissionsRequestItem{
-		Resource: &v1.ObjectReference{ObjectType: "document", ObjectId: "doc"},
+		Resource:   &v1.ObjectReference{ObjectType: "document", ObjectId: "doc"},
 		Permission: "view",
-		Subject: &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: "user", ObjectId: "alice"}},
-		Context: goodStruct,
+		Subject:    &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: "user", ObjectId: "alice"}},
+		Context:    goodStruct,
 	}
 
 	badStruct, err := structpb.NewStruct(map[string]any{"x": []any{"a", []any{}, "b"}})
 	require.NoError(t, err)
 	bad := &v1.CheckBulkPermissionsRequestItem{
-		Resource: &v1.ObjectReference{ObjectType: "document", ObjectId: "doc"},
+		Resource:   &v1.ObjectReference{ObjectType: "document", ObjectId: "doc"},
 		Permission: "view",
-		Subject: &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: "user", ObjectId: "alice"}},
-		Context: badStruct,
+		Subject:    &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: "user", ObjectId: "alice"}},
+		Context:    badStruct,
 	}
 
 	singleBad, err := client.CheckPermission(t.Context(), &v1.CheckPermissionRequest{
-		Resource: bad.Resource,
-		Permission: bad.Permission,
-		Subject: bad.Subject,
-		Context: bad.Context,
+		Resource:    bad.Resource,
+		Permission:  bad.Permission,
+		Subject:     bad.Subject,
+		Context:     bad.Context,
 		Consistency: &v1.Consistency{Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true}},
 	})
 	require.NoError(t, err)
@@ -2499,13 +2499,13 @@ func TestBulkCheckCaveatContextCollision(t *testing.T) {
 
 	bulk, err := client.CheckBulkPermissions(t.Context(), &v1.CheckBulkPermissionsRequest{
 		Consistency: &v1.Consistency{Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true}},
-		Items: []*v1.CheckBulkPermissionsRequestItem{good, bad},
+		Items:       []*v1.CheckBulkPermissionsRequestItem{good, bad},
 	})
 	require.NoError(t, err)
 
 	require.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, bulk.Pairs[0].GetItem().Permissionship)
 	require.Equal(
-		t, 
+		t,
 		v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION,
 		bulk.Pairs[1].GetItem().Permissionship,
 		"the bad request should have a no permission result",

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -2447,6 +2447,8 @@ func TestExportBulkRelationshipsWithFilter(t *testing.T) {
 	}
 }
 
+// TestBulkCheckCaveatContextCollision is a regression test for an issue with
+// caveat hash collision.
 func TestBulkCheckCaveatContextCollision(t *testing.T) {
 	dsInit := func(ds datastore.Datastore, r *require.Assertions) (datastore.Datastore, datastore.Revision) {
 		schema := `

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -2446,3 +2446,66 @@ func TestExportBulkRelationshipsWithFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestBulkCheckCaveatContextCollision(t *testing.T) {
+	dsInit := func(ds datastore.Datastore, r *require.Assertions) (datastore.Datastore, datastore.Revision) {
+		schema := `
+		definition user {}
+		caveat shape(x list<any>) {
+			x == [["a"], "b"]
+		}
+		definition document {
+			relation viewer: user with shape
+			permission view = viewer
+		}`
+		rels := []tuple.Relationship{
+			tuple.MustParse(`document:doc#viewer@user:alice[shape]`),
+		}
+		return tf.DatastoreFromSchemaAndTestRelationships(ds, schema, rels, r)
+	}
+	conn, cleanup, _, _ := testserver.NewTestServer(require.New(t), 0, memdb.DisableGC, true, dsInit)
+	t.Cleanup(cleanup)
+	client := v1.NewPermissionsServiceClient(conn)
+
+	goodStruct, err := structpb.NewStruct(map[string]any{"x": []any{[]any{"a"}, "b"}})
+	require.NoError(t, err)
+	good := &v1.CheckBulkPermissionsRequestItem{
+		Resource: &v1.ObjectReference{ObjectType: "document", ObjectId: "doc"},
+		Permission: "view",
+		Subject: &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: "user", ObjectId: "alice"}},
+		Context: goodStruct,
+	}
+
+	badStruct, err := structpb.NewStruct(map[string]any{"x": []any{"a", []any{}, "b"}})
+	require.NoError(t, err)
+	bad := &v1.CheckBulkPermissionsRequestItem{
+		Resource: &v1.ObjectReference{ObjectType: "document", ObjectId: "doc"},
+		Permission: "view",
+		Subject: &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: "user", ObjectId: "alice"}},
+		Context: badStruct,
+	}
+
+	singleBad, err := client.CheckPermission(t.Context(), &v1.CheckPermissionRequest{
+		Resource: bad.Resource,
+		Permission: bad.Permission,
+		Subject: bad.Subject,
+		Context: bad.Context,
+		Consistency: &v1.Consistency{Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION, singleBad.Permissionship)
+
+	bulk, err := client.CheckBulkPermissions(t.Context(), &v1.CheckBulkPermissionsRequest{
+		Consistency: &v1.Consistency{Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true}},
+		Items: []*v1.CheckBulkPermissionsRequestItem{good, bad},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, bulk.Pairs[0].GetItem().Permissionship)
+	require.Equal(
+		t, 
+		v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION,
+		bulk.Pairs[1].GetItem().Permissionship,
+		"the bad request should have a no permission result",
+	)
+}

--- a/pkg/caveats/context_hash.go
+++ b/pkg/caveats/context_hash.go
@@ -1,91 +1,28 @@
 package caveats
 
 import (
-	"bytes"
-	"fmt"
-	"maps"
-	"net/url"
-	"slices"
-	"sort"
-	"strconv"
+	"encoding/base64"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// HasherInterface is an interface for writing context to be hashed.
-type HasherInterface interface {
-	WriteString(value string)
-}
+const (
+	prefix = "ctx-"
+)
 
 // StableContextStringForHashing returns a stable string version of the context, for use in hashing.
-func StableContextStringForHashing(context *structpb.Struct) string {
-	b := bytes.NewBufferString("")
-	hc := HashableContext{context}
-	hc.AppendToHash(wrappedBuffer{b})
-	return b.String()
-}
-
-type wrappedBuffer struct{ *bytes.Buffer }
-
-func (wb wrappedBuffer) WriteString(value string) {
-	wb.Buffer.WriteString(value)
-}
-
-// HashableContext is a wrapper around a context Struct that provides hashing.
-type HashableContext struct{ *structpb.Struct }
-
-func (hc HashableContext) AppendToHash(hasher HasherInterface) {
-	// NOTE: the order of keys in the Struct and its resulting JSON output are *unspecified*,
-	// as the go runtime randomizes iterator order to ensure that if relied upon, a sort is used.
-	// Therefore, we sort the keys here before adding them to the hash.
-	if hc.Struct == nil {
-		return
+func StableContextStringForHashing(context *structpb.Struct) (string, error) {
+	// NOTE: using Deterministic: true guarantees that the same message will always be
+	// serialized to the same bytes within the same binary:
+	// https://pkg.go.dev/google.golang.org/protobuf/proto#MarshalOptions
+	// This does mean that during a rollout, different SpiceDB instances running
+	// different versions may disagree about how context is hashed; this slight
+	// reduction in cache efficiency is offset by the guarantees that we get
+	// around serialization correctness.
+	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(context)
+	if err != nil {
+		return "", err
 	}
-
-	fields := hc.Fields
-	keys := slices.Collect(maps.Keys(fields))
-	sort.Strings(keys)
-
-	for _, key := range keys {
-		hasher.WriteString("`")
-		hasher.WriteString(key)
-		hasher.WriteString("`:")
-		hashableStructValue{fields[key]}.AppendToHash(hasher)
-		hasher.WriteString(",\n")
-	}
-}
-
-type hashableStructValue struct{ *structpb.Value }
-
-func (hsv hashableStructValue) AppendToHash(hasher HasherInterface) {
-	switch t := hsv.Kind.(type) {
-	case *structpb.Value_BoolValue:
-		hasher.WriteString(strconv.FormatBool(t.BoolValue))
-
-	case *structpb.Value_ListValue:
-		for _, value := range t.ListValue.Values {
-			hashableStructValue{value}.AppendToHash(hasher)
-			hasher.WriteString(",")
-		}
-
-	case *structpb.Value_NullValue:
-		hasher.WriteString("null")
-
-	case *structpb.Value_NumberValue:
-		// AFAICT, this is how Sprintf-style formats float64s
-		hasher.WriteString(strconv.FormatFloat(t.NumberValue, 'f', 6, 64))
-
-	case *structpb.Value_StringValue:
-		// NOTE: we escape the string value here to prevent accidental overlap in keys for string
-		// values that may themselves contain backticks.
-		hasher.WriteString("`" + url.PathEscape(t.StringValue) + "`")
-
-	case *structpb.Value_StructValue:
-		hasher.WriteString("{")
-		HashableContext{t.StructValue}.AppendToHash(hasher)
-		hasher.WriteString("}")
-
-	default:
-		panic(fmt.Sprintf("unknown struct value type: %T", t))
-	}
+	return prefix + base64.RawStdEncoding.EncodeToString(encoded), nil
 }

--- a/pkg/caveats/context_hash_test.go
+++ b/pkg/caveats/context_hash_test.go
@@ -1,0 +1,41 @@
+package caveats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TestDistinctStructsHaveDistinctHashes is a regression test -
+// under a previous version of the code the serializations were
+// equivalent
+func TestDistinctStructsHaveDistinctHashes(t *testing.T) {
+	oneStruct, err := structpb.NewStruct(map[string]any{"x": []any{[]any{"a"}, "b"}})
+	require.NoError(t, err)
+	anotherStruct, err := structpb.NewStruct(map[string]any{"x": []any{"a", []any{}, "b"}})
+	require.NoError(t, err)
+
+	oneSerialization, err := StableContextStringForHashing(oneStruct)
+	require.NoError(t, err)
+	anotherSerialization, err := StableContextStringForHashing(anotherStruct)
+	require.NoError(t, err)
+
+	require.NotEqual(t, oneSerialization, anotherSerialization)
+}
+
+func TestSameStructsHaveSameHashes(t *testing.T) {
+	// NOTE: these are distinct structs but with the same contents,
+	// to ensure that their serializations aren't vacuously the same.
+	oneStruct, err := structpb.NewStruct(map[string]any{"x": []any{[]any{"a"}, "b"}})
+	require.NoError(t, err)
+	anotherStruct, err := structpb.NewStruct(map[string]any{"x": []any{[]any{"a"}, "b"}})
+	require.NoError(t, err)
+
+	oneSerialization, err := StableContextStringForHashing(oneStruct)
+	require.NoError(t, err)
+	anotherSerialization, err := StableContextStringForHashing(anotherStruct)
+	require.NoError(t, err)
+
+	require.Equal(t, oneSerialization, anotherSerialization)
+}


### PR DESCRIPTION
## Description
Someone pointed out to us that if you use a nested list of lists in a caveat context, it was possible under our current serialization and hashing logic to have a serialization collision and therefore a dispatch cache hash collision.

This fixes that by using deterministic proto marshalling of the caveat context Struct object.

## Changes
* Update `context_hash.go` to use deterministic marshalling
* Propagate the error signature change through the stack
* change `hashableContext` to `hashableContextString` to satisfy the interface
## Testing
Review