### PR TITLE
feat: add a DispatchExecutor for query plans to the dispatch package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Add DispatchExecutor, a query plan executor that is Dispatch-aware and sends subproblems on Alias boundaries (https://github.com/authzed/spicedb/pull/3074)
 
 ## [1.52.0] - 2026-04-30
 ### Added

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -1,0 +1,230 @@
+package dispatch
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/query"
+)
+
+// DispatchExecutor is an Executor that selectively dispatches sub-operations
+// through the dispatch infrastructure at alias iterator boundaries.
+// For non-alias iterators, it delegates locally like LocalExecutor.
+type DispatchExecutor struct {
+	dispatcher  Dispatcher
+	planContext *v1.PlanContext
+}
+
+var _ query.Executor = &DispatchExecutor{}
+
+// NewDispatchExecutor creates a new DispatchExecutor that dispatches alias
+// iterator operations through the given Dispatcher chain.
+func NewDispatchExecutor(dispatcher Dispatcher, planContext *v1.PlanContext) *DispatchExecutor {
+	return &DispatchExecutor{
+		dispatcher:  dispatcher,
+		planContext: planContext,
+	}
+}
+
+func (e *DispatchExecutor) Check(ctx *query.Context, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) (*query.Path, error) {
+	if _, ok := it.(*query.AliasIterator); ok {
+		return e.dispatchCheck(ctx, it, resource, subject)
+	}
+	return it.CheckImpl(ctx, resource, subject)
+}
+
+func (e *DispatchExecutor) IterSubjects(ctx *query.Context, it query.Iterator, resource query.Object, filterSubjectType query.ObjectType) (query.PathSeq, error) {
+	if _, ok := it.(*query.AliasIterator); ok {
+		return e.dispatchIterSubjects(ctx, it, resource, filterSubjectType)
+	}
+	pathSeq, err := it.IterSubjectsImpl(ctx, resource, filterSubjectType)
+	if err != nil {
+		return nil, err
+	}
+	return query.FilterSubjectsByType(pathSeq, filterSubjectType), nil
+}
+
+func (e *DispatchExecutor) IterResources(ctx *query.Context, it query.Iterator, subject query.ObjectAndRelation, filterResourceType query.ObjectType) (query.PathSeq, error) {
+	if _, ok := it.(*query.AliasIterator); ok {
+		return e.dispatchIterResources(ctx, it, subject, filterResourceType)
+	}
+	pathSeq, err := it.IterResourcesImpl(ctx, subject, filterResourceType)
+	if err != nil {
+		return nil, err
+	}
+	return query.FilterResourcesByType(pathSeq, filterResourceType), nil
+}
+
+func (e *DispatchExecutor) dispatchCheck(ctx *query.Context, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) (*query.Path, error) {
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	req := e.buildRequest(v1.PlanOperation_PLAN_OPERATION_CHECK, it, resource, subject)
+	stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
+	if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
+		return nil, err
+	}
+
+	for _, resp := range stream.Results() {
+		for _, rp := range resp.Paths {
+			path := resultPathToQueryPath(rp)
+			return path, nil
+		}
+	}
+	return nil, nil
+}
+
+func (e *DispatchExecutor) dispatchIterSubjects(ctx *query.Context, it query.Iterator, resource query.Object, filterSubjectType query.ObjectType) (query.PathSeq, error) {
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	req := e.buildRequest(v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS, it, resource, query.ObjectAndRelation{
+		ObjectType: resource.ObjectType,
+		ObjectID:   resource.ObjectID,
+	})
+	stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
+	if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
+		return nil, err
+	}
+
+	paths := collectPathsFromResponses(stream.Results())
+	return query.FilterSubjectsByType(query.PathSeqFromSlice(paths), filterSubjectType), nil
+}
+
+func (e *DispatchExecutor) dispatchIterResources(ctx *query.Context, it query.Iterator, subject query.ObjectAndRelation, filterResourceType query.ObjectType) (query.PathSeq, error) {
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	req := e.buildRequest(v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES, it, query.Object{
+		ObjectType: subject.ObjectType,
+		ObjectID:   subject.ObjectID,
+	}, subject)
+	stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
+	if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
+		return nil, err
+	}
+
+	paths := collectPathsFromResponses(stream.Results())
+	return query.FilterResourcesByType(query.PathSeqFromSlice(paths), filterResourceType), nil
+}
+
+func (e *DispatchExecutor) buildRequest(op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
+	return &v1.DispatchQueryPlanRequest{
+		Operation:    op,
+		CanonicalKey: string(it.CanonicalKey()),
+		Resource: &core.ObjectAndRelation{
+			Namespace: resource.ObjectType,
+			ObjectId:  resource.ObjectID,
+		},
+		Subject: &core.ObjectAndRelation{
+			Namespace: subject.ObjectType,
+			ObjectId:  subject.ObjectID,
+			Relation:  subject.Relation,
+		},
+		PlanContext: e.planContext,
+	}
+}
+
+func collectPathsFromResponses(responses []*v1.DispatchQueryPlanResponse) []*query.Path {
+	var paths []*query.Path
+	for _, resp := range responses {
+		for _, rp := range resp.Paths {
+			paths = append(paths, resultPathToQueryPath(rp))
+		}
+	}
+	return paths
+}
+
+// resultPathToQueryPath converts a proto ResultPath to a query.Path.
+func resultPathToQueryPath(rp *v1.ResultPath) *query.Path {
+	p := &query.Path{
+		Resource: query.Object{
+			ObjectType: rp.ResourceType,
+			ObjectID:   rp.ResourceId,
+		},
+		Relation: rp.Relation,
+		Subject: query.ObjectAndRelation{
+			ObjectType: rp.SubjectType,
+			ObjectID:   rp.SubjectId,
+			Relation:   rp.SubjectRelation,
+		},
+		Caveat:    rp.Caveat,
+		Integrity: rp.Integrity,
+	}
+	if rp.Expiration != nil {
+		t := rp.Expiration.AsTime()
+		p.Expiration = &t
+	}
+	if rp.Metadata != nil {
+		p.Metadata = rp.Metadata.AsMap()
+	}
+	return p
+}
+
+// QueryPathToResultPath converts a query.Path to a proto ResultPath.
+func QueryPathToResultPath(p *query.Path) *v1.ResultPath {
+	rp := &v1.ResultPath{
+		ResourceType:    p.Resource.ObjectType,
+		ResourceId:      p.Resource.ObjectID,
+		Relation:        p.Relation,
+		SubjectType:     p.Subject.ObjectType,
+		SubjectId:       p.Subject.ObjectID,
+		SubjectRelation: p.Subject.Relation,
+		Caveat:          p.Caveat,
+		Integrity:       p.Integrity,
+	}
+	if p.Expiration != nil {
+		rp.Expiration = timestamppb.New(*p.Expiration)
+	}
+	if p.Metadata != nil {
+		md, err := toProtoStruct(p.Metadata)
+		if err == nil {
+			rp.Metadata = md
+		}
+	}
+	return rp
+}
+
+func toProtoStruct(m map[string]any) (*structpb.Struct, error) {
+	if len(m) == 0 {
+		return nil, nil
+	}
+	return structpb.NewStruct(m)
+}
+
+// NewPlanContext builds a PlanContext proto from query.Context fields.
+func NewPlanContext(revision string, caveatContext map[string]any, maxRecursionDepth int, datastoreLimit uint64) *v1.PlanContext {
+	pc := &v1.PlanContext{
+		Revision:               revision,
+		MaxRecursionDepth:      int32(maxRecursionDepth),
+		OptionalDatastoreLimit: datastoreLimit,
+	}
+	if caveatContext != nil {
+		cc, err := structpb.NewStruct(caveatContext)
+		if err == nil {
+			pc.CaveatContext = cc
+		}
+	}
+	return pc
+}
+
+// CaveatContextFromPlanContext extracts the caveat context map from a PlanContext.
+func CaveatContextFromPlanContext(pc *v1.PlanContext) map[string]any {
+	if pc == nil || pc.CaveatContext == nil {
+		return nil
+	}
+	return pc.CaveatContext.AsMap()
+}
+
+// PaginationLimitFromPlanContext returns the datastore limit from a PlanContext, or nil if unset.
+func PaginationLimitFromPlanContext(pc *v1.PlanContext) *uint64 {
+	if pc == nil || pc.OptionalDatastoreLimit == 0 {
+		return nil
+	}
+	limit := pc.OptionalDatastoreLimit
+	return &limit
+}

