### PR TITLE
chore: add claude skill to debug flaky tests

### DIFF
--- a/.claude/skills/flaky-test-diagnoser/ANALYSIS.md
+++ b/.claude/skills/flaky-test-diagnoser/ANALYSIS.md
@@ -1,0 +1,205 @@
+# Root Cause Analysis
+
+How to classify hypotheses into the 6 categories, what code patterns indicate each category, how to check environment factors, and the decision matrix for choosing an initial hypothesis set.
+
+## Contents
+- Root cause categories (the 6 hypothesis buckets)
+- Code pattern signals (grep shopping list per category)
+- Environment factor checklist
+- Decision matrix for initial hypothesis generation
+
+---
+
+## Root Cause Categories
+
+Every hypothesis is classified into exactly one of these 6 categories. The coordinator generates >=3 hypotheses spanning different categories during step 4 of the workflow.
+
+### 1. ORDERING — Test depends on execution order
+
+**Signature:** Passes in isolation, fails in-suite. Bisection identifies a specific interfering test.
+**Mechanism:** A prior test modifies shared state (database rows, module-level variables, singleton instances, environment variables, filesystem) that the target test assumes is clean.
+**Common evidence:**
+- Interfering test writes to a database/cache without cleanup
+- Module-level variable mutated by interfering test
+- Environment variable set by interfering test and not restored
+- Temp files created by interfering test not cleaned up
+
+**Canonical distinguisher:** Bisection finding a confirmed interferer (>=2/3 runs fail with INTERFERER + TARGET).
+**Typical fix:** Add setup/teardown that resets shared state. Make the target independent of assumed initial state.
+
+### 2. TIMING — Race condition or timeout sensitivity
+
+**Signature:** Fails in both isolation and in-suite; fail rate changes with parallelism or system load; failing runs show significantly longer execution times.
+**Mechanism:** A race condition (concurrent operations observed in wrong order) or a time-window assumption violated under load.
+**Common evidence:**
+- `sleep()` or `setTimeout()` used to wait for async operations
+- Assertions on time-sensitive values (timestamps, durations)
+- Missing `await` on async operations
+- Polling with fixed timeout instead of condition-based waiting
+- Go race detector reports data races
+
+**Canonical distinguisher:** Fails under `--runInBand` / `-parallel 1` (TIMING persists); fail rate changes when injecting a sleep between setup and test body.
+**Typical fix:** Replace sleeps with condition-based waits. Add missing `await`. Use deterministic synchronization (mutexes, channels, promises).
+
+### 3. SHARED_STATE — Shared mutable state without isolation
+
+**Signature:** Fails in both isolation and in-suite, but serial execution (no parallelism) makes it pass reliably.
+**Mechanism:** Multiple test threads/processes access the same mutable resource (singleton, shared database, shared port, shared file) without synchronization.
+**Common evidence:**
+- Static/global mutable variables in test setup
+- Hard-coded port numbers in tests
+- Shared database without per-test transactions or cleanup
+- Shared temp directory without per-test namespacing
+
+**Canonical distinguisher:** Fail rate drops to 0% under `--runInBand` / `-parallel 1`.
+**Typical fix:** Isolate shared resources per test (unique ports, per-test transactions, per-test tmp dirs). Fallback: force serial execution for the affected suite.
+
+### 4. EXTERNAL_DEPENDENCY — Test relies on an external service
+
+**Signature:** Fail rate varies across environments (local vs CI). Failures correlate with network availability or external service status.
+**Mechanism:** The test calls a real external service (API, DNS, NTP, database) instead of a mock/stub.
+**Common evidence:**
+- HTTP calls to external URLs in test code (not mocked)
+- DNS resolution in tests
+- `time.Now()` / `Date.now()` with assertions on specific values
+- Dependency on system locale or timezone
+
+**Canonical distinguisher:** Block the specific URL (iptables / hosts file) — EXTERNAL_DEPENDENCY fails 100%; other hypotheses unaffected.
+**Typical fix:** Mock external calls. Use fixed/injected time sources. Use test containers for database dependencies.
+
+### 5. RESOURCE_LEAK — Test leaks resources across runs
+
+**Signature:** First N runs pass, then failures start. Fail rate increases over time within a batch.
+**Mechanism:** Test allocates resources (file handles, connections, threads, memory) not released, eventually hitting system limits.
+**Common evidence:**
+- File handles opened but not closed
+- Database connections acquired but not released
+- Goroutines/threads started but not joined/stopped
+- Increasing memory usage across runs
+- "too many open files" or "connection refused" errors in later runs
+
+**Canonical distinguisher:** N=30 sequential single-test runs — RESOURCE_LEAK fail rate monotonically increases; SHARED_STATE rate is flat.
+**Typical fix:** Add resource cleanup in teardown/finally. Use context managers (Python), try-with-resources (Java), `defer` (Go). Verify cleanup runs on test failure.
+
+### 6. NON_DETERMINISM — Test output depends on non-deterministic input
+
+**Signature:** Fails in isolation at a consistent rate regardless of ordering or parallelism. No timing variance between pass/fail runs.
+**Mechanism:** Test depends on random values, hash map iteration order, filesystem readdir order, or other non-determinism sources.
+**Common evidence:**
+- `Math.random()`, `random.random()`, `rand.Int()` without seeding
+- HashMap/dict iteration used to assert order
+- Filesystem listing (`readdir`, `os.listdir`, `glob`) used to assert order
+- UUID generation used in assertions
+- Floating point comparison without epsilon
+
+**Canonical distinguisher:** Same fail rate in isolation as in-suite, same fail rate parallel vs serial, no timing variance between pass/fail runs.
+**Typical fix:** Seed random generators. Sort before comparing collections. Use ordered data structures. Use approximate float comparison.
+
+---
+
+## Code Pattern Signals
+
+The grep shopping list when reading the test code (workflow step 7). Matches at the listed paths become `evidence_for` entries in the relevant hypothesis files at strength `single-source code-path inference` (tier 4) unless backed by an experiment.
+
+### ORDERING signals
+- Grep: `setUp`, `tearDown`, `beforeAll`, `afterAll`, `beforeEach`, `afterEach`, `@Before`, `@After`, `fixture`
+- Check: does teardown reset ALL state that setup creates?
+- Check: module-level variables mutated by tests?
+
+### TIMING signals
+- Grep: `sleep`, `setTimeout`, `time.Sleep`, `Thread.sleep`, `wait_for`, `asyncio.sleep`
+- Grep: `await` missing before async calls (audit all `async` function calls)
+- Grep: `timeout`, `deadline`, `Duration`
+- Check: polling loop with fixed timeout?
+
+### SHARED_STATE signals
+- Grep: `static`, `global`, `module-level`, `singleton`
+- Grep: hard-coded ports (`8080`, `3000`, `5432`, `27017`)
+- Grep: shared file paths (`/tmp/test`, fixed filenames)
+- Check: shared database without rollback?
+
+### EXTERNAL_DEPENDENCY signals
+- Grep: `http://`, `https://` in test files (real URLs, not mocks)
+- Grep: `requests.get`, `fetch(`, `http.Get` in tests
+- Grep: `Date.now`, `time.time`, `Instant.now`, `System.currentTimeMillis` in assertions
+- Check: test doubles/mocks for all external calls?
+
+### RESOURCE_LEAK signals
+- Grep: `open(` without context manager (Python); `new FileInputStream` without try-with-resources (Java)
+- Grep: connections created in setup; check closed in teardown
+- Grep: goroutines started (`go func`) without shutdown
+- Check: error path cleans up resources?
+
+### NON_DETERMINISM signals
+- Grep: `random`, `rand`, `Math.random`, `uuid`, `UUID`
+- Grep: `HashMap`, `dict`, `map` used in order-sensitive assertions
+- Grep: `os.listdir`, `readdir`, `glob` used in assertions
+- Check: collection comparisons order-dependent?
+
+---
+
+## Environment Factor Checklist
+
+Run through this list during the Environment Analysis Protocol ([EXPERIMENTS.md](EXPERIMENTS.md)). Each factor either feeds one hypothesis category or falsifies another.
+
+| Factor | How to check | Feeds hypothesis |
+|---|---|---|
+| Parallelism | Read runner config for `workers`, `forks`, `parallel`, `--jobs` | SHARED_STATE, TIMING |
+| CI vs local | Ask user if flakiness differs across environments | EXTERNAL_DEPENDENCY, environment delta |
+| Docker/container | `Dockerfile`, `docker-compose.test.yml` | Resource limits, networking |
+| Database | Test DB config, migrations, seeding | SHARED_STATE, ORDERING |
+| Network | Grep test code for external URLs | EXTERNAL_DEPENDENCY |
+| Filesystem | Grep for file operations in tests | ORDERING, RESOURCE_LEAK |
+| Time | Grep for time-dependent assertions | TIMING, EXTERNAL_DEPENDENCY |
+| Memory | Runner memory limits | RESOURCE_LEAK |
+| Test framework upgrades | `git log` on test config | Environment delta — can invalidate prior baseline |
+| Retry policy | Grep for `@Retry`, `rerunFailingTestsCount`, `--retries` | Masking prior flakiness |
+
+---
+
+## Decision Matrix for Initial Hypothesis Generation
+
+When generating the initial >=3 competing hypotheses (step 4 of the workflow), use this matrix to seed at least one hypothesis per signal tier. The goal is to **deliberately generate different hypotheses**, not the same explanation repeated.
+
+| Experiment signal | Initial hypothesis to seed |
+|---|---|
+| Passes alone, fails in-suite, bisection narrows | ORDERING |
+| Passes alone, fails in-suite, no bisection leader | SHARED_STATE (indirect via parallelism) |
+| Fails alone AND in-suite, serial fixes it | SHARED_STATE (direct) |
+| Fails alone AND in-suite, serial does not fix, high timing variance | TIMING |
+| Fails alone AND in-suite, low timing variance, consistent fail rate | NON_DETERMINISM |
+| Fail rate increases with run index | RESOURCE_LEAK |
+| Fail rate differs across environments | EXTERNAL_DEPENDENCY |
+
+### Required spread
+
+The initial hypothesis set MUST include at least one hypothesis from each of the following super-groups:
+
+1. **State-based**: ORDERING or SHARED_STATE
+2. **Time-based**: TIMING or RESOURCE_LEAK
+3. **Input-based**: NON_DETERMINISM or EXTERNAL_DEPENDENCY
+
+This prevents the coordinator from anchoring on a single category when evidence is still thin. If the signals strongly point to only one super-group, still generate a strawman hypothesis from another super-group so the distinguishing experiment has something to falsify.
+
+### Down-ranking and merging
+
+After experiments run, down-rank a hypothesis when:
+- Direct evidence contradicts it (distinguisher says `contradicts`)
+- It survives only by adding unverified assumptions
+- It makes no distinctive prediction vs rivals
+- A rival explains the same facts with fewer assumptions
+- Its support is mostly tiers 5-6 (weak circumstantial / intuition) while a rival has tiers 1-3
+
+Merge two hypotheses if they reduce to the same underlying mechanism AND predict the same outcomes for every planned distinguisher. Record the merge in the surviving hypothesis file's `Rebuttal Round` section with `outcome: merged_with_rival`.
+
+Keep two hypotheses separate if they imply different next probes, even when they sound similar — different probes = different discriminators.
+
+---
+
+## When multiple categories match
+
+If a hypothesis fits two categories (e.g. SHARED_STATE + TIMING), prefer the one with the strongest experimental evidence. Generate both as separate hypotheses initially — the distinguishing experiment will separate them. Only merge after the experiment confirms they predict the same outcomes.
+
+## When no category fits
+
+If no hypothesis can be seeded from the signals, mark the run `blocked_by_environment` and ask the user for: (a) the CI log of a failing run, (b) the full test file, (c) the test fixtures. Do not fabricate a category to fill the slot.

