### PR TITLE
feat: introduce protobuf and gRPC for dispatching query plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added support for YAML-based validation files in the Language Server (https://github.com/authzed/spicedb/pull/3024)
 - Enable statistics-based optimizations when `--experimental-query-plan` is enabled. (https://github.com/authzed/spicedb/pull/3052)
 - Added missing implementations of cursoring for LookupResource, LookupSubjects and ReadRelationships calls in FDW (https://github.com/authzed/spicedb/pull/3016)
+- Add new gRPC Dispatch API and messages for dispatching query plans (https://github.com/authzed/spicedb/pull/3072)
 
 ### Changed
 - Removed MySQL metrics prefixed with `go_sql_stats_connections_*` in favor of those prefixed with `go_sql_*` (https://github.com/authzed/spicedb/pull/2980)

--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -404,6 +404,11 @@ func (cd *Dispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsReque
 	return nil
 }
 
+func (cd *Dispatcher) DispatchPlan(req *v1.DispatchPlanRequest, stream dispatch.PlanStream) error {
+	// TODO: add caching logic
+	return cd.d.DispatchPlan(req, stream)
+}
+
 func (cd *Dispatcher) Close() error {
 	prometheus.Unregister(cd.checkTotalCounter)
 	prometheus.Unregister(cd.checkFromCacheCounter)

--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -404,9 +404,9 @@ func (cd *Dispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsReque
 	return nil
 }
 
-func (cd *Dispatcher) DispatchPlan(req *v1.DispatchPlanRequest, stream dispatch.PlanStream) error {
+func (cd *Dispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
 	// TODO: add caching logic
-	return cd.d.DispatchPlan(req, stream)
+	return cd.d.DispatchQueryPlan(req, stream)
 }
 
 func (cd *Dispatcher) Close() error {

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -246,7 +246,7 @@ func (ddm delegateDispatchMock) DispatchLookupSubjects(_ *v1.DispatchLookupSubje
 	return nil
 }
 
-func (ddm delegateDispatchMock) DispatchPlan(_ *v1.DispatchPlanRequest, _ dispatch.PlanStream) error {
+func (ddm delegateDispatchMock) DispatchQueryPlan(_ *v1.DispatchQueryPlanRequest, _ dispatch.PlanStream) error {
 	return nil
 }
 

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -246,6 +246,10 @@ func (ddm delegateDispatchMock) DispatchLookupSubjects(_ *v1.DispatchLookupSubje
 	return nil
 }
 
+func (ddm delegateDispatchMock) DispatchPlan(_ *v1.DispatchPlanRequest, _ dispatch.PlanStream) error {
+	return nil
+}
+
 func (ddm delegateDispatchMock) Close() error {
 	return nil
 }

--- a/internal/dispatch/caching/delegate.go
+++ b/internal/dispatch/caching/delegate.go
@@ -40,7 +40,7 @@ func (fd fakeDelegate) DispatchLookupSubjects(_ *v1.DispatchLookupSubjectsReques
 	return spiceerrors.MustBugf(errMessage)
 }
 
-func (fd fakeDelegate) DispatchPlan(_ *v1.DispatchPlanRequest, _ dispatch.PlanStream) error {
+func (fd fakeDelegate) DispatchQueryPlan(_ *v1.DispatchQueryPlanRequest, _ dispatch.PlanStream) error {
 	return spiceerrors.MustBugf(errMessage)
 }
 

--- a/internal/dispatch/caching/delegate.go
+++ b/internal/dispatch/caching/delegate.go
@@ -40,4 +40,8 @@ func (fd fakeDelegate) DispatchLookupSubjects(_ *v1.DispatchLookupSubjectsReques
 	return spiceerrors.MustBugf(errMessage)
 }
 
+func (fd fakeDelegate) DispatchPlan(_ *v1.DispatchPlanRequest, _ dispatch.PlanStream) error {
+	return spiceerrors.MustBugf(errMessage)
+}
+
 var _ dispatch.Dispatcher = fakeDelegate{}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -81,13 +81,13 @@ type LookupSubjects interface {
 }
 
 // PlanStream is an alias for the stream to which plan results will be written.
-type PlanStream = Stream[*v1.DispatchPlanResponse]
+type PlanStream = Stream[*v1.DispatchQueryPlanResponse]
 
 // Plan interface describes the methods required to dispatch plan-based query planner requests.
 type Plan interface {
-	// DispatchPlan submits a plan-based query request, writing its results to the specified stream.
-	DispatchPlan(
-		req *v1.DispatchPlanRequest,
+	// DispatchQueryPlan submits a plan-based query request, writing its results to the specified stream.
+	DispatchQueryPlan(
+		req *v1.DispatchQueryPlanRequest,
 		stream PlanStream,
 	) error
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -27,6 +27,7 @@ type Dispatcher interface {
 	LookupSubjects
 	LookupResources2
 	LookupResources3
+	Plan
 
 	// Close closes the dispatcher.
 	Close() error
@@ -76,6 +77,18 @@ type LookupSubjects interface {
 	DispatchLookupSubjects(
 		req *v1.DispatchLookupSubjectsRequest,
 		stream LookupSubjectsStream,
+	) error
+}
+
+// PlanStream is an alias for the stream to which plan results will be written.
+type PlanStream = Stream[*v1.DispatchPlanResponse]
+
+// Plan interface describes the methods required to dispatch plan-based query planner requests.
+type Plan interface {
+	// DispatchPlan submits a plan-based query request, writing its results to the specified stream.
+	DispatchPlan(
+		req *v1.DispatchPlanRequest,
+		stream PlanStream,
 	) error
 }
 

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -471,6 +471,14 @@ func (ld *localDispatcher) DispatchLookupSubjects(
 	)
 }
 
+// DispatchPlan implements dispatch.Plan interface
+func (ld *localDispatcher) DispatchPlan(
+	req *v1.DispatchPlanRequest,
+	stream dispatch.PlanStream,
+) error {
+	return fmt.Errorf("DispatchPlan not yet implemented")
+}
+
 func (ld *localDispatcher) Close() error {
 	if ld.lookupResourcesHandler3 != nil {
 		ld.lookupResourcesHandler3.Close()

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -471,12 +471,12 @@ func (ld *localDispatcher) DispatchLookupSubjects(
 	)
 }
 
-// DispatchPlan implements dispatch.Plan interface
-func (ld *localDispatcher) DispatchPlan(
-	req *v1.DispatchPlanRequest,
+// DispatchQueryPlan implements dispatch.Plan interface
+func (ld *localDispatcher) DispatchQueryPlan(
+	req *v1.DispatchQueryPlanRequest,
 	stream dispatch.PlanStream,
 ) error {
-	return errors.New("DispatchPlan not yet implemented")
+	return errors.New("DispatchQueryPlan not yet implemented")
 }
 
 func (ld *localDispatcher) Close() error {

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -476,7 +476,7 @@ func (ld *localDispatcher) DispatchPlan(
 	req *v1.DispatchPlanRequest,
 	stream dispatch.PlanStream,
 ) error {
-	return fmt.Errorf("DispatchPlan not yet implemented")
+	return errors.New("DispatchPlan not yet implemented")
 }
 
 func (ld *localDispatcher) Close() error {

--- a/internal/dispatch/mocks/mock_dispatcher.go
+++ b/internal/dispatch/mocks/mock_dispatcher.go
@@ -129,18 +129,18 @@ func (mr *MockDispatcherMockRecorder) DispatchLookupSubjects(req, stream any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchLookupSubjects", reflect.TypeOf((*MockDispatcher)(nil).DispatchLookupSubjects), req, stream)
 }
 
-// DispatchPlan mocks base method.
-func (m *MockDispatcher) DispatchPlan(req *dispatchv1.DispatchPlanRequest, stream dispatch.PlanStream) error {
+// DispatchQueryPlan mocks base method.
+func (m *MockDispatcher) DispatchQueryPlan(req *dispatchv1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DispatchPlan", req, stream)
+	ret := m.ctrl.Call(m, "DispatchQueryPlan", req, stream)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DispatchPlan indicates an expected call of DispatchPlan.
-func (mr *MockDispatcherMockRecorder) DispatchPlan(req, stream any) *gomock.Call {
+// DispatchQueryPlan indicates an expected call of DispatchQueryPlan.
+func (mr *MockDispatcherMockRecorder) DispatchQueryPlan(req, stream any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchPlan", reflect.TypeOf((*MockDispatcher)(nil).DispatchPlan), req, stream)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchQueryPlan", reflect.TypeOf((*MockDispatcher)(nil).DispatchQueryPlan), req, stream)
 }
 
 // ReadyState mocks base method.
@@ -373,18 +373,18 @@ func (m *MockPlan) EXPECT() *MockPlanMockRecorder {
 	return m.recorder
 }
 
-// DispatchPlan mocks base method.
-func (m *MockPlan) DispatchPlan(req *dispatchv1.DispatchPlanRequest, stream dispatch.PlanStream) error {
+// DispatchQueryPlan mocks base method.
+func (m *MockPlan) DispatchQueryPlan(req *dispatchv1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DispatchPlan", req, stream)
+	ret := m.ctrl.Call(m, "DispatchQueryPlan", req, stream)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DispatchPlan indicates an expected call of DispatchPlan.
-func (mr *MockPlanMockRecorder) DispatchPlan(req, stream any) *gomock.Call {
+// DispatchQueryPlan indicates an expected call of DispatchQueryPlan.
+func (mr *MockPlanMockRecorder) DispatchQueryPlan(req, stream any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchPlan", reflect.TypeOf((*MockPlan)(nil).DispatchPlan), req, stream)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchQueryPlan", reflect.TypeOf((*MockPlan)(nil).DispatchQueryPlan), req, stream)
 }
 
 // MockDispatchableRequest is a mock of DispatchableRequest interface.

--- a/internal/dispatch/mocks/mock_dispatcher.go
+++ b/internal/dispatch/mocks/mock_dispatcher.go
@@ -129,6 +129,20 @@ func (mr *MockDispatcherMockRecorder) DispatchLookupSubjects(req, stream any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchLookupSubjects", reflect.TypeOf((*MockDispatcher)(nil).DispatchLookupSubjects), req, stream)
 }
 
+// DispatchPlan mocks base method.
+func (m *MockDispatcher) DispatchPlan(req *dispatchv1.DispatchPlanRequest, stream dispatch.PlanStream) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DispatchPlan", req, stream)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DispatchPlan indicates an expected call of DispatchPlan.
+func (mr *MockDispatcherMockRecorder) DispatchPlan(req, stream any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchPlan", reflect.TypeOf((*MockDispatcher)(nil).DispatchPlan), req, stream)
+}
+
 // ReadyState mocks base method.
 func (m *MockDispatcher) ReadyState() dispatch.ReadyState {
 	m.ctrl.T.Helper()
@@ -333,6 +347,44 @@ func (m *MockLookupSubjects) DispatchLookupSubjects(req *dispatchv1.DispatchLook
 func (mr *MockLookupSubjectsMockRecorder) DispatchLookupSubjects(req, stream any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchLookupSubjects", reflect.TypeOf((*MockLookupSubjects)(nil).DispatchLookupSubjects), req, stream)
+}
+
+// MockPlan is a mock of Plan interface.
+type MockPlan struct {
+	ctrl     *gomock.Controller
+	recorder *MockPlanMockRecorder
+	isgomock struct{}
+}
+
+// MockPlanMockRecorder is the mock recorder for MockPlan.
+type MockPlanMockRecorder struct {
+	mock *MockPlan
+}
+
+// NewMockPlan creates a new mock instance.
+func NewMockPlan(ctrl *gomock.Controller) *MockPlan {
+	mock := &MockPlan{ctrl: ctrl}
+	mock.recorder = &MockPlanMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPlan) EXPECT() *MockPlanMockRecorder {
+	return m.recorder
+}
+
+// DispatchPlan mocks base method.
+func (m *MockPlan) DispatchPlan(req *dispatchv1.DispatchPlanRequest, stream dispatch.PlanStream) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DispatchPlan", req, stream)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DispatchPlan indicates an expected call of DispatchPlan.
+func (mr *MockPlanMockRecorder) DispatchPlan(req, stream any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchPlan", reflect.TypeOf((*MockPlan)(nil).DispatchPlan), req, stream)
 }
 
 // MockDispatchableRequest is a mock of DispatchableRequest interface.

--- a/internal/dispatch/remote/cluster.go
+++ b/internal/dispatch/remote/cluster.go
@@ -853,7 +853,7 @@ func (cr *clusterDispatcher) DispatchLookupSubjects(
 
 func (cr *clusterDispatcher) DispatchPlan(req *v1.DispatchPlanRequest, stream dispatch.PlanStream) error {
 	// TODO: implement cluster dispatch for plan
-	return fmt.Errorf("DispatchPlan not yet implemented for cluster dispatch")
+	return errors.New("DispatchPlan not yet implemented for cluster dispatch")
 }
 
 func (cr *clusterDispatcher) Close() error {

--- a/internal/dispatch/remote/cluster.go
+++ b/internal/dispatch/remote/cluster.go
@@ -851,6 +851,11 @@ func (cr *clusterDispatcher) DispatchLookupSubjects(
 		})
 }
 
+func (cr *clusterDispatcher) DispatchPlan(req *v1.DispatchPlanRequest, stream dispatch.PlanStream) error {
+	// TODO: implement cluster dispatch for plan
+	return fmt.Errorf("DispatchPlan not yet implemented for cluster dispatch")
+}
+
 func (cr *clusterDispatcher) Close() error {
 	if cr.conn != nil {
 		return cr.conn.Close()

--- a/internal/dispatch/remote/cluster.go
+++ b/internal/dispatch/remote/cluster.go
@@ -851,9 +851,9 @@ func (cr *clusterDispatcher) DispatchLookupSubjects(
 		})
 }
 
-func (cr *clusterDispatcher) DispatchPlan(req *v1.DispatchPlanRequest, stream dispatch.PlanStream) error {
+func (cr *clusterDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
 	// TODO: implement cluster dispatch for plan
-	return errors.New("DispatchPlan not yet implemented for cluster dispatch")
+	return errors.New("DispatchQueryPlan not yet implemented for cluster dispatch")
 }
 
 func (cr *clusterDispatcher) Close() error {

--- a/internal/dispatch/singleflight/singleflight.go
+++ b/internal/dispatch/singleflight/singleflight.go
@@ -146,5 +146,9 @@ func (d *Dispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsReques
 	return d.delegate.DispatchLookupSubjects(req, stream)
 }
 
+func (d *Dispatcher) DispatchPlan(req *v1.DispatchPlanRequest, stream dispatch.PlanStream) error {
+	return d.delegate.DispatchPlan(req, stream)
+}
+
 func (d *Dispatcher) Close() error                    { return d.delegate.Close() }
 func (d *Dispatcher) ReadyState() dispatch.ReadyState { return d.delegate.ReadyState() }

--- a/internal/dispatch/singleflight/singleflight.go
+++ b/internal/dispatch/singleflight/singleflight.go
@@ -146,8 +146,8 @@ func (d *Dispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsReques
 	return d.delegate.DispatchLookupSubjects(req, stream)
 }
 
-func (d *Dispatcher) DispatchPlan(req *v1.DispatchPlanRequest, stream dispatch.PlanStream) error {
-	return d.delegate.DispatchPlan(req, stream)
+func (d *Dispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
+	return d.delegate.DispatchQueryPlan(req, stream)
 }
 
 func (d *Dispatcher) Close() error                    { return d.delegate.Close() }

--- a/internal/dispatch/singleflight/singleflight_test.go
+++ b/internal/dispatch/singleflight/singleflight_test.go
@@ -393,6 +393,10 @@ func (m mockDispatcher) DispatchLookupSubjects(_ *v1.DispatchLookupSubjectsReque
 	return nil
 }
 
+func (m mockDispatcher) DispatchPlan(_ *v1.DispatchPlanRequest, _ dispatch.PlanStream) error {
+	return nil
+}
+
 func (m mockDispatcher) Close() error {
 	return nil
 }

--- a/internal/dispatch/singleflight/singleflight_test.go
+++ b/internal/dispatch/singleflight/singleflight_test.go
@@ -393,7 +393,7 @@ func (m mockDispatcher) DispatchLookupSubjects(_ *v1.DispatchLookupSubjectsReque
 	return nil
 }
 
-func (m mockDispatcher) DispatchPlan(_ *v1.DispatchPlanRequest, _ dispatch.PlanStream) error {
+func (m mockDispatcher) DispatchQueryPlan(_ *v1.DispatchQueryPlanRequest, _ dispatch.PlanStream) error {
 	return nil
 }
 

--- a/internal/services/dispatch/v1/acl.go
+++ b/internal/services/dispatch/v1/acl.go
@@ -69,6 +69,13 @@ func (ds *dispatchServer) DispatchLookupSubjects(
 	return ds.localDispatch.DispatchLookupSubjects(req, dispatch.WrapGRPCStream(resp))
 }
 
+func (ds *dispatchServer) DispatchPlan(
+	req *dispatchv1.DispatchPlanRequest,
+	resp dispatchv1.DispatchService_DispatchPlanServer,
+) error {
+	return ds.localDispatch.DispatchPlan(req, dispatch.WrapGRPCStream(resp))
+}
+
 func (ds *dispatchServer) Close() error {
 	return nil
 }

--- a/internal/services/dispatch/v1/acl.go
+++ b/internal/services/dispatch/v1/acl.go
@@ -69,11 +69,11 @@ func (ds *dispatchServer) DispatchLookupSubjects(
 	return ds.localDispatch.DispatchLookupSubjects(req, dispatch.WrapGRPCStream(resp))
 }
 
-func (ds *dispatchServer) DispatchPlan(
-	req *dispatchv1.DispatchPlanRequest,
-	resp dispatchv1.DispatchService_DispatchPlanServer,
+func (ds *dispatchServer) DispatchQueryPlan(
+	req *dispatchv1.DispatchQueryPlanRequest,
+	resp dispatchv1.DispatchService_DispatchQueryPlanServer,
 ) error {
-	return ds.localDispatch.DispatchPlan(req, dispatch.WrapGRPCStream(resp))
+	return ds.localDispatch.DispatchQueryPlan(req, dispatch.WrapGRPCStream(resp))
 }
 
 func (ds *dispatchServer) Close() error {

--- a/pkg/middleware/dispatcher/dispatcher_test.go
+++ b/pkg/middleware/dispatcher/dispatcher_test.go
@@ -50,6 +50,10 @@ func (m *fakeDispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsRe
 	return nil
 }
 
+func (m *fakeDispatcher) DispatchPlan(_ *v1.DispatchPlanRequest, _ dispatch.PlanStream) error {
+	return nil
+}
+
 func (m *fakeDispatcher) Close() error {
 	return nil
 }

--- a/pkg/middleware/dispatcher/dispatcher_test.go
+++ b/pkg/middleware/dispatcher/dispatcher_test.go
@@ -50,7 +50,7 @@ func (m *fakeDispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsRe
 	return nil
 }
 
-func (m *fakeDispatcher) DispatchPlan(_ *v1.DispatchPlanRequest, _ dispatch.PlanStream) error {
+func (m *fakeDispatcher) DispatchQueryPlan(_ *v1.DispatchQueryPlanRequest, _ dispatch.PlanStream) error {
 	return nil
 }
 

--- a/pkg/proto/dispatch/v1/dispatch.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch.pb.go
@@ -1765,7 +1765,7 @@ func (x *PlanContext) GetOptionalDatastoreLimit() uint64 {
 	return 0
 }
 
-type DispatchPlanRequest struct {
+type DispatchQueryPlanRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Operation     PlanOperation          `protobuf:"varint,1,opt,name=operation,proto3,enum=dispatch.v1.PlanOperation" json:"operation,omitempty"`
 	CanonicalKey  string                 `protobuf:"bytes,2,opt,name=canonical_key,json=canonicalKey,proto3" json:"canonical_key,omitempty"`
@@ -1776,20 +1776,20 @@ type DispatchPlanRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DispatchPlanRequest) Reset() {
-	*x = DispatchPlanRequest{}
+func (x *DispatchQueryPlanRequest) Reset() {
+	*x = DispatchQueryPlanRequest{}
 	mi := &file_dispatch_v1_dispatch_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DispatchPlanRequest) String() string {
+func (x *DispatchQueryPlanRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DispatchPlanRequest) ProtoMessage() {}
+func (*DispatchQueryPlanRequest) ProtoMessage() {}
 
-func (x *DispatchPlanRequest) ProtoReflect() protoreflect.Message {
+func (x *DispatchQueryPlanRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_dispatch_v1_dispatch_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1801,47 +1801,47 @@ func (x *DispatchPlanRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DispatchPlanRequest.ProtoReflect.Descriptor instead.
-func (*DispatchPlanRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use DispatchQueryPlanRequest.ProtoReflect.Descriptor instead.
+func (*DispatchQueryPlanRequest) Descriptor() ([]byte, []int) {
 	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{22}
 }
 
-func (x *DispatchPlanRequest) GetOperation() PlanOperation {
+func (x *DispatchQueryPlanRequest) GetOperation() PlanOperation {
 	if x != nil {
 		return x.Operation
 	}
 	return PlanOperation_PLAN_OPERATION_CHECK
 }
 
-func (x *DispatchPlanRequest) GetCanonicalKey() string {
+func (x *DispatchQueryPlanRequest) GetCanonicalKey() string {
 	if x != nil {
 		return x.CanonicalKey
 	}
 	return ""
 }
 
-func (x *DispatchPlanRequest) GetResource() *v1.ObjectAndRelation {
+func (x *DispatchQueryPlanRequest) GetResource() *v1.ObjectAndRelation {
 	if x != nil {
 		return x.Resource
 	}
 	return nil
 }
 
-func (x *DispatchPlanRequest) GetSubject() *v1.ObjectAndRelation {
+func (x *DispatchQueryPlanRequest) GetSubject() *v1.ObjectAndRelation {
 	if x != nil {
 		return x.Subject
 	}
 	return nil
 }
 
-func (x *DispatchPlanRequest) GetPlanContext() *PlanContext {
+func (x *DispatchQueryPlanRequest) GetPlanContext() *PlanContext {
 	if x != nil {
 		return x.PlanContext
 	}
 	return nil
 }
 
-type DispatchPlanResponse struct {
+type DispatchQueryPlanResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Metadata      *ResponseMeta          `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	Paths         []*ResultPath          `protobuf:"bytes,2,rep,name=paths,proto3" json:"paths,omitempty"`
@@ -1849,20 +1849,20 @@ type DispatchPlanResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DispatchPlanResponse) Reset() {
-	*x = DispatchPlanResponse{}
+func (x *DispatchQueryPlanResponse) Reset() {
+	*x = DispatchQueryPlanResponse{}
 	mi := &file_dispatch_v1_dispatch_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DispatchPlanResponse) String() string {
+func (x *DispatchQueryPlanResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DispatchPlanResponse) ProtoMessage() {}
+func (*DispatchQueryPlanResponse) ProtoMessage() {}
 
-func (x *DispatchPlanResponse) ProtoReflect() protoreflect.Message {
+func (x *DispatchQueryPlanResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_dispatch_v1_dispatch_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1874,19 +1874,19 @@ func (x *DispatchPlanResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DispatchPlanResponse.ProtoReflect.Descriptor instead.
-func (*DispatchPlanResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use DispatchQueryPlanResponse.ProtoReflect.Descriptor instead.
+func (*DispatchQueryPlanResponse) Descriptor() ([]byte, []int) {
 	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{23}
 }
 
-func (x *DispatchPlanResponse) GetMetadata() *ResponseMeta {
+func (x *DispatchQueryPlanResponse) GetMetadata() *ResponseMeta {
 	if x != nil {
 		return x.Metadata
 	}
 	return nil
 }
 
-func (x *DispatchPlanResponse) GetPaths() []*ResultPath {
+func (x *DispatchQueryPlanResponse) GetPaths() []*ResultPath {
 	if x != nil {
 		return x.Paths
 	}
@@ -2169,14 +2169,14 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\brevision\x18\x01 \x01(\tR\brevision\x12>\n" +
 	"\x0ecaveat_context\x18\x02 \x01(\v2\x17.google.protobuf.StructR\rcaveatContext\x12.\n" +
 	"\x13max_recursion_depth\x18\x03 \x01(\x05R\x11maxRecursionDepth\x128\n" +
-	"\x18optional_datastore_limit\x18\x04 \x01(\x04R\x16optionalDatastoreLimit\"\x9f\x02\n" +
-	"\x13DispatchPlanRequest\x128\n" +
+	"\x18optional_datastore_limit\x18\x04 \x01(\x04R\x16optionalDatastoreLimit\"\xa4\x02\n" +
+	"\x18DispatchQueryPlanRequest\x128\n" +
 	"\toperation\x18\x01 \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\toperation\x12#\n" +
 	"\rcanonical_key\x18\x02 \x01(\tR\fcanonicalKey\x126\n" +
 	"\bresource\x18\x03 \x01(\v2\x1a.core.v1.ObjectAndRelationR\bresource\x124\n" +
 	"\asubject\x18\x04 \x01(\v2\x1a.core.v1.ObjectAndRelationR\asubject\x12;\n" +
-	"\fplan_context\x18\x05 \x01(\v2\x18.dispatch.v1.PlanContextR\vplanContext\"|\n" +
-	"\x14DispatchPlanResponse\x125\n" +
+	"\fplan_context\x18\x05 \x01(\v2\x18.dispatch.v1.PlanContextR\vplanContext\"\x81\x01\n" +
+	"\x19DispatchQueryPlanResponse\x125\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x19.dispatch.v1.ResponseMetaR\bmetadata\x12-\n" +
 	"\x05paths\x18\x02 \x03(\v2\x17.dispatch.v1.ResultPathR\x05paths\"\x83\x04\n" +
 	"\n" +
@@ -2200,14 +2200,14 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\rPlanOperation\x12\x18\n" +
 	"\x14PLAN_OPERATION_CHECK\x10\x00\x12#\n" +
 	"\x1fPLAN_OPERATION_LOOKUP_RESOURCES\x10\x01\x12\"\n" +
-	"\x1ePLAN_OPERATION_LOOKUP_SUBJECTS\x10\x022\x92\x05\n" +
+	"\x1ePLAN_OPERATION_LOOKUP_SUBJECTS\x10\x022\xa1\x05\n" +
 	"\x0fDispatchService\x12X\n" +
 	"\rDispatchCheck\x12!.dispatch.v1.DispatchCheckRequest\x1a\".dispatch.v1.DispatchCheckResponse\"\x00\x12[\n" +
 	"\x0eDispatchExpand\x12\".dispatch.v1.DispatchExpandRequest\x1a#.dispatch.v1.DispatchExpandResponse\"\x00\x12u\n" +
 	"\x16DispatchLookupSubjects\x12*.dispatch.v1.DispatchLookupSubjectsRequest\x1a+.dispatch.v1.DispatchLookupSubjectsResponse\"\x000\x01\x12{\n" +
 	"\x18DispatchLookupResources2\x12,.dispatch.v1.DispatchLookupResources2Request\x1a-.dispatch.v1.DispatchLookupResources2Response\"\x000\x01\x12{\n" +
-	"\x18DispatchLookupResources3\x12,.dispatch.v1.DispatchLookupResources3Request\x1a-.dispatch.v1.DispatchLookupResources3Response\"\x000\x01\x12W\n" +
-	"\fDispatchPlan\x12 .dispatch.v1.DispatchPlanRequest\x1a!.dispatch.v1.DispatchPlanResponse\"\x000\x01B\xaa\x01\n" +
+	"\x18DispatchLookupResources3\x12,.dispatch.v1.DispatchLookupResources3Request\x1a-.dispatch.v1.DispatchLookupResources3Response\"\x000\x01\x12f\n" +
+	"\x11DispatchQueryPlan\x12%.dispatch.v1.DispatchQueryPlanRequest\x1a&.dispatch.v1.DispatchQueryPlanResponse\"\x000\x01B\xaa\x01\n" +
 	"\x0fcom.dispatch.v1B\rDispatchProtoP\x01Z;github.com/authzed/spicedb/pkg/proto/dispatch/v1;dispatchv1\xa2\x02\x03DXX\xaa\x02\vDispatch.V1\xca\x02\vDispatch\\V1\xe2\x02\x17Dispatch\\V1\\GPBMetadata\xea\x02\fDispatch::V1b\x06proto3"
 
 var (
@@ -2253,8 +2253,8 @@ var file_dispatch_v1_dispatch_proto_goTypes = []any{
 	(*DebugInformation)(nil),                 // 25: dispatch.v1.DebugInformation
 	(*CheckDebugTrace)(nil),                  // 26: dispatch.v1.CheckDebugTrace
 	(*PlanContext)(nil),                      // 27: dispatch.v1.PlanContext
-	(*DispatchPlanRequest)(nil),              // 28: dispatch.v1.DispatchPlanRequest
-	(*DispatchPlanResponse)(nil),             // 29: dispatch.v1.DispatchPlanResponse
+	(*DispatchQueryPlanRequest)(nil),         // 28: dispatch.v1.DispatchQueryPlanRequest
+	(*DispatchQueryPlanResponse)(nil),        // 29: dispatch.v1.DispatchQueryPlanResponse
 	(*ResultPath)(nil),                       // 30: dispatch.v1.ResultPath
 	nil,                                      // 31: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry
 	nil,                                      // 32: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry
@@ -2318,12 +2318,12 @@ var file_dispatch_v1_dispatch_proto_depIdxs = []int32{
 	26, // 46: dispatch.v1.CheckDebugTrace.sub_problems:type_name -> dispatch.v1.CheckDebugTrace
 	39, // 47: dispatch.v1.CheckDebugTrace.duration:type_name -> google.protobuf.Duration
 	38, // 48: dispatch.v1.PlanContext.caveat_context:type_name -> google.protobuf.Struct
-	0,  // 49: dispatch.v1.DispatchPlanRequest.operation:type_name -> dispatch.v1.PlanOperation
-	35, // 50: dispatch.v1.DispatchPlanRequest.resource:type_name -> core.v1.ObjectAndRelation
-	35, // 51: dispatch.v1.DispatchPlanRequest.subject:type_name -> core.v1.ObjectAndRelation
-	27, // 52: dispatch.v1.DispatchPlanRequest.plan_context:type_name -> dispatch.v1.PlanContext
-	24, // 53: dispatch.v1.DispatchPlanResponse.metadata:type_name -> dispatch.v1.ResponseMeta
-	30, // 54: dispatch.v1.DispatchPlanResponse.paths:type_name -> dispatch.v1.ResultPath
+	0,  // 49: dispatch.v1.DispatchQueryPlanRequest.operation:type_name -> dispatch.v1.PlanOperation
+	35, // 50: dispatch.v1.DispatchQueryPlanRequest.resource:type_name -> core.v1.ObjectAndRelation
+	35, // 51: dispatch.v1.DispatchQueryPlanRequest.subject:type_name -> core.v1.ObjectAndRelation
+	27, // 52: dispatch.v1.DispatchQueryPlanRequest.plan_context:type_name -> dispatch.v1.PlanContext
+	24, // 53: dispatch.v1.DispatchQueryPlanResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	30, // 54: dispatch.v1.DispatchQueryPlanResponse.paths:type_name -> dispatch.v1.ResultPath
 	36, // 55: dispatch.v1.ResultPath.caveat:type_name -> core.v1.CaveatExpression
 	40, // 56: dispatch.v1.ResultPath.expiration:type_name -> google.protobuf.Timestamp
 	41, // 57: dispatch.v1.ResultPath.integrity:type_name -> core.v1.RelationshipIntegrity
@@ -2337,13 +2337,13 @@ var file_dispatch_v1_dispatch_proto_depIdxs = []int32{
 	19, // 65: dispatch.v1.DispatchService.DispatchLookupSubjects:input_type -> dispatch.v1.DispatchLookupSubjectsRequest
 	13, // 66: dispatch.v1.DispatchService.DispatchLookupResources2:input_type -> dispatch.v1.DispatchLookupResources2Request
 	16, // 67: dispatch.v1.DispatchService.DispatchLookupResources3:input_type -> dispatch.v1.DispatchLookupResources3Request
-	28, // 68: dispatch.v1.DispatchService.DispatchPlan:input_type -> dispatch.v1.DispatchPlanRequest
+	28, // 68: dispatch.v1.DispatchService.DispatchQueryPlan:input_type -> dispatch.v1.DispatchQueryPlanRequest
 	8,  // 69: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
 	11, // 70: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
 	22, // 71: dispatch.v1.DispatchService.DispatchLookupSubjects:output_type -> dispatch.v1.DispatchLookupSubjectsResponse
 	15, // 72: dispatch.v1.DispatchService.DispatchLookupResources2:output_type -> dispatch.v1.DispatchLookupResources2Response
 	17, // 73: dispatch.v1.DispatchService.DispatchLookupResources3:output_type -> dispatch.v1.DispatchLookupResources3Response
-	29, // 74: dispatch.v1.DispatchService.DispatchPlan:output_type -> dispatch.v1.DispatchPlanResponse
+	29, // 74: dispatch.v1.DispatchService.DispatchQueryPlan:output_type -> dispatch.v1.DispatchQueryPlanResponse
 	69, // [69:75] is the sub-list for method output_type
 	63, // [63:69] is the sub-list for method input_type
 	63, // [63:63] is the sub-list for extension type_name

--- a/pkg/proto/dispatch/v1/dispatch.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch.pb.go
@@ -1894,19 +1894,20 @@ func (x *DispatchPlanResponse) GetPaths() []*ResultPath {
 }
 
 type ResultPath struct {
-	state           protoimpl.MessageState      `protogen:"open.v1"`
-	ResourceType    string                      `protobuf:"bytes,1,opt,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
-	ResourceId      string                      `protobuf:"bytes,2,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
-	Relation        string                      `protobuf:"bytes,3,opt,name=relation,proto3" json:"relation,omitempty"`
-	SubjectType     string                      `protobuf:"bytes,4,opt,name=subject_type,json=subjectType,proto3" json:"subject_type,omitempty"`
-	SubjectId       string                      `protobuf:"bytes,5,opt,name=subject_id,json=subjectId,proto3" json:"subject_id,omitempty"`
-	SubjectRelation string                      `protobuf:"bytes,6,opt,name=subject_relation,json=subjectRelation,proto3" json:"subject_relation,omitempty"`
-	Caveat          *v1.CaveatExpression        `protobuf:"bytes,7,opt,name=caveat,proto3" json:"caveat,omitempty"`
-	Expiration      *timestamppb.Timestamp      `protobuf:"bytes,8,opt,name=expiration,proto3" json:"expiration,omitempty"`
-	Integrity       []*v1.RelationshipIntegrity `protobuf:"bytes,9,rep,name=integrity,proto3" json:"integrity,omitempty"`
-	Metadata        *structpb.Struct            `protobuf:"bytes,10,opt,name=metadata,proto3" json:"metadata,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state            protoimpl.MessageState      `protogen:"open.v1"`
+	ResourceType     string                      `protobuf:"bytes,1,opt,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
+	ResourceId       string                      `protobuf:"bytes,2,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
+	Relation         string                      `protobuf:"bytes,3,opt,name=relation,proto3" json:"relation,omitempty"`
+	SubjectType      string                      `protobuf:"bytes,4,opt,name=subject_type,json=subjectType,proto3" json:"subject_type,omitempty"`
+	SubjectId        string                      `protobuf:"bytes,5,opt,name=subject_id,json=subjectId,proto3" json:"subject_id,omitempty"`
+	SubjectRelation  string                      `protobuf:"bytes,6,opt,name=subject_relation,json=subjectRelation,proto3" json:"subject_relation,omitempty"`
+	Caveat           *v1.CaveatExpression        `protobuf:"bytes,7,opt,name=caveat,proto3" json:"caveat,omitempty"`
+	Expiration       *timestamppb.Timestamp      `protobuf:"bytes,8,opt,name=expiration,proto3" json:"expiration,omitempty"`
+	Integrity        []*v1.RelationshipIntegrity `protobuf:"bytes,9,rep,name=integrity,proto3" json:"integrity,omitempty"`
+	Metadata         *structpb.Struct            `protobuf:"bytes,10,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	ExcludedSubjects []*ResultPath               `protobuf:"bytes,11,rep,name=excluded_subjects,json=excludedSubjects,proto3" json:"excluded_subjects,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ResultPath) Reset() {
@@ -2005,6 +2006,13 @@ func (x *ResultPath) GetIntegrity() []*v1.RelationshipIntegrity {
 func (x *ResultPath) GetMetadata() *structpb.Struct {
 	if x != nil {
 		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ResultPath) GetExcludedSubjects() []*ResultPath {
+	if x != nil {
+		return x.ExcludedSubjects
 	}
 	return nil
 }
@@ -2170,7 +2178,7 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\fplan_context\x18\x05 \x01(\v2\x18.dispatch.v1.PlanContextR\vplanContext\"|\n" +
 	"\x14DispatchPlanResponse\x125\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x19.dispatch.v1.ResponseMetaR\bmetadata\x12-\n" +
-	"\x05paths\x18\x02 \x03(\v2\x17.dispatch.v1.ResultPathR\x05paths\"\xbd\x03\n" +
+	"\x05paths\x18\x02 \x03(\v2\x17.dispatch.v1.ResultPathR\x05paths\"\x83\x04\n" +
 	"\n" +
 	"ResultPath\x12#\n" +
 	"\rresource_type\x18\x01 \x01(\tR\fresourceType\x12\x1f\n" +
@@ -2187,7 +2195,8 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"expiration\x12<\n" +
 	"\tintegrity\x18\t \x03(\v2\x1e.core.v1.RelationshipIntegrityR\tintegrity\x123\n" +
 	"\bmetadata\x18\n" +
-	" \x01(\v2\x17.google.protobuf.StructR\bmetadata*r\n" +
+	" \x01(\v2\x17.google.protobuf.StructR\bmetadata\x12D\n" +
+	"\x11excluded_subjects\x18\v \x03(\v2\x17.dispatch.v1.ResultPathR\x10excludedSubjects*r\n" +
 	"\rPlanOperation\x12\x18\n" +
 	"\x14PLAN_OPERATION_CHECK\x10\x00\x12#\n" +
 	"\x1fPLAN_OPERATION_LOOKUP_RESOURCES\x10\x01\x12\"\n" +
@@ -2319,26 +2328,27 @@ var file_dispatch_v1_dispatch_proto_depIdxs = []int32{
 	40, // 56: dispatch.v1.ResultPath.expiration:type_name -> google.protobuf.Timestamp
 	41, // 57: dispatch.v1.ResultPath.integrity:type_name -> core.v1.RelationshipIntegrity
 	38, // 58: dispatch.v1.ResultPath.metadata:type_name -> google.protobuf.Struct
-	9,  // 59: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry.value:type_name -> dispatch.v1.ResourceCheckResult
-	21, // 60: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry.value:type_name -> dispatch.v1.FoundSubjects
-	9,  // 61: dispatch.v1.CheckDebugTrace.ResultsEntry.value:type_name -> dispatch.v1.ResourceCheckResult
-	6,  // 62: dispatch.v1.DispatchService.DispatchCheck:input_type -> dispatch.v1.DispatchCheckRequest
-	10, // 63: dispatch.v1.DispatchService.DispatchExpand:input_type -> dispatch.v1.DispatchExpandRequest
-	19, // 64: dispatch.v1.DispatchService.DispatchLookupSubjects:input_type -> dispatch.v1.DispatchLookupSubjectsRequest
-	13, // 65: dispatch.v1.DispatchService.DispatchLookupResources2:input_type -> dispatch.v1.DispatchLookupResources2Request
-	16, // 66: dispatch.v1.DispatchService.DispatchLookupResources3:input_type -> dispatch.v1.DispatchLookupResources3Request
-	28, // 67: dispatch.v1.DispatchService.DispatchPlan:input_type -> dispatch.v1.DispatchPlanRequest
-	8,  // 68: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
-	11, // 69: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
-	22, // 70: dispatch.v1.DispatchService.DispatchLookupSubjects:output_type -> dispatch.v1.DispatchLookupSubjectsResponse
-	15, // 71: dispatch.v1.DispatchService.DispatchLookupResources2:output_type -> dispatch.v1.DispatchLookupResources2Response
-	17, // 72: dispatch.v1.DispatchService.DispatchLookupResources3:output_type -> dispatch.v1.DispatchLookupResources3Response
-	29, // 73: dispatch.v1.DispatchService.DispatchPlan:output_type -> dispatch.v1.DispatchPlanResponse
-	68, // [68:74] is the sub-list for method output_type
-	62, // [62:68] is the sub-list for method input_type
-	62, // [62:62] is the sub-list for extension type_name
-	62, // [62:62] is the sub-list for extension extendee
-	0,  // [0:62] is the sub-list for field type_name
+	30, // 59: dispatch.v1.ResultPath.excluded_subjects:type_name -> dispatch.v1.ResultPath
+	9,  // 60: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry.value:type_name -> dispatch.v1.ResourceCheckResult
+	21, // 61: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry.value:type_name -> dispatch.v1.FoundSubjects
+	9,  // 62: dispatch.v1.CheckDebugTrace.ResultsEntry.value:type_name -> dispatch.v1.ResourceCheckResult
+	6,  // 63: dispatch.v1.DispatchService.DispatchCheck:input_type -> dispatch.v1.DispatchCheckRequest
+	10, // 64: dispatch.v1.DispatchService.DispatchExpand:input_type -> dispatch.v1.DispatchExpandRequest
+	19, // 65: dispatch.v1.DispatchService.DispatchLookupSubjects:input_type -> dispatch.v1.DispatchLookupSubjectsRequest
+	13, // 66: dispatch.v1.DispatchService.DispatchLookupResources2:input_type -> dispatch.v1.DispatchLookupResources2Request
+	16, // 67: dispatch.v1.DispatchService.DispatchLookupResources3:input_type -> dispatch.v1.DispatchLookupResources3Request
+	28, // 68: dispatch.v1.DispatchService.DispatchPlan:input_type -> dispatch.v1.DispatchPlanRequest
+	8,  // 69: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
+	11, // 70: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
+	22, // 71: dispatch.v1.DispatchService.DispatchLookupSubjects:output_type -> dispatch.v1.DispatchLookupSubjectsResponse
+	15, // 72: dispatch.v1.DispatchService.DispatchLookupResources2:output_type -> dispatch.v1.DispatchLookupResources2Response
+	17, // 73: dispatch.v1.DispatchService.DispatchLookupResources3:output_type -> dispatch.v1.DispatchLookupResources3Response
+	29, // 74: dispatch.v1.DispatchService.DispatchPlan:output_type -> dispatch.v1.DispatchPlanResponse
+	69, // [69:75] is the sub-list for method output_type
+	63, // [63:69] is the sub-list for method input_type
+	63, // [63:63] is the sub-list for extension type_name
+	63, // [63:63] is the sub-list for extension extendee
+	0,  // [0:63] is the sub-list for field type_name
 }
 
 func init() { file_dispatch_v1_dispatch_proto_init() }

--- a/pkg/proto/dispatch/v1/dispatch.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch.pb.go
@@ -13,6 +13,7 @@ import (
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -24,6 +25,55 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+type PlanOperation int32
+
+const (
+	PlanOperation_PLAN_OPERATION_CHECK            PlanOperation = 0
+	PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES PlanOperation = 1
+	PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS  PlanOperation = 2
+)
+
+// Enum value maps for PlanOperation.
+var (
+	PlanOperation_name = map[int32]string{
+		0: "PLAN_OPERATION_CHECK",
+		1: "PLAN_OPERATION_LOOKUP_RESOURCES",
+		2: "PLAN_OPERATION_LOOKUP_SUBJECTS",
+	}
+	PlanOperation_value = map[string]int32{
+		"PLAN_OPERATION_CHECK":            0,
+		"PLAN_OPERATION_LOOKUP_RESOURCES": 1,
+		"PLAN_OPERATION_LOOKUP_SUBJECTS":  2,
+	}
+)
+
+func (x PlanOperation) Enum() *PlanOperation {
+	p := new(PlanOperation)
+	*p = x
+	return p
+}
+
+func (x PlanOperation) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PlanOperation) Descriptor() protoreflect.EnumDescriptor {
+	return file_dispatch_v1_dispatch_proto_enumTypes[0].Descriptor()
+}
+
+func (PlanOperation) Type() protoreflect.EnumType {
+	return &file_dispatch_v1_dispatch_proto_enumTypes[0]
+}
+
+func (x PlanOperation) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PlanOperation.Descriptor instead.
+func (PlanOperation) EnumDescriptor() ([]byte, []int) {
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{0}
+}
 
 type DispatchCheckRequest_DebugSetting int32
 
@@ -58,11 +108,11 @@ func (x DispatchCheckRequest_DebugSetting) String() string {
 }
 
 func (DispatchCheckRequest_DebugSetting) Descriptor() protoreflect.EnumDescriptor {
-	return file_dispatch_v1_dispatch_proto_enumTypes[0].Descriptor()
+	return file_dispatch_v1_dispatch_proto_enumTypes[1].Descriptor()
 }
 
 func (DispatchCheckRequest_DebugSetting) Type() protoreflect.EnumType {
-	return &file_dispatch_v1_dispatch_proto_enumTypes[0]
+	return &file_dispatch_v1_dispatch_proto_enumTypes[1]
 }
 
 func (x DispatchCheckRequest_DebugSetting) Number() protoreflect.EnumNumber {
@@ -104,11 +154,11 @@ func (x DispatchCheckRequest_ResultsSetting) String() string {
 }
 
 func (DispatchCheckRequest_ResultsSetting) Descriptor() protoreflect.EnumDescriptor {
-	return file_dispatch_v1_dispatch_proto_enumTypes[1].Descriptor()
+	return file_dispatch_v1_dispatch_proto_enumTypes[2].Descriptor()
 }
 
 func (DispatchCheckRequest_ResultsSetting) Type() protoreflect.EnumType {
-	return &file_dispatch_v1_dispatch_proto_enumTypes[1]
+	return &file_dispatch_v1_dispatch_proto_enumTypes[2]
 }
 
 func (x DispatchCheckRequest_ResultsSetting) Number() protoreflect.EnumNumber {
@@ -156,11 +206,11 @@ func (x ResourceCheckResult_Membership) String() string {
 }
 
 func (ResourceCheckResult_Membership) Descriptor() protoreflect.EnumDescriptor {
-	return file_dispatch_v1_dispatch_proto_enumTypes[2].Descriptor()
+	return file_dispatch_v1_dispatch_proto_enumTypes[3].Descriptor()
 }
 
 func (ResourceCheckResult_Membership) Type() protoreflect.EnumType {
-	return &file_dispatch_v1_dispatch_proto_enumTypes[2]
+	return &file_dispatch_v1_dispatch_proto_enumTypes[3]
 }
 
 func (x ResourceCheckResult_Membership) Number() protoreflect.EnumNumber {
@@ -202,11 +252,11 @@ func (x DispatchExpandRequest_ExpansionMode) String() string {
 }
 
 func (DispatchExpandRequest_ExpansionMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_dispatch_v1_dispatch_proto_enumTypes[3].Descriptor()
+	return file_dispatch_v1_dispatch_proto_enumTypes[4].Descriptor()
 }
 
 func (DispatchExpandRequest_ExpansionMode) Type() protoreflect.EnumType {
-	return &file_dispatch_v1_dispatch_proto_enumTypes[3]
+	return &file_dispatch_v1_dispatch_proto_enumTypes[4]
 }
 
 func (x DispatchExpandRequest_ExpansionMode) Number() protoreflect.EnumNumber {
@@ -251,11 +301,11 @@ func (x CheckDebugTrace_RelationType) String() string {
 }
 
 func (CheckDebugTrace_RelationType) Descriptor() protoreflect.EnumDescriptor {
-	return file_dispatch_v1_dispatch_proto_enumTypes[4].Descriptor()
+	return file_dispatch_v1_dispatch_proto_enumTypes[5].Descriptor()
 }
 
 func (CheckDebugTrace_RelationType) Type() protoreflect.EnumType {
-	return &file_dispatch_v1_dispatch_proto_enumTypes[4]
+	return &file_dispatch_v1_dispatch_proto_enumTypes[5]
 }
 
 func (x CheckDebugTrace_RelationType) Number() protoreflect.EnumNumber {
@@ -1647,11 +1697,323 @@ func (x *CheckDebugTrace) GetSourceId() string {
 	return ""
 }
 
+type PlanContext struct {
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	Revision               string                 `protobuf:"bytes,1,opt,name=revision,proto3" json:"revision,omitempty"`
+	CaveatContext          *structpb.Struct       `protobuf:"bytes,2,opt,name=caveat_context,json=caveatContext,proto3" json:"caveat_context,omitempty"`
+	MaxRecursionDepth      int32                  `protobuf:"varint,3,opt,name=max_recursion_depth,json=maxRecursionDepth,proto3" json:"max_recursion_depth,omitempty"`
+	OptionalDatastoreLimit uint64                 `protobuf:"varint,4,opt,name=optional_datastore_limit,json=optionalDatastoreLimit,proto3" json:"optional_datastore_limit,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *PlanContext) Reset() {
+	*x = PlanContext{}
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PlanContext) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PlanContext) ProtoMessage() {}
+
+func (x *PlanContext) ProtoReflect() protoreflect.Message {
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PlanContext.ProtoReflect.Descriptor instead.
+func (*PlanContext) Descriptor() ([]byte, []int) {
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *PlanContext) GetRevision() string {
+	if x != nil {
+		return x.Revision
+	}
+	return ""
+}
+
+func (x *PlanContext) GetCaveatContext() *structpb.Struct {
+	if x != nil {
+		return x.CaveatContext
+	}
+	return nil
+}
+
+func (x *PlanContext) GetMaxRecursionDepth() int32 {
+	if x != nil {
+		return x.MaxRecursionDepth
+	}
+	return 0
+}
+
+func (x *PlanContext) GetOptionalDatastoreLimit() uint64 {
+	if x != nil {
+		return x.OptionalDatastoreLimit
+	}
+	return 0
+}
+
+type DispatchPlanRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Operation     PlanOperation          `protobuf:"varint,1,opt,name=operation,proto3,enum=dispatch.v1.PlanOperation" json:"operation,omitempty"`
+	CanonicalKey  string                 `protobuf:"bytes,2,opt,name=canonical_key,json=canonicalKey,proto3" json:"canonical_key,omitempty"`
+	Resource      *v1.ObjectAndRelation  `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
+	Subject       *v1.ObjectAndRelation  `protobuf:"bytes,4,opt,name=subject,proto3" json:"subject,omitempty"`
+	PlanContext   *PlanContext           `protobuf:"bytes,5,opt,name=plan_context,json=planContext,proto3" json:"plan_context,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DispatchPlanRequest) Reset() {
+	*x = DispatchPlanRequest{}
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DispatchPlanRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DispatchPlanRequest) ProtoMessage() {}
+
+func (x *DispatchPlanRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DispatchPlanRequest.ProtoReflect.Descriptor instead.
+func (*DispatchPlanRequest) Descriptor() ([]byte, []int) {
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *DispatchPlanRequest) GetOperation() PlanOperation {
+	if x != nil {
+		return x.Operation
+	}
+	return PlanOperation_PLAN_OPERATION_CHECK
+}
+
+func (x *DispatchPlanRequest) GetCanonicalKey() string {
+	if x != nil {
+		return x.CanonicalKey
+	}
+	return ""
+}
+
+func (x *DispatchPlanRequest) GetResource() *v1.ObjectAndRelation {
+	if x != nil {
+		return x.Resource
+	}
+	return nil
+}
+
+func (x *DispatchPlanRequest) GetSubject() *v1.ObjectAndRelation {
+	if x != nil {
+		return x.Subject
+	}
+	return nil
+}
+
+func (x *DispatchPlanRequest) GetPlanContext() *PlanContext {
+	if x != nil {
+		return x.PlanContext
+	}
+	return nil
+}
+
+type DispatchPlanResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Metadata      *ResponseMeta          `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Paths         []*ResultPath          `protobuf:"bytes,2,rep,name=paths,proto3" json:"paths,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DispatchPlanResponse) Reset() {
+	*x = DispatchPlanResponse{}
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DispatchPlanResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DispatchPlanResponse) ProtoMessage() {}
+
+func (x *DispatchPlanResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DispatchPlanResponse.ProtoReflect.Descriptor instead.
+func (*DispatchPlanResponse) Descriptor() ([]byte, []int) {
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *DispatchPlanResponse) GetMetadata() *ResponseMeta {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *DispatchPlanResponse) GetPaths() []*ResultPath {
+	if x != nil {
+		return x.Paths
+	}
+	return nil
+}
+
+type ResultPath struct {
+	state           protoimpl.MessageState      `protogen:"open.v1"`
+	ResourceType    string                      `protobuf:"bytes,1,opt,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
+	ResourceId      string                      `protobuf:"bytes,2,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
+	Relation        string                      `protobuf:"bytes,3,opt,name=relation,proto3" json:"relation,omitempty"`
+	SubjectType     string                      `protobuf:"bytes,4,opt,name=subject_type,json=subjectType,proto3" json:"subject_type,omitempty"`
+	SubjectId       string                      `protobuf:"bytes,5,opt,name=subject_id,json=subjectId,proto3" json:"subject_id,omitempty"`
+	SubjectRelation string                      `protobuf:"bytes,6,opt,name=subject_relation,json=subjectRelation,proto3" json:"subject_relation,omitempty"`
+	Caveat          *v1.CaveatExpression        `protobuf:"bytes,7,opt,name=caveat,proto3" json:"caveat,omitempty"`
+	Expiration      *timestamppb.Timestamp      `protobuf:"bytes,8,opt,name=expiration,proto3" json:"expiration,omitempty"`
+	Integrity       []*v1.RelationshipIntegrity `protobuf:"bytes,9,rep,name=integrity,proto3" json:"integrity,omitempty"`
+	Metadata        *structpb.Struct            `protobuf:"bytes,10,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ResultPath) Reset() {
+	*x = ResultPath{}
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResultPath) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResultPath) ProtoMessage() {}
+
+func (x *ResultPath) ProtoReflect() protoreflect.Message {
+	mi := &file_dispatch_v1_dispatch_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResultPath.ProtoReflect.Descriptor instead.
+func (*ResultPath) Descriptor() ([]byte, []int) {
+	return file_dispatch_v1_dispatch_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *ResultPath) GetResourceType() string {
+	if x != nil {
+		return x.ResourceType
+	}
+	return ""
+}
+
+func (x *ResultPath) GetResourceId() string {
+	if x != nil {
+		return x.ResourceId
+	}
+	return ""
+}
+
+func (x *ResultPath) GetRelation() string {
+	if x != nil {
+		return x.Relation
+	}
+	return ""
+}
+
+func (x *ResultPath) GetSubjectType() string {
+	if x != nil {
+		return x.SubjectType
+	}
+	return ""
+}
+
+func (x *ResultPath) GetSubjectId() string {
+	if x != nil {
+		return x.SubjectId
+	}
+	return ""
+}
+
+func (x *ResultPath) GetSubjectRelation() string {
+	if x != nil {
+		return x.SubjectRelation
+	}
+	return ""
+}
+
+func (x *ResultPath) GetCaveat() *v1.CaveatExpression {
+	if x != nil {
+		return x.Caveat
+	}
+	return nil
+}
+
+func (x *ResultPath) GetExpiration() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Expiration
+	}
+	return nil
+}
+
+func (x *ResultPath) GetIntegrity() []*v1.RelationshipIntegrity {
+	if x != nil {
+		return x.Integrity
+	}
+	return nil
+}
+
+func (x *ResultPath) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 var File_dispatch_v1_dispatch_proto protoreflect.FileDescriptor
 
 const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\n" +
-	"\x1adispatch/v1/dispatch.proto\x12\vdispatch.v1\x1a\x1bbuf/validate/validate.proto\x1a\x12core/v1/core.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xfb\x04\n" +
+	"\x1adispatch/v1/dispatch.proto\x12\vdispatch.v1\x1a\x1bbuf/validate/validate.proto\x1a\x12core/v1/core.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xfb\x04\n" +
 	"\x14DispatchCheckRequest\x12=\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x19.dispatch.v1.ResolverMetaB\x06\xbaH\x03\xc8\x01\x01R\bmetadata\x12O\n" +
 	"\x11resource_relation\x18\x02 \x01(\v2\x1a.core.v1.RelationReferenceB\x06\xbaH\x03\xc8\x01\x01R\x10resourceRelation\x12!\n" +
@@ -1794,13 +2156,49 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\f\n" +
 	"\bRELATION\x10\x01\x12\x0e\n" +
 	"\n" +
-	"PERMISSION\x10\x022\xb9\x04\n" +
+	"PERMISSION\x10\x02\"\xd3\x01\n" +
+	"\vPlanContext\x12\x1a\n" +
+	"\brevision\x18\x01 \x01(\tR\brevision\x12>\n" +
+	"\x0ecaveat_context\x18\x02 \x01(\v2\x17.google.protobuf.StructR\rcaveatContext\x12.\n" +
+	"\x13max_recursion_depth\x18\x03 \x01(\x05R\x11maxRecursionDepth\x128\n" +
+	"\x18optional_datastore_limit\x18\x04 \x01(\x04R\x16optionalDatastoreLimit\"\x9f\x02\n" +
+	"\x13DispatchPlanRequest\x128\n" +
+	"\toperation\x18\x01 \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\toperation\x12#\n" +
+	"\rcanonical_key\x18\x02 \x01(\tR\fcanonicalKey\x126\n" +
+	"\bresource\x18\x03 \x01(\v2\x1a.core.v1.ObjectAndRelationR\bresource\x124\n" +
+	"\asubject\x18\x04 \x01(\v2\x1a.core.v1.ObjectAndRelationR\asubject\x12;\n" +
+	"\fplan_context\x18\x05 \x01(\v2\x18.dispatch.v1.PlanContextR\vplanContext\"|\n" +
+	"\x14DispatchPlanResponse\x125\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x19.dispatch.v1.ResponseMetaR\bmetadata\x12-\n" +
+	"\x05paths\x18\x02 \x03(\v2\x17.dispatch.v1.ResultPathR\x05paths\"\xbd\x03\n" +
+	"\n" +
+	"ResultPath\x12#\n" +
+	"\rresource_type\x18\x01 \x01(\tR\fresourceType\x12\x1f\n" +
+	"\vresource_id\x18\x02 \x01(\tR\n" +
+	"resourceId\x12\x1a\n" +
+	"\brelation\x18\x03 \x01(\tR\brelation\x12!\n" +
+	"\fsubject_type\x18\x04 \x01(\tR\vsubjectType\x12\x1d\n" +
+	"\n" +
+	"subject_id\x18\x05 \x01(\tR\tsubjectId\x12)\n" +
+	"\x10subject_relation\x18\x06 \x01(\tR\x0fsubjectRelation\x121\n" +
+	"\x06caveat\x18\a \x01(\v2\x19.core.v1.CaveatExpressionR\x06caveat\x12:\n" +
+	"\n" +
+	"expiration\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"expiration\x12<\n" +
+	"\tintegrity\x18\t \x03(\v2\x1e.core.v1.RelationshipIntegrityR\tintegrity\x123\n" +
+	"\bmetadata\x18\n" +
+	" \x01(\v2\x17.google.protobuf.StructR\bmetadata*r\n" +
+	"\rPlanOperation\x12\x18\n" +
+	"\x14PLAN_OPERATION_CHECK\x10\x00\x12#\n" +
+	"\x1fPLAN_OPERATION_LOOKUP_RESOURCES\x10\x01\x12\"\n" +
+	"\x1ePLAN_OPERATION_LOOKUP_SUBJECTS\x10\x022\x92\x05\n" +
 	"\x0fDispatchService\x12X\n" +
 	"\rDispatchCheck\x12!.dispatch.v1.DispatchCheckRequest\x1a\".dispatch.v1.DispatchCheckResponse\"\x00\x12[\n" +
 	"\x0eDispatchExpand\x12\".dispatch.v1.DispatchExpandRequest\x1a#.dispatch.v1.DispatchExpandResponse\"\x00\x12u\n" +
 	"\x16DispatchLookupSubjects\x12*.dispatch.v1.DispatchLookupSubjectsRequest\x1a+.dispatch.v1.DispatchLookupSubjectsResponse\"\x000\x01\x12{\n" +
 	"\x18DispatchLookupResources2\x12,.dispatch.v1.DispatchLookupResources2Request\x1a-.dispatch.v1.DispatchLookupResources2Response\"\x000\x01\x12{\n" +
-	"\x18DispatchLookupResources3\x12,.dispatch.v1.DispatchLookupResources3Request\x1a-.dispatch.v1.DispatchLookupResources3Response\"\x000\x01B\xaa\x01\n" +
+	"\x18DispatchLookupResources3\x12,.dispatch.v1.DispatchLookupResources3Request\x1a-.dispatch.v1.DispatchLookupResources3Response\"\x000\x01\x12W\n" +
+	"\fDispatchPlan\x12 .dispatch.v1.DispatchPlanRequest\x1a!.dispatch.v1.DispatchPlanResponse\"\x000\x01B\xaa\x01\n" +
 	"\x0fcom.dispatch.v1B\rDispatchProtoP\x01Z;github.com/authzed/spicedb/pkg/proto/dispatch/v1;dispatchv1\xa2\x02\x03DXX\xaa\x02\vDispatch.V1\xca\x02\vDispatch\\V1\xe2\x02\x17Dispatch\\V1\\GPBMetadata\xea\x02\fDispatch::V1b\x06proto3"
 
 var (
@@ -1815,112 +2213,132 @@ func file_dispatch_v1_dispatch_proto_rawDescGZIP() []byte {
 	return file_dispatch_v1_dispatch_proto_rawDescData
 }
 
-var file_dispatch_v1_dispatch_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_dispatch_v1_dispatch_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_dispatch_v1_dispatch_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
+var file_dispatch_v1_dispatch_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_dispatch_v1_dispatch_proto_goTypes = []any{
-	(DispatchCheckRequest_DebugSetting)(0),   // 0: dispatch.v1.DispatchCheckRequest.DebugSetting
-	(DispatchCheckRequest_ResultsSetting)(0), // 1: dispatch.v1.DispatchCheckRequest.ResultsSetting
-	(ResourceCheckResult_Membership)(0),      // 2: dispatch.v1.ResourceCheckResult.Membership
-	(DispatchExpandRequest_ExpansionMode)(0), // 3: dispatch.v1.DispatchExpandRequest.ExpansionMode
-	(CheckDebugTrace_RelationType)(0),        // 4: dispatch.v1.CheckDebugTrace.RelationType
-	(*DispatchCheckRequest)(nil),             // 5: dispatch.v1.DispatchCheckRequest
-	(*CheckHint)(nil),                        // 6: dispatch.v1.CheckHint
-	(*DispatchCheckResponse)(nil),            // 7: dispatch.v1.DispatchCheckResponse
-	(*ResourceCheckResult)(nil),              // 8: dispatch.v1.ResourceCheckResult
-	(*DispatchExpandRequest)(nil),            // 9: dispatch.v1.DispatchExpandRequest
-	(*DispatchExpandResponse)(nil),           // 10: dispatch.v1.DispatchExpandResponse
-	(*Cursor)(nil),                           // 11: dispatch.v1.Cursor
-	(*DispatchLookupResources2Request)(nil),  // 12: dispatch.v1.DispatchLookupResources2Request
-	(*PossibleResource)(nil),                 // 13: dispatch.v1.PossibleResource
-	(*DispatchLookupResources2Response)(nil), // 14: dispatch.v1.DispatchLookupResources2Response
-	(*DispatchLookupResources3Request)(nil),  // 15: dispatch.v1.DispatchLookupResources3Request
-	(*DispatchLookupResources3Response)(nil), // 16: dispatch.v1.DispatchLookupResources3Response
-	(*LR3Item)(nil),                          // 17: dispatch.v1.LR3Item
-	(*DispatchLookupSubjectsRequest)(nil),    // 18: dispatch.v1.DispatchLookupSubjectsRequest
-	(*FoundSubject)(nil),                     // 19: dispatch.v1.FoundSubject
-	(*FoundSubjects)(nil),                    // 20: dispatch.v1.FoundSubjects
-	(*DispatchLookupSubjectsResponse)(nil),   // 21: dispatch.v1.DispatchLookupSubjectsResponse
-	(*ResolverMeta)(nil),                     // 22: dispatch.v1.ResolverMeta
-	(*ResponseMeta)(nil),                     // 23: dispatch.v1.ResponseMeta
-	(*DebugInformation)(nil),                 // 24: dispatch.v1.DebugInformation
-	(*CheckDebugTrace)(nil),                  // 25: dispatch.v1.CheckDebugTrace
-	nil,                                      // 26: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry
-	nil,                                      // 27: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry
-	nil,                                      // 28: dispatch.v1.CheckDebugTrace.ResultsEntry
-	(*v1.RelationReference)(nil),             // 29: core.v1.RelationReference
-	(*v1.ObjectAndRelation)(nil),             // 30: core.v1.ObjectAndRelation
-	(*v1.CaveatExpression)(nil),              // 31: core.v1.CaveatExpression
-	(*v1.RelationTupleTreeNode)(nil),         // 32: core.v1.RelationTupleTreeNode
-	(*structpb.Struct)(nil),                  // 33: google.protobuf.Struct
-	(*durationpb.Duration)(nil),              // 34: google.protobuf.Duration
+	(PlanOperation)(0),                       // 0: dispatch.v1.PlanOperation
+	(DispatchCheckRequest_DebugSetting)(0),   // 1: dispatch.v1.DispatchCheckRequest.DebugSetting
+	(DispatchCheckRequest_ResultsSetting)(0), // 2: dispatch.v1.DispatchCheckRequest.ResultsSetting
+	(ResourceCheckResult_Membership)(0),      // 3: dispatch.v1.ResourceCheckResult.Membership
+	(DispatchExpandRequest_ExpansionMode)(0), // 4: dispatch.v1.DispatchExpandRequest.ExpansionMode
+	(CheckDebugTrace_RelationType)(0),        // 5: dispatch.v1.CheckDebugTrace.RelationType
+	(*DispatchCheckRequest)(nil),             // 6: dispatch.v1.DispatchCheckRequest
+	(*CheckHint)(nil),                        // 7: dispatch.v1.CheckHint
+	(*DispatchCheckResponse)(nil),            // 8: dispatch.v1.DispatchCheckResponse
+	(*ResourceCheckResult)(nil),              // 9: dispatch.v1.ResourceCheckResult
+	(*DispatchExpandRequest)(nil),            // 10: dispatch.v1.DispatchExpandRequest
+	(*DispatchExpandResponse)(nil),           // 11: dispatch.v1.DispatchExpandResponse
+	(*Cursor)(nil),                           // 12: dispatch.v1.Cursor
+	(*DispatchLookupResources2Request)(nil),  // 13: dispatch.v1.DispatchLookupResources2Request
+	(*PossibleResource)(nil),                 // 14: dispatch.v1.PossibleResource
+	(*DispatchLookupResources2Response)(nil), // 15: dispatch.v1.DispatchLookupResources2Response
+	(*DispatchLookupResources3Request)(nil),  // 16: dispatch.v1.DispatchLookupResources3Request
+	(*DispatchLookupResources3Response)(nil), // 17: dispatch.v1.DispatchLookupResources3Response
+	(*LR3Item)(nil),                          // 18: dispatch.v1.LR3Item
+	(*DispatchLookupSubjectsRequest)(nil),    // 19: dispatch.v1.DispatchLookupSubjectsRequest
+	(*FoundSubject)(nil),                     // 20: dispatch.v1.FoundSubject
+	(*FoundSubjects)(nil),                    // 21: dispatch.v1.FoundSubjects
+	(*DispatchLookupSubjectsResponse)(nil),   // 22: dispatch.v1.DispatchLookupSubjectsResponse
+	(*ResolverMeta)(nil),                     // 23: dispatch.v1.ResolverMeta
+	(*ResponseMeta)(nil),                     // 24: dispatch.v1.ResponseMeta
+	(*DebugInformation)(nil),                 // 25: dispatch.v1.DebugInformation
+	(*CheckDebugTrace)(nil),                  // 26: dispatch.v1.CheckDebugTrace
+	(*PlanContext)(nil),                      // 27: dispatch.v1.PlanContext
+	(*DispatchPlanRequest)(nil),              // 28: dispatch.v1.DispatchPlanRequest
+	(*DispatchPlanResponse)(nil),             // 29: dispatch.v1.DispatchPlanResponse
+	(*ResultPath)(nil),                       // 30: dispatch.v1.ResultPath
+	nil,                                      // 31: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry
+	nil,                                      // 32: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry
+	nil,                                      // 33: dispatch.v1.CheckDebugTrace.ResultsEntry
+	(*v1.RelationReference)(nil),             // 34: core.v1.RelationReference
+	(*v1.ObjectAndRelation)(nil),             // 35: core.v1.ObjectAndRelation
+	(*v1.CaveatExpression)(nil),              // 36: core.v1.CaveatExpression
+	(*v1.RelationTupleTreeNode)(nil),         // 37: core.v1.RelationTupleTreeNode
+	(*structpb.Struct)(nil),                  // 38: google.protobuf.Struct
+	(*durationpb.Duration)(nil),              // 39: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),            // 40: google.protobuf.Timestamp
+	(*v1.RelationshipIntegrity)(nil),         // 41: core.v1.RelationshipIntegrity
 }
 var file_dispatch_v1_dispatch_proto_depIdxs = []int32{
-	22, // 0: dispatch.v1.DispatchCheckRequest.metadata:type_name -> dispatch.v1.ResolverMeta
-	29, // 1: dispatch.v1.DispatchCheckRequest.resource_relation:type_name -> core.v1.RelationReference
-	30, // 2: dispatch.v1.DispatchCheckRequest.subject:type_name -> core.v1.ObjectAndRelation
-	1,  // 3: dispatch.v1.DispatchCheckRequest.results_setting:type_name -> dispatch.v1.DispatchCheckRequest.ResultsSetting
-	0,  // 4: dispatch.v1.DispatchCheckRequest.debug:type_name -> dispatch.v1.DispatchCheckRequest.DebugSetting
-	6,  // 5: dispatch.v1.DispatchCheckRequest.check_hints:type_name -> dispatch.v1.CheckHint
-	30, // 6: dispatch.v1.CheckHint.resource:type_name -> core.v1.ObjectAndRelation
-	30, // 7: dispatch.v1.CheckHint.subject:type_name -> core.v1.ObjectAndRelation
-	8,  // 8: dispatch.v1.CheckHint.result:type_name -> dispatch.v1.ResourceCheckResult
-	23, // 9: dispatch.v1.DispatchCheckResponse.metadata:type_name -> dispatch.v1.ResponseMeta
-	26, // 10: dispatch.v1.DispatchCheckResponse.results_by_resource_id:type_name -> dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry
-	2,  // 11: dispatch.v1.ResourceCheckResult.membership:type_name -> dispatch.v1.ResourceCheckResult.Membership
-	31, // 12: dispatch.v1.ResourceCheckResult.expression:type_name -> core.v1.CaveatExpression
-	22, // 13: dispatch.v1.DispatchExpandRequest.metadata:type_name -> dispatch.v1.ResolverMeta
-	30, // 14: dispatch.v1.DispatchExpandRequest.resource_and_relation:type_name -> core.v1.ObjectAndRelation
-	3,  // 15: dispatch.v1.DispatchExpandRequest.expansion_mode:type_name -> dispatch.v1.DispatchExpandRequest.ExpansionMode
-	23, // 16: dispatch.v1.DispatchExpandResponse.metadata:type_name -> dispatch.v1.ResponseMeta
-	32, // 17: dispatch.v1.DispatchExpandResponse.tree_node:type_name -> core.v1.RelationTupleTreeNode
-	22, // 18: dispatch.v1.DispatchLookupResources2Request.metadata:type_name -> dispatch.v1.ResolverMeta
-	29, // 19: dispatch.v1.DispatchLookupResources2Request.resource_relation:type_name -> core.v1.RelationReference
-	29, // 20: dispatch.v1.DispatchLookupResources2Request.subject_relation:type_name -> core.v1.RelationReference
-	30, // 21: dispatch.v1.DispatchLookupResources2Request.terminal_subject:type_name -> core.v1.ObjectAndRelation
-	33, // 22: dispatch.v1.DispatchLookupResources2Request.context:type_name -> google.protobuf.Struct
-	11, // 23: dispatch.v1.DispatchLookupResources2Request.optional_cursor:type_name -> dispatch.v1.Cursor
-	13, // 24: dispatch.v1.DispatchLookupResources2Response.resource:type_name -> dispatch.v1.PossibleResource
-	23, // 25: dispatch.v1.DispatchLookupResources2Response.metadata:type_name -> dispatch.v1.ResponseMeta
-	11, // 26: dispatch.v1.DispatchLookupResources2Response.after_response_cursor:type_name -> dispatch.v1.Cursor
-	22, // 27: dispatch.v1.DispatchLookupResources3Request.metadata:type_name -> dispatch.v1.ResolverMeta
-	29, // 28: dispatch.v1.DispatchLookupResources3Request.resource_relation:type_name -> core.v1.RelationReference
-	29, // 29: dispatch.v1.DispatchLookupResources3Request.subject_relation:type_name -> core.v1.RelationReference
-	30, // 30: dispatch.v1.DispatchLookupResources3Request.terminal_subject:type_name -> core.v1.ObjectAndRelation
-	33, // 31: dispatch.v1.DispatchLookupResources3Request.context:type_name -> google.protobuf.Struct
-	17, // 32: dispatch.v1.DispatchLookupResources3Response.items:type_name -> dispatch.v1.LR3Item
-	22, // 33: dispatch.v1.DispatchLookupSubjectsRequest.metadata:type_name -> dispatch.v1.ResolverMeta
-	29, // 34: dispatch.v1.DispatchLookupSubjectsRequest.resource_relation:type_name -> core.v1.RelationReference
-	29, // 35: dispatch.v1.DispatchLookupSubjectsRequest.subject_relation:type_name -> core.v1.RelationReference
-	31, // 36: dispatch.v1.FoundSubject.caveat_expression:type_name -> core.v1.CaveatExpression
-	19, // 37: dispatch.v1.FoundSubject.excluded_subjects:type_name -> dispatch.v1.FoundSubject
-	19, // 38: dispatch.v1.FoundSubjects.found_subjects:type_name -> dispatch.v1.FoundSubject
-	27, // 39: dispatch.v1.DispatchLookupSubjectsResponse.found_subjects_by_resource_id:type_name -> dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry
-	23, // 40: dispatch.v1.DispatchLookupSubjectsResponse.metadata:type_name -> dispatch.v1.ResponseMeta
-	24, // 41: dispatch.v1.ResponseMeta.debug_info:type_name -> dispatch.v1.DebugInformation
-	25, // 42: dispatch.v1.DebugInformation.check:type_name -> dispatch.v1.CheckDebugTrace
-	5,  // 43: dispatch.v1.CheckDebugTrace.request:type_name -> dispatch.v1.DispatchCheckRequest
-	4,  // 44: dispatch.v1.CheckDebugTrace.resource_relation_type:type_name -> dispatch.v1.CheckDebugTrace.RelationType
-	28, // 45: dispatch.v1.CheckDebugTrace.results:type_name -> dispatch.v1.CheckDebugTrace.ResultsEntry
-	25, // 46: dispatch.v1.CheckDebugTrace.sub_problems:type_name -> dispatch.v1.CheckDebugTrace
-	34, // 47: dispatch.v1.CheckDebugTrace.duration:type_name -> google.protobuf.Duration
-	8,  // 48: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry.value:type_name -> dispatch.v1.ResourceCheckResult
-	20, // 49: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry.value:type_name -> dispatch.v1.FoundSubjects
-	8,  // 50: dispatch.v1.CheckDebugTrace.ResultsEntry.value:type_name -> dispatch.v1.ResourceCheckResult
-	5,  // 51: dispatch.v1.DispatchService.DispatchCheck:input_type -> dispatch.v1.DispatchCheckRequest
-	9,  // 52: dispatch.v1.DispatchService.DispatchExpand:input_type -> dispatch.v1.DispatchExpandRequest
-	18, // 53: dispatch.v1.DispatchService.DispatchLookupSubjects:input_type -> dispatch.v1.DispatchLookupSubjectsRequest
-	12, // 54: dispatch.v1.DispatchService.DispatchLookupResources2:input_type -> dispatch.v1.DispatchLookupResources2Request
-	15, // 55: dispatch.v1.DispatchService.DispatchLookupResources3:input_type -> dispatch.v1.DispatchLookupResources3Request
-	7,  // 56: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
-	10, // 57: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
-	21, // 58: dispatch.v1.DispatchService.DispatchLookupSubjects:output_type -> dispatch.v1.DispatchLookupSubjectsResponse
-	14, // 59: dispatch.v1.DispatchService.DispatchLookupResources2:output_type -> dispatch.v1.DispatchLookupResources2Response
-	16, // 60: dispatch.v1.DispatchService.DispatchLookupResources3:output_type -> dispatch.v1.DispatchLookupResources3Response
-	56, // [56:61] is the sub-list for method output_type
-	51, // [51:56] is the sub-list for method input_type
-	51, // [51:51] is the sub-list for extension type_name
-	51, // [51:51] is the sub-list for extension extendee
-	0,  // [0:51] is the sub-list for field type_name
+	23, // 0: dispatch.v1.DispatchCheckRequest.metadata:type_name -> dispatch.v1.ResolverMeta
+	34, // 1: dispatch.v1.DispatchCheckRequest.resource_relation:type_name -> core.v1.RelationReference
+	35, // 2: dispatch.v1.DispatchCheckRequest.subject:type_name -> core.v1.ObjectAndRelation
+	2,  // 3: dispatch.v1.DispatchCheckRequest.results_setting:type_name -> dispatch.v1.DispatchCheckRequest.ResultsSetting
+	1,  // 4: dispatch.v1.DispatchCheckRequest.debug:type_name -> dispatch.v1.DispatchCheckRequest.DebugSetting
+	7,  // 5: dispatch.v1.DispatchCheckRequest.check_hints:type_name -> dispatch.v1.CheckHint
+	35, // 6: dispatch.v1.CheckHint.resource:type_name -> core.v1.ObjectAndRelation
+	35, // 7: dispatch.v1.CheckHint.subject:type_name -> core.v1.ObjectAndRelation
+	9,  // 8: dispatch.v1.CheckHint.result:type_name -> dispatch.v1.ResourceCheckResult
+	24, // 9: dispatch.v1.DispatchCheckResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	31, // 10: dispatch.v1.DispatchCheckResponse.results_by_resource_id:type_name -> dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry
+	3,  // 11: dispatch.v1.ResourceCheckResult.membership:type_name -> dispatch.v1.ResourceCheckResult.Membership
+	36, // 12: dispatch.v1.ResourceCheckResult.expression:type_name -> core.v1.CaveatExpression
+	23, // 13: dispatch.v1.DispatchExpandRequest.metadata:type_name -> dispatch.v1.ResolverMeta
+	35, // 14: dispatch.v1.DispatchExpandRequest.resource_and_relation:type_name -> core.v1.ObjectAndRelation
+	4,  // 15: dispatch.v1.DispatchExpandRequest.expansion_mode:type_name -> dispatch.v1.DispatchExpandRequest.ExpansionMode
+	24, // 16: dispatch.v1.DispatchExpandResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	37, // 17: dispatch.v1.DispatchExpandResponse.tree_node:type_name -> core.v1.RelationTupleTreeNode
+	23, // 18: dispatch.v1.DispatchLookupResources2Request.metadata:type_name -> dispatch.v1.ResolverMeta
+	34, // 19: dispatch.v1.DispatchLookupResources2Request.resource_relation:type_name -> core.v1.RelationReference
+	34, // 20: dispatch.v1.DispatchLookupResources2Request.subject_relation:type_name -> core.v1.RelationReference
+	35, // 21: dispatch.v1.DispatchLookupResources2Request.terminal_subject:type_name -> core.v1.ObjectAndRelation
+	38, // 22: dispatch.v1.DispatchLookupResources2Request.context:type_name -> google.protobuf.Struct
+	12, // 23: dispatch.v1.DispatchLookupResources2Request.optional_cursor:type_name -> dispatch.v1.Cursor
+	14, // 24: dispatch.v1.DispatchLookupResources2Response.resource:type_name -> dispatch.v1.PossibleResource
+	24, // 25: dispatch.v1.DispatchLookupResources2Response.metadata:type_name -> dispatch.v1.ResponseMeta
+	12, // 26: dispatch.v1.DispatchLookupResources2Response.after_response_cursor:type_name -> dispatch.v1.Cursor
+	23, // 27: dispatch.v1.DispatchLookupResources3Request.metadata:type_name -> dispatch.v1.ResolverMeta
+	34, // 28: dispatch.v1.DispatchLookupResources3Request.resource_relation:type_name -> core.v1.RelationReference
+	34, // 29: dispatch.v1.DispatchLookupResources3Request.subject_relation:type_name -> core.v1.RelationReference
+	35, // 30: dispatch.v1.DispatchLookupResources3Request.terminal_subject:type_name -> core.v1.ObjectAndRelation
+	38, // 31: dispatch.v1.DispatchLookupResources3Request.context:type_name -> google.protobuf.Struct
+	18, // 32: dispatch.v1.DispatchLookupResources3Response.items:type_name -> dispatch.v1.LR3Item
+	23, // 33: dispatch.v1.DispatchLookupSubjectsRequest.metadata:type_name -> dispatch.v1.ResolverMeta
+	34, // 34: dispatch.v1.DispatchLookupSubjectsRequest.resource_relation:type_name -> core.v1.RelationReference
+	34, // 35: dispatch.v1.DispatchLookupSubjectsRequest.subject_relation:type_name -> core.v1.RelationReference
+	36, // 36: dispatch.v1.FoundSubject.caveat_expression:type_name -> core.v1.CaveatExpression
+	20, // 37: dispatch.v1.FoundSubject.excluded_subjects:type_name -> dispatch.v1.FoundSubject
+	20, // 38: dispatch.v1.FoundSubjects.found_subjects:type_name -> dispatch.v1.FoundSubject
+	32, // 39: dispatch.v1.DispatchLookupSubjectsResponse.found_subjects_by_resource_id:type_name -> dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry
+	24, // 40: dispatch.v1.DispatchLookupSubjectsResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	25, // 41: dispatch.v1.ResponseMeta.debug_info:type_name -> dispatch.v1.DebugInformation
+	26, // 42: dispatch.v1.DebugInformation.check:type_name -> dispatch.v1.CheckDebugTrace
+	6,  // 43: dispatch.v1.CheckDebugTrace.request:type_name -> dispatch.v1.DispatchCheckRequest
+	5,  // 44: dispatch.v1.CheckDebugTrace.resource_relation_type:type_name -> dispatch.v1.CheckDebugTrace.RelationType
+	33, // 45: dispatch.v1.CheckDebugTrace.results:type_name -> dispatch.v1.CheckDebugTrace.ResultsEntry
+	26, // 46: dispatch.v1.CheckDebugTrace.sub_problems:type_name -> dispatch.v1.CheckDebugTrace
+	39, // 47: dispatch.v1.CheckDebugTrace.duration:type_name -> google.protobuf.Duration
+	38, // 48: dispatch.v1.PlanContext.caveat_context:type_name -> google.protobuf.Struct
+	0,  // 49: dispatch.v1.DispatchPlanRequest.operation:type_name -> dispatch.v1.PlanOperation
+	35, // 50: dispatch.v1.DispatchPlanRequest.resource:type_name -> core.v1.ObjectAndRelation
+	35, // 51: dispatch.v1.DispatchPlanRequest.subject:type_name -> core.v1.ObjectAndRelation
+	27, // 52: dispatch.v1.DispatchPlanRequest.plan_context:type_name -> dispatch.v1.PlanContext
+	24, // 53: dispatch.v1.DispatchPlanResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	30, // 54: dispatch.v1.DispatchPlanResponse.paths:type_name -> dispatch.v1.ResultPath
+	36, // 55: dispatch.v1.ResultPath.caveat:type_name -> core.v1.CaveatExpression
+	40, // 56: dispatch.v1.ResultPath.expiration:type_name -> google.protobuf.Timestamp
+	41, // 57: dispatch.v1.ResultPath.integrity:type_name -> core.v1.RelationshipIntegrity
+	38, // 58: dispatch.v1.ResultPath.metadata:type_name -> google.protobuf.Struct
+	9,  // 59: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry.value:type_name -> dispatch.v1.ResourceCheckResult
+	21, // 60: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry.value:type_name -> dispatch.v1.FoundSubjects
+	9,  // 61: dispatch.v1.CheckDebugTrace.ResultsEntry.value:type_name -> dispatch.v1.ResourceCheckResult
+	6,  // 62: dispatch.v1.DispatchService.DispatchCheck:input_type -> dispatch.v1.DispatchCheckRequest
+	10, // 63: dispatch.v1.DispatchService.DispatchExpand:input_type -> dispatch.v1.DispatchExpandRequest
+	19, // 64: dispatch.v1.DispatchService.DispatchLookupSubjects:input_type -> dispatch.v1.DispatchLookupSubjectsRequest
+	13, // 65: dispatch.v1.DispatchService.DispatchLookupResources2:input_type -> dispatch.v1.DispatchLookupResources2Request
+	16, // 66: dispatch.v1.DispatchService.DispatchLookupResources3:input_type -> dispatch.v1.DispatchLookupResources3Request
+	28, // 67: dispatch.v1.DispatchService.DispatchPlan:input_type -> dispatch.v1.DispatchPlanRequest
+	8,  // 68: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
+	11, // 69: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
+	22, // 70: dispatch.v1.DispatchService.DispatchLookupSubjects:output_type -> dispatch.v1.DispatchLookupSubjectsResponse
+	15, // 71: dispatch.v1.DispatchService.DispatchLookupResources2:output_type -> dispatch.v1.DispatchLookupResources2Response
+	17, // 72: dispatch.v1.DispatchService.DispatchLookupResources3:output_type -> dispatch.v1.DispatchLookupResources3Response
+	29, // 73: dispatch.v1.DispatchService.DispatchPlan:output_type -> dispatch.v1.DispatchPlanResponse
+	68, // [68:74] is the sub-list for method output_type
+	62, // [62:68] is the sub-list for method input_type
+	62, // [62:62] is the sub-list for extension type_name
+	62, // [62:62] is the sub-list for extension extendee
+	0,  // [0:62] is the sub-list for field type_name
 }
 
 func init() { file_dispatch_v1_dispatch_proto_init() }
@@ -1933,8 +2351,8 @@ func file_dispatch_v1_dispatch_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_dispatch_v1_dispatch_proto_rawDesc), len(file_dispatch_v1_dispatch_proto_rawDesc)),
-			NumEnums:      5,
-			NumMessages:   24,
+			NumEnums:      6,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/proto/dispatch/v1/dispatch_grpc.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_grpc.pb.go
@@ -24,7 +24,7 @@ const (
 	DispatchService_DispatchLookupSubjects_FullMethodName   = "/dispatch.v1.DispatchService/DispatchLookupSubjects"
 	DispatchService_DispatchLookupResources2_FullMethodName = "/dispatch.v1.DispatchService/DispatchLookupResources2"
 	DispatchService_DispatchLookupResources3_FullMethodName = "/dispatch.v1.DispatchService/DispatchLookupResources3"
-	DispatchService_DispatchPlan_FullMethodName             = "/dispatch.v1.DispatchService/DispatchPlan"
+	DispatchService_DispatchQueryPlan_FullMethodName        = "/dispatch.v1.DispatchService/DispatchQueryPlan"
 )
 
 // DispatchServiceClient is the client API for DispatchService service.
@@ -36,7 +36,7 @@ type DispatchServiceClient interface {
 	DispatchLookupSubjects(ctx context.Context, in *DispatchLookupSubjectsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchLookupSubjectsResponse], error)
 	DispatchLookupResources2(ctx context.Context, in *DispatchLookupResources2Request, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchLookupResources2Response], error)
 	DispatchLookupResources3(ctx context.Context, in *DispatchLookupResources3Request, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchLookupResources3Response], error)
-	DispatchPlan(ctx context.Context, in *DispatchPlanRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchPlanResponse], error)
+	DispatchQueryPlan(ctx context.Context, in *DispatchQueryPlanRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchQueryPlanResponse], error)
 }
 
 type dispatchServiceClient struct {
@@ -124,13 +124,13 @@ func (c *dispatchServiceClient) DispatchLookupResources3(ctx context.Context, in
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type DispatchService_DispatchLookupResources3Client = grpc.ServerStreamingClient[DispatchLookupResources3Response]
 
-func (c *dispatchServiceClient) DispatchPlan(ctx context.Context, in *DispatchPlanRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchPlanResponse], error) {
+func (c *dispatchServiceClient) DispatchQueryPlan(ctx context.Context, in *DispatchQueryPlanRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchQueryPlanResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &DispatchService_ServiceDesc.Streams[3], DispatchService_DispatchPlan_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &DispatchService_ServiceDesc.Streams[3], DispatchService_DispatchQueryPlan_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &grpc.GenericClientStream[DispatchPlanRequest, DispatchPlanResponse]{ClientStream: stream}
+	x := &grpc.GenericClientStream[DispatchQueryPlanRequest, DispatchQueryPlanResponse]{ClientStream: stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (c *dispatchServiceClient) DispatchPlan(ctx context.Context, in *DispatchPl
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type DispatchService_DispatchPlanClient = grpc.ServerStreamingClient[DispatchPlanResponse]
+type DispatchService_DispatchQueryPlanClient = grpc.ServerStreamingClient[DispatchQueryPlanResponse]
 
 // DispatchServiceServer is the server API for DispatchService service.
 // All implementations must embed UnimplementedDispatchServiceServer
@@ -152,7 +152,7 @@ type DispatchServiceServer interface {
 	DispatchLookupSubjects(*DispatchLookupSubjectsRequest, grpc.ServerStreamingServer[DispatchLookupSubjectsResponse]) error
 	DispatchLookupResources2(*DispatchLookupResources2Request, grpc.ServerStreamingServer[DispatchLookupResources2Response]) error
 	DispatchLookupResources3(*DispatchLookupResources3Request, grpc.ServerStreamingServer[DispatchLookupResources3Response]) error
-	DispatchPlan(*DispatchPlanRequest, grpc.ServerStreamingServer[DispatchPlanResponse]) error
+	DispatchQueryPlan(*DispatchQueryPlanRequest, grpc.ServerStreamingServer[DispatchQueryPlanResponse]) error
 	mustEmbedUnimplementedDispatchServiceServer()
 }
 
@@ -178,8 +178,8 @@ func (UnimplementedDispatchServiceServer) DispatchLookupResources2(*DispatchLook
 func (UnimplementedDispatchServiceServer) DispatchLookupResources3(*DispatchLookupResources3Request, grpc.ServerStreamingServer[DispatchLookupResources3Response]) error {
 	return status.Errorf(codes.Unimplemented, "method DispatchLookupResources3 not implemented")
 }
-func (UnimplementedDispatchServiceServer) DispatchPlan(*DispatchPlanRequest, grpc.ServerStreamingServer[DispatchPlanResponse]) error {
-	return status.Errorf(codes.Unimplemented, "method DispatchPlan not implemented")
+func (UnimplementedDispatchServiceServer) DispatchQueryPlan(*DispatchQueryPlanRequest, grpc.ServerStreamingServer[DispatchQueryPlanResponse]) error {
+	return status.Errorf(codes.Unimplemented, "method DispatchQueryPlan not implemented")
 }
 func (UnimplementedDispatchServiceServer) mustEmbedUnimplementedDispatchServiceServer() {}
 func (UnimplementedDispatchServiceServer) testEmbeddedByValue()                         {}
@@ -271,16 +271,16 @@ func _DispatchService_DispatchLookupResources3_Handler(srv interface{}, stream g
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type DispatchService_DispatchLookupResources3Server = grpc.ServerStreamingServer[DispatchLookupResources3Response]
 
-func _DispatchService_DispatchPlan_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(DispatchPlanRequest)
+func _DispatchService_DispatchQueryPlan_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(DispatchQueryPlanRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(DispatchServiceServer).DispatchPlan(m, &grpc.GenericServerStream[DispatchPlanRequest, DispatchPlanResponse]{ServerStream: stream})
+	return srv.(DispatchServiceServer).DispatchQueryPlan(m, &grpc.GenericServerStream[DispatchQueryPlanRequest, DispatchQueryPlanResponse]{ServerStream: stream})
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type DispatchService_DispatchPlanServer = grpc.ServerStreamingServer[DispatchPlanResponse]
+type DispatchService_DispatchQueryPlanServer = grpc.ServerStreamingServer[DispatchQueryPlanResponse]
 
 // DispatchService_ServiceDesc is the grpc.ServiceDesc for DispatchService service.
 // It's only intended for direct use with grpc.RegisterService,
@@ -315,8 +315,8 @@ var DispatchService_ServiceDesc = grpc.ServiceDesc{
 			ServerStreams: true,
 		},
 		{
-			StreamName:    "DispatchPlan",
-			Handler:       _DispatchService_DispatchPlan_Handler,
+			StreamName:    "DispatchQueryPlan",
+			Handler:       _DispatchService_DispatchQueryPlan_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/proto/dispatch/v1/dispatch_grpc.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	DispatchService_DispatchLookupSubjects_FullMethodName   = "/dispatch.v1.DispatchService/DispatchLookupSubjects"
 	DispatchService_DispatchLookupResources2_FullMethodName = "/dispatch.v1.DispatchService/DispatchLookupResources2"
 	DispatchService_DispatchLookupResources3_FullMethodName = "/dispatch.v1.DispatchService/DispatchLookupResources3"
+	DispatchService_DispatchPlan_FullMethodName             = "/dispatch.v1.DispatchService/DispatchPlan"
 )
 
 // DispatchServiceClient is the client API for DispatchService service.
@@ -35,6 +36,7 @@ type DispatchServiceClient interface {
 	DispatchLookupSubjects(ctx context.Context, in *DispatchLookupSubjectsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchLookupSubjectsResponse], error)
 	DispatchLookupResources2(ctx context.Context, in *DispatchLookupResources2Request, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchLookupResources2Response], error)
 	DispatchLookupResources3(ctx context.Context, in *DispatchLookupResources3Request, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchLookupResources3Response], error)
+	DispatchPlan(ctx context.Context, in *DispatchPlanRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchPlanResponse], error)
 }
 
 type dispatchServiceClient struct {
@@ -122,6 +124,25 @@ func (c *dispatchServiceClient) DispatchLookupResources3(ctx context.Context, in
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type DispatchService_DispatchLookupResources3Client = grpc.ServerStreamingClient[DispatchLookupResources3Response]
 
+func (c *dispatchServiceClient) DispatchPlan(ctx context.Context, in *DispatchPlanRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DispatchPlanResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &DispatchService_ServiceDesc.Streams[3], DispatchService_DispatchPlan_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[DispatchPlanRequest, DispatchPlanResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DispatchService_DispatchPlanClient = grpc.ServerStreamingClient[DispatchPlanResponse]
+
 // DispatchServiceServer is the server API for DispatchService service.
 // All implementations must embed UnimplementedDispatchServiceServer
 // for forward compatibility.
@@ -131,6 +152,7 @@ type DispatchServiceServer interface {
 	DispatchLookupSubjects(*DispatchLookupSubjectsRequest, grpc.ServerStreamingServer[DispatchLookupSubjectsResponse]) error
 	DispatchLookupResources2(*DispatchLookupResources2Request, grpc.ServerStreamingServer[DispatchLookupResources2Response]) error
 	DispatchLookupResources3(*DispatchLookupResources3Request, grpc.ServerStreamingServer[DispatchLookupResources3Response]) error
+	DispatchPlan(*DispatchPlanRequest, grpc.ServerStreamingServer[DispatchPlanResponse]) error
 	mustEmbedUnimplementedDispatchServiceServer()
 }
 
@@ -155,6 +177,9 @@ func (UnimplementedDispatchServiceServer) DispatchLookupResources2(*DispatchLook
 }
 func (UnimplementedDispatchServiceServer) DispatchLookupResources3(*DispatchLookupResources3Request, grpc.ServerStreamingServer[DispatchLookupResources3Response]) error {
 	return status.Errorf(codes.Unimplemented, "method DispatchLookupResources3 not implemented")
+}
+func (UnimplementedDispatchServiceServer) DispatchPlan(*DispatchPlanRequest, grpc.ServerStreamingServer[DispatchPlanResponse]) error {
+	return status.Errorf(codes.Unimplemented, "method DispatchPlan not implemented")
 }
 func (UnimplementedDispatchServiceServer) mustEmbedUnimplementedDispatchServiceServer() {}
 func (UnimplementedDispatchServiceServer) testEmbeddedByValue()                         {}
@@ -246,6 +271,17 @@ func _DispatchService_DispatchLookupResources3_Handler(srv interface{}, stream g
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type DispatchService_DispatchLookupResources3Server = grpc.ServerStreamingServer[DispatchLookupResources3Response]
 
+func _DispatchService_DispatchPlan_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(DispatchPlanRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(DispatchServiceServer).DispatchPlan(m, &grpc.GenericServerStream[DispatchPlanRequest, DispatchPlanResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DispatchService_DispatchPlanServer = grpc.ServerStreamingServer[DispatchPlanResponse]
+
 // DispatchService_ServiceDesc is the grpc.ServiceDesc for DispatchService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -276,6 +312,11 @@ var DispatchService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "DispatchLookupResources3",
 			Handler:       _DispatchService_DispatchLookupResources3_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "DispatchPlan",
+			Handler:       _DispatchService_DispatchPlan_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
@@ -10,10 +10,12 @@ import (
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	durationpb1 "github.com/planetscale/vtprotobuf/types/known/durationpb"
 	structpb1 "github.com/planetscale/vtprotobuf/types/known/structpb"
+	timestamppb1 "github.com/planetscale/vtprotobuf/types/known/timestamppb"
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	io "io"
 )
 
@@ -632,6 +634,127 @@ func (m *CheckDebugTrace) CloneVT() *CheckDebugTrace {
 }
 
 func (m *CheckDebugTrace) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *PlanContext) CloneVT() *PlanContext {
+	if m == nil {
+		return (*PlanContext)(nil)
+	}
+	r := new(PlanContext)
+	r.Revision = m.Revision
+	r.CaveatContext = (*structpb.Struct)((*structpb1.Struct)(m.CaveatContext).CloneVT())
+	r.MaxRecursionDepth = m.MaxRecursionDepth
+	r.OptionalDatastoreLimit = m.OptionalDatastoreLimit
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *PlanContext) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *DispatchPlanRequest) CloneVT() *DispatchPlanRequest {
+	if m == nil {
+		return (*DispatchPlanRequest)(nil)
+	}
+	r := new(DispatchPlanRequest)
+	r.Operation = m.Operation
+	r.CanonicalKey = m.CanonicalKey
+	r.PlanContext = m.PlanContext.CloneVT()
+	if rhs := m.Resource; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *v1.ObjectAndRelation }); ok {
+			r.Resource = vtpb.CloneVT()
+		} else {
+			r.Resource = proto.Clone(rhs).(*v1.ObjectAndRelation)
+		}
+	}
+	if rhs := m.Subject; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *v1.ObjectAndRelation }); ok {
+			r.Subject = vtpb.CloneVT()
+		} else {
+			r.Subject = proto.Clone(rhs).(*v1.ObjectAndRelation)
+		}
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *DispatchPlanRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *DispatchPlanResponse) CloneVT() *DispatchPlanResponse {
+	if m == nil {
+		return (*DispatchPlanResponse)(nil)
+	}
+	r := new(DispatchPlanResponse)
+	r.Metadata = m.Metadata.CloneVT()
+	if rhs := m.Paths; rhs != nil {
+		tmpContainer := make([]*ResultPath, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Paths = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *DispatchPlanResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ResultPath) CloneVT() *ResultPath {
+	if m == nil {
+		return (*ResultPath)(nil)
+	}
+	r := new(ResultPath)
+	r.ResourceType = m.ResourceType
+	r.ResourceId = m.ResourceId
+	r.Relation = m.Relation
+	r.SubjectType = m.SubjectType
+	r.SubjectId = m.SubjectId
+	r.SubjectRelation = m.SubjectRelation
+	r.Expiration = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.Expiration).CloneVT())
+	r.Metadata = (*structpb.Struct)((*structpb1.Struct)(m.Metadata).CloneVT())
+	if rhs := m.Caveat; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *v1.CaveatExpression }); ok {
+			r.Caveat = vtpb.CloneVT()
+		} else {
+			r.Caveat = proto.Clone(rhs).(*v1.CaveatExpression)
+		}
+	}
+	if rhs := m.Integrity; rhs != nil {
+		tmpContainer := make([]*v1.RelationshipIntegrity, len(rhs))
+		for k, v := range rhs {
+			if vtpb, ok := interface{}(v).(interface {
+				CloneVT() *v1.RelationshipIntegrity
+			}); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*v1.RelationshipIntegrity)
+			}
+		}
+		r.Integrity = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ResultPath) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -1486,6 +1609,185 @@ func (this *CheckDebugTrace) EqualVT(that *CheckDebugTrace) bool {
 
 func (this *CheckDebugTrace) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*CheckDebugTrace)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *PlanContext) EqualVT(that *PlanContext) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Revision != that.Revision {
+		return false
+	}
+	if !(*structpb1.Struct)(this.CaveatContext).EqualVT((*structpb1.Struct)(that.CaveatContext)) {
+		return false
+	}
+	if this.MaxRecursionDepth != that.MaxRecursionDepth {
+		return false
+	}
+	if this.OptionalDatastoreLimit != that.OptionalDatastoreLimit {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *PlanContext) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*PlanContext)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *DispatchPlanRequest) EqualVT(that *DispatchPlanRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Operation != that.Operation {
+		return false
+	}
+	if this.CanonicalKey != that.CanonicalKey {
+		return false
+	}
+	if equal, ok := interface{}(this.Resource).(interface {
+		EqualVT(*v1.ObjectAndRelation) bool
+	}); ok {
+		if !equal.EqualVT(that.Resource) {
+			return false
+		}
+	} else if !proto.Equal(this.Resource, that.Resource) {
+		return false
+	}
+	if equal, ok := interface{}(this.Subject).(interface {
+		EqualVT(*v1.ObjectAndRelation) bool
+	}); ok {
+		if !equal.EqualVT(that.Subject) {
+			return false
+		}
+	} else if !proto.Equal(this.Subject, that.Subject) {
+		return false
+	}
+	if !this.PlanContext.EqualVT(that.PlanContext) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *DispatchPlanRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DispatchPlanRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *DispatchPlanResponse) EqualVT(that *DispatchPlanResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Metadata.EqualVT(that.Metadata) {
+		return false
+	}
+	if len(this.Paths) != len(that.Paths) {
+		return false
+	}
+	for i, vx := range this.Paths {
+		vy := that.Paths[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ResultPath{}
+			}
+			if q == nil {
+				q = &ResultPath{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *DispatchPlanResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DispatchPlanResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ResultPath) EqualVT(that *ResultPath) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.ResourceType != that.ResourceType {
+		return false
+	}
+	if this.ResourceId != that.ResourceId {
+		return false
+	}
+	if this.Relation != that.Relation {
+		return false
+	}
+	if this.SubjectType != that.SubjectType {
+		return false
+	}
+	if this.SubjectId != that.SubjectId {
+		return false
+	}
+	if this.SubjectRelation != that.SubjectRelation {
+		return false
+	}
+	if equal, ok := interface{}(this.Caveat).(interface {
+		EqualVT(*v1.CaveatExpression) bool
+	}); ok {
+		if !equal.EqualVT(that.Caveat) {
+			return false
+		}
+	} else if !proto.Equal(this.Caveat, that.Caveat) {
+		return false
+	}
+	if !(*timestamppb1.Timestamp)(this.Expiration).EqualVT((*timestamppb1.Timestamp)(that.Expiration)) {
+		return false
+	}
+	if len(this.Integrity) != len(that.Integrity) {
+		return false
+	}
+	for i, vx := range this.Integrity {
+		vy := that.Integrity[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &v1.RelationshipIntegrity{}
+			}
+			if q == nil {
+				q = &v1.RelationshipIntegrity{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*v1.RelationshipIntegrity) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
+				return false
+			}
+		}
+	}
+	if !(*structpb1.Struct)(this.Metadata).EqualVT((*structpb1.Struct)(that.Metadata)) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ResultPath) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ResultPath)
 	if !ok {
 		return false
 	}
@@ -3093,6 +3395,361 @@ func (m *CheckDebugTrace) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *PlanContext) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PlanContext) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *PlanContext) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.OptionalDatastoreLimit != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OptionalDatastoreLimit))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.MaxRecursionDepth != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.MaxRecursionDepth))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.CaveatContext != nil {
+		size, err := (*structpb1.Struct)(m.CaveatContext).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Revision) > 0 {
+		i -= len(m.Revision)
+		copy(dAtA[i:], m.Revision)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Revision)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DispatchPlanRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DispatchPlanRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *DispatchPlanRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.PlanContext != nil {
+		size, err := m.PlanContext.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if m.Subject != nil {
+		if vtmsg, ok := interface{}(m.Subject).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.Subject)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.Resource != nil {
+		if vtmsg, ok := interface{}(m.Resource).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.Resource)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.CanonicalKey) > 0 {
+		i -= len(m.CanonicalKey)
+		copy(dAtA[i:], m.CanonicalKey)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CanonicalKey)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Operation != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Operation))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DispatchPlanResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DispatchPlanResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *DispatchPlanResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Paths) > 0 {
+		for iNdEx := len(m.Paths) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Paths[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.Metadata != nil {
+		size, err := m.Metadata.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ResultPath) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ResultPath) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ResultPath) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Metadata != nil {
+		size, err := (*structpb1.Struct)(m.Metadata).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x52
+	}
+	if len(m.Integrity) > 0 {
+		for iNdEx := len(m.Integrity) - 1; iNdEx >= 0; iNdEx-- {
+			if vtmsg, ok := interface{}(m.Integrity[iNdEx]).(interface {
+				MarshalToSizedBufferVT([]byte) (int, error)
+			}); ok {
+				size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			} else {
+				encoded, err := proto.Marshal(m.Integrity[iNdEx])
+				if err != nil {
+					return 0, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			}
+			i--
+			dAtA[i] = 0x4a
+		}
+	}
+	if m.Expiration != nil {
+		size, err := (*timestamppb1.Timestamp)(m.Expiration).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x42
+	}
+	if m.Caveat != nil {
+		if vtmsg, ok := interface{}(m.Caveat).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.Caveat)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x3a
+	}
+	if len(m.SubjectRelation) > 0 {
+		i -= len(m.SubjectRelation)
+		copy(dAtA[i:], m.SubjectRelation)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SubjectRelation)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.SubjectId) > 0 {
+		i -= len(m.SubjectId)
+		copy(dAtA[i:], m.SubjectId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SubjectId)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.SubjectType) > 0 {
+		i -= len(m.SubjectType)
+		copy(dAtA[i:], m.SubjectType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SubjectType)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Relation) > 0 {
+		i -= len(m.Relation)
+		copy(dAtA[i:], m.Relation)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Relation)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.ResourceId) > 0 {
+		i -= len(m.ResourceId)
+		copy(dAtA[i:], m.ResourceId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ResourceId)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ResourceType) > 0 {
+		i -= len(m.ResourceType)
+		copy(dAtA[i:], m.ResourceType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ResourceType)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *DispatchCheckRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -3749,6 +4406,155 @@ func (m *CheckDebugTrace) SizeVT() (n int) {
 	}
 	l = len(m.SourceId)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *PlanContext) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Revision)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.CaveatContext != nil {
+		l = (*structpb1.Struct)(m.CaveatContext).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.MaxRecursionDepth != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.MaxRecursionDepth))
+	}
+	if m.OptionalDatastoreLimit != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.OptionalDatastoreLimit))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *DispatchPlanRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Operation != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Operation))
+	}
+	l = len(m.CanonicalKey)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Resource != nil {
+		if size, ok := interface{}(m.Resource).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.Resource)
+		}
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Subject != nil {
+		if size, ok := interface{}(m.Subject).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.Subject)
+		}
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.PlanContext != nil {
+		l = m.PlanContext.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *DispatchPlanResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Paths) > 0 {
+		for _, e := range m.Paths {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ResultPath) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ResourceType)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ResourceId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Relation)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.SubjectType)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.SubjectId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.SubjectRelation)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Caveat != nil {
+		if size, ok := interface{}(m.Caveat).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.Caveat)
+		}
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Expiration != nil {
+		l = (*timestamppb1.Timestamp)(m.Expiration).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Integrity) > 0 {
+		for _, e := range m.Integrity {
+			if size, ok := interface{}(e).(interface {
+				SizeVT() int
+			}); ok {
+				l = size.SizeVT()
+			} else {
+				l = proto.Size(e)
+			}
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if m.Metadata != nil {
+		l = (*structpb1.Struct)(m.Metadata).SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -7670,6 +8476,911 @@ func (m *CheckDebugTrace) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.SourceId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PlanContext) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PlanContext: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PlanContext: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Revision", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Revision = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CaveatContext", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CaveatContext == nil {
+				m.CaveatContext = &structpb.Struct{}
+			}
+			if err := (*structpb1.Struct)(m.CaveatContext).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxRecursionDepth", wireType)
+			}
+			m.MaxRecursionDepth = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.MaxRecursionDepth |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OptionalDatastoreLimit", wireType)
+			}
+			m.OptionalDatastoreLimit = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.OptionalDatastoreLimit |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DispatchPlanRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DispatchPlanRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DispatchPlanRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Operation", wireType)
+			}
+			m.Operation = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Operation |= PlanOperation(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CanonicalKey", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CanonicalKey = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Resource", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Resource == nil {
+				m.Resource = &v1.ObjectAndRelation{}
+			}
+			if unmarshal, ok := interface{}(m.Resource).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Resource); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Subject", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Subject == nil {
+				m.Subject = &v1.ObjectAndRelation{}
+			}
+			if unmarshal, ok := interface{}(m.Subject).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Subject); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PlanContext", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.PlanContext == nil {
+				m.PlanContext = &PlanContext{}
+			}
+			if err := m.PlanContext.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DispatchPlanResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DispatchPlanResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DispatchPlanResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &ResponseMeta{}
+			}
+			if err := m.Metadata.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Paths", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Paths = append(m.Paths, &ResultPath{})
+			if err := m.Paths[len(m.Paths)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ResultPath) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ResultPath: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ResultPath: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResourceType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ResourceType = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResourceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ResourceId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Relation", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Relation = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SubjectType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SubjectType = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SubjectId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SubjectId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SubjectRelation", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SubjectRelation = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Caveat", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Caveat == nil {
+				m.Caveat = &v1.CaveatExpression{}
+			}
+			if unmarshal, ok := interface{}(m.Caveat).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Caveat); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Expiration", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Expiration == nil {
+				m.Expiration = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.Expiration).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Integrity", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Integrity = append(m.Integrity, &v1.RelationshipIntegrity{})
+			if unmarshal, ok := interface{}(m.Integrity[len(m.Integrity)-1]).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Integrity[len(m.Integrity)-1]); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &structpb.Struct{}
+			}
+			if err := (*structpb1.Struct)(m.Metadata).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
@@ -657,11 +657,11 @@ func (m *PlanContext) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
-func (m *DispatchPlanRequest) CloneVT() *DispatchPlanRequest {
+func (m *DispatchQueryPlanRequest) CloneVT() *DispatchQueryPlanRequest {
 	if m == nil {
-		return (*DispatchPlanRequest)(nil)
+		return (*DispatchQueryPlanRequest)(nil)
 	}
-	r := new(DispatchPlanRequest)
+	r := new(DispatchQueryPlanRequest)
 	r.Operation = m.Operation
 	r.CanonicalKey = m.CanonicalKey
 	r.PlanContext = m.PlanContext.CloneVT()
@@ -686,15 +686,15 @@ func (m *DispatchPlanRequest) CloneVT() *DispatchPlanRequest {
 	return r
 }
 
-func (m *DispatchPlanRequest) CloneMessageVT() proto.Message {
+func (m *DispatchQueryPlanRequest) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
-func (m *DispatchPlanResponse) CloneVT() *DispatchPlanResponse {
+func (m *DispatchQueryPlanResponse) CloneVT() *DispatchQueryPlanResponse {
 	if m == nil {
-		return (*DispatchPlanResponse)(nil)
+		return (*DispatchQueryPlanResponse)(nil)
 	}
-	r := new(DispatchPlanResponse)
+	r := new(DispatchQueryPlanResponse)
 	r.Metadata = m.Metadata.CloneVT()
 	if rhs := m.Paths; rhs != nil {
 		tmpContainer := make([]*ResultPath, len(rhs))
@@ -710,7 +710,7 @@ func (m *DispatchPlanResponse) CloneVT() *DispatchPlanResponse {
 	return r
 }
 
-func (m *DispatchPlanResponse) CloneMessageVT() proto.Message {
+func (m *DispatchQueryPlanResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -1649,7 +1649,7 @@ func (this *PlanContext) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
-func (this *DispatchPlanRequest) EqualVT(that *DispatchPlanRequest) bool {
+func (this *DispatchQueryPlanRequest) EqualVT(that *DispatchQueryPlanRequest) bool {
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
@@ -1685,14 +1685,14 @@ func (this *DispatchPlanRequest) EqualVT(that *DispatchPlanRequest) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
-func (this *DispatchPlanRequest) EqualMessageVT(thatMsg proto.Message) bool {
-	that, ok := thatMsg.(*DispatchPlanRequest)
+func (this *DispatchQueryPlanRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DispatchQueryPlanRequest)
 	if !ok {
 		return false
 	}
 	return this.EqualVT(that)
 }
-func (this *DispatchPlanResponse) EqualVT(that *DispatchPlanResponse) bool {
+func (this *DispatchQueryPlanResponse) EqualVT(that *DispatchQueryPlanResponse) bool {
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
@@ -1721,8 +1721,8 @@ func (this *DispatchPlanResponse) EqualVT(that *DispatchPlanResponse) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
-func (this *DispatchPlanResponse) EqualMessageVT(thatMsg proto.Message) bool {
-	that, ok := thatMsg.(*DispatchPlanResponse)
+func (this *DispatchQueryPlanResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DispatchQueryPlanResponse)
 	if !ok {
 		return false
 	}
@@ -3479,7 +3479,7 @@ func (m *PlanContext) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *DispatchPlanRequest) MarshalVT() (dAtA []byte, err error) {
+func (m *DispatchQueryPlanRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -3492,12 +3492,12 @@ func (m *DispatchPlanRequest) MarshalVT() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *DispatchPlanRequest) MarshalToVT(dAtA []byte) (int, error) {
+func (m *DispatchQueryPlanRequest) MarshalToVT(dAtA []byte) (int, error) {
 	size := m.SizeVT()
 	return m.MarshalToSizedBufferVT(dAtA[:size])
 }
 
-func (m *DispatchPlanRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+func (m *DispatchQueryPlanRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}
@@ -3578,7 +3578,7 @@ func (m *DispatchPlanRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *DispatchPlanResponse) MarshalVT() (dAtA []byte, err error) {
+func (m *DispatchQueryPlanResponse) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -3591,12 +3591,12 @@ func (m *DispatchPlanResponse) MarshalVT() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *DispatchPlanResponse) MarshalToVT(dAtA []byte) (int, error) {
+func (m *DispatchQueryPlanResponse) MarshalToVT(dAtA []byte) (int, error) {
 	size := m.SizeVT()
 	return m.MarshalToSizedBufferVT(dAtA[:size])
 }
 
-func (m *DispatchPlanResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+func (m *DispatchQueryPlanResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}
@@ -4472,7 +4472,7 @@ func (m *PlanContext) SizeVT() (n int) {
 	return n
 }
 
-func (m *DispatchPlanRequest) SizeVT() (n int) {
+func (m *DispatchQueryPlanRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -4513,7 +4513,7 @@ func (m *DispatchPlanRequest) SizeVT() (n int) {
 	return n
 }
 
-func (m *DispatchPlanResponse) SizeVT() (n int) {
+func (m *DispatchQueryPlanResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -8698,7 +8698,7 @@ func (m *PlanContext) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *DispatchPlanRequest) UnmarshalVT(dAtA []byte) error {
+func (m *DispatchQueryPlanRequest) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -8721,10 +8721,10 @@ func (m *DispatchPlanRequest) UnmarshalVT(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: DispatchPlanRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: DispatchQueryPlanRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: DispatchPlanRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: DispatchQueryPlanRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -8924,7 +8924,7 @@ func (m *DispatchPlanRequest) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *DispatchPlanResponse) UnmarshalVT(dAtA []byte) error {
+func (m *DispatchQueryPlanResponse) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -8947,10 +8947,10 @@ func (m *DispatchPlanResponse) UnmarshalVT(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: DispatchPlanResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: DispatchQueryPlanResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: DispatchPlanResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: DispatchQueryPlanResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
@@ -747,6 +747,13 @@ func (m *ResultPath) CloneVT() *ResultPath {
 		}
 		r.Integrity = tmpContainer
 	}
+	if rhs := m.ExcludedSubjects; rhs != nil {
+		tmpContainer := make([]*ResultPath, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.ExcludedSubjects = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1782,6 +1789,23 @@ func (this *ResultPath) EqualVT(that *ResultPath) bool {
 	}
 	if !(*structpb1.Struct)(this.Metadata).EqualVT((*structpb1.Struct)(that.Metadata)) {
 		return false
+	}
+	if len(this.ExcludedSubjects) != len(that.ExcludedSubjects) {
+		return false
+	}
+	for i, vx := range this.ExcludedSubjects {
+		vy := that.ExcludedSubjects[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ResultPath{}
+			}
+			if q == nil {
+				q = &ResultPath{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -3639,6 +3663,18 @@ func (m *ResultPath) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.ExcludedSubjects) > 0 {
+		for iNdEx := len(m.ExcludedSubjects) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.ExcludedSubjects[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x5a
+		}
+	}
 	if m.Metadata != nil {
 		size, err := (*structpb1.Struct)(m.Metadata).MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -4556,6 +4592,12 @@ func (m *ResultPath) SizeVT() (n int) {
 	if m.Metadata != nil {
 		l = (*structpb1.Struct)(m.Metadata).SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.ExcludedSubjects) > 0 {
+		for _, e := range m.ExcludedSubjects {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9379,6 +9421,40 @@ func (m *ResultPath) UnmarshalVT(dAtA []byte) error {
 				m.Metadata = &structpb.Struct{}
 			}
 			if err := (*structpb1.Struct)(m.Metadata).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExcludedSubjects", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ExcludedSubjects = append(m.ExcludedSubjects, &ResultPath{})
+			if err := m.ExcludedSubjects[len(m.ExcludedSubjects)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/query/path_proto.go
+++ b/pkg/query/path_proto.go
@@ -1,0 +1,105 @@
+package query
+
+import (
+	"time"
+
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+)
+
+// ToProto converts a Path into its dispatch.v1.ResultPath wire representation.
+func (p *Path) ToProto() (*dispatchv1.ResultPath, error) {
+	if p == nil {
+		return nil, nil
+	}
+
+	var metadata *structpb.Struct
+	if len(p.Metadata) > 0 {
+		m, err := structpb.NewStruct(p.Metadata)
+		if err != nil {
+			return nil, err
+		}
+		metadata = m
+	}
+
+	var expiration *timestamppb.Timestamp
+	if p.Expiration != nil {
+		expiration = timestamppb.New(*p.Expiration)
+	}
+
+	var excluded []*dispatchv1.ResultPath
+	if len(p.ExcludedSubjects) > 0 {
+		excluded = make([]*dispatchv1.ResultPath, 0, len(p.ExcludedSubjects))
+		for _, es := range p.ExcludedSubjects {
+			esProto, err := es.ToProto()
+			if err != nil {
+				return nil, err
+			}
+			excluded = append(excluded, esProto)
+		}
+	}
+
+	return &dispatchv1.ResultPath{
+		ResourceType:     p.Resource.ObjectType,
+		ResourceId:       p.Resource.ObjectID,
+		Relation:         p.Relation,
+		SubjectType:      p.Subject.ObjectType,
+		SubjectId:        p.Subject.ObjectID,
+		SubjectRelation:  p.Subject.Relation,
+		Caveat:           p.Caveat,
+		Expiration:       expiration,
+		Integrity:        p.Integrity,
+		Metadata:         metadata,
+		ExcludedSubjects: excluded,
+	}, nil
+}
+
+// PathFromProto converts a dispatch.v1.ResultPath back into a Path.
+func PathFromProto(rp *dispatchv1.ResultPath) (*Path, error) {
+	if rp == nil {
+		return nil, nil
+	}
+
+	var metadata map[string]any
+	if rp.Metadata != nil {
+		metadata = rp.Metadata.AsMap()
+	}
+
+	var expiration *time.Time
+	if rp.Expiration != nil {
+		t := rp.Expiration.AsTime()
+		expiration = &t
+	}
+
+	var excluded []*Path
+	if len(rp.ExcludedSubjects) > 0 {
+		excluded = make([]*Path, 0, len(rp.ExcludedSubjects))
+		for _, esp := range rp.ExcludedSubjects {
+			es, err := PathFromProto(esp)
+			if err != nil {
+				return nil, err
+			}
+			excluded = append(excluded, es)
+		}
+	}
+
+	return &Path{
+		Resource: Object{
+			ObjectType: rp.ResourceType,
+			ObjectID:   rp.ResourceId,
+		},
+		Relation: rp.Relation,
+		Subject: ObjectAndRelation{
+			ObjectType: rp.SubjectType,
+			ObjectID:   rp.SubjectId,
+			Relation:   rp.SubjectRelation,
+		},
+		Caveat:           rp.Caveat,
+		Expiration:       expiration,
+		Integrity:        rp.Integrity,
+		ExcludedSubjects: excluded,
+		Metadata:         metadata,
+	}, nil
+}

--- a/proto/internal/dispatch/v1/dispatch.proto
+++ b/proto/internal/dispatch/v1/dispatch.proto
@@ -251,4 +251,5 @@ message ResultPath {
   google.protobuf.Timestamp expiration = 8;
   repeated core.v1.RelationshipIntegrity integrity = 9;
   google.protobuf.Struct metadata = 10;
+  repeated ResultPath excluded_subjects = 11;
 }

--- a/proto/internal/dispatch/v1/dispatch.proto
+++ b/proto/internal/dispatch/v1/dispatch.proto
@@ -5,6 +5,7 @@ import "buf/validate/validate.proto";
 import "core/v1/core.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/authzed/spicedb/pkg/proto/dispatch/v1";
 
@@ -15,6 +16,8 @@ service DispatchService {
   rpc DispatchLookupSubjects(DispatchLookupSubjectsRequest) returns (stream DispatchLookupSubjectsResponse) {}
   rpc DispatchLookupResources2(DispatchLookupResources2Request) returns (stream DispatchLookupResources2Response) {}
   rpc DispatchLookupResources3(DispatchLookupResources3Request) returns (stream DispatchLookupResources3Response) {}
+
+  rpc DispatchPlan(DispatchPlanRequest) returns (stream DispatchPlanResponse) {}
 }
 
 message DispatchCheckRequest {
@@ -209,4 +212,43 @@ message CheckDebugTrace {
   google.protobuf.Duration duration = 6;
   string trace_id = 7;
   string source_id = 8;
+}
+
+enum PlanOperation {
+  PLAN_OPERATION_CHECK = 0;
+  PLAN_OPERATION_LOOKUP_RESOURCES = 1;
+  PLAN_OPERATION_LOOKUP_SUBJECTS = 2;
+}
+
+message PlanContext {
+  string revision = 1;
+  google.protobuf.Struct caveat_context = 2;
+  int32 max_recursion_depth = 3;
+  uint64 optional_datastore_limit = 4;
+}
+
+message DispatchPlanRequest {
+  PlanOperation operation = 1;
+  string canonical_key = 2;
+  core.v1.ObjectAndRelation resource = 3;
+  core.v1.ObjectAndRelation subject = 4;
+  PlanContext plan_context = 5;
+}
+
+message DispatchPlanResponse {
+  ResponseMeta metadata = 1;
+  repeated ResultPath paths = 2;
+}
+
+message ResultPath {
+  string resource_type = 1;
+  string resource_id = 2;
+  string relation = 3;
+  string subject_type = 4;
+  string subject_id = 5;
+  string subject_relation = 6;
+  core.v1.CaveatExpression caveat = 7;
+  google.protobuf.Timestamp expiration = 8;
+  repeated core.v1.RelationshipIntegrity integrity = 9;
+  google.protobuf.Struct metadata = 10;
 }

--- a/proto/internal/dispatch/v1/dispatch.proto
+++ b/proto/internal/dispatch/v1/dispatch.proto
@@ -17,7 +17,7 @@ service DispatchService {
   rpc DispatchLookupResources2(DispatchLookupResources2Request) returns (stream DispatchLookupResources2Response) {}
   rpc DispatchLookupResources3(DispatchLookupResources3Request) returns (stream DispatchLookupResources3Response) {}
 
-  rpc DispatchPlan(DispatchPlanRequest) returns (stream DispatchPlanResponse) {}
+  rpc DispatchQueryPlan(DispatchQueryPlanRequest) returns (stream DispatchQueryPlanResponse) {}
 }
 
 message DispatchCheckRequest {
@@ -227,7 +227,7 @@ message PlanContext {
   uint64 optional_datastore_limit = 4;
 }
 
-message DispatchPlanRequest {
+message DispatchQueryPlanRequest {
   PlanOperation operation = 1;
   string canonical_key = 2;
   core.v1.ObjectAndRelation resource = 3;
@@ -235,7 +235,7 @@ message DispatchPlanRequest {
   PlanContext plan_context = 5;
 }
 
-message DispatchPlanResponse {
+message DispatchQueryPlanResponse {
   ResponseMeta metadata = 1;
   repeated ResultPath paths = 2;
 }


### PR DESCRIPTION
## Description

Step one in integrating Query Planner with dispatch (for distributed caching, mostly) is to stub out the implementation and provide the request structure. Implementing a dispatch-aware executor is next.