--- a/internal/dispatch/executor_test.go
+++ b/internal/dispatch/executor_test.go
@@ -1,0 +1,426 @@
+package dispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/query"
+)
+
+// testDispatcher is a minimal dispatcher that records DispatchQueryPlan calls
+// and writes configurable responses to the stream.
+type testDispatcher struct {
+	planCalls     []*v1.DispatchQueryPlanRequest
+	planResponses []*v1.DispatchQueryPlanResponse
+	planErr       error
+}
+
+func (d *testDispatcher) DispatchCheck(_ context.Context, _ *v1.DispatchCheckRequest) (*v1.DispatchCheckResponse, error) {
+	return &v1.DispatchCheckResponse{}, nil
+}
+
+func (d *testDispatcher) DispatchExpand(_ context.Context, _ *v1.DispatchExpandRequest) (*v1.DispatchExpandResponse, error) {
+	return &v1.DispatchExpandResponse{}, nil
+}
+
+func (d *testDispatcher) DispatchLookupResources2(_ *v1.DispatchLookupResources2Request, _ LookupResources2Stream) error {
+	return nil
+}
+
+func (d *testDispatcher) DispatchLookupResources3(_ *v1.DispatchLookupResources3Request, _ LookupResources3Stream) error {
+	return nil
+}
+
+func (d *testDispatcher) DispatchLookupSubjects(_ *v1.DispatchLookupSubjectsRequest, _ LookupSubjectsStream) error {
+	return nil
+}
+
+func (d *testDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream PlanStream) error {
+	d.planCalls = append(d.planCalls, req)
+	if d.planErr != nil {
+		return d.planErr
+	}
+	for _, resp := range d.planResponses {
+		if err := stream.Publish(resp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (d *testDispatcher) Close() error           { return nil }
+func (d *testDispatcher) ReadyState() ReadyState { return ReadyState{IsReady: true} }
+
+var _ Dispatcher = &testDispatcher{}
+
+func newTestContext() *query.Context {
+	return query.NewLocalContext(context.Background())
+}
+
+func TestDispatchExecutor_Check_AliasDispatches(t *testing.T) {
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{
+			Paths: []*v1.ResultPath{{
+				ResourceType:    "document",
+				ResourceId:      "doc1",
+				Relation:        "viewer",
+				SubjectType:     "user",
+				SubjectId:       "alice",
+				SubjectRelation: "...",
+			}},
+		}},
+	}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	// AliasIterator wrapping a FixedIterator — should trigger dispatch
+	inner := query.NewFixedIterator()
+	alias := query.NewAliasIterator("viewer", inner)
+
+	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	require.NoError(t, err)
+	require.NotNil(t, path)
+	require.Equal(t, "document", path.Resource.ObjectType)
+	require.Equal(t, "doc1", path.Resource.ObjectID)
+	require.Equal(t, "alice", path.Subject.ObjectID)
+
+	// Verify dispatch was called
+	require.Len(t, td.planCalls, 1)
+	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_CHECK, td.planCalls[0].Operation)
+	require.Equal(t, "rev1", td.planCalls[0].PlanContext.Revision)
+}
+
+func TestDispatchExecutor_Check_NonAliasLocal(t *testing.T) {
+	td := &testDispatcher{}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	// FixedIterator (not an alias) — should delegate locally, no dispatch
+	fixed := query.NewFixedIterator(query.Path{
+		Resource: query.Object{ObjectType: "document", ObjectID: "doc1"},
+		Relation: "viewer",
+		Subject:  query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."},
+	})
+
+	path, err := exec.Check(ctx, fixed, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	require.NoError(t, err)
+	require.NotNil(t, path)
+	require.Equal(t, "alice", path.Subject.ObjectID)
+
+	// Verify NO dispatch was called
+	require.Empty(t, td.planCalls)
+}
+
+func TestDispatchExecutor_Check_AliasNoResult(t *testing.T) {
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{
+			Paths: []*v1.ResultPath{}, // empty = no permission
+		}},
+	}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+
+	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	require.NoError(t, err)
+	require.Nil(t, path)
+	require.Len(t, td.planCalls, 1)
+}
+
+func TestDispatchExecutor_IterSubjects_AliasDispatches(t *testing.T) {
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{
+			Paths: []*v1.ResultPath{
+				{ResourceType: "document", ResourceId: "doc1", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
+				{ResourceType: "document", ResourceId: "doc1", Relation: "viewer", SubjectType: "user", SubjectId: "bob", SubjectRelation: "..."},
+			},
+		}},
+	}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+
+	pathSeq, err := exec.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	require.NoError(t, err)
+
+	paths, err := query.CollectAll(pathSeq)
+	require.NoError(t, err)
+	require.Len(t, paths, 2)
+	require.Equal(t, "alice", paths[0].Subject.ObjectID)
+	require.Equal(t, "bob", paths[1].Subject.ObjectID)
+
+	require.Len(t, td.planCalls, 1)
+	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS, td.planCalls[0].Operation)
+}
+
+func TestDispatchExecutor_IterSubjects_NonAliasLocal(t *testing.T) {
+	td := &testDispatcher{}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	fixed := query.NewFixedIterator(
+		query.Path{
+			Resource: query.Object{ObjectType: "document", ObjectID: "doc1"},
+			Relation: "viewer",
+			Subject:  query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."},
+		},
+		query.Path{
+			Resource: query.Object{ObjectType: "document", ObjectID: "doc1"},
+			Relation: "viewer",
+			Subject:  query.ObjectAndRelation{ObjectType: "user", ObjectID: "bob", Relation: "..."},
+		},
+	)
+
+	pathSeq, err := exec.IterSubjects(ctx, fixed, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	require.NoError(t, err)
+
+	paths, err := query.CollectAll(pathSeq)
+	require.NoError(t, err)
+	require.Len(t, paths, 2)
+	require.Empty(t, td.planCalls)
+}
+
+func TestDispatchExecutor_IterResources_AliasDispatches(t *testing.T) {
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{
+			Paths: []*v1.ResultPath{
+				{ResourceType: "document", ResourceId: "doc1", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
+				{ResourceType: "document", ResourceId: "doc2", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
+			},
+		}},
+	}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+
+	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	require.NoError(t, err)
+
+	paths, err := query.CollectAll(pathSeq)
+	require.NoError(t, err)
+	require.Len(t, paths, 2)
+	require.Equal(t, "doc1", paths[0].Resource.ObjectID)
+	require.Equal(t, "doc2", paths[1].Resource.ObjectID)
+
+	require.Len(t, td.planCalls, 1)
+	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES, td.planCalls[0].Operation)
+}
+
+func TestDispatchExecutor_IterResources_NonAliasLocal(t *testing.T) {
+	td := &testDispatcher{}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	fixed := query.NewFixedIterator(
+		query.Path{
+			Resource: query.Object{ObjectType: "document", ObjectID: "doc1"},
+			Relation: "viewer",
+			Subject:  query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."},
+		},
+	)
+
+	pathSeq, err := exec.IterResources(ctx, fixed, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	require.NoError(t, err)
+
+	paths, err := query.CollectAll(pathSeq)
+	require.NoError(t, err)
+	require.Len(t, paths, 1)
+	require.Empty(t, td.planCalls)
+}
+
+func TestDispatchExecutor_StreamBatching(t *testing.T) {
+	// Multiple streamed responses should be collected correctly
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{
+			{Paths: []*v1.ResultPath{
+				{ResourceType: "document", ResourceId: "doc1", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
+			}},
+			{Paths: []*v1.ResultPath{
+				{ResourceType: "document", ResourceId: "doc2", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
+				{ResourceType: "document", ResourceId: "doc3", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
+			}},
+		},
+	}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+
+	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	require.NoError(t, err)
+
+	paths, err := query.CollectAll(pathSeq)
+	require.NoError(t, err)
+	require.Len(t, paths, 3)
+	require.Equal(t, "doc1", paths[0].Resource.ObjectID)
+	require.Equal(t, "doc2", paths[1].Resource.ObjectID)
+	require.Equal(t, "doc3", paths[2].Resource.ObjectID)
+}
+
+func TestDispatchExecutor_PlanContextForwarded(t *testing.T) {
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{Paths: []*v1.ResultPath{}}},
+	}
+
+	pc := &v1.PlanContext{
+		Revision:               "rev42",
+		MaxRecursionDepth:      5,
+		OptionalDatastoreLimit: 100,
+	}
+	exec := NewDispatchExecutor(td, pc)
+	ctx := newTestContext()
+
+	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	_, _ = exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+
+	require.Len(t, td.planCalls, 1)
+	require.Equal(t, "rev42", td.planCalls[0].PlanContext.Revision)
+	require.Equal(t, int32(5), td.planCalls[0].PlanContext.MaxRecursionDepth)
+	require.Equal(t, uint64(100), td.planCalls[0].PlanContext.OptionalDatastoreLimit)
+}
+
+func TestDispatchExecutor_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately
+
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{Paths: []*v1.ResultPath{}}},
+	}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	qctx := query.NewLocalContext(ctx)
+
+	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	_, err := exec.Check(qctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+
+	// The dispatch itself succeeds (our test dispatcher doesn't check context),
+	// but the subcontext created inside dispatchCheck is derived from the cancelled parent.
+	// In a real dispatcher, this would propagate cancellation.
+	// Here we just verify the call completes without panic.
+	_ = err
+}
+
+// --- Path conversion tests ---
+
+func TestResultPathRoundTrip(t *testing.T) {
+	original := &query.Path{
+		Resource: query.Object{ObjectType: "document", ObjectID: "doc1"},
+		Relation: "viewer",
+		Subject:  query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."},
+	}
+
+	rp := QueryPathToResultPath(original)
+	roundTripped := resultPathToQueryPath(rp)
+
+	require.Equal(t, original.Resource, roundTripped.Resource)
+	require.Equal(t, original.Relation, roundTripped.Relation)
+	require.Equal(t, original.Subject, roundTripped.Subject)
+	require.Nil(t, roundTripped.Caveat)
+	require.Nil(t, roundTripped.Expiration)
+}
+
+func TestResultPathRoundTrip_WithExpiration(t *testing.T) {
+	expTime := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	original := &query.Path{
+		Resource:   query.Object{ObjectType: "document", ObjectID: "doc1"},
+		Relation:   "viewer",
+		Subject:    query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."},
+		Expiration: &expTime,
+	}
+
+	rp := QueryPathToResultPath(original)
+	require.NotNil(t, rp.Expiration)
+	require.Equal(t, timestamppb.New(expTime).AsTime(), rp.Expiration.AsTime())
+
+	roundTripped := resultPathToQueryPath(rp)
+	require.NotNil(t, roundTripped.Expiration)
+	require.True(t, expTime.Equal(*roundTripped.Expiration))
+}
+
+func TestResultPathRoundTrip_WithCaveat(t *testing.T) {
+	caveat := &core.CaveatExpression{
+		OperationOrCaveat: &core.CaveatExpression_Caveat{
+			Caveat: &core.ContextualizedCaveat{
+				CaveatName: "test_caveat",
+			},
+		},
+	}
+	original := &query.Path{
+		Resource: query.Object{ObjectType: "document", ObjectID: "doc1"},
+		Relation: "viewer",
+		Subject:  query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."},
+		Caveat:   caveat,
+	}
+
+	rp := QueryPathToResultPath(original)
+	require.NotNil(t, rp.Caveat)
+
+	roundTripped := resultPathToQueryPath(rp)
+	require.NotNil(t, roundTripped.Caveat)
+	require.Equal(t, "test_caveat", roundTripped.Caveat.GetCaveat().CaveatName)
+}
+
+func TestResultPathRoundTrip_WithMetadata(t *testing.T) {
+	original := &query.Path{
+		Resource: query.Object{ObjectType: "document", ObjectID: "doc1"},
+		Relation: "viewer",
+		Subject:  query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."},
+		Metadata: map[string]any{"key": "value"},
+	}
+
+	rp := QueryPathToResultPath(original)
+	require.NotNil(t, rp.Metadata)
+
+	roundTripped := resultPathToQueryPath(rp)
+	require.NotNil(t, roundTripped.Metadata)
+	require.Equal(t, "value", roundTripped.Metadata["key"])
+}
+
+// --- PlanContext helper tests ---
+
+func TestNewPlanContext(t *testing.T) {
+	pc := NewPlanContext("rev1", map[string]any{"ip": "1.2.3.4"}, 10, 500)
+	require.Equal(t, "rev1", pc.Revision)
+	require.Equal(t, int32(10), pc.MaxRecursionDepth)
+	require.Equal(t, uint64(500), pc.OptionalDatastoreLimit)
+	require.NotNil(t, pc.CaveatContext)
+}
+
+func TestCaveatContextFromPlanContext(t *testing.T) {
+	pc := NewPlanContext("rev1", map[string]any{"ip": "1.2.3.4"}, 0, 0)
+	cc := CaveatContextFromPlanContext(pc)
+	require.Equal(t, "1.2.3.4", cc["ip"])
+}
+
+func TestCaveatContextFromPlanContext_Nil(t *testing.T) {
+	require.Nil(t, CaveatContextFromPlanContext(nil))
+	require.Nil(t, CaveatContextFromPlanContext(&v1.PlanContext{}))
+}
+
+func TestPaginationLimitFromPlanContext(t *testing.T) {
+	pc := NewPlanContext("rev1", nil, 0, 100)
+	limit := PaginationLimitFromPlanContext(pc)
+	require.NotNil(t, limit)
+	require.Equal(t, uint64(100), *limit)
+}
+
+func TestPaginationLimitFromPlanContext_Zero(t *testing.T) {
+	pc := NewPlanContext("rev1", nil, 0, 0)
+	require.Nil(t, PaginationLimitFromPlanContext(pc))
+}