--- a/.claude/skills/flaky-test-diagnoser/EXPERIMENTS.md
+++ b/.claude/skills/flaky-test-diagnoser/EXPERIMENTS.md
@@ -1,0 +1,254 @@
+# Experiment Protocols
+
+Step-by-step protocols for each experiment phase. Each protocol feeds evidence into one or more hypotheses per the schema in [FORMAT.md](FORMAT.md).
+
+## Contents
+- Multi-run protocol (confirm flakiness)
+- Isolation protocol (alone vs in-suite)
+- Ordering bisection protocol (find interfering test)
+- Timing analysis protocol (race conditions, timeout sensitivity)
+- Environment analysis protocol (parallelism, external deps)
+- Distinguishing experiment protocol (per-hypothesis discriminators)
+- Red-green-red demonstration protocol (mandatory for `root_cause_isolated_with_repro`)
+
+Every protocol writes results to `flaky-diag-{run_id}/experiments/{exp_id}.md` and individual run logs to `flaky-diag-{run_id}/runs/run-{NNN}.log`. Experiments attach `hypotheses_tested: [H-001, H-002, ...]` metadata so outcomes flow back into the hypothesis files.
+
+---
+
+## Multi-Run Protocol
+
+**Goal:** Confirm the test is flaky and measure its fail rate. This is the baseline for every downstream hypothesis.
+
+### Steps
+
+1. Construct the single-test run command from [RUNNERS.md](RUNNERS.md) for the detected runner.
+2. Run the test N=10 times using the loop template. Append one `runs/run-{NNN}.log` per invocation with the full `COMMAND`, `EXIT`, `DURATION_MS`, and `STDOUT_TAIL_20`/`STDERR_TAIL_20` fields (see [FORMAT.md](FORMAT.md) run record format).
+3. Parse exits: `EXIT: 0` = pass; non-zero = fail.
+4. Compute fail rate: `fail_count / total_runs * 100`.
+5. Write `experiments/multi-run-initial.md` with the `exp_id: multi-run-initial`, `n_runs`, and `results` fields.
+6. Set `state.json.flakiness_confirmed` accordingly.
+
+### Decision tree
+
+| Result | Next step | State impact |
+|---|---|---|
+| 0 failures in 10 runs | Increase to N=20. If still 0 failures, set `flakiness_confirmed.status: not_reproduced`. Ask the user for the original failing CI log so we can record the environment delta. | Candidate termination: `inconclusive_after_N_runs` or `blocked_by_environment` if user can't provide logs. |
+| 1-3 failures | Flakiness confirmed. Proceed to hypothesis generation + isolation. | `flakiness_confirmed.status: confirmed` |
+| 4-7 failures | Highly flaky. Proceed. | same |
+| 8-10 failures | Likely a real bug. Inform user; still proceed to isolation — consistently broken can masquerade as flaky when ordering is involved. | `flakiness_confirmed.status: consistently_broken` |
+
+### Evidence flow
+
+The multi-run outcome feeds the **fail-rate baseline** that every later experiment compares against. Record it in every hypothesis's `Evidence For` section if the hypothesis predicts the observed fail-rate, and `Evidence Against` if the hypothesis predicts a different rate.
+
+---
+
+## Isolation Protocol
+
+**Goal:** Determine if the test fails on its own or only when other tests run first. This cleanly separates ORDERING / SHARED_STATE hypotheses from TIMING / NON_DETERMINISM / EXTERNAL_DEPENDENCY hypotheses.
+
+### Steps
+
+1. **Isolated run:** Run the target test alone 5 times using the single-test command.
+2. **In-suite run:** Run the full test suite (or the test file) 5 times; extract the target test's pass/fail from each run.
+3. Write `experiments/isolation.md` with both result sequences.
+
+### Decision tree
+
+| Isolated | In-suite | Diagnosis | Hypotheses affected |
+|---|---|---|---|
+| Always passes | Sometimes fails | Ordering-dependent | Strengthens ORDERING, SHARED_STATE; weakens TIMING, NON_DETERMINISM |
+| Sometimes fails | Sometimes fails | Not ordering-dependent | Weakens ORDERING; keeps TIMING, SHARED_STATE, NON_DETERMINISM, EXTERNAL_DEPENDENCY in play |
+| Sometimes fails | Always passes | Unusual — possible RESOURCE_LEAK from the test itself in isolation, or in-suite parallelism changing timing | Strengthens RESOURCE_LEAK; flag for careful timing analysis |
+| Always fails | Always fails | Not flaky — consistently broken | Exit with `flakiness_confirmed.status: consistently_broken`; report as a real bug |
+
+Update every hypothesis file's `Evidence For` / `Evidence Against` section with the isolation outcome.
+
+---
+
+## Ordering Bisection Protocol
+
+**Goal:** Find the specific test(s) that, when run before the target, cause it to fail.
+
+**Prerequisites:** Isolation protocol showed target passes alone and fails in-suite.
+
+### Steps
+
+1. **List all tests** in the runner's natural order:
+   - pytest: `pytest --co -q`
+   - Jest: `npx jest --listTests`
+   - go test: `go test -list ".*" ./PACKAGE/`
+   - Gradle: `./gradlew test --tests "*" --dry-run`
+2. **Find target position.** All tests before it are candidates.
+3. **Binary bisection** — for each bisection step:
+   - Split candidates into FIRST_HALF and SECOND_HALF.
+   - Run `FIRST_HALF + TARGET` 3 times. If target fails >=2 times → interferer in FIRST_HALF.
+   - Run `SECOND_HALF + TARGET` 3 times. If target fails >=2 times → interferer in SECOND_HALF.
+   - Recurse on the failing half.
+4. **Confirm** by running `INTERFERER + TARGET` 5 times. If target fails >=2 times → interferer confirmed.
+5. Write each bisection step to `experiments/bisection-step-NN.md`. Final confirmation goes to `experiments/bisection-confirmed.md`.
+
+### Flaky-test-inside-bisection guard
+
+Bisection itself can flake. Require >=2 of 3 runs at each step to classify a half as "interfering." A single failure is not evidence — it is noise-compatible with the baseline fail rate. See anti-rationalization row #8 in [GOLDEN-RULES.md](GOLDEN-RULES.md).
+
+### Bisection command construction
+
+- **pytest:** `pytest TEST_A TEST_B ... TARGET -v --tb=short`
+- **Jest:** `npx jest FILE_A FILE_B TARGET_FILE --verbose --runInBand`
+- **go test:** `go test -run "TestA|TestB|Target" -v ./pkg/`
+- **Gradle:** `./gradlew test --tests "A" --tests "B" --tests "TARGET" --info`
+
+For runners that don't support arbitrary ordering, run the subset as the entire suite using test filters.
+
+### Evidence flow
+
+A confirmed interferer becomes `evidence_for` at strength `strong` in the ORDERING hypothesis, and `evidence_against` at strength `strong` in TIMING / NON_DETERMINISM (which would not be explained by ordering).
+
+---
+
+## Timing Analysis Protocol
+
+**Goal:** Detect race conditions, timeout sensitivity, and slow operations that cause intermittent failures.
+
+### Steps
+
+1. **Timed runs:** Run the target test 5 times with verbose/duration output:
+   - pytest: `--durations=0 --setup-show`
+   - Jest: `--verbose`
+   - go test: `-v`
+2. **Record timing per phase** (setup / test body / teardown) in `experiments/timing.md`.
+3. **Analyze variance** — flag:
+   - Setup >10x median → slow resource initialization
+   - Test body >5x median on failing runs → timeout or blocking call
+   - Teardown spike → cleanup race
+4. **Parallel vs serial** — run with parallelism disabled:
+   - pytest: `-p no:xdist` or `--forked`
+   - Jest: `--runInBand`
+   - go test: `-parallel 1`
+   - Vitest: `--pool=forks --poolOptions.forks.singleFork`
+5. **Language-specific race detection**:
+   - Go: `go test -race`
+   - Python: check for shared mutable module-level variables
+   - Java: check for `static` mutable fields in test classes; consider `@DirtiesContext` on Spring tests
+
+### Evidence flow
+
+- Fail rate drops to 0% under `--runInBand` or `-parallel 1` → strong evidence for SHARED_STATE.
+- Fail rate unchanged under serial → weakens SHARED_STATE, keeps TIMING and NON_DETERMINISM in play.
+- Race detector flags a data race → strong evidence for TIMING.
+- Absence of race-detector output → NOT evidence against TIMING (see counter-table row #6).
+
+---
+
+## Environment Analysis Protocol
+
+**Goal:** Surface environment factors that feed EXTERNAL_DEPENDENCY, RESOURCE_LEAK, and NON_DETERMINISM hypotheses.
+
+### Steps
+
+1. Walk the checklist in [ANALYSIS.md](ANALYSIS.md) "Environment Factor Checklist."
+2. For each factor, record a finding in `experiments/environment.md`:
+   - Parallelism config (workers, forks)
+   - CI vs local divergence (ask the user)
+   - Docker/container limits
+   - Test database config and cleanup strategy
+   - External URLs in test code
+   - Filesystem operations
+   - Time-dependent assertions (timezone, clock)
+   - Memory limits
+3. For each finding, update the relevant hypothesis file with evidence_for/against.
+
+### Read the test code
+
+1. Read the target test, its fixtures, and its setup/teardown methods. Track every shared resource, external call, time-dependent assertion, and non-deterministic input.
+2. Read any interfering test identified by bisection.
+3. Record findings as `Evidence For` entries in the relevant hypothesis files, citing `code:{file}:{line}` as the source.
+
+The code-pattern signals in [ANALYSIS.md](ANALYSIS.md) are the grep shopping list.
+
+---
+
+## Distinguishing Experiment Protocol
+
+**Goal:** Produce an experiment whose outcome uniquely separates the leading hypothesis from each surviving rival. This is the bar the falsifiability gate checks (see [GOLDEN-RULES.md](GOLDEN-RULES.md)).
+
+### Steps
+
+1. For the top 2-3 hypotheses after multi-run + isolation + ordering + timing, design a distinguisher following the template in [FORMAT.md](FORMAT.md).
+2. The experiment must produce **mutually exclusive observable outcomes** for the hypotheses it tests. If the same outcome is compatible with multiple hypotheses, the experiment is NOT distinguishing — redesign it.
+3. Write `experiments/exp-NNN.md` with the hypothesis-outcome table BEFORE running.
+4. Run the experiment. Record the observed outcome.
+5. For each hypothesis, record the verdict in that hypothesis's `Experiment Outcomes` table as `supports` / `contradicts` / `indeterminate`.
+6. Update `STRUCTURED_OUTPUT` block: set `distinguishing_experiment_verdict` for the hypothesis; set `status: falsified` for any hypothesis whose outcome came back `contradicts`.
+
+### Canonical distinguishers
+
+| Rival pair | Distinguisher |
+|---|---|
+| ORDERING vs SHARED_STATE | Run target after a known-unrelated test (should still fail if SHARED_STATE via parallelism; should pass if purely ORDERING) |
+| TIMING vs SHARED_STATE | Run with `--runInBand` / `-parallel 1`. TIMING persists; SHARED_STATE disappears. |
+| TIMING vs NON_DETERMINISM | Run with artificially slow sleep injected between setup and test. TIMING fail rate drops or rises; NON_DETERMINISM unchanged. |
+| SHARED_STATE vs RESOURCE_LEAK | Run N=30 single-test runs. SHARED_STATE fail rate stays constant; RESOURCE_LEAK rate increases over runs. |
+| EXTERNAL_DEPENDENCY vs RESOURCE_LEAK | Disconnect network (or block the specific URL). EXTERNAL_DEPENDENCY fails every run; RESOURCE_LEAK unaffected. |
+| ORDERING vs NON_DETERMINISM | Run the target alone N=20 times. ORDERING fail rate is 0%; NON_DETERMINISM rate matches in-suite rate. |
+
+Add a distinguisher to `experiments/` before declaring a leader.
+
+### If no distinguisher is available
+
+Mark the hypothesis's `distinguishing_experiment_id` as `no_distinguisher_available` with a rationale. This blocks promotion to `root_cause_isolated_with_repro` and forces the label to `narrowed_to_N_hypotheses`.
+
+---
+
+## Red-Green-Red Demonstration Protocol
+
+**Goal:** Prove a hypothesis is the root cause by producing a fix that deterministically eliminates the failure. Required for `root_cause_isolated_with_repro`.
+
+### Prerequisites
+
+- One hypothesis has `status: confirmed` with a distinguishing experiment recording `supports`.
+- All surviving rivals have `contradicts` verdicts from the same distinguisher.
+- The user has approved applying a fix (or has asked the skill to operate in an experimental branch).
+
+### Phase 1 — RED (pre-fix baseline)
+
+1. Record the branch/commit SHA.
+2. Run N>=10 invocations of the single-test command.
+3. Verify the fail rate is >= 10%. If lower, increase N until it is — the flakiness must be observable before attempting a fix.
+4. Log to `runs/red-001` through `runs/red-NNN`.
+
+### Phase 2 — GREEN (fix applied)
+
+1. Apply the minimal fix implied by the confirmed hypothesis:
+   - ORDERING → add teardown or reset fixture
+   - TIMING → replace sleep with condition-based wait; add missing await; add synchronization primitive
+   - SHARED_STATE → isolate per-test (unique port, per-test transaction, separate tmp dir)
+   - EXTERNAL_DEPENDENCY → mock or inject
+   - RESOURCE_LEAK → add cleanup in teardown/finally
+   - NON_DETERMINISM → seed random generator, sort before compare, use ordered data structures
+2. Record files changed and the diff in `experiments/rgr-{hypothesis_id}.md`.
+3. Run N>=10 invocations of the single-test command.
+4. Verify **all N runs pass** — fail rate MUST be exactly 0%. Any failure means the fix is incomplete; do NOT promote.
+5. Log to `runs/green-001` through `runs/green-NNN`.
+
+### Phase 3 — RED (revert and rerun)
+
+1. Revert the diff from Phase 2 (apply its reverse).
+2. Run N>=10 invocations of the single-test command.
+3. Verify failure rate reproduces within 2x of Phase 1's rate. If Phase 3 does not reproduce, the original observation may have been transient — downgrade the label to `inconclusive_after_N_runs`.
+4. Log to `runs/red2-001` through `runs/red2-NNN`.
+
+### Record
+
+Write the full `experiments/rgr-{hypothesis_id}.md` per the schema in [FORMAT.md](FORMAT.md). Set `hypotheses/{id}.md` `STRUCTURED_OUTPUT.red_green_red_completed: true` and `promoted_to_root_cause: true`.
+
+### Reapply the fix
+
+After Phase 3, reapply the fix (re-apply the Phase 2 diff) so the repository is left in the green state. Record this in `logs/coordinator.jsonl` as `event: "fix_reapplied"`.
+
+---
+
+## Resume-safe execution
+
+Every protocol writes its incremental progress to `runs/` and `experiments/` before advancing. On resume (see [STATE.md](STATE.md)), completed runs are trusted — do not re-execute. Only replay from the last incomplete protocol step.

--- a/.claude/skills/flaky-test-diagnoser/FORMAT.md
+++ b/.claude/skills/flaky-test-diagnoser/FORMAT.md
@@ -1,0 +1,209 @@
+# Output Formats
+
+Per-hypothesis evaluation schema, structured-output markers, distinguishing-experiment template, and the final report hand-off shape.
+
+## Contents
+- Per-hypothesis evaluation file
+- Structured output block (required for every hypothesis)
+- Distinguishing experiment template
+- Run record format
+- Red-green-red demonstration record
+
+---
+
+## Per-Hypothesis Evaluation File
+
+Each hypothesis gets its own file at `flaky-diag-{run_id}/hypotheses/{hypothesis_id}.md`. `hypothesis_id` is `H-{NNN}` (three-digit, zero-padded, allocated in discovery order).
+
+```markdown
+# {hypothesis_id}: {short name}
+
+**Category:** ORDERING | TIMING | SHARED_STATE | EXTERNAL_DEPENDENCY | RESOURCE_LEAK | NON_DETERMINISM
+**Status:** active | falsified | confirmed | deferred
+**Uncertainty level:** high | medium | low
+**Created generation:** {integer, matches state.json.generation}
+**Last updated generation:** {integer}
+
+## Hypothesis statement
+
+One to three sentences stating the proposed mechanism for the flakiness. Be specific: name the suspected shared resource, timing window, interfering test, or non-determinism source if possible. A vague hypothesis ("maybe a race") is rejected — sharpen it before recording.
+
+## Evidence For
+
+- `{evidence_id}` | `{source: runs/run-003.log OR code:{file}:{line} OR experiments/{exp_id}.md}` | {what this evidence shows} | strength: {strong | moderate | weak | circumstantial}
+
+[At least one entry required. Pure speculation is not evidence. If a hypothesis has no evidence_for after the initial experiment pass, mark it `falsified` and move on.]
+
+## Evidence Against
+
+- `{evidence_id}` | `{source}` | {what contradicts the hypothesis} | strength: {strong | moderate | weak | circumstantial}
+
+[At least one entry required. A hypothesis with zero evidence_against is unfalsifiable — flag as `uncertainty_level: high` and design a distinguishing experiment that would produce contradicting evidence if the hypothesis is wrong. A hypothesis that cannot be contradicted by any observable experiment is not a scientific hypothesis; mark `deferred` with rationale.]
+
+## Distinguishing Experiment
+
+**Experiment id:** `{exp_id}` or `no_distinguisher_available`
+**Procedure:** {exact shell command(s) or procedure}
+**Prediction if hypothesis is TRUE:** {specific observable outcome}
+**Prediction if hypothesis is FALSE:** {specific observable outcome, must differ from TRUE outcome}
+**Rivals this distinguishes from:** [H-002, H-003]
+**Budget estimate:** {wall-clock seconds, runs needed}
+
+The experiment MUST produce different observable outcomes for this hypothesis vs every listed rival. If the experiment's outcome is compatible with multiple hypotheses, it is not distinguishing — redesign it before running.
+
+If no distinguisher is available within budget, write `no_distinguisher_available` and include a rationale in a `Notes` section. This forces the termination label toward `narrowed_to_N_hypotheses` — never `root_cause_isolated_with_repro`.
+
+## Experiment Outcomes
+
+| Run | Exp id | Command | Predicted (if true) | Observed | Verdict |
+|-----|--------|---------|--------------------|---------|---------|
+| 1 | exp-007 | `pytest test_foo.py -v --forked` | fail rate 0% | fail rate 0% (10 runs) | supports |
+| 2 | exp-008 | `pytest test_foo.py -v` | fail rate >20% | fail rate 30% (10 runs) | supports |
+
+Verdict values: `supports` | `contradicts` | `indeterminate`. Indeterminate outcomes are not evidence — do not count them toward confirmation or falsification.
+
+## Rebuttal Round
+
+If this hypothesis was the leader and a rival presented a rebuttal:
+
+- **Rival:** {hypothesis_id}
+- **Rebuttal:** {rival's best argument, one paragraph}
+- **Leader response:** {evidence-backed reply, not assertion}
+- **Outcome:** leader_held | leader_fell_to_rival | merged_with_rival
+
+## Red-Green-Red Demo
+
+[Only populated if this hypothesis was promoted to `root_cause_isolated_with_repro`.]
+
+- **Fix description:** {what code changed, file:line}
+- **Pre-fix multi-run:** N={n}, results: `{P F sequence}`, fail rate: {%}
+- **Post-fix multi-run:** N={n}, results: `{P sequence, all P required}`, fail rate: 0%
+- **Revert and rerun:** N={n}, results: `{P F sequence with fails reproduced}`, fail rate: {%}
+
+All three phases required for the `root_cause_isolated_with_repro` label. Post-fix phase MUST be N>=10 runs, all passes. If post-fix shows any fail, the fix is incomplete — do NOT promote.
+
+---
+
+STRUCTURED_OUTPUT_START
+hypothesis_id: {H-NNN}
+category: {ORDERING | TIMING | SHARED_STATE | EXTERNAL_DEPENDENCY | RESOURCE_LEAK | NON_DETERMINISM}
+status: {active | falsified | confirmed | deferred}
+uncertainty_level: {high | medium | low}
+evidence_for_count: {integer}
+evidence_against_count: {integer}
+distinguishing_experiment_id: {exp_id | no_distinguisher_available}
+distinguishing_experiment_verdict: {supports | contradicts | indeterminate | not_run}
+rebuttal_outcome: {leader_held | leader_fell_to_rival | merged_with_rival | no_rebuttal}
+red_green_red_completed: {true | false}
+promoted_to_root_cause: {true | false}
+STRUCTURED_OUTPUT_END
+```
+
+The `STRUCTURED_OUTPUT_START`/`STRUCTURED_OUTPUT_END` block is the machine-readable contract. The coordinator synthesizes the final verdict by reading these blocks from every hypothesis file — free-text commentary is ignored. Unparseable blocks are treated as `status: active, uncertainty_level: high, promoted_to_root_cause: false`.
+
+## Evidence strength hierarchy
+
+Rank evidence by tier, not by rhetoric. From strongest to weakest:
+
+1. **Controlled reproduction or distinguishing experiment** — an experiment whose outcome differs between this hypothesis and every rival
+2. **Primary artifact with tight provenance** — run log, race-detector output, bisection isolation, timing percentile
+3. **Multiple independent sources converging** — code pattern + experiment outcome + environment factor agree
+4. **Single-source code-path inference** — greppable pattern without experimental confirmation
+5. **Weak circumstantial** — naming, stack order, resemblance to prior bugs
+6. **Intuition / analogy** — unranked; does not count as evidence
+
+Down-rank hypotheses whose support is mostly tiers 5-6 when a rival has tiers 1-2 evidence.
+
+---
+
+## Distinguishing Experiment Template
+
+Fill this before running. If you cannot fill every field, the experiment is not a distinguisher yet.
+
+```markdown
+# {exp_id}: {short name}
+
+**Purpose:** Discriminate {H-001: TIMING} from {H-002: SHARED_STATE}
+**Procedure:**
+1. {exact step with shell command}
+2. {exact step}
+3. Record outcome in `experiments/{exp_id}.md` with per-run pass/fail
+
+**Hypothesis-outcome table:**
+
+| Hypothesis | Predicted outcome if this hypothesis is true |
+|---|---|
+| H-001 TIMING | Serial run (pool=1) still shows fail rate >10% |
+| H-002 SHARED_STATE | Serial run shows fail rate 0% (shared state is absent with single worker) |
+
+The outcomes MUST be mutually exclusive observable states. If they overlap, redesign.
+
+**Runs executed:** {N}
+**Raw result:** {exact pass/fail sequence}
+**Verdict for H-001:** {supports | contradicts | indeterminate}
+**Verdict for H-002:** {supports | contradicts | indeterminate}
+**Wall clock:** {seconds}
+```
+
+---
+
+## Run Record Format
+
+Each individual test invocation during multi-run / isolation / bisection / timing is recorded at `flaky-diag-{run_id}/runs/run-{NNN}.log`:
+
+```
+COMMAND: pytest tests/test_foo.py::test_bar -v --tb=short
+STARTED_AT: 2026-04-16T15:30:22Z
+RUN_INDEX: 3
+EXP_ID: multi-run-initial
+EXIT: 1
+DURATION_MS: 2034
+STDOUT_TAIL_20: <last 20 lines>
+STDERR_TAIL_20: <last 20 lines>
+```
+
+Aggregation scripts parse `EXIT: 0` (pass) vs `EXIT: [^0]` (fail). Do not paraphrase the command — store it verbatim so the user can reproduce.
+
+---
+
+## Red-Green-Red Demonstration Record
+
+Stored at `flaky-diag-{run_id}/experiments/rgr-{hypothesis_id}.md`:
+
+```markdown
+# Red-Green-Red: {hypothesis_id}
+
+## Phase 1: RED (pre-fix baseline)
+- Branch / commit: {sha or "main"}
+- Multi-run: N=10, results: `F P F P P F P F P P`, fail rate: 40%
+- Run log dir: `runs/red-001` through `runs/red-010`
+
+## Phase 2: GREEN (fix applied)
+- Fix: {short description}
+- Files changed: `{file}:{line range}`
+- Diff: {unified diff or path to patch file}
+- Multi-run: N=10, results: `P P P P P P P P P P`, fail rate: 0%
+- Run log dir: `runs/green-001` through `runs/green-010`
+
+## Phase 3: RED (revert and rerun)
+- Revert: applied reverse of Phase 2 diff
+- Multi-run: N=10, results: `F P P F P F P P F P`, fail rate: 40%
+- Run log dir: `runs/red2-001` through `runs/red2-010`
+
+## Verdict
+
+- Phase 1 fail rate: {x}%  (>= 10% required)
+- Phase 2 fail rate: 0%    (MUST be exactly 0%)
+- Phase 3 fail rate: {y}%  (must reproduce within 2x of Phase 1)
+
+If all three conditions hold, the fix is confirmed. Promote the hypothesis to `confirmed`; set `promoted_to_root_cause: true` in its structured output.
+
+If Phase 2 shows any failure, the fix is incomplete — do NOT promote. Return to hypothesis generation.
+If Phase 3 fails to reproduce the original flakiness, the original observation may itself have been transient — downgrade the label to `inconclusive_after_N_runs`.
+```
+
+---
+
+## Final Report Output
+
+The top-level report emitted at the end of the run follows [REPORT.md](REPORT.md). It is generated by synthesizing the `STRUCTURED_OUTPUT` blocks from every hypothesis file plus the honest termination label from `state.json`.

--- a/.claude/skills/flaky-test-diagnoser/GOLDEN-RULES.md
+++ b/.claude/skills/flaky-test-diagnoser/GOLDEN-RULES.md
@@ -1,0 +1,117 @@
+# Golden Rules
+
+Hard rules, the falsifiability gate, and the anti-rationalization counter-table. Consulted before finalizing any termination label.
+
+## The 10 Golden Rules
+
+1. **Never promote a hypothesis to root cause without a distinguishing experiment.** The experiment must be one whose outcome differs between the leading hypothesis and every surviving rival. An experiment that "supports everything" is not a distinguisher. Label it `narrowed_to_N_hypotheses` instead.
+
+2. **"Diagnosed" requires red-green-red.** To claim `root_cause_isolated_with_repro` you MUST demonstrate: (a) RED baseline with failing runs, (b) GREEN post-fix with N>=10 deterministic passes, (c) RED revert reproducing the original failure. Two out of three is not enough. See [FORMAT.md](FORMAT.md) for the demo schema.
+
+3. **Always run isolation before ordering.** If the test fails in isolation, ordering analysis is irrelevant. Skip to timing and environment analysis.
+
+4. **Bisect, never brute-force.** Binary bisection of the test suite — cut the search space in half each iteration. Never linear elimination.
+
+5. **Capture exact commands verbatim.** Every experiment logs its shell command verbatim so the user can reproduce it. Never paraphrase.
+
+6. **Minimum 10 runs for any statistical claim.** Flaky tests can have fail rates under 10%. Never claim "passes reliably" with fewer than 10 runs.
+
+7. **Never modify test code during diagnosis** beyond temporary instrumentation that is reverted before the report is delivered. Instrumentation must not change test semantics.
+
+8. **Evidence FOR and AGAINST every hypothesis.** A hypothesis with only supporting evidence is unfalsifiable — the framework cannot rule it out or in. Flag it as `uncertainty_level: high` and design a distinguishing experiment that would contradict it if wrong.
+
+9. **Coordinator does not self-approve.** The ranking and promotion decisions are computed from the `STRUCTURED_OUTPUT` blocks of every hypothesis file — not from the coordinator's narrative. The coordinator orchestrates and records; it never evaluates its own conclusions.
+
+10. **Structured output is the contract.** Per-hypothesis verdicts live between `STRUCTURED_OUTPUT_START`/`STRUCTURED_OUTPUT_END` markers. Free-text is ignored when computing the final label. Unparseable → treat as `uncertainty_level: high, promoted_to_root_cause: false`.
+
+---
+
+## The Falsifiability Gate
+
+A hypothesis passes the gate and may be promoted to `root_cause_isolated_with_repro` **only if all four conditions hold**:
+
+1. It has at least one `evidence_for` entry at strength `strong` or `moderate` (not circumstantial-only).
+2. It has a completed `distinguishing_experiment` whose observed outcome matches the "predicted if TRUE" branch.
+3. Every surviving rival hypothesis has that same experiment's outcome recorded in its file as `contradicts` (the observed outcome matches the rival's "predicted if FALSE" branch).
+4. A red-green-red demonstration has been completed with Phase 2 (green) showing 0% fail rate across N>=10 runs.
+
+If any condition fails, the label cannot be `root_cause_isolated_with_repro`. Downgrade to `narrowed_to_N_hypotheses` with the surviving hypothesis list.
+
+A hypothesis also passes the gate **negatively** (gets falsified) if its distinguishing experiment outcome matches the "predicted if FALSE" branch. Mark `status: falsified` — do not keep reasoning about it.
+
+---
+
+## Anti-Rationalization Counter-Table
+
+Consult this table every time the coordinator is tempted to declare done, skip a stage, or soften a label. Each row is an excuse-pattern observed in prior flaky-test investigations that led to wrong diagnoses.
+
+| Excuse the coordinator is tempted to make | Reality check | Required action |
+|---|---|---|
+| "Tests probably pass on retry — let's just rerun and move on." | Retry is not a fix. A test that fails 30% is broken; retry only masks it. | Run N>=10. Record the fail rate. Do not propose retry as a remedy. |
+| "This is just a CI flake — the code is fine." | "CI flake" is a label for an unidentified bug. Flakiness originates from shared state, timing, or non-determinism regardless of host. | Apply the 6-category decision matrix. Do not exit with "CI flake" as a verdict. |
+| "The timeout was too short — bump it and ship." | Longer timeout masks timing hypotheses; it does not falsify them. A flaky test at 10s timeout is still flaky at 60s timeout with lower frequency. | Run at the original timeout. Identify the operation whose variance exceeds the window. |
+| "Let's just rerun it — probably transient." | Probably ≠ evidence. Transient is a pattern, not a cause. | Require distinguishing experiment. No shipping on "probably." |
+| "Good enough for now — ordering dependency is obvious." | Obvious ≠ confirmed. Bisection often finds a different interferer than the one suspected. | Run the bisection; record the confirmed interferer name. |
+| "Race detector didn't flag it, so no race." | Race detectors catch data races, not higher-level ordering races (transactions, file locks, shared caches). | Do not use absence of race-detector output as evidence against TIMING hypotheses. |
+| "Passes locally 10/10 — must be CI-specific." | Local-CI divergence is a hypothesis (EXTERNAL_DEPENDENCY or environment), not a conclusion. | Log the environment diff (parallelism, workers, network, env vars) and make it a hypothesis with evidence. |
+| "One bisection pass is enough." | Bisection of a flaky test can itself flake — a negative step at 3 runs is noise-compatible. | Run each bisection step N>=3 times; require >=2 confirmations before narrowing. |
+| "Timing analysis showed variance, therefore TIMING is the cause." | Timing variance is consistent with TIMING, SHARED_STATE, and RESOURCE_LEAK. Variance alone doesn't discriminate. | Design a distinguisher (e.g. parallel-vs-serial) that separates these three. |
+| "We found the first hypothesis that fits — done." | First-fit is confirmation bias. A distinguishing experiment often falsifies a plausible leader. | Run the distinguisher even when the hypothesis "feels right." |
+
+Each row is a trapdoor. If the coordinator's narrative starts matching the "Excuse" column, stop, read the "Required action" column, and do that instead.
+
+---
+
+## Termination Label Rules
+
+Pick exactly one — never invent a synonym, never mix labels.
+
+### `root_cause_isolated_with_repro`
+**Requires:**
+- Exactly one hypothesis at `status: confirmed, promoted_to_root_cause: true`
+- All other hypotheses at `status: falsified` with contradicting distinguishing-experiment outcomes
+- Red-green-red demonstration complete (all 3 phases, Phase 2 at 0% fail rate across N>=10)
+- `state.json.invariants.no_test_code_modified_except_reverted_instrumentation: true`
+
+**Forbidden combinations:** multiple confirmed hypotheses; any `active` hypothesis; missing red-green-red.
+
+### `narrowed_to_N_hypotheses`
+**Requires:**
+- N >= 1 hypotheses at `status: active`, each with evidence_for at strength moderate or better
+- Insufficient distinguishing experiments to falsify all-but-one
+- A list of recommended next probes included in the report
+
+**Forbidden:** claiming this label when the user has not been given a list of concrete next experiments.
+
+### `inconclusive_after_N_runs`
+**Requires:**
+- Total runs consumed >= 20
+- No hypothesis reached `status: confirmed`
+- Multi-run protocol did not establish a clear fail rate OR every generated hypothesis was falsified without a replacement
+
+**Forbidden:** using this label when fewer than 20 runs were executed. Increase budget first.
+
+### `blocked_by_environment`
+**Requires:**
+- Specific blocker identified: missing dependency, failing runner, missing secret, permission denied, network unreachable, etc.
+- Exact error output captured in `logs/coordinator.jsonl`
+- No remediation attempted beyond documenting the blocker
+
+**Forbidden:** using this label when the blocker was caused by the diagnosis itself (e.g. our instrumentation broke the runner). In that case, revert instrumentation and retry.
+
+---
+
+## Invariants checked before emitting the report
+
+Every one of these must pass. The coordinator refuses to emit a report until all pass.
+
+1. `state.json.generation` increased monotonically throughout the run (no out-of-order writes).
+2. Every hypothesis referenced in `state.json.hypotheses` has a file at `hypotheses/{id}.md` with a parseable `STRUCTURED_OUTPUT` block.
+3. Every experiment referenced has a file at `experiments/{id}.md`.
+4. The termination label matches the file invariants (see per-label requirements above).
+5. No hypothesis is marked `promoted_to_root_cause: true` without a completed red-green-red demo.
+6. No hypothesis is marked `status: confirmed` without its distinguishing experiment recording a `supports` verdict.
+7. The anti-rationalization counter-table was consulted (recorded in `logs/coordinator.jsonl` with `event: "counter_table_consulted"`).
+8. If `status: confirmed` was assigned: every other hypothesis either has `status: falsified` with a `contradicts` experiment verdict, or an explicit note explaining why it was deferred.
+
+Failed invariant → coordinator emits `blocked_by_environment` with the invariant name, not the intended label.

