### PR TITLE
chore: fix flaking middleware tests

### DIFF
--- a/pkg/cmd/server/middleware_test.go
+++ b/pkg/cmd/server/middleware_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -392,7 +391,6 @@ func TestMiddlewareOrdering(t *testing.T) {
 	go func() {
 		errChan <- rs.Run(ctx)
 	}()
-	time.Sleep(100 * time.Millisecond)
 
 	req := &v1.CheckPermissionRequest{
 		Resource: &v1.ObjectReference{
@@ -408,7 +406,9 @@ func TestMiddlewareOrdering(t *testing.T) {
 		Permission: "read",
 	}
 
-	_, err = psc.CheckPermission(ctx, req)
+	// NOTE: using WaitForReady ensures that the connection is active
+	// and can accept RPCs, rather than returning an EOF error.
+	_, err = psc.CheckPermission(ctx, req, grpc.WaitForReady(true))
 	require.NoError(t, err)
 
 	lrreq := &v1.LookupResourcesRequest{
@@ -502,7 +502,6 @@ func TestIncorrectOrderAssertionFails(t *testing.T) {
 	go func() {
 		errChan <- rs.Run(ctx)
 	}()
-	time.Sleep(100 * time.Millisecond)
 
 	req := &v1.CheckPermissionRequest{
 		Resource: &v1.ObjectReference{
@@ -518,7 +517,9 @@ func TestIncorrectOrderAssertionFails(t *testing.T) {
 		Permission: "read",
 	}
 
-	_, err = psc.CheckPermission(ctx, req)
+	// NOTE: using WaitForReady ensures that the connection is active
+	// and can accept RPCs, rather than returning an EOF error.
+	_, err = psc.CheckPermission(ctx, req, grpc.WaitForReady(true))
 	require.ErrorContains(t, err, "expected interceptor does-not-exist to be already executed")
 
 	lrreq := &v1.LookupResourcesRequest{


### PR DESCRIPTION
## Description
This has been a consistent flake, with an "unexpected EOF" error that was hard to parse. Using `grpc.WaitForReady` should make the test deterministic.

## Context
From an LLM.

Root cause: time.Sleep(100ms) is the race

GRPCDialContext uses grpchelpers.Dial → grpc.DialContext without grpc.WithBlock(). The dial is lazy — no actual connection is made until an RPC. The test then starts rs.Run(ctx) in a goroutine and sleeps 100ms hoping the gRPC server has called srv.Serve(listener) by then.

On a loaded CI runner, that 100ms often isn't enough. The server goroutine may not even be scheduled yet. Here's why the failure is on lrc.Recv() specifically and not on CheckPermission:

- gRPC unary calls (CheckPermission) can benefit from automatic reconnect/retry behavior at the transport layer, and returning a "not permitted" response (as resource:resource1 isn't in the bootstrap data) still counts as a successful RPC with no transport error
- LookupResources is a server-streaming call. If the server isn't serving yet, the stream opens successfully (bufconn accepts connections before Serve is called), but then the server races to handle it — and the test sees EOF when the transport is reset or the stream ends with 0 results

There's also a secondary timing hazard: lrc, err := psc.LookupResources(ctx, lrreq) only opens the stream, it doesn't block for data. If the connection became unhealthy between the unary call and the stream read, lrc.Recv() gets EOF from the transport.

## Changes
* Get rid of sleeps
* Add `grpc.WaitForReady`
## Testing
Review. See that the test passes.