--- a/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
+++ b/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
@@ -1,0 +1,415 @@
+//go:build integration
+
+package integrationtesting_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/caveats"
+	"github.com/authzed/spicedb/internal/datastore/dsfortesting"
+	"github.com/authzed/spicedb/internal/datastore/memdb"
+	"github.com/authzed/spicedb/internal/dispatch"
+	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+	"github.com/authzed/spicedb/pkg/datalayer"
+	"github.com/authzed/spicedb/pkg/datastore"
+	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/query"
+	"github.com/authzed/spicedb/pkg/query/queryopt"
+	"github.com/authzed/spicedb/pkg/schema/v2"
+	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/validationfile"
+)
+
+const benchTimedelta = 1 * time.Second
+
+// dispatchQueryPlanHandle holds the precompiled state needed to run dispatch query plan benchmarks.
+type dispatchQueryPlanHandle struct {
+	ds       datastore.Datastore
+	revision datastore.Revision
+	schema   *schema.Schema
+}
+
+func newDispatchQueryPlanHandle(b *testing.B, fileName string) *dispatchQueryPlanHandle {
+	b.Helper()
+	ds, err := dsfortesting.NewMemDBDatastoreForTesting(b, 0, benchTimedelta, memdb.DisableGC)
+	require.NoError(b, err)
+
+	contents, err := testFiles.ReadFile(fileName)
+	require.NoError(b, err)
+
+	populated, rev, err := validationfile.PopulateFromFilesContents(
+		b.Context(), datalayer.NewDataLayer(ds), caveattypes.Default.TypeSet,
+		map[string][]byte{"testfile": contents},
+	)
+	require.NoError(b, err)
+
+	fullSchema, err := schema.BuildSchemaFromDefinitions(populated.NamespaceDefinitions, populated.CaveatDefinitions)
+	require.NoError(b, err)
+
+	return &dispatchQueryPlanHandle{ds: ds, revision: rev, schema: fullSchema}
+}
+
+// compileIterator builds and compiles an iterator for the given resource type and permission.
+func (h *dispatchQueryPlanHandle) compileIterator(b *testing.B, resourceType, permission, subjectType, subjectRelation string) query.Iterator {
+	b.Helper()
+	co, err := query.BuildOutlineFromSchema(h.schema, resourceType, permission)
+	require.NoError(b, err)
+
+	optimized, err := queryopt.ApplyOptimizations(co, queryopt.StandardOptimzations, queryopt.RequestParams{
+		SubjectType:     subjectType,
+		SubjectRelation: subjectRelation,
+	})
+	require.NoError(b, err)
+
+	it, err := optimized.Compile()
+	require.NoError(b, err)
+	return it
+}
+
+// newLocalContext creates a query context using LocalExecutor for baseline comparison.
+func (h *dispatchQueryPlanHandle) newLocalContext(ctx context.Context) *query.Context {
+	return query.NewLocalContext(ctx,
+		query.WithRevisionedReader(datalayer.NewDataLayer(h.ds).SnapshotReader(h.revision)),
+		query.WithCaveatRunner(caveats.NewCaveatRunner(caveattypes.Default.TypeSet)),
+	)
+}
+
+// newDispatchContext creates a query context using a DispatchExecutor backed by a
+// localQueryPlanDispatcher that handles DispatchQueryPlan by compiling and executing the plan locally.
+func (h *dispatchQueryPlanHandle) newDispatchContext(ctx context.Context) *query.Context {
+	planCtx := dispatch.NewPlanContext(h.revision.String(), nil, 0, 0)
+	lpd := &localQueryPlanDispatcher{handle: h}
+	executor := dispatch.NewDispatchExecutor(lpd, planCtx)
+
+	qctx := &query.Context{
+		Context:       ctx,
+		Executor:      executor,
+		Reader:        query.NewQueryDatastoreReader(datalayer.NewDataLayer(h.ds).SnapshotReader(h.revision)),
+		CaveatRunner:  caveats.NewCaveatRunner(caveattypes.Default.TypeSet),
+		CaveatContext: nil,
+	}
+	return qctx
+}
+
+// localQueryPlanDispatcher is a minimal dispatcher that handles DispatchQueryPlan by compiling
+// the plan from schema and executing it locally. This simulates what the real
+// localDispatcher will do in Phase 4.
+type localQueryPlanDispatcher struct {
+	handle *dispatchQueryPlanHandle
+}
+
+func (d *localQueryPlanDispatcher) DispatchCheck(_ context.Context, _ *v1.DispatchCheckRequest) (*v1.DispatchCheckResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (d *localQueryPlanDispatcher) DispatchExpand(_ context.Context, _ *v1.DispatchExpandRequest) (*v1.DispatchExpandResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (d *localQueryPlanDispatcher) DispatchLookupResources2(_ *v1.DispatchLookupResources2Request, _ dispatch.LookupResources2Stream) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (d *localQueryPlanDispatcher) DispatchLookupResources3(_ *v1.DispatchLookupResources3Request, _ dispatch.LookupResources3Stream) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (d *localQueryPlanDispatcher) DispatchLookupSubjects(_ *v1.DispatchLookupSubjectsRequest, _ dispatch.LookupSubjectsStream) error {
+	return fmt.Errorf("not implemented")
+}
+func (d *localQueryPlanDispatcher) Close() error { return nil }
+func (d *localQueryPlanDispatcher) ReadyState() dispatch.ReadyState {
+	return dispatch.ReadyState{IsReady: true}
+}
+
+func (d *localQueryPlanDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
+	ctx := stream.Context()
+
+	// Find the iterator for this canonical key by compiling the full plan.
+	// In the real implementation, this would be cached.
+	it, err := d.findIterator(req)
+	if err != nil {
+		return err
+	}
+
+	// Build execution context with DispatchExecutor so nested aliases in the subtree
+	// can re-dispatch to other nodes (multi-hop chains).
+	//
+	// We call it.CheckImpl / it.IterSubjectsImpl / it.IterResourcesImpl directly
+	// (not qctx.Check) because the dispatch boundary has already been crossed.
+	// Calling qctx.Check would route back through the executor, which would see the
+	// alias and dispatch again — infinite loop. By entering the iterator's Impl method
+	// directly, we execute the alias's own logic (relation rewriting, self-edge checks)
+	// while letting anything underneath go through the executor normally.
+	planCtx := req.PlanContext
+	lpd := &localQueryPlanDispatcher{handle: d.handle}
+	executor := dispatch.NewDispatchExecutor(lpd, planCtx)
+
+	qctx := &query.Context{
+		Context:       ctx,
+		Executor:      executor,
+		Reader:        query.NewQueryDatastoreReader(datalayer.NewDataLayer(d.handle.ds).SnapshotReader(d.handle.revision)),
+		CaveatRunner:  caveats.NewCaveatRunner(caveattypes.Default.TypeSet),
+		CaveatContext: dispatch.CaveatContextFromPlanContext(planCtx),
+	}
+
+	resource := query.Object{ObjectType: req.Resource.Namespace, ObjectID: req.Resource.ObjectId}
+	subject := query.ObjectAndRelation{
+		ObjectType: req.Subject.Namespace,
+		ObjectID:   req.Subject.ObjectId,
+		Relation:   req.Subject.Relation,
+	}
+
+	switch req.Operation {
+	case v1.PlanOperation_PLAN_OPERATION_CHECK:
+		path, err := it.CheckImpl(qctx, resource, subject)
+		if err != nil {
+			return err
+		}
+		if path != nil {
+			return stream.Publish(&v1.DispatchQueryPlanResponse{
+				Paths: []*v1.ResultPath{dispatch.QueryPathToResultPath(path)},
+			})
+		}
+		return nil
+
+	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES:
+		pathSeq, err := it.IterResourcesImpl(qctx, subject, query.NoObjectFilter())
+		if err != nil {
+			return err
+		}
+		for path, err := range pathSeq {
+			if err != nil {
+				return err
+			}
+			if err := stream.Publish(&v1.DispatchQueryPlanResponse{
+				Paths: []*v1.ResultPath{dispatch.QueryPathToResultPath(path)},
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS:
+		pathSeq, err := it.IterSubjectsImpl(qctx, resource, query.NoObjectFilter())
+		if err != nil {
+			return err
+		}
+		for path, err := range pathSeq {
+			if err != nil {
+				return err
+			}
+			if err := stream.Publish(&v1.DispatchQueryPlanResponse{
+				Paths: []*v1.ResultPath{dispatch.QueryPathToResultPath(path)},
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unknown plan operation: %v", req.Operation)
+	}
+}
+
+// findIterator compiles the full plan from schema and walks the iterator tree
+// to find the subtree matching the requested canonical key.
+func (d *localQueryPlanDispatcher) findIterator(req *v1.DispatchQueryPlanRequest) (query.Iterator, error) {
+	// Compile all permissions in the schema and search for the matching canonical key.
+	// In a real implementation this would use a cached plan.
+	targetKey := query.CanonicalKey(req.CanonicalKey)
+	for nsName, def := range d.handle.schema.Definitions() {
+		for permName := range def.Permissions() {
+			co, err := query.BuildOutlineFromSchema(d.handle.schema, nsName, permName)
+			if err != nil {
+				continue
+			}
+			it, err := co.Compile()
+			if err != nil {
+				continue
+			}
+			if found := findByCanonicalKey(it, targetKey); found != nil {
+				return found, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no iterator found for canonical key %q", req.CanonicalKey)
+}
+
+// findByCanonicalKey recursively searches an iterator tree for a node with the given key.
+func findByCanonicalKey(it query.Iterator, key query.CanonicalKey) query.Iterator {
+	if it.CanonicalKey() == key {
+		return it
+	}
+	for _, sub := range it.Subiterators() {
+		if found := findByCanonicalKey(sub, key); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// --- Benchmarks ---
+
+func BenchmarkDispatchQueryPlanCheck(b *testing.B) {
+	tests := []struct {
+		name                                    string
+		file                                    string
+		resourceType, resourceID, permission    string
+		subjectType, subjectID, subjectRelation string
+	}{
+		{
+			name:            "basic_rbac",
+			file:            "testconfigs/basicrbac.yaml",
+			resourceType:    "example/document",
+			resourceID:      "firstdoc",
+			permission:      "view",
+			subjectType:     "example/user",
+			subjectID:       "tom",
+			subjectRelation: tuple.Ellipsis,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			handle := newDispatchQueryPlanHandle(b, tt.file)
+			it := handle.compileIterator(b, tt.resourceType, tt.permission, tt.subjectType, tt.subjectRelation)
+
+			resource := query.Object{ObjectType: tt.resourceType, ObjectID: tt.resourceID}
+			subject := query.ObjectAndRelation{ObjectType: tt.subjectType, ObjectID: tt.subjectID, Relation: tt.subjectRelation}
+
+			b.Run("local_executor", func(b *testing.B) {
+				for b.Loop() {
+					qctx := handle.newLocalContext(b.Context())
+					path, err := qctx.Check(it.Clone(), resource, subject)
+					require.NoError(b, err)
+					require.NotNil(b, path)
+				}
+			})
+
+			b.Run("dispatch_executor", func(b *testing.B) {
+				for b.Loop() {
+					qctx := handle.newDispatchContext(b.Context())
+					path, err := qctx.Check(it.Clone(), resource, subject)
+					require.NoError(b, err)
+					require.NotNil(b, path)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkDispatchQueryPlanLookupResources(b *testing.B) {
+	tests := []struct {
+		name                                    string
+		file                                    string
+		resourceType, permission                string
+		subjectType, subjectID, subjectRelation string
+		expectedResults                         int
+	}{
+		{
+			name:            "basic_rbac",
+			file:            "testconfigs/basicrbac.yaml",
+			resourceType:    "example/document",
+			permission:      "view",
+			subjectType:     "example/user",
+			subjectID:       "tom",
+			subjectRelation: tuple.Ellipsis,
+			// tom is writer on firstdoc and reader on seconddoc → 2 documents with view.
+			expectedResults: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			handle := newDispatchQueryPlanHandle(b, tt.file)
+			it := handle.compileIterator(b, tt.resourceType, tt.permission, tt.subjectType, tt.subjectRelation)
+
+			subject := query.ObjectAndRelation{ObjectType: tt.subjectType, ObjectID: tt.subjectID, Relation: tt.subjectRelation}
+
+			b.Run("local_executor", func(b *testing.B) {
+				for b.Loop() {
+					qctx := handle.newLocalContext(b.Context())
+					pathSeq, err := qctx.IterResources(it.Clone(), subject, query.NoObjectFilter())
+					require.NoError(b, err)
+
+					paths, err := query.CollectAll(pathSeq)
+					require.NoError(b, err)
+					require.Len(b, paths, tt.expectedResults)
+				}
+			})
+
+			b.Run("dispatch_executor", func(b *testing.B) {
+				for b.Loop() {
+					qctx := handle.newDispatchContext(b.Context())
+					pathSeq, err := qctx.IterResources(it.Clone(), subject, query.NoObjectFilter())
+					require.NoError(b, err)
+
+					paths, err := query.CollectAll(pathSeq)
+					require.NoError(b, err)
+					require.Len(b, paths, tt.expectedResults)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkDispatchQueryPlanLookupSubjects(b *testing.B) {
+	tests := []struct {
+		name                                 string
+		file                                 string
+		resourceType, resourceID, permission string
+		subjectType, subjectRelation         string
+		expectedResults                      int
+	}{
+		{
+			name:            "basic_rbac",
+			file:            "testconfigs/basicrbac.yaml",
+			resourceType:    "example/document",
+			resourceID:      "firstdoc",
+			permission:      "view",
+			subjectType:     "example/user",
+			subjectRelation: tuple.Ellipsis,
+			// tom is writer on firstdoc, fred is reader on firstdoc → 2 subjects with view.
+			expectedResults: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			handle := newDispatchQueryPlanHandle(b, tt.file)
+			it := handle.compileIterator(b, tt.resourceType, tt.permission, tt.subjectType, tt.subjectRelation)
+
+			resource := query.Object{ObjectType: tt.resourceType, ObjectID: tt.resourceID}
+
+			b.Run("local_executor", func(b *testing.B) {
+				for b.Loop() {
+					qctx := handle.newLocalContext(b.Context())
+					pathSeq, err := qctx.IterSubjects(it.Clone(), resource, query.NoObjectFilter())
+					require.NoError(b, err)
+
+					paths, err := query.CollectAll(pathSeq)
+					require.NoError(b, err)
+					require.Len(b, paths, tt.expectedResults)
+				}
+			})
+
+			b.Run("dispatch_executor", func(b *testing.B) {
+				for b.Loop() {
+					qctx := handle.newDispatchContext(b.Context())
+					pathSeq, err := qctx.IterSubjects(it.Clone(), resource, query.NoObjectFilter())
+					require.NoError(b, err)
+
+					paths, err := query.CollectAll(pathSeq)
+					require.NoError(b, err)
+					require.Len(b, paths, tt.expectedResults)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

Implement a DispatchExecutor inside of the dispatch package. It is an implementation of the query.Executor interface targeted at running subproblems of a query plan through dispatch (using the new DispatchQueryPlan api). In this initial implementation, it only dispatches at Alias boundaries.

## Testing

Benchmarks and testing included