--- a/.claude/skills/flaky-test-diagnoser/REPORT.md
+++ b/.claude/skills/flaky-test-diagnoser/REPORT.md
@@ -1,0 +1,290 @@
+# Diagnosis Report Format
+
+The exact output structure for the final diagnosis report. The report is synthesized from the `STRUCTURED_OUTPUT` blocks of every hypothesis file plus the honest termination label in `state.json`.
+
+Written to `flaky-diag-{run_id}/report.md` and returned inline to the user.
+
+## Report Template
+
+```markdown
+# Flaky Test Diagnosis Report
+
+**Test:** [full test identifier — file::class::method or file > describe > it]
+**Runner:** [detected test runner and version]
+**Run ID:** `flaky-diag-{run_id}`
+**Date:** [current date]
+
+## Termination Label
+
+`root_cause_isolated_with_repro | narrowed_to_N_hypotheses | inconclusive_after_N_runs | blocked_by_environment`
+
+[One-sentence rationale consistent with the label.]
+
+## Verdict
+
+[For `root_cause_isolated_with_repro`:]
+
+**Confirmed root cause:** [H-{id} — category — short name]
+**Selected hypothesis:** [H-{id}]
+**Red-green-red demonstrated:** yes
+**Fail rate (baseline):** [X]% across [N] runs
+**Fail rate (post-fix):** 0% across [N] runs
+
+[For `narrowed_to_N_hypotheses`:]
+
+**Surviving hypotheses:** [list of hypothesis IDs]
+**Reason unable to discriminate:** [one of: distinguisher not available within budget | distinguisher outcome indeterminate | competing hypotheses predict same outcome]
+**Recommended next probes:** [list of concrete next experiments]
+
+[For `inconclusive_after_N_runs`:]
+
+**Runs executed:** [N]
+**Reason:** [flakiness not reproduced | every hypothesis falsified without replacement]
+**Recommended next step:** [specific additional context needed — CI logs, environment details, larger run budget]
+
+[For `blocked_by_environment`:]
+
+**Blocker:** [specific blocker]
+**Error output:** [captured error]
+**Remediation suggested:** [what user must provide to unblock]
+
+## Competing Hypotheses
+
+| ID | Category | Status | Uncertainty | Distinguishing exp | Verdict |
+|----|----------|--------|-------------|--------------------|---------|
+| H-001 | ORDERING | confirmed | low | exp-007 | supports |
+| H-002 | TIMING | falsified | low | exp-007 | contradicts |
+| H-003 | SHARED_STATE | falsified | low | exp-008 | contradicts |
+
+## Evidence Summary
+
+### H-001: [short name] — [category] — status: [confirmed/active/falsified]
+
+**Evidence For:**
+- [evidence 1 with source | strength]
+- [evidence 2 with source | strength]
+
+**Evidence Against:**
+- [evidence 1 with source | strength]
+
+**Distinguishing experiment:** [exp_id]
+- Procedure: [command]
+- Predicted if true: [observable]
+- Predicted if false: [observable]
+- Observed: [observable]
+- Verdict: supports | contradicts | indeterminate
+
+[Repeat block for every hypothesis with `status` in {confirmed, active, falsified}. Omit `deferred` hypotheses unless they carry unique context.]
+
+## Experiments Executed
+
+### Multi-Run (baseline)
+
+**Command:** `[exact command]`
+**Runs:** [N]
+**Results:** [P F P P F P P P P P]
+**Fail rate:** [X]%
+
+### Isolation
+
+**Isolated (5 runs):** [P P P P P] — fail rate: [X]%
+**In-suite (5 runs):** [P F P F P] — fail rate: [X]%
+**Conclusion:** [ordering-dependent | not ordering-dependent | inconclusive]
+
+### Ordering Bisection
+
+[Include only if isolation showed ordering-dependent behavior.]
+
+**Suite size:** [N] tests before target
+**Bisection steps:** [N]
+**Interfering test:** [full test identifier]
+**Confirmation:** [INTERFERER + TARGET ran 5 times: F P F F P — confirmed]
+
+### Timing Analysis
+
+**Parallel mode (5 runs):** [results] — fail rate: [X]%
+**Serial mode (5 runs):** [results] — fail rate: [X]%
+**Timing variance:**
+- Setup: median=[X]ms, max=[Y]ms ([Z]x variance)
+- Test body: median=[X]ms, max=[Y]ms ([Z]x variance)
+- Teardown: median=[X]ms, max=[Y]ms ([Z]x variance)
+
+### Environment Analysis
+
+| Factor | Finding |
+|--------|---------|
+| Parallelism config | [e.g., "4 workers via pytest-xdist"] |
+| External calls in test | [e.g., "None detected" or "HTTP call to api.example.com"] |
+| Shared state signals | [e.g., "Module-level `_cache` dict mutated by 3 tests"] |
+| Resource cleanup | [e.g., "DB connection opened in setUp, not closed in tearDown"] |
+| CI vs local divergence | [e.g., "User reports passes locally; fails ~30% in CI"] |
+
+### Distinguishing Experiments
+
+[Per-experiment block listing the exp_id, purpose, procedure, hypothesis-outcome table, observed outcome, and per-hypothesis verdicts. Link to `experiments/{exp_id}.md`.]
+
+## Red-Green-Red Demonstration
+
+[Include only if `termination.label == root_cause_isolated_with_repro`.]
+
+**Hypothesis:** H-{id} — [category]
+
+### Phase 1 — RED (baseline)
+- Commit: [sha]
+- N=[N], results: [P F sequence], fail rate: [X]%
+
+### Phase 2 — GREEN (fix applied)
+- Files changed: [list with line ranges]
+- Diff summary: [2-5 line summary of fix]
+- N=[N], results: [P sequence, all P], fail rate: 0%
+
+### Phase 3 — RED (revert)
+- N=[N], results: [P F sequence with failures reproduced], fail rate: [X]%
+
+Fix reapplied after Phase 3. Repository left in green state.
+
+## Code Analysis
+
+**Flakiness signals found in test code (tier-4 evidence unless backed by experiment):**
+- `[file:line]` — [signal description — e.g., "time.sleep(0.1) used to wait for async operation"]
+- `[file:line]` — [signal description]
+
+## Recommended Fix
+
+[Populate fully if `termination.label == root_cause_isolated_with_repro` or `narrowed_to_N_hypotheses` with a leading hypothesis.]
+
+### Root cause explanation
+
+[1-2 paragraphs explaining the exact mechanism causing flakiness. Reference specific code locations and the confirmed hypothesis.]
+
+### Fix
+
+[Specific code change with file path and line numbers.]
+
+**Before (the problematic pattern):**
+```
+[3-10 lines showing the current code]
+```
+
+**After (the fix):**
+```
+[3-10 lines showing the corrected code]
+```
+
+### Verification
+
+After applying the fix, run:
+
+```
+[exact command to run the test N times]
+```
+
+Expected result: 0 failures in [N] runs.
+
+## Anti-Rationalization Check
+
+Before emitting this report, the coordinator confirmed:
+- [ ] No "probably" or "likely" promoted to root cause — only `status: confirmed` with a distinguishing experiment
+- [ ] No label upgraded without required evidence (e.g. `root_cause_isolated_with_repro` has a completed red-green-red)
+- [ ] No hypothesis with only evidence_for (every hypothesis has both for AND against or is marked falsified)
+- [ ] All hypotheses referenced in `state.json` have corresponding files in `hypotheses/`
+- [ ] The counter-table in GOLDEN-RULES.md was consulted
+
+## Artifacts
+
+All experiment data is preserved at:
+- `flaky-diag-{run_id}/state.json` — authoritative state
+- `flaky-diag-{run_id}/hypotheses/` — per-hypothesis evaluations
+- `flaky-diag-{run_id}/runs/` — per-run logs
+- `flaky-diag-{run_id}/experiments/` — per-experiment records
+- `flaky-diag-{run_id}/logs/coordinator.jsonl` — decision audit trail
+
+Resume this run with `--resume {run_id}`. See [STATE.md](STATE.md).
+```
+
+---
+
+## Section Rules
+
+### Required sections (all labels)
+
+- Termination Label
+- Verdict
+- Competing Hypotheses
+- Evidence Summary
+- Experiments Executed
+- Anti-Rationalization Check
+- Artifacts
+
+### Conditional sections
+
+- **Red-Green-Red Demonstration**: only for `root_cause_isolated_with_repro`
+- **Recommended Fix**: populated fully only for `root_cause_isolated_with_repro` or `narrowed_to_N_hypotheses` with a clear leading hypothesis; for other labels, emit "deferred until additional evidence" with explicit next-probe list
+- **Ordering Bisection**: only if isolation showed ordering-dependent behavior
+
+### Forbidden phrases
+
+Never emit these phrases in the report:
+- "probably the root cause"
+- "likely caused by"
+- "appears to be"
+- "seems to be"
+- "diagnosed" (without red-green-red)
+- "CI flake"
+- "transient failure"
+
+Instead, use:
+- "confirmed by [experiment]" (when backed by a distinguisher with `supports`)
+- "hypothesis H-{id} ranked first with [N] tier-{N} evidence items"
+- "unable to discriminate between H-{a} and H-{b} within budget; recommend [specific probe]"
+
+### Report length targets
+
+- Termination Label + Verdict: 5-15 lines
+- Competing Hypotheses table: 3-8 rows
+- Per-hypothesis Evidence Summary: 8-15 lines each
+- Experiments section: 10-40 lines
+- Recommended Fix: 15-40 lines (when populated)
+- Total report: 120-300 lines
+
+---
+
+## When experiments are inconclusive
+
+If no single hypothesis reaches `status: confirmed` with a distinguishing experiment:
+
+```markdown
+## Termination Label
+
+`narrowed_to_N_hypotheses`
+
+The investigation narrowed the cause to {N} surviving hypotheses that could not be discriminated within the session budget.
+
+## Verdict
+
+**Surviving hypotheses:**
+1. H-{id} — [category] — [why it survives] — [what would falsify it]
+2. H-{id} — [category] — [why it survives] — [what would falsify it]
+
+**Reason no leader emerged:** [specific reason — distinguisher not available | budget exhausted | indeterminate outcome]
+
+**Recommended next probes:**
+1. [specific experiment with exact command and prediction]
+2. [specific experiment with exact command and prediction]
+```
+
+Never fabricate a root cause when evidence is insufficient. `narrowed_to_N_hypotheses` with a concrete probe list is a valid, honest termination.
+
+---
+
+## Report emission invariants
+
+Before writing `report.md`, verify:
+
+1. Every hypothesis referenced in the report has a `STRUCTURED_OUTPUT` block at `hypotheses/{id}.md`.
+2. The termination label matches the state in `state.json`.
+3. No forbidden phrase appears in the report (grep the output before emission).
+4. If the label is `root_cause_isolated_with_repro`, the Red-Green-Red section is fully populated with N>=10 runs in each phase.
+5. If the label is `narrowed_to_N_hypotheses`, the Recommended next probes list has >=1 concrete entry with an exact command.
+
+Failed invariant → refuse to emit. Set `termination.label` to `blocked_by_environment` with the invariant name and retry after remediation.

