### PR TITLE
fix: add benchmark fixes after schema cache, applying optimizations

### DIFF
--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -26,6 +26,7 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/query"
+	"github.com/authzed/spicedb/pkg/query/queryopt"
 	"github.com/authzed/spicedb/pkg/schema/v2"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
@@ -499,7 +500,25 @@ func (ld *localDispatcher) DispatchQueryPlan(
 
 	// Load schema at the requested revision.
 	// TODO: use cached compiled plans (Phase 7) instead of recompiling each time.
-	it, err := ld.findIteratorByCanonicalKey(ctx, revision, schemaHash, query.CanonicalKey(req.CanonicalKey))
+
+	// Map PlanOperation to query.Operation for optimizer selection.
+	var operation query.Operation
+	switch req.Operation {
+	case v1.PlanOperation_PLAN_OPERATION_CHECK:
+		operation = query.OperationCheck
+	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES:
+		operation = query.OperationIterResources
+	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS:
+		operation = query.OperationIterSubjects
+	}
+
+	queryParams := queryopt.RequestParams{
+		Operation:       operation,
+		SubjectType:     req.Subject.Namespace,
+		SubjectRelation: req.Subject.Relation,
+	}
+
+	it, err := ld.findIteratorByCanonicalKey(ctx, revision, schemaHash, query.CanonicalKey(req.CanonicalKey), queryParams)
 	if err != nil {
 		return err
 	}
@@ -579,8 +598,9 @@ func (ld *localDispatcher) DispatchQueryPlan(
 }
 
 // findIteratorByCanonicalKey loads the schema at the given revision, compiles
-// all permissions, and returns the iterator subtree matching the canonical key.
-func (ld *localDispatcher) findIteratorByCanonicalKey(ctx context.Context, revision datastore.Revision, schemaHash datalayer.SchemaHash, targetKey query.CanonicalKey) (query.Iterator, error) {
+// all permissions with the given request parameters for optimization, and returns
+// the iterator subtree matching the canonical key.
+func (ld *localDispatcher) findIteratorByCanonicalKey(ctx context.Context, revision datastore.Revision, schemaHash datalayer.SchemaHash, targetKey query.CanonicalKey, queryParams queryopt.RequestParams) (query.Iterator, error) {
 	dl := datalayer.MustFromContext(ctx)
 	reader := dl.SnapshotReader(revision, schemaHash)
 
@@ -613,7 +633,13 @@ func (ld *localDispatcher) findIteratorByCanonicalKey(ctx context.Context, revis
 			if err != nil {
 				continue
 			}
-			it, err := co.Compile()
+
+			optimized, err := queryopt.ApplyOptimizations(co, queryopt.OptimizersForRequest(queryParams), queryParams)
+			if err != nil {
+				continue
+			}
+
+			it, err := optimized.Compile()
 			if err != nil {
 				continue
 			}

--- a/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
+++ b/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
@@ -63,21 +63,68 @@ func newDispatchQueryPlanHandle(b *testing.B, fileName string) *dispatchQueryPla
 	return &dispatchQueryPlanHandle{ds: ds, revision: rev, schema: fullSchema, schemaHash: schemaHash}
 }
 
-// compileIterator builds and compiles an iterator for the given resource type and permission.
-func (h *dispatchQueryPlanHandle) compileIterator(b *testing.B, resourceType, permission, subjectType, subjectRelation string) query.Iterator {
+// compileIterator builds, warms up, and compiles an iterator for the given
+// resource type and permission. It runs a warm-up pass with a CountObserver to
+// collect statistics, then applies a CountAdvisor to incorporate data-driven
+// hints (e.g., arrow direction reversal) before returning the final iterator.
+// The operation parameter determines which warm-up operation is used so the
+// CountAdvisor sees realistic fan-out ratios for the actual query type.
+// The resourceID and subjectID are used for the warm-up pass to exercise the
+// same data paths as the actual benchmark queries.
+func (h *dispatchQueryPlanHandle) compileIterator(b *testing.B, operation query.Operation, resourceType, resourceID, permission, subjectType, subjectID, subjectRelation string) query.Iterator {
 	b.Helper()
 	co, err := query.BuildOutlineFromSchema(h.schema, resourceType, permission)
 	require.NoError(b, err)
 
+	// Apply structural optimizations (reachability pruning, caveat pushdown, alias collapse).
 	queryParams := queryopt.RequestParams{
-		Operation:       query.OperationCheck,
+		Operation:       operation,
 		SubjectType:     subjectType,
 		SubjectRelation: subjectRelation,
 	}
 	optimized, err := queryopt.ApplyOptimizations(co, queryopt.OptimizersForRequest(queryParams), queryParams)
 	require.NoError(b, err)
 
-	it, err := optimized.Compile()
+	// Warm-up pass: run the iterator once with a CountObserver to
+	// collect per-node statistics for the CountAdvisor.
+	warmIt, err := optimized.Compile()
+	require.NoError(b, err)
+
+	obs := query.NewCountObserver()
+	warmCtx := query.NewLocalContext(b.Context(),
+		query.WithReader(query.NewQueryDatastoreReader(
+			datalayer.NewDataLayer(h.ds).SnapshotReader(h.revision, h.schemaHash),
+		)),
+		query.WithObserver(obs),
+		query.WithCaveatRunner(caveats.NewCaveatRunner(caveattypes.Default.TypeSet)),
+	)
+
+	resource := query.NewObject(resourceType, resourceID)
+	subject := query.NewObject(subjectType, subjectID).WithEllipses()
+
+	switch operation {
+	case query.OperationCheck:
+		_, err = warmCtx.Check(warmIt, resource, subject)
+		require.NoError(b, err)
+	case query.OperationIterResources:
+		seq, werr := warmCtx.IterResources(warmIt, subject, query.NoObjectFilter())
+		require.NoError(b, werr)
+		_, werr = query.CollectAll(seq)
+		require.NoError(b, werr)
+	case query.OperationIterSubjects:
+		seq, werr := warmCtx.IterSubjects(warmIt, resource, query.NoObjectFilter())
+		require.NoError(b, werr)
+		_, werr = query.CollectAll(seq)
+		require.NoError(b, werr)
+	}
+
+	// Apply the CountAdvisor to incorporate data-driven hints (e.g., arrow
+	// direction reversal) on top of the optimized canonical outline.
+	advisor := query.NewCountAdvisor(obs.GetStats())
+	advisedCO, err := query.ApplyAdvisor(optimized, advisor)
+	require.NoError(b, err)
+
+	it, err := advisedCO.Compile()
 	require.NoError(b, err)
 	return it
 }
@@ -265,16 +312,38 @@ func (d *localQueryPlanDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRe
 // findIterator compiles the full plan from schema and walks the iterator tree
 // to find the subtree matching the requested canonical key.
 func (d *localQueryPlanDispatcher) findIterator(req *v1.DispatchQueryPlanRequest) (query.Iterator, error) {
-	// Compile all permissions in the schema and search for the matching canonical key.
-	// In a real implementation this would use a cached plan.
 	targetKey := query.CanonicalKey(req.CanonicalKey)
+
+	// Map PlanOperation to query.Operation for optimizer selection.
+	var operation query.Operation
+	switch req.Operation {
+	case v1.PlanOperation_PLAN_OPERATION_CHECK:
+		operation = query.OperationCheck
+	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES:
+		operation = query.OperationIterResources
+	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS:
+		operation = query.OperationIterSubjects
+	}
+
+	queryParams := queryopt.RequestParams{
+		Operation:       operation,
+		SubjectType:     req.Subject.Namespace,
+		SubjectRelation: req.Subject.Relation,
+	}
+
 	for nsName, def := range d.handle.schema.Definitions() {
 		for permName := range def.Permissions() {
 			co, err := query.BuildOutlineFromSchema(d.handle.schema, nsName, permName)
 			if err != nil {
 				continue
 			}
-			it, err := co.Compile()
+
+			optimized, err := queryopt.ApplyOptimizations(co, queryopt.OptimizersForRequest(queryParams), queryParams)
+			if err != nil {
+				continue
+			}
+
+			it, err := optimized.Compile()
 			if err != nil {
 				continue
 			}
@@ -323,7 +392,7 @@ func BenchmarkDispatchQueryPlanCheck(b *testing.B) {
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
 			handle := newDispatchQueryPlanHandle(b, tt.file)
-			it := handle.compileIterator(b, tt.resourceType, tt.permission, tt.subjectType, tt.subjectRelation)
+			it := handle.compileIterator(b, query.OperationCheck, tt.resourceType, tt.resourceID, tt.permission, tt.subjectType, tt.subjectID, tt.subjectRelation)
 
 			resource := query.Object{ObjectType: tt.resourceType, ObjectID: tt.resourceID}
 			subject := query.ObjectAndRelation{ObjectType: tt.subjectType, ObjectID: tt.subjectID, Relation: tt.subjectRelation}
@@ -383,7 +452,7 @@ func BenchmarkDispatchQueryPlanLookupResources(b *testing.B) {
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
 			handle := newDispatchQueryPlanHandle(b, tt.file)
-			it := handle.compileIterator(b, tt.resourceType, tt.permission, tt.subjectType, tt.subjectRelation)
+			it := handle.compileIterator(b, query.OperationIterResources, tt.resourceType, "", tt.permission, tt.subjectType, tt.subjectID, tt.subjectRelation)
 
 			subject := query.ObjectAndRelation{ObjectType: tt.subjectType, ObjectID: tt.subjectID, Relation: tt.subjectRelation}
 
@@ -438,7 +507,7 @@ func BenchmarkDispatchQueryPlanLookupSubjects(b *testing.B) {
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
 			handle := newDispatchQueryPlanHandle(b, tt.file)
-			it := handle.compileIterator(b, tt.resourceType, tt.permission, tt.subjectType, tt.subjectRelation)
+			it := handle.compileIterator(b, query.OperationIterSubjects, tt.resourceType, tt.resourceID, tt.permission, tt.subjectType, "", tt.subjectRelation)
 
 			resource := query.Object{ObjectType: tt.resourceType, ObjectID: tt.resourceID}
 

--- a/internal/services/integrationtesting/benchmark_test.go
+++ b/internal/services/integrationtesting/benchmark_test.go
@@ -210,7 +210,7 @@ var allScenarios = []benchmarkScenario{
 				Relation:   "viewer",
 			}, tuple.ObjectAndRelation{
 				ObjectType: "user",
-				ObjectID:   "user181",
+				ObjectID:   "user214",
 				Relation:   tuple.Ellipsis,
 			}, revision, nil)
 			require.Equal(b, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, result)

--- a/pkg/benchmarks/double_wide_arrow.go
+++ b/pkg/benchmarks/double_wide_arrow.go
@@ -110,7 +110,7 @@ func setupDoubleWideArrow(ctx context.Context, ds datastore.Datastore) (*QuerySe
 				ResourceID:      "file0",
 				Permission:      "viewer",
 				SubjectType:     "user",
-				SubjectID:       "user181",
+				SubjectID:       "user214",
 				SubjectRelation: tuple.Ellipsis,
 			},
 		},

--- a/pkg/datalayer/testutil.go
+++ b/pkg/datalayer/testutil.go
@@ -29,9 +29,12 @@ func WriteStoredSchemaForTest(ctx context.Context, ds datastore.Datastore, schem
 		schemaDefinitions = append(schemaDefinitions, objDef)
 	}
 
-	rev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
-		// TODO: add cache to this?
-		return WriteSchemaViaStoredSchema(ctx, rwt, schemaDefinitions, schemaText, nil)
+	// Use WriteBoth mode so the schema is written to both legacy namespace/caveat
+	// storage and the new unified StoredSchema storage. This ensures compatibility
+	// regardless of which schema mode the server/DataLayer is running in.
+	dl := NewDataLayer(ds, WithSchemaMode(SchemaModeReadLegacyWriteBoth))
+	rev, err := dl.ReadWriteTx(ctx, func(ctx context.Context, rwt ReadWriteTransaction) error {
+		return rwt.WriteSchema(ctx, schemaDefinitions, schemaText, nil)
 	})
 
 	return rev, err


### PR DESCRIPTION
## Description
Schema cache -- writing the legacy way and the new way (and reading from legacy) broke the benchmark integration tests. This remedies that. It also fixes the fact that most of the benchmarks weren't applying optimizations, so now we are.

## Testing

These are the affected tests. 

## References

Each commit in this PR is relatively stand-alone, for reviewers