### PR TITLE
build: strip quarantine attribute for macos

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -103,6 +103,15 @@ homebrew_casks:
       email: "infrastructure@authzed.com"
     commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
     skip_upload: "auto"
+    # Our release binaries are not notarized, so macOS Gatekeeper quarantines
+    # them on download and refuses to run them ("Apple could not verify spicedb
+    # is free of malware"). Strip the quarantine attribute on install.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/spicedb"]
+          end
 dockers_v2:
   # Standard images
   - id: "standard"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add DispatchExecutor, a query plan executor that is Dispatch-aware and sends subproblems on Alias boundaries (https://github.com/authzed/spicedb/pull/3074)
 
+### Changed
+- Build: strip quarantine attribute for MacOS (https://github.com/authzed/spicedb/pull/3082)
+
 ### Fixed
 - Query plan contexts are written to during recursive calls -- for now, disble dispatch inside recursive calls (https://github.com/authzed/spicedb/pull/3078)
 


### PR DESCRIPTION
## Description

Starting with v1.52.0, SpiceDB ships to Homebrew as a cask instead of a formula (changed in #3042 as part of the GoReleaser deprecation migration off `brews:`). Casks behave differently from formulas in one critical way for unsigned binaries:

  - `brew install <formula>` downloads via curl, which does not set `com.apple.quarantine`. macOS Gatekeeper never inspects the binary, so unsigned binaries run without complaint.
  - `brew install --cask <cask>` deliberately sets `com.apple.quarantine` on the downloaded artifact. Gatekeeper then inspects it on first run, and because our release binaries aren't signed or notarized, it refuses to launch them with:

<img width="260" height="268" alt="image" src="https://github.com/user-attachments/assets/cd070995-6c72-4b81-b9d0-11d5aaf70023" />

  The binary itself is unchanged; only the install path is different. v1.52.0 macOS users currently can't run `spicedb` at all after `brew install/brew upgrade`.

  Signing and notarizing the release binaries is the right long-term fix, but it requires Apple Developer Program enrollment + cert provisioning. That's a separate, larger piece of work. 

The strip-quarantine hook I'm adding is documented by GoReleaser as the recommended workaround for unsigned binaries (see here https://goreleaser.com/resources/deprecations/#brews)