--- a/.claude/skills/flaky-test-diagnoser/RUNNERS.md
+++ b/.claude/skills/flaky-test-diagnoser/RUNNERS.md
@@ -1,0 +1,33 @@
+# Test Runner Detection and Commands
+
+## Command templates
+
+### go test (Go)
+
+```bash
+# Run single test 
+ go test -run "TEST_NAME" -v ./PACKAGE/ 2>&1 
+  
+ # Run N times 
+ go test -run "TEST_NAME" -v -count=N ./PACKAGE/ 2>&1 
+  
+ # Run with race detector 
+ go test -run "TEST_NAME" -v -race ./PACKAGE/ 2>&1 
+  
+ # Run with timeout 
+ go test -run "TEST_NAME" -v -timeout 30s ./PACKAGE/ 2>&1 
+  
+ # Shuffle order 
+ go test -v -shuffle=on ./PACKAGE/ 2>&1 
+ 
+# run until failure is seen or until 4 hours have elapsed, whichever comes first.
+go test ./PACKAGE/ -race -c && stress ./PACKAGE.test -test.run TEST_NAME
+```
+
+## Parsing exit codes
+
+All runners use exit code conventions:
+- `0` = all tests passed
+- `1` or non-zero = at least one test failed
+
+When parsing multi-run output, count exits by grepping for `EXIT: 0` (pass) vs `EXIT: [^0]` (fail).

