### PR TITLE
fix: improve error when expiration is before caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reduce memory consumption of Watch API (https://github.com/authzed/spicedb/pull/2578)
 
 ### Fixed
+- Improved error message when expiration is written before caveat in a relationship (https://github.com/authzed/spicedb/pull/3071)
 - On a Postgres setup with read replicas, some requests may silently swallow errors of sort "revision not found in replica" (https://github.com/authzed/spicedb/pull/2979)
 - Use cgroup-aware memory detection for cache and watch buffer sizing in containerized environments (https://github.com/authzed/spicedb/pull/3000)
 - Upgraded the spanner client, which changed the internal implementation to not use a session pool. This means that the `--datastore-spanner-max-sessions` and `--datastore-spanner-min-sessions` flags are now deprecated and no-op. We also strongly recommend using [Application Default Credentials](https://docs.cloud.google.com/docs/authentication/client-libraries#adc) in favor of a credentials file. (https://github.com/authzed/spicedb/pull/3038)

--- a/pkg/schemadsl/parser/parser.go
+++ b/pkg/schemadsl/parser/parser.go
@@ -451,6 +451,12 @@ func (p *sourceParser) consumeSpecificTypeWithCaveat() AstNode {
 
 		// Decorate with the expiration trait.
 		specificNode.Connect(dslshape.NodeSpecificReferencePredicateTrait, traitNode)
+
+		// If `and` follows expiration, the user likely wrote the caveat and
+		// expiration in the wrong order.
+		if p.isKeyword("and") {
+			p.emitErrorf("Unexpected keyword after expiration: the caveat must come before expiration, e.g. `with <caveat_name> and expiration`")
+		}
 	}
 
 	return specificNode

--- a/pkg/schemadsl/parser/parser_test.go
+++ b/pkg/schemadsl/parser/parser_test.go
@@ -153,6 +153,7 @@ func TestParser(t *testing.T) {
 		{"partials with malformed partial reference", "partials_with_malformed_partial_reference"},
 		{"partials with malformed reference splat", "partials_with_malformed_reference_splat"},
 		{"partials with malformed partial block", "partials_with_malformed_partial_block"},
+		{"expiration before caveat test", "expirationbeforecaveat"},
 	}
 
 	for _, test := range parserTests {

--- a/pkg/schemadsl/parser/tests/expirationbeforecaveat.zed
+++ b/pkg/schemadsl/parser/tests/expirationbeforecaveat.zed
@@ -1,0 +1,5 @@
+use expiration
+
+definition resource {
+    relation editor: user with expiration and somecaveat
+}

--- a/pkg/schemadsl/parser/tests/expirationbeforecaveat.zed.expected
+++ b/pkg/schemadsl/parser/tests/expirationbeforecaveat.zed.expected
@@ -1,0 +1,57 @@
+NodeTypeFile
+  end-rune = 78
+  input-source = expiration before caveat test
+  start-rune = 0
+  child-node =>
+    NodeTypeUseFlag
+      end-rune = 13
+      input-source = expiration before caveat test
+      start-rune = 0
+      use-flag-name = expiration
+    NodeTypeDefinition
+      definition-name = resource
+      end-rune = 78
+      input-source = expiration before caveat test
+      start-rune = 16
+      child-node =>
+        NodeTypeRelation
+          end-rune = 78
+          input-source = expiration before caveat test
+          relation-name = editor
+          start-rune = 42
+          allowed-types =>
+            NodeTypeTypeReference
+              end-rune = 78
+              input-source = expiration before caveat test
+              start-rune = 59
+              type-ref-type =>
+                NodeTypeSpecificTypeReference
+                  end-rune = 78
+                  input-source = expiration before caveat test
+                  start-rune = 59
+                  type-name = user
+                  child-node =>
+                    NodeTypeError
+                      end-rune = 78
+                      error-message = Unexpected keyword after expiration: the caveat must come before expiration, e.g. `with <caveat_name> and expiration`
+                      error-source = and
+                      input-source = expiration before caveat test
+                      start-rune = 80
+                  trait =>
+                    NodeTypeTraitReference
+                      end-rune = 78
+                      input-source = expiration before caveat test
+                      start-rune = 69
+                      trait-name = expiration
+        NodeTypeError
+          end-rune = 78
+          error-message = Expected end of statement or definition, found: TokenTypeKeyword
+          error-source = and
+          input-source = expiration before caveat test
+          start-rune = 80
+    NodeTypeError
+      end-rune = 78
+      error-message = Unexpected token at root level: TokenTypeKeyword
+      error-source = and
+      input-source = expiration before caveat test
+      start-rune = 80


### PR DESCRIPTION
## Summary
- Emit a clear error when users write `with expiration and <caveat>` instead of `with <caveat> and expiration`

Fixes #2995