### PR TITLE
fix: do not dispatch within a recursive context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add DispatchExecutor, a query plan executor that is Dispatch-aware and sends subproblems on Alias boundaries (https://github.com/authzed/spicedb/pull/3074)
 
+### Fixed
+- Query plan contexts are written to during recursive calls -- for now, disble dispatch inside recursive calls (https://github.com/authzed/spicedb/pull/3078)
+
 ## [1.52.0] - 2026-04-30
 ### Added
 - Added support for YAML-based validation files in DevContext (https://github.com/authzed/spicedb/pull/3024)

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -21,21 +21,47 @@ type DispatchExecutor struct {
 
 var _ query.Executor = &DispatchExecutor{}
 
-// containsRecursiveSentinel checks if the iterator tree contains a RecursiveSentinelIterator
-// that is NOT already managed by a RecursiveIterator boundary.
-// A sentinel inside a RecursiveIterator is safe to dispatch — the RecursiveIterator
-// manages its own collection context. We only block dispatch when a sentinel is exposed
-// at the top level (outside any RecursiveIterator).
-func containsRecursiveSentinel(it query.Iterator) bool {
-	if _, ok := it.(*query.RecursiveSentinelIterator); ok {
-		return true
+// recursiveKey uniquely identifies a recursion pair by definition and relation name.
+type recursiveKey struct {
+	definitionName string
+	relationName   string
+}
+
+// containsUnmatchedRecursiveSentinel walks the entire iterator tree and checks whether
+// there is a RecursiveSentinelIterator whose (definitionName, relationName) pair has no
+// matching RecursiveIterator anywhere in the tree. A sentinel is "managed" (safe to
+// dispatch) only when a RecursiveIterator with the same key exists to handle its
+// collection context. This handles the double-recursion case where a RecursiveIterator
+// for one recursion pair contains a sentinel for a different pair in its subtree.
+func containsUnmatchedRecursiveSentinel(it query.Iterator) bool {
+	// Collect all keys from RecursiveIterator and RecursiveSentinelIterator nodes.
+	var iteratorKeys map[recursiveKey]struct{}
+	var sentinelKeys map[recursiveKey]struct{}
+
+	var walk func(query.Iterator)
+	walk = func(sub query.Iterator) {
+		if ri, ok := sub.(*query.RecursiveIterator); ok {
+			if iteratorKeys == nil {
+				iteratorKeys = make(map[recursiveKey]struct{})
+			}
+			iteratorKeys[recursiveKey{ri.DefinitionName(), ri.RelationName()}] = struct{}{}
+		}
+		if si, ok := sub.(*query.RecursiveSentinelIterator); ok {
+			if sentinelKeys == nil {
+				sentinelKeys = make(map[recursiveKey]struct{})
+			}
+			sentinelKeys[recursiveKey{si.DefinitionName(), si.RelationName()}] = struct{}{}
+		}
+		for _, child := range sub.Subiterators() {
+			walk(child)
+		}
 	}
-	// A RecursiveIterator is a boundary — sentinels inside are managed by its context.
-	if _, ok := it.(*query.RecursiveIterator); ok {
-		return false
-	}
-	for _, sub := range it.Subiterators() {
-		if containsRecursiveSentinel(sub) {
+	walk(it)
+
+	// Every sentinel must have a matching iterator; an unmatched sentinel means
+	// its collection context won't be established and dispatch would break.
+	for key := range sentinelKeys {
+		if _, managed := iteratorKeys[key]; !managed {
 			return true
 		}
 	}
@@ -52,14 +78,14 @@ func NewDispatchExecutor(dispatcher Dispatcher, planContext *v1.PlanContext) *Di
 }
 
 func (e *DispatchExecutor) Check(ctx *query.Context, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) (*query.Path, error) {
-	if _, ok := it.(*query.AliasIterator); ok && !containsRecursiveSentinel(it) {
+	if _, ok := it.(*query.AliasIterator); ok && !containsUnmatchedRecursiveSentinel(it) {
 		return e.dispatchCheck(ctx, it, resource, subject)
 	}
 	return it.CheckImpl(ctx, resource, subject)
 }
 
 func (e *DispatchExecutor) IterSubjects(ctx *query.Context, it query.Iterator, resource query.Object, filterSubjectType query.ObjectType) (query.PathSeq, error) {
-	if _, ok := it.(*query.AliasIterator); ok && !containsRecursiveSentinel(it) {
+	if _, ok := it.(*query.AliasIterator); ok && !containsUnmatchedRecursiveSentinel(it) {
 		return e.dispatchIterSubjects(ctx, it, resource, filterSubjectType)
 	}
 	pathSeq, err := it.IterSubjectsImpl(ctx, resource, filterSubjectType)
@@ -70,7 +96,7 @@ func (e *DispatchExecutor) IterSubjects(ctx *query.Context, it query.Iterator, r
 }
 
 func (e *DispatchExecutor) IterResources(ctx *query.Context, it query.Iterator, subject query.ObjectAndRelation, filterResourceType query.ObjectType) (query.PathSeq, error) {
-	if _, ok := it.(*query.AliasIterator); ok && !containsRecursiveSentinel(it) {
+	if _, ok := it.(*query.AliasIterator); ok && !containsUnmatchedRecursiveSentinel(it) {
 		return e.dispatchIterResources(ctx, it, subject, filterResourceType)
 	}
 	pathSeq, err := it.IterResourcesImpl(ctx, subject, filterResourceType)

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -21,6 +21,27 @@ type DispatchExecutor struct {
 
 var _ query.Executor = &DispatchExecutor{}
 
+// containsRecursiveSentinel checks if the iterator tree contains a RecursiveSentinelIterator
+// that is NOT already managed by a RecursiveIterator boundary.
+// A sentinel inside a RecursiveIterator is safe to dispatch — the RecursiveIterator
+// manages its own collection context. We only block dispatch when a sentinel is exposed
+// at the top level (outside any RecursiveIterator).
+func containsRecursiveSentinel(it query.Iterator) bool {
+	if _, ok := it.(*query.RecursiveSentinelIterator); ok {
+		return true
+	}
+	// A RecursiveIterator is a boundary — sentinels inside are managed by its context.
+	if _, ok := it.(*query.RecursiveIterator); ok {
+		return false
+	}
+	for _, sub := range it.Subiterators() {
+		if containsRecursiveSentinel(sub) {
+			return true
+		}
+	}
+	return false
+}
+
 // NewDispatchExecutor creates a new DispatchExecutor that dispatches alias
 // iterator operations through the given Dispatcher chain.
 func NewDispatchExecutor(dispatcher Dispatcher, planContext *v1.PlanContext) *DispatchExecutor {
@@ -31,14 +52,14 @@ func NewDispatchExecutor(dispatcher Dispatcher, planContext *v1.PlanContext) *Di
 }
 
 func (e *DispatchExecutor) Check(ctx *query.Context, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) (*query.Path, error) {
-	if _, ok := it.(*query.AliasIterator); ok {
+	if _, ok := it.(*query.AliasIterator); ok && !containsRecursiveSentinel(it) {
 		return e.dispatchCheck(ctx, it, resource, subject)
 	}
 	return it.CheckImpl(ctx, resource, subject)
 }
 
 func (e *DispatchExecutor) IterSubjects(ctx *query.Context, it query.Iterator, resource query.Object, filterSubjectType query.ObjectType) (query.PathSeq, error) {
-	if _, ok := it.(*query.AliasIterator); ok {
+	if _, ok := it.(*query.AliasIterator); ok && !containsRecursiveSentinel(it) {
 		return e.dispatchIterSubjects(ctx, it, resource, filterSubjectType)
 	}
 	pathSeq, err := it.IterSubjectsImpl(ctx, resource, filterSubjectType)
@@ -49,7 +70,7 @@ func (e *DispatchExecutor) IterSubjects(ctx *query.Context, it query.Iterator, r
 }
 
 func (e *DispatchExecutor) IterResources(ctx *query.Context, it query.Iterator, subject query.ObjectAndRelation, filterResourceType query.ObjectType) (query.PathSeq, error) {
-	if _, ok := it.(*query.AliasIterator); ok {
+	if _, ok := it.(*query.AliasIterator); ok && !containsRecursiveSentinel(it) {
 		return e.dispatchIterResources(ctx, it, subject, filterResourceType)
 	}
 	pathSeq, err := it.IterResourcesImpl(ctx, subject, filterResourceType)

--- a/internal/dispatch/executor_test.go
+++ b/internal/dispatch/executor_test.go
@@ -243,6 +243,157 @@ func TestDispatchExecutor_IterResources_NonAliasLocal(t *testing.T) {
 	require.Empty(t, td.planCalls)
 }
 
+func TestDispatchExecutor_Check_AliasWithRecursiveSentinelDoesNotDispatch(t *testing.T) {
+	td := &testDispatcher{}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	// AliasIterator wrapping a RecursiveSentinel — should NOT dispatch
+	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
+	alias := query.NewAliasIterator("viewer", sentinel)
+
+	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	require.NoError(t, err)
+	// RecursiveSentinel.CheckImpl returns nil
+	require.Nil(t, path)
+
+	// Verify NO dispatch was called
+	require.Empty(t, td.planCalls)
+}
+
+func TestDispatchExecutor_IterSubjects_AliasWithRecursiveSentinelDoesNotDispatch(t *testing.T) {
+	td := &testDispatcher{}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
+	alias := query.NewAliasIterator("viewer", sentinel)
+
+	pathSeq, err := exec.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	require.NoError(t, err)
+
+	paths, err := query.CollectAll(pathSeq)
+	require.NoError(t, err)
+	require.Empty(t, paths)
+	require.Empty(t, td.planCalls)
+}
+
+func TestDispatchExecutor_IterResources_AliasWithRecursiveSentinelDoesNotDispatch(t *testing.T) {
+	td := &testDispatcher{}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
+	alias := query.NewAliasIterator("viewer", sentinel)
+
+	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	require.NoError(t, err)
+
+	paths, err := query.CollectAll(pathSeq)
+	require.NoError(t, err)
+	require.Empty(t, paths)
+	require.Empty(t, td.planCalls)
+}
+
+func TestDispatchExecutor_Check_AliasWithSentinelInsideRecursiveDispatches(t *testing.T) {
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{
+			Paths: []*v1.ResultPath{{
+				ResourceType:    "document",
+				ResourceId:      "doc1",
+				Relation:        "viewer",
+				SubjectType:     "user",
+				SubjectId:       "alice",
+				SubjectRelation: "...",
+			}},
+		}},
+	}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	// AliasIterator wrapping a RecursiveIterator that contains a RecursiveSentinel.
+	// The sentinel is managed by the RecursiveIterator's context, so dispatch is allowed.
+	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
+	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
+	alias := query.NewAliasIterator("viewer", recursive)
+
+	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	require.NoError(t, err)
+	require.NotNil(t, path)
+	require.Equal(t, "alice", path.Subject.ObjectID)
+
+	// Verify dispatch WAS called — the RecursiveIterator boundary makes it safe
+	require.Len(t, td.planCalls, 1)
+}
+
+func TestDispatchExecutor_IterSubjects_AliasWithSentinelInsideRecursiveDispatches(t *testing.T) {
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{
+			Paths: []*v1.ResultPath{{
+				ResourceType:    "document",
+				ResourceId:      "doc1",
+				Relation:        "viewer",
+				SubjectType:     "user",
+				SubjectId:       "alice",
+				SubjectRelation: "...",
+			}},
+		}},
+	}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
+	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
+	alias := query.NewAliasIterator("viewer", recursive)
+
+	pathSeq, err := exec.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	require.NoError(t, err)
+
+	paths, err := query.CollectAll(pathSeq)
+	require.NoError(t, err)
+	require.Len(t, paths, 1)
+	require.Equal(t, "alice", paths[0].Subject.ObjectID)
+
+	require.Len(t, td.planCalls, 1)
+}
+
+func TestDispatchExecutor_IterResources_AliasWithSentinelInsideRecursiveDispatches(t *testing.T) {
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{
+			Paths: []*v1.ResultPath{{
+				ResourceType:    "document",
+				ResourceId:      "doc1",
+				Relation:        "viewer",
+				SubjectType:     "user",
+				SubjectId:       "alice",
+				SubjectRelation: "...",
+			}},
+		}},
+	}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
+	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
+	alias := query.NewAliasIterator("viewer", recursive)
+
+	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	require.NoError(t, err)
+
+	paths, err := query.CollectAll(pathSeq)
+	require.NoError(t, err)
+	require.Len(t, paths, 1)
+	require.Equal(t, "doc1", paths[0].Resource.ObjectID)
+
+	require.Len(t, td.planCalls, 1)
+}
+
 func TestDispatchExecutor_StreamBatching(t *testing.T) {
 	// Multiple streamed responses should be collected correctly
 	td := &testDispatcher{

--- a/internal/dispatch/executor_test.go
+++ b/internal/dispatch/executor_test.go
@@ -394,6 +394,64 @@ func TestDispatchExecutor_IterResources_AliasWithSentinelInsideRecursiveDispatch
 	require.Len(t, td.planCalls, 1)
 }
 
+func TestDispatchExecutor_Check_DoubleRecursionUnmatchedSentinelDoesNotDispatch(t *testing.T) {
+	td := &testDispatcher{}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	// Double recursion: RecursiveIterator for "folder#viewer" contains a
+	// RecursiveSentinelIterator for "document#reader" in its subtree.
+	// The document#reader sentinel is unmatched (no RecursiveIterator for it),
+	// so dispatch should be blocked.
+	documentSentinel := query.NewRecursiveSentinelIterator("document", "reader", false)
+	folderRecursive := query.NewRecursiveIterator(documentSentinel, "folder", "viewer",
+	)
+	alias := query.NewAliasIterator("viewer", folderRecursive)
+
+	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	require.NoError(t, err)
+	require.Nil(t, path)
+
+	// Verify NO dispatch was called — unmatched sentinel blocks dispatch
+	require.Empty(t, td.planCalls)
+}
+
+func TestDispatchExecutor_Check_DoubleRecursionBothMatchedDispatches(t *testing.T) {
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{
+			Paths: []*v1.ResultPath{{
+				ResourceType:    "folder",
+				ResourceId:      "f1",
+				Relation:        "viewer",
+				SubjectType:     "user",
+				SubjectId:       "alice",
+				SubjectRelation: "...",
+			}},
+		}},
+	}
+
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	ctx := newTestContext()
+
+	// Double recursion with both pairs matched:
+	// RecursiveIterator(folder#viewer) contains RecursiveIterator(document#reader)
+	// which contains RecursiveSentinelIterator(document#reader).
+	// All sentinels have a matching iterator, so dispatch is allowed.
+	documentSentinel := query.NewRecursiveSentinelIterator("document", "reader", false)
+	documentRecursive := query.NewRecursiveIterator(documentSentinel, "document", "reader")
+	folderRecursive := query.NewRecursiveIterator(documentRecursive, "folder", "viewer")
+	alias := query.NewAliasIterator("viewer", folderRecursive)
+
+	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	require.NoError(t, err)
+	require.NotNil(t, path)
+	require.Equal(t, "alice", path.Subject.ObjectID)
+
+	// Verify dispatch WAS called — all sentinels are matched
+	require.Len(t, td.planCalls, 1)
+}
+
 func TestDispatchExecutor_StreamBatching(t *testing.T) {
 	// Multiple streamed responses should be collected correctly
 	td := &testDispatcher{

--- a/internal/dispatch/executor_test.go
+++ b/internal/dispatch/executor_test.go
@@ -405,8 +405,7 @@ func TestDispatchExecutor_Check_DoubleRecursionUnmatchedSentinelDoesNotDispatch(
 	// The document#reader sentinel is unmatched (no RecursiveIterator for it),
 	// so dispatch should be blocked.
 	documentSentinel := query.NewRecursiveSentinelIterator("document", "reader", false)
-	folderRecursive := query.NewRecursiveIterator(documentSentinel, "folder", "viewer",
-	)
+	folderRecursive := query.NewRecursiveIterator(documentSentinel, "folder", "viewer")
 	alias := query.NewAliasIterator("viewer", folderRecursive)
 
 	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})

--- a/pkg/query/recursive.go
+++ b/pkg/query/recursive.go
@@ -56,6 +56,16 @@ func NewRecursiveIterator(templateTree Iterator, definitionName, relationName st
 	}
 }
 
+// DefinitionName returns the definition name this iterator is recursing on
+func (r *RecursiveIterator) DefinitionName() string {
+	return r.definitionName
+}
+
+// RelationName returns the relation name this iterator is recursing on
+func (r *RecursiveIterator) RelationName() string {
+	return r.relationName
+}
+
 // findMatchingSentinels walks the template tree and returns canonical key hashes of sentinels that match
 // this RecursiveIterator's definition and relation (but stops at nested RecursiveIterators).
 func (r *RecursiveIterator) findMatchingSentinels() []uint64 {


### PR DESCRIPTION
## Description

Since we use the RecursiveSentinel to collect the frontier of the recursive transitive closure, we'd need a way to communicate that across dispatch boundaries. This would require some deeper planning, perhaps another dispatch message, but in the short term, it's correct to simply not dispatch if the branch we're in contains a lone RecursiveSentinel (meaning we're inside a recursive iterator)