--- a/.claude/skills/flaky-test-diagnoser/SKILL.md
+++ b/.claude/skills/flaky-test-diagnoser/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: flaky-test-diagnoser
+description: Systematically diagnoses why a test is flaky by running multi-run experiments, isolation tests, ordering permutations, and timing analysis. Use when the user says a test is flaky, intermittent, non-deterministic, randomly failing, passes sometimes, or asks to debug test flakiness.
+---
+
+# Flaky Test Diagnoser
+
+Runs competing-hypothesis experiments to isolate the true root cause of a flaky test. Produces a diagnosis with reproducible evidence — or an honest inconclusive label. Never promotes a guess to "root cause."
+
+This is a tracing skill, not a fixer. The goal is to explain **why** the test is intermittent with falsifiable evidence, not to jump into patching code.
+
+## Workflow
+
+1. **Bootstrap run state** — create `flaky-diag-{run_id}/` in CWD with `state.json`, `hypotheses/`, `runs/`, `experiments/`. See [STATE.md](STATE.md).
+2. **Detect test runner** — identify the project's test framework and runner command from config files. See [RUNNERS.md](RUNNERS.md).
+3. **Confirm flakiness** — run the target test N>=10 times in isolation, record pass/fail per run, compute fail rate. Record each run under `runs/`. See [EXPERIMENTS.md](EXPERIMENTS.md).
+4. **Generate competing hypotheses** — produce >=3 deliberately different hypotheses from the 6 categories (ORDERING, TIMING, SHARED_STATE, EXTERNAL_DEPENDENCY, RESOURCE_LEAK, NON_DETERMINISM). Each hypothesis gets its own file in `hypotheses/` following the schema in [FORMAT.md](FORMAT.md). See [ANALYSIS.md](ANALYSIS.md) for category signatures.
+5. **Gather evidence for AND against each hypothesis** — run the structured experiments (isolation, ordering bisection, timing, environment, code reads) and record findings as `evidence_for` / `evidence_against` entries per hypothesis. See [EXPERIMENTS.md](EXPERIMENTS.md).
+6. **Design a distinguishing experiment per surviving hypothesis** — an experiment whose outcome uniquely discriminates that hypothesis from its rivals. An experiment that "merely supports" all hypotheses does NOT count. See [FORMAT.md](FORMAT.md).
+7. **Run distinguishing experiments** — record outcomes under `experiments/`. Down-rank hypotheses whose distinctive prediction failed. See [GOLDEN-RULES.md](GOLDEN-RULES.md) for the falsifiability gate.
+8. **Rebuttal round** — let the second-ranked hypothesis present its best rebuttal against the leader. The leader must answer with evidence, not assertion.
+9. **Attempt red-green-red demonstration** — if a leader has been selected, describe the minimal fix and have the user apply it (or apply it in an experimental branch). Rerun the multi-run protocol (N>=10). Only label `root_cause_isolated_with_repro` if the red-green-red cycle succeeds.
+10. **Emit structured output and diagnosis report** — each hypothesis gets a `STRUCTURED_OUTPUT_START` / `STRUCTURED_OUTPUT_END` block. Final report follows [REPORT.md](REPORT.md).
+
+## Honest termination labels
+
+Pick exactly one. Never invent synonyms.
+
+| Label | Meaning | Requires |
+|---|---|---|
+| `root_cause_isolated_with_repro` | Single hypothesis confirmed; fix demonstrated with red-green-red across N>=10 runs | Distinguishing experiment passed; all rivals empirically falsified; fix verified |
+| `narrowed_to_N_hypotheses` | Could not discriminate between N surviving hypotheses; additional probes recommended | Each surviving hypothesis has evidence_for; no distinguishing experiment available within budget |
+| `inconclusive_after_N_runs` | Could not reproduce flakiness or no hypothesis gathered sufficient evidence | N>=20 runs executed; no consistent signal |
+| `blocked_by_environment` | Cannot execute experiments (runner broken, missing deps, no shell access, tests require secrets) | Specific blocker identified with the exact error output |
+
+Never use: "diagnosed", "likely root cause", "probably", "should be", "root cause found" as a terminal label without a red-green-red demo. See [GOLDEN-RULES.md](GOLDEN-RULES.md).
+
+## Self-review checklist
+
+Before delivering the report, verify ALL:
+
+- [ ] State file exists at `flaky-diag-{run_id}/state.json` with `generation` >= 1
+- [ ] >=3 competing hypotheses were generated, each with its own file in `hypotheses/`
+- [ ] Every hypothesis has both `evidence_for` AND `evidence_against` entries (never empty)
+- [ ] Every hypothesis has an explicit `uncertainty_level` in {high, medium, low}
+- [ ] Every hypothesis has a `distinguishing_experiment` field (or is explicitly marked "no distinguisher available within budget")
+- [ ] Flakiness was confirmed: at least one fail AND at least one pass in N>=10 runs
+- [ ] Isolation vs in-suite comparison completed (both were run)
+- [ ] If a hypothesis is promoted to `root_cause_isolated_with_repro`: a red-green-red demonstration exists with N>=10 post-fix runs (all green)
+- [ ] Report uses one of the 4 honest termination labels — never "diagnosed" without red-green-red
+- [ ] Each hypothesis evaluation has a `STRUCTURED_OUTPUT_START` / `STRUCTURED_OUTPUT_END` block per [FORMAT.md](FORMAT.md)
+- [ ] Anti-rationalization counter-table was consulted before finalizing the label ([GOLDEN-RULES.md](GOLDEN-RULES.md))
+
+## Golden rules
+
+Hard rules. See [GOLDEN-RULES.md](GOLDEN-RULES.md) for the full text, anti-rationalization counter-table, and the falsifiability gate.
+
+1. **Never promote a hypothesis to root cause without a distinguishing experiment** that empirically rejects all rivals.
+2. **"Diagnosed" requires red-green-red.** Test fails → fix applied → test passes deterministically across N>=10 runs. Without it, the label is `narrowed_to_N_hypotheses`.
+3. **Always run isolation before ordering.** If the test fails in isolation, ordering analysis is irrelevant.
+4. **Bisect, never brute-force** when searching for an interfering test.
+5. **Capture exact commands verbatim.** Every experiment logs its shell command so the user can reproduce it.
+6. **Minimum 10 runs for any statistical claim.** Flaky tests can have fail rates under 10%.
+7. **Never modify test code during diagnosis** beyond temporary instrumentation that is reverted before the report is emitted.
+8. **Evidence for AND against every hypothesis.** A hypothesis with only supporting evidence is unfalsifiable and must be flagged.
+9. **Coordinator does not self-approve.** The hypothesis ranking is based on experiment outcomes recorded in files, not coordinator opinion.
+10. **Structured output is the contract.** Per-hypothesis evaluations live between `STRUCTURED_OUTPUT_START`/`STRUCTURED_OUTPUT_END` markers; free-text commentary is ignored when computing the verdict.
+
+## Cancellation / resume
+
+If interrupted mid-run: on next invocation read `flaky-diag-{run_id}/state.json`, identify the highest-`generation` completed stage, and replay from the next stage. Never recompute completed experiments — trust the recorded run artifacts. See [STATE.md](STATE.md) for the replay protocol.
+
+## Reference files
+
+| File | Contents |
+|------|----------|
+| [RUNNERS.md](RUNNERS.md) | Test runner detection, command templates for pytest/jest/junit/go test/cargo test, and how to target a single test |
+| [EXPERIMENTS.md](EXPERIMENTS.md) | Multi-run protocol, isolation protocol, ordering bisection algorithm, timing instrumentation, red-green-red demo protocol |
+| [ANALYSIS.md](ANALYSIS.md) | Root cause categories, code pattern matching for flakiness signals, environment factor checklist, decision matrix |
+| [FORMAT.md](FORMAT.md) | Per-hypothesis evaluation schema, `STRUCTURED_OUTPUT_START` markers, distinguishing-experiment template |
+| [STATE.md](STATE.md) | `state.json` schema, per-stage state layout, resume protocol |
+| [GOLDEN-RULES.md](GOLDEN-RULES.md) | Full golden rules text, falsifiability gate, anti-rationalization counter-table |
+| [REPORT.md](REPORT.md) | Diagnosis report output template with honest termination labels |

