### PR TITLE
test: prevent flaky TestCertWatcher

### DIFF
--- a/pkg/cmd/util/util.go
+++ b/pkg/cmd/util/util.go
@@ -225,10 +225,12 @@ type completedGRPCServer struct {
 func (c *completedGRPCServer) Listen(ctx context.Context) error {
 	if c.certWatcher != nil {
 		go func() {
-			if err := c.certWatcher.Start(ctx); err != nil {
-				log.Ctx(ctx).Error().Err(err).Msg("error watching tls certs")
-			}
+			c.certWatcher.Start(ctx)
 		}()
+		err := <-c.certWatcher.Started()
+		if err != nil {
+			return err
+		}
 	}
 	return c.srv.Serve(c.listener)
 }

--- a/pkg/x509util/certwatcher.go
+++ b/pkg/x509util/certwatcher.go
@@ -58,6 +58,11 @@ type CertWatcher struct {
 	keyPath           string
 	cachedKeyPEMBlock []byte
 
+	// started is closed once Start() has registered fsnotify watches for
+	// both files. Callers can block on Started() before mutating the watched
+	// paths to avoid racing the Start goroutine.
+	started chan error
+
 	// callback is a function to be invoked when the certificate changes.
 	callback func(tls.Certificate)
 
@@ -76,6 +81,7 @@ func NewTLSCertWatcher(certPath, keyPath string) (*CertWatcher, error) {
 		certPath:              certPath,
 		keyPath:               keyPath,
 		interval:              defaultWatchInterval,
+		started:               make(chan error),
 		ReadCertificateTotal:  ReadTotal,
 		ReadCertificateErrors: ReadErrors,
 	}
@@ -129,17 +135,29 @@ func (cw *CertWatcher) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate,
 	return cw.currentCert, nil
 }
 
+// Started returns a channel that is closed when Start() has finished
+// registering the fsnotify watches for the certificate and key files.
+// Callers that need to mutate the watched files should block on this
+// channel after calling Start() in a goroutine to avoid races.
+func (cw *CertWatcher) Started() <-chan error {
+	return cw.started
+}
+
 // Start starts the watch on the certificate and key files.
+// Any startup errors will be sent through the Started() channel.
 // When Start returns, it unregisters the prometheus metrics that were registered
 // in NewTLSCertWatcher.
-func (cw *CertWatcher) Start(ctx context.Context) error {
+func (cw *CertWatcher) Start(ctx context.Context) {
 	defer cw.unregisterMetrics()
 
 	for _, f := range []string{cw.certPath, cw.keyPath} {
 		if err := cw.watcher.Add(f); err != nil {
-			return fmt.Errorf("failed to add watch for %s: %w", f, err)
+			cw.started <- fmt.Errorf("failed to add watch for %s: %w", f, err)
+			close(cw.started)
+			return
 		}
 	}
+	close(cw.started)
 
 	go cw.Watch()
 
@@ -150,7 +168,8 @@ func (cw *CertWatcher) Start(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return cw.watcher.Close()
+			_ = cw.watcher.Close()
+			return
 		case <-ticker.C:
 			if err := cw.ReadCertificate(); err != nil {
 				log.Err(err).Msg("failed to read certificate")

--- a/pkg/x509util/certwatcher_test.go
+++ b/pkg/x509util/certwatcher_test.go
@@ -57,7 +57,7 @@ func TestCertWatcherSequentialMetricRegistration(t *testing.T) {
 	require.NoError(t, err)
 
 	go func() {
-		_ = watcher1.Start(ctx1)
+		watcher1.Start(ctx1)
 	}()
 	cancel1()
 
@@ -67,7 +67,7 @@ func TestCertWatcherSequentialMetricRegistration(t *testing.T) {
 	require.NoError(t, err)
 
 	go func() {
-		_ = watcher2.Start(ctx2)
+		watcher2.Start(ctx2)
 	}()
 	cancel2()
 }
@@ -91,8 +91,10 @@ func setupWatcher(t *testing.T, ip string) (certPath, keyPath string, watcher *C
 
 	startWatcher = func(interval time.Duration) {
 		go func() {
-			_ = watcher.WithWatchInterval(interval).Start(t.Context())
+			watcher.WithWatchInterval(interval).Start(t.Context())
 		}()
+		err := <-watcher.Started()
+		assert.NoError(t, err)
 		assert.NoError(t, watcher.ReadCertificate())
 	}
 


### PR DESCRIPTION
## Description

```
--- FAIL: TestCertWatcherStart (12.99s)
    --- FAIL: TestCertWatcherStart/should_reload_currentCert_after_move_out (10.31s)
        certwatcher_test.go:182: 
            	Error Trace:	/home/runner/work/spicedb/spicedb/pkg/x509util/certwatcher_test.go:189
            	            				/opt/hostedtoolcache/go/1.26.2/arm64/src/runtime/asm_arm64.s:1447
            	Error:      	Should be false
            	Messages:   	first and second privatekeys should not be equal
        certwatcher_test.go:182: 
            	Error Trace:	/home/runner/work/spicedb/spicedb/pkg/x509util/certwatcher_test.go:190
            	            				/opt/hostedtoolcache/go/1.26.2/arm64/src/runtime/asm_arm64.s:1447
            	Error:      	Should not be zero, but was 0
            	Messages:   	the serial numbers should compare as different
        certwatcher_test.go:182: 
            	Error Trace:	/home/runner/work/spicedb/spicedb/pkg/x509util/certwatcher_test.go:182
            	Error:      	Condition never satisfied
            	Test:       	TestCertWatcherStart/should_reload_currentCert_after_move_out
FAIL
```

`setupWatcher` launched `Start()` in a goroutine and immediately let the test mutate the watched files. Under CPU contention, the `Start` goroutine could be delayed past the test's   `os.Rename(certPath, …) call `. So when `Start` finally ran `cw.watcher.Add(certPath)`, the file no longer existed at that path, `Add` returned ENOENT, and `Start` exited. The polling ticker  was never created, the cert was never reloaded, and `EventuallyWithT` timed out.

The bug was not in the certwatcher's reload logic — it was in the test's failure to wait for the watcher to be ready before changing the files it was supposed to watch. The `Start()` error was also being swallowed (`_ = ...`), which hid the real cause.

## Testing

```
[17:23:49] ~/Documents/GitHub/spicedb (flakiness-certwatcher-2) $ go test -c -race ./pkg/x509util/
[17:27:25] ~/Documents/GitHub/spicedb (flakiness-certwatcher-2) $ stress ./x509util.test -test.run TestCertWatcherStart/should_reload_currentCert_after_move_out
5s: 30 runs so far, 0 failures, 16 active
10s: 64 runs so far, 0 failures, 16 active
15s: 96 runs so far, 0 failures, 16 active
20s: 134 runs so far, 0 failures, 16 active
25s: 176 runs so far, 0 failures, 16 active
```