--- a/.claude/skills/flaky-test-diagnoser/STATE.md
+++ b/.claude/skills/flaky-test-diagnoser/STATE.md
@@ -1,0 +1,164 @@
+# State Management
+
+File-based state for the flaky-test-diagnoser run. Everything the coordinator decides is written to disk before proceeding; nothing is reconstructed from memory on resume.
+
+## Directory Layout
+
+Created in the current working directory at the start of every invocation:
+
+```
+flaky-diag-{run_id}/
+├── state.json                        # authoritative state; written before every stage transition
+├── hypotheses/
+│   ├── H-001.md                      # per-hypothesis evaluation (see FORMAT.md)
+│   ├── H-002.md
+│   └── H-003.md
+├── runs/
+│   ├── run-001.log                   # individual test invocation
+│   ├── run-002.log
+│   └── ...
+├── experiments/
+│   ├── multi-run-initial.md          # N>=10 baseline
+│   ├── isolation.md                  # isolation vs in-suite
+│   ├── bisection-step-01.md          # ordering bisection steps
+│   ├── timing-parallel-vs-serial.md
+│   ├── exp-007.md                    # distinguishing experiments (one per surviving hypothesis)
+│   └── rgr-H-001.md                  # red-green-red demo, if a hypothesis is promoted
+├── logs/
+│   ├── coordinator.jsonl             # decision audit trail
+│   └── stage-transitions.jsonl       # one line per stage transition
+└── report.md                         # final report; only written after termination label decided
+```
+
+`run_id` format: `YYYYMMDD-HHMMSS` using UTC, computed once at invocation start.
+
+## state.json Schema
+
+```json
+{
+  "run_id": "20260416-153022",
+  "skill": "flaky-test-diagnoser",
+  "created_at": "2026-04-16T15:30:22Z",
+  "current_stage": "bootstrap | detect_runner | confirm_flakiness | generate_hypotheses | gather_evidence | distinguishing_experiments | rebuttal | red_green_red | report",
+  "generation": 17,
+  "target": {
+    "test_identifier": "tests/test_foo.py::test_bar",
+    "user_description": "fails ~30% of the time in CI but passes locally",
+    "working_directory": "/abs/path/to/repo"
+  },
+  "runner": {
+    "detected": "pytest",
+    "version": "7.4.3",
+    "single_test_command_template": "pytest {TEST} -v --tb=short",
+    "multi_run_template": "for i in $(seq 1 {N}); do ... ; done",
+    "parallel_config": "xdist workers=4"
+  },
+  "flakiness_confirmed": {
+    "status": "confirmed | not_reproduced | consistently_broken",
+    "experiment_id": "multi-run-initial",
+    "n_runs": 10,
+    "fail_rate": 0.30,
+    "results": "F P F P P F P F P P"
+  },
+  "hypotheses": {
+    "H-001": {
+      "category": "ORDERING",
+      "status": "active | falsified | confirmed | deferred",
+      "uncertainty_level": "high | medium | low",
+      "evidence_for_count": 2,
+      "evidence_against_count": 1,
+      "distinguishing_experiment_id": "exp-007",
+      "distinguishing_experiment_verdict": "supports | contradicts | indeterminate | not_run",
+      "spawn_time_iso": "2026-04-16T15:35:00Z",
+      "completion_time_iso": null,
+      "promoted_to_root_cause": false,
+      "file_path": "hypotheses/H-001.md"
+    }
+  },
+  "experiments": {
+    "exp-007": {
+      "purpose": "discriminate H-001 from H-002",
+      "hypotheses_tested": ["H-001", "H-002"],
+      "status": "planned | running | complete | failed",
+      "n_runs": 10,
+      "started_at": "...",
+      "completed_at": "...",
+      "file_path": "experiments/exp-007.md"
+    }
+  },
+  "budget": {
+    "max_total_runs": 200,
+    "runs_consumed": 47,
+    "max_wall_clock_seconds": 1800,
+    "wall_clock_consumed_seconds": 312
+  },
+  "rebuttal_round": {
+    "leader_hypothesis_id": "H-001",
+    "challenger_hypothesis_id": "H-002",
+    "outcome": "leader_held | leader_fell | merged | not_run"
+  },
+  "red_green_red": {
+    "hypothesis_id": "H-001",
+    "status": "not_started | red_baseline | green_fix | red_revert | complete | failed",
+    "phases_complete": ["red_baseline"],
+    "file_path": "experiments/rgr-H-001.md"
+  },
+  "invariants": {
+    "coordinator_never_promoted_without_distinguishing_experiment": true,
+    "all_evidence_fresh_this_session": true,
+    "no_test_code_modified_except_reverted_instrumentation": true
+  },
+  "termination": {
+    "label": "root_cause_isolated_with_repro | narrowed_to_N_hypotheses | inconclusive_after_N_runs | blocked_by_environment | null",
+    "reason": "Free-text rationale consistent with the label",
+    "decided_at": "2026-04-16T16:02:14Z",
+    "selected_hypothesis_id": "H-001 | null",
+    "surviving_hypothesis_ids": ["H-001"]
+  }
+}
+```
+
+## Generation counter
+
+`generation` is incremented on every write to `state.json`. Atomic write pattern: write to `state.json.tmp`, fsync, rename to `state.json`. Partial writes are detected by comparing `generation` against per-hypothesis file timestamps.
+
+## Stage transition log
+
+Each stage transition appends one JSON line to `logs/stage-transitions.jsonl`:
+
+```json
+{"generation": 12, "from": "confirm_flakiness", "to": "generate_hypotheses", "timestamp": "2026-04-16T15:34:10Z", "evidence_files": ["experiments/multi-run-initial.md"], "guard_passed": true}
+```
+
+`guard_passed: true` means the transition's pre-condition (e.g. flakiness confirmed, at least 3 hypotheses exist) was validated against file contents before incrementing stage. `guard_passed: false` transitions MUST NOT occur — coordinator refuses and records `guard_failed` with the failing predicate.
+
+## Resume protocol
+
+If the user reinvokes the skill in a directory containing an existing `flaky-diag-{run_id}/`:
+
+1. Read `state.json`.
+2. Compute the last stage with a `guard_passed: true` transition log entry.
+3. Re-verify that stage's evidence files still exist and are unchanged (sha256 stored in log).
+4. Resume from the next stage — do not replay completed experiments. Trust the recorded `runs/` and `experiments/` artifacts.
+5. If re-verification fails (corrupted state, missing file, sha mismatch), emit `blocked_by_environment` with the specific corruption identified — do not attempt partial recovery.
+
+## When multiple runs exist in the same CWD
+
+If multiple `flaky-diag-*/` directories exist:
+
+- Default: create a new `flaky-diag-{now}/`. Do not merge.
+- If the user specifies `--resume {run_id}`: resume that run only.
+- Never write to an older run_id's directory during a new invocation.
+
+## Invariants checked on every state write
+
+Before `state.json` is written, the coordinator must verify:
+
+- `generation` strictly increases
+- Every hypothesis listed in `state.json.hypotheses` has a matching file at `hypotheses/{id}.md`
+- Every experiment listed has a matching file at `experiments/{id}.md`
+- No `promoted_to_root_cause: true` hypothesis exists without a completed red-green-red entry (`red_green_red.status: complete`)
+- No `termination.label: root_cause_isolated_with_repro` without a `selected_hypothesis_id` and `red_green_red.status: complete`
+- If `termination.label` is set, `current_stage: report` and the report file exists
+
+A failed invariant blocks the write and escalates to `blocked_by_environment` with the failing invariant name. The coordinator does not self-recover — it reports.


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

Copy-pasted from https://github.com/npow/claude-skills/tree/main/flaky-test-diagnoser

Usage:

```
/flaky-test-diagnoser <flakytestname>
```

## Testing


Used as an alternative of https://github.com/authzed/spicedb/pull/3066 with the following outcome: 

<img width="2118" height="1680" alt="image" src="https://github.com/user-attachments/assets/479bf3fc-1a8d-4c1a-8f66-962132f6af61" />

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->