### PR TITLE
backport: size-aware CRDB bulk export partitioning

### DIFF
--- a/internal/datastore/crdb/partitioner.go
+++ b/internal/datastore/crdb/partitioner.go
@@ -120,24 +120,32 @@ func groupRanges(ctx context.Context, ranges []rangeInfo, desiredCount uint32) [
 		target = 1
 	}
 
-	// Greedy pack: walk ranges in order, accumulating size into the current
-	// partition. As soon as it reaches the target, close it off by splitting
-	// at the next range's cursor and start a new partition. Ranges smaller
-	// than the target are absorbed into whichever partition they land in,
-	// which means very skewed inputs may produce fewer than K partitions —
-	// but each one we do produce is close to target-sized, so workers stay
-	// balanced.
+	// Greedy pack: walk ranges in order, deciding at each cursor whether to
+	// close off the current partition by splitting there. Each ranges[i].cursor
+	// is a usable split point — including ranges[0].cursor, which separates
+	// the unparseable prefix region (whose start_key we can't parse, but which
+	// holds real data) from the rest. We seed the accumulator with an estimate
+	// of the prefix region's size so it becomes a candidate split point: one
+	// unit in unit-size mode, or the average range size in size-aware mode.
+	// Without this seed the algorithm would always merge the prefix into the
+	// first partition and produce at most len(ranges) partitions instead of
+	// len(ranges)+1.
 	splits := make([]options.Cursor, 0, K-1)
 	var acc int64
-	for i := 0; i < len(ranges)-1 && len(splits) < K-1; i++ {
+	if useUnitSize {
+		acc = 1
+	} else if len(ranges) > 0 {
+		acc = totalSize / int64(len(ranges))
+	}
+	for i := 0; i < len(ranges) && len(splits) < K-1; i++ {
+		if acc >= target {
+			splits = append(splits, ranges[i].cursor)
+			acc = 0
+		}
 		if useUnitSize {
 			acc++
 		} else {
 			acc += ranges[i].size
-		}
-		if acc >= target {
-			splits = append(splits, ranges[i+1].cursor)
-			acc = 0
 		}
 	}
 

--- a/internal/datastore/crdb/partitioner.go
+++ b/internal/datastore/crdb/partitioner.go
@@ -16,11 +16,13 @@ import (
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
-// queryShowRanges queries ranges from the primary index only. Using
-// SHOW RANGES FROM TABLE would include secondary index ranges whose start keys
-// have columns in a different order than the PK, producing partition bounds
-// that overlap when compared in PK tuple order.
-const queryShowRanges = "SELECT start_key FROM [SHOW RANGES FROM INDEX %s@primary] ORDER BY start_key"
+// queryShowRanges queries ranges from the primary index only, including
+// each range's size in bytes. Using SHOW RANGES FROM TABLE would include
+// secondary index ranges whose start keys have columns in a different order
+// than the PK, producing partition bounds that overlap when compared in PK
+// tuple order. WITH DETAILS exposes range_size, which we use to balance
+// partitions by data volume rather than by range count.
+const queryShowRanges = "SELECT start_key, range_size FROM [SHOW RANGES FROM INDEX %s@primary WITH DETAILS] ORDER BY start_key"
 
 var (
 	// SinglePartitionRange is a single partition covering the entire table,
@@ -31,9 +33,17 @@ var (
 	_ datastore.BulkExportPartitioner = (*crdbDatastore)(nil)
 )
 
+// rangeInfo describes a single CRDB range whose start_key parses to a valid
+// PK cursor (a usable split candidate), along with its size in bytes.
+type rangeInfo struct {
+	cursor options.Cursor
+	size   int64
+}
+
 // PlanPartitions splits the relationship table into non-overlapping key ranges
 // for parallel bulk export. It uses CRDB's SHOW RANGES to align partitions
-// with physical data distribution.
+// with physical data distribution, and balances partitions by total range size
+// so that workers process roughly equal amounts of data.
 //
 // CRDB automatically splits ranges when they exceed range_max_bytes (default
 // 512MB), regardless of the number of nodes. A table with tens of billions of
@@ -45,24 +55,24 @@ func (cds *crdbDatastore) PlanPartitions(ctx context.Context, desiredCount uint3
 		return SinglePartitionRange, nil
 	}
 
-	boundaries, err := cds.rangeBoundaries(ctx)
+	ranges, err := cds.rangeInfos(ctx)
 	if err != nil {
 		log.Ctx(ctx).Warn().Err(err).Uint32("desired_partitions", desiredCount).
 			Msg("SHOW RANGES failed, returning single partition")
 		return SinglePartitionRange, nil
 	}
 
-	if len(boundaries) == 0 {
+	if len(ranges) == 0 {
 		log.Ctx(ctx).Info().Uint32("desired_partitions", desiredCount).
 			Str("table", cds.schema.RelationshipTableName).
 			Msg("no parseable range boundaries found (table may be < 512MB), returning single partition")
 		return SinglePartitionRange, nil
 	}
 
-	partitions := groupBoundaries(boundaries, desiredCount)
+	partitions := groupRanges(ctx, ranges, desiredCount)
 	log.Ctx(ctx).Info().
 		Uint32("desired_partitions", desiredCount).
-		Int("parseable_boundaries", len(boundaries)).
+		Int("parseable_ranges", len(ranges)).
 		Int("actual_partitions", len(partitions)).
 		Str("table", cds.schema.RelationshipTableName).
 		Msg("planned partitioned export from SHOW RANGES")
@@ -70,73 +80,123 @@ func (cds *crdbDatastore) PlanPartitions(ctx context.Context, desiredCount uint3
 	return partitions, nil
 }
 
-// groupBoundaries takes N split-point boundaries and a desired partition count K,
-// and returns up to K non-overlapping PartitionRange values.
-// N boundaries divide the key space into N+1 regions.
-// Boundaries must be sorted in ascending key order.
-func groupBoundaries(boundaries []options.Cursor, desiredCount uint32) []datastore.PartitionRange {
-	if desiredCount <= 1 || len(boundaries) == 0 {
+// groupRanges takes a sorted list of ranges (each with a parseable cursor
+// usable as a split point and a size) and a desired partition count K. It
+// returns up to K non-overlapping PartitionRange values, choosing boundaries
+// so that the cumulative size of each partition is as close as possible to
+// totalSize/K. If fewer than K-1 ranges are available, fewer than K
+// partitions are returned.
+//
+// Ranges must be sorted in ascending key order. Each range's cursor is the
+// lower bound of that range (and, equivalently, the upper bound of the
+// preceding range); a split at ranges[i].cursor closes off the partition
+// containing ranges[0..i-1] and starts a new one.
+func groupRanges(ctx context.Context, ranges []rangeInfo, desiredCount uint32) []datastore.PartitionRange {
+	if desiredCount <= 1 || len(ranges) == 0 {
 		return SinglePartitionRange
 	}
 
 	K := int(desiredCount)
-	N := len(boundaries)
-	if K > N+1 {
-		K = N + 1
+	var totalSize int64
+	for _, r := range ranges {
+		totalSize += r.size
 	}
 
-	partitions := make([]datastore.PartitionRange, K)
+	// If every range reports size 0 (e.g., the table is brand new and CRDB
+	// hasn't accounted for it yet), fall back to range-count balancing by
+	// treating each range as one unit. This is logged at info level because
+	// it materially changes how splits are chosen — partitions will be
+	// balanced by range count, not by data volume.
+	useUnitSize := totalSize == 0
+	if useUnitSize {
+		log.Ctx(ctx).Info().
+			Int("ranges", len(ranges)).
+			Msg("range_size unavailable for all ranges; falling back to range-count balancing")
+		totalSize = int64(len(ranges))
+	}
+
+	target := totalSize / int64(K)
+	if target <= 0 {
+		target = 1
+	}
+
+	// Greedy pack: walk ranges in order, accumulating size into the current
+	// partition. As soon as it reaches the target, close it off by splitting
+	// at the next range's cursor and start a new partition. Ranges smaller
+	// than the target are absorbed into whichever partition they land in,
+	// which means very skewed inputs may produce fewer than K partitions —
+	// but each one we do produce is close to target-sized, so workers stay
+	// balanced.
+	splits := make([]options.Cursor, 0, K-1)
+	var acc int64
+	for i := 0; i < len(ranges)-1 && len(splits) < K-1; i++ {
+		if useUnitSize {
+			acc++
+		} else {
+			acc += ranges[i].size
+		}
+		if acc >= target {
+			splits = append(splits, ranges[i+1].cursor)
+			acc = 0
+		}
+	}
+
+	partitions := make([]datastore.PartitionRange, len(splits)+1)
 	for i := range partitions {
-		// Select K-1 evenly-spaced boundaries from the N available.
 		if i > 0 {
-			idx := (i * N) / K
-			partitions[i].LowerBound = boundaries[idx]
+			partitions[i].LowerBound = splits[i-1]
 		}
-		if i < K-1 {
-			idx := ((i + 1) * N) / K
-			partitions[i].UpperBound = boundaries[idx]
+		if i < len(splits) {
+			partitions[i].UpperBound = splits[i]
 		}
 	}
-
 	return partitions
 }
 
-// rangeBoundaries returns the start keys of CRDB ranges for the relationship
-// table, parsed into Cursor values. Each cursor represents a PK tuple.
-func (cds *crdbDatastore) rangeBoundaries(ctx context.Context) ([]options.Cursor, error) {
+// rangeInfos returns CRDB primary-index ranges for the relationship table in
+// ascending key order, with each range annotated by its size in bytes. Rows
+// whose start_key cannot be parsed as a PK tuple — most commonly the first
+// range, whose key is just the table prefix — are skipped: they cannot serve
+// as split points, and their size contribution (bounded by range_max_bytes,
+// ~512MB) is negligible on the large tables this feature targets.
+func (cds *crdbDatastore) rangeInfos(ctx context.Context) ([]rangeInfo, error) {
 	query := fmt.Sprintf(queryShowRanges, cds.schema.RelationshipTableName)
 
-	var boundaries []options.Cursor
+	var ranges []rangeInfo
 	var totalRows, skippedRows int
 	if err := cds.readPool.QueryFunc(ctx, func(ctx context.Context, rows pgx.Rows) error {
 		for rows.Next() {
 			totalRows++
-			var startKey string
-			if err := rows.Scan(&startKey); err != nil {
-				return fmt.Errorf("unable to scan range start_key: %w", err)
+			var (
+				startKey string
+				size     int64
+			)
+
+			if err := rows.Scan(&startKey, &size); err != nil {
+				return fmt.Errorf("unable to scan range row: %w", err)
 			}
 
 			cursor, err := parseRangeStartKey(startKey)
 			if err != nil {
 				skippedRows++
-				log.Ctx(ctx).Debug().Err(err).Str("start_key", startKey).Msg("skipping unparseable range boundary")
+				log.Ctx(ctx).Debug().Err(err).Str("start_key", startKey).Msg("skipping range with unparseable start_key")
 				continue
 			}
 
-			boundaries = append(boundaries, cursor)
+			ranges = append(ranges, rangeInfo{cursor: cursor, size: size})
 		}
 		return nil
 	}, query); err != nil {
-		return nil, fmt.Errorf("range boundaries query failed: %w", err)
+		return nil, fmt.Errorf("range query failed: %w", err)
 	}
 
 	log.Ctx(ctx).Debug().
 		Int("total_ranges", totalRows).
-		Int("parseable_boundaries", len(boundaries)).
+		Int("parseable_boundaries", len(ranges)).
 		Int("skipped", skippedRows).
 		Msg("SHOW RANGES results")
 
-	return boundaries, nil
+	return ranges, nil
 }
 
 // parseRangeStartKey parses a CRDB range start key like:

--- a/internal/datastore/crdb/partitioner_test.go
+++ b/internal/datastore/crdb/partitioner_test.go
@@ -440,14 +440,23 @@ func TestPlanPartitionsLogic(t *testing.T) {
 		require.Len(t, partitions, 1)
 	})
 
-	t.Run("single range yields single partition", func(t *testing.T) {
-		// One kept range gives no usable split point (you can't split inside
-		// a range), so we collapse to a single full-table partition.
+	t.Run("single boundary yields two partitions", func(t *testing.T) {
+		// One parseable boundary is a usable split point: it separates the
+		// unparseable prefix region from the parseable range, giving two
+		// partitions [-∞, b) and [b, +∞).
 		b := makeBoundary("ns1", "oid1", "rel1", "uns1", "uoid1", "urel1")
 		partitions := groupRanges(t.Context(), equalSizeRanges(b), 4)
-		require.Len(t, partitions, 1)
+		require.Len(t, partitions, 2)
 		require.Nil(t, partitions[0].LowerBound)
-		require.Nil(t, partitions[0].UpperBound)
+		require.Equal(t,
+			*dsoptions.ToRelationship(b),
+			*dsoptions.ToRelationship(partitions[0].UpperBound),
+		)
+		require.Equal(t,
+			*dsoptions.ToRelationship(b),
+			*dsoptions.ToRelationship(partitions[1].LowerBound),
+		)
+		require.Nil(t, partitions[1].UpperBound)
 	})
 
 	t.Run("equal-sized ranges split into K partitions", func(t *testing.T) {
@@ -472,10 +481,10 @@ func TestPlanPartitionsLogic(t *testing.T) {
 	})
 
 	t.Run("partition count caps at usable splits", func(t *testing.T) {
-		// 1 range, K=100: nothing to split on, single partition.
+		// 1 boundary, K=100: only one split point available, two partitions.
 		b := makeBoundary("a", "0", "r", "u", "0", "...")
 		partitions := groupRanges(t.Context(), equalSizeRanges(b), 100)
-		require.Len(t, partitions, 1)
+		require.Len(t, partitions, 2)
 	})
 
 	t.Run("many equal ranges with small K balances by size", func(t *testing.T) {
@@ -587,9 +596,9 @@ func TestPlanPartitionsLogic(t *testing.T) {
 }
 
 // equalSizeRanges builds a rangeInfo slice modeling N ranges of equal size,
-// each keyed by one of the supplied boundaries. With N parseable boundaries
-// only N-1 of them are usable as split points (the first is the lower bound
-// of range 0), so groupRanges produces at most N partitions.
+// each keyed by one of the supplied boundaries. All N boundaries are usable
+// as split points (the first separates the unparseable prefix region from
+// ranges[0]), so groupRanges produces at most N+1 partitions.
 func equalSizeRanges(boundaries ...dsoptions.Cursor) []rangeInfo {
 	ranges := make([]rangeInfo, 0, len(boundaries))
 	for _, b := range boundaries {

--- a/internal/datastore/crdb/partitioner_test.go
+++ b/internal/datastore/crdb/partitioner_test.go
@@ -51,80 +51,23 @@ func TestPlanPartitionedExport(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Split points: resource2, resource4, resource5, resource7, resource8
-	// These are the boundaries available for groupBoundaries to select from.
-	b2 := "resource2:0#viewer@user:0"
-	b4 := "resource4:0#viewer@user:0"
-	b5 := "resource5:0#viewer@user:0"
-	b7 := "resource7:0#viewer@user:0"
-	b8 := "resource8:0#viewer@user:0"
-
-	type bound struct {
-		lower string // "" = nil (start of table)
-		upper string // "" = nil (end of table)
-	}
-
 	tests := []struct {
 		name              string
 		desiredPartitions uint32
-		expectedBounds    []bound
+		// expectSinglePartition is true when we expect exactly one full-table
+		// partition (lower=nil, upper=nil). When false, we just check that
+		// the plan returns ≤desired partitions, all non-overlapping, and
+		// covering all data exactly once. We avoid asserting exact split
+		// positions because real CRDB's range_size for tiny test data is
+		// not deterministic enough to pin them down.
+		expectSinglePartition bool
 	}{
-		{
-			name:              "desired=0 defaults to 1",
-			desiredPartitions: 0,
-			expectedBounds:    []bound{{"", ""}},
-		},
-		{
-			name:              "desired=1 returns single partition",
-			desiredPartitions: 1,
-			expectedBounds:    []bound{{"", ""}},
-		},
-		{
-			name:              "desired=2 groups boundaries into 2",
-			desiredPartitions: 2,
-			// idx for upper[0] = (1*5)/2 = 2 → boundary[2] = resource5
-			// idx for lower[1] = (1*5)/2 = 2 → boundary[2] = resource5
-			expectedBounds: []bound{
-				{"", b5},
-				{b5, ""},
-			},
-		},
-		{
-			name:              "desired=3 downsamples from 5 boundaries",
-			desiredPartitions: 3,
-			// upper[0] = boundary[(1*5)/3=1] = resource4
-			// lower[1] = boundary[(1*5)/3=1] = resource4, upper[1] = boundary[(2*5)/3=3] = resource7
-			// lower[2] = boundary[(2*5)/3=3] = resource7
-			expectedBounds: []bound{
-				{"", b4},
-				{b4, b7},
-				{b7, ""},
-			},
-		},
-		{
-			name:              "desired=exact boundary count+1",
-			desiredPartitions: 6, // 5 boundaries → 6 partitions, all boundaries used
-			expectedBounds: []bound{
-				{"", b2},
-				{b2, b4},
-				{b4, b5},
-				{b5, b7},
-				{b7, b8},
-				{b8, ""},
-			},
-		},
-		{
-			name:              "desired exceeds boundary count+1, capped at 6",
-			desiredPartitions: 100,
-			expectedBounds: []bound{
-				{"", b2},
-				{b2, b4},
-				{b4, b5},
-				{b5, b7},
-				{b7, b8},
-				{b8, ""},
-			},
-		},
+		{name: "desired=0 defaults to 1", desiredPartitions: 0, expectSinglePartition: true},
+		{name: "desired=1 returns single partition", desiredPartitions: 1, expectSinglePartition: true},
+		{name: "desired=2 returns at most 2 partitions", desiredPartitions: 2},
+		{name: "desired=3 returns at most 3 partitions", desiredPartitions: 3},
+		{name: "desired=6 returns at most 6 partitions", desiredPartitions: 6},
+		{name: "desired=100 caps at usable splits", desiredPartitions: 100},
 	}
 
 	rev, err := ds.HeadRevision(ctx)
@@ -134,42 +77,47 @@ func TestPlanPartitionedExport(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			plan, err := v1.PlanPartitionedExport(ctx, ds, tc.desiredPartitions)
 			require.NoError(t, err)
-			require.Len(t, plan.Partitions, len(tc.expectedBounds))
+			require.NotEmpty(t, plan.Partitions)
 
-			for i, expected := range tc.expectedBounds {
-				p := plan.Partitions[i]
-
-				if expected.lower == "" {
-					require.Nil(t, p.LowerBound, "partition %d lower bound should be nil", i)
-				} else {
-					require.NotNil(t, p.LowerBound, "partition %d lower bound should not be nil", i)
-					require.Equal(t, expected.lower, tuple.MustString(*dsoptions.ToRelationship(p.LowerBound)),
-						"partition %d lower bound mismatch", i)
-				}
-
-				if expected.upper == "" {
-					require.Nil(t, p.UpperBound, "partition %d upper bound should be nil", i)
-				} else {
-					require.NotNil(t, p.UpperBound, "partition %d upper bound should not be nil", i)
-					require.Equal(t, expected.upper, tuple.MustString(*dsoptions.ToRelationship(p.UpperBound)),
-						"partition %d upper bound mismatch", i)
+			if tc.expectSinglePartition {
+				require.Len(t, plan.Partitions, 1)
+				require.Nil(t, plan.Partitions[0].LowerBound)
+				require.Nil(t, plan.Partitions[0].UpperBound)
+			} else {
+				require.LessOrEqual(t, len(plan.Partitions), int(tc.desiredPartitions),
+					"got more partitions than requested")
+				// First partition starts at -∞, last ends at +∞, and every
+				// internal boundary is shared.
+				require.Nil(t, plan.Partitions[0].LowerBound)
+				require.Nil(t, plan.Partitions[len(plan.Partitions)-1].UpperBound)
+				for i := 1; i < len(plan.Partitions); i++ {
+					require.NotNil(t, plan.Partitions[i-1].UpperBound)
+					require.NotNil(t, plan.Partitions[i].LowerBound)
+					require.Equal(t,
+						*dsoptions.ToRelationship(plan.Partitions[i-1].UpperBound),
+						*dsoptions.ToRelationship(plan.Partitions[i].LowerBound),
+						"partition %d/%d boundaries do not match", i-1, i)
 				}
 			}
 
-			// All partitions together should cover all data.
-			totalRels := 0
-			for _, partition := range plan.Partitions {
+			// All partitions together should cover all 1000 relationships
+			// exactly once.
+			seen := make(map[string]int)
+			for pi, partition := range plan.Partitions {
 				iter, err := v1.StreamPartitionedExport(ctx, ds, v1.StreamRequest{
 					Partition: partition,
 					Revision:  rev,
 				})
 				require.NoError(t, err)
-				for _, err := range iter {
+				for rel, err := range iter {
 					require.NoError(t, err)
-					totalRels++
+					key := tuple.MustString(rel)
+					prev, dup := seen[key]
+					require.False(t, dup, "rel %s appeared in partitions %d and %d", key, prev, pi)
+					seen[key] = pi
 				}
 			}
-			require.Equal(t, 1000, totalRels, "all partitions should cover all 1000 relationships")
+			require.Len(t, seen, 1000, "all partitions should cover all 1000 relationships")
 		})
 	}
 }
@@ -481,50 +429,40 @@ func TestParseRangeStartKey(t *testing.T) {
 
 func TestPlanPartitionsLogic(t *testing.T) {
 	t.Run("desiredCount=0 returns single partition", func(t *testing.T) {
-		// PlanPartitions with 0 should behave like 1.
-		// We can't call the real method without a datastore, so test the
-		// boundary grouping logic directly.
-		partitions := groupBoundaries(nil, 0)
+		partitions := groupRanges(t.Context(), nil, 0)
 		require.Len(t, partitions, 1)
 		require.Nil(t, partitions[0].LowerBound)
 		require.Nil(t, partitions[0].UpperBound)
 	})
 
 	t.Run("desiredCount=1 returns single partition", func(t *testing.T) {
-		partitions := groupBoundaries(nil, 1)
+		partitions := groupRanges(t.Context(), nil, 1)
 		require.Len(t, partitions, 1)
 	})
 
-	t.Run("1 boundary produces 2 partitions", func(t *testing.T) {
+	t.Run("single range yields single partition", func(t *testing.T) {
+		// One kept range gives no usable split point (you can't split inside
+		// a range), so we collapse to a single full-table partition.
 		b := makeBoundary("ns1", "oid1", "rel1", "uns1", "uoid1", "urel1")
-		partitions := groupBoundaries([]dsoptions.Cursor{b}, 4)
-		require.Len(t, partitions, 2)
-
+		partitions := groupRanges(t.Context(), equalSizeRanges(b), 4)
+		require.Len(t, partitions, 1)
 		require.Nil(t, partitions[0].LowerBound)
-		require.NotNil(t, partitions[0].UpperBound)
-		require.NotNil(t, partitions[1].LowerBound)
-		require.Nil(t, partitions[1].UpperBound)
-
-		// Shared boundary.
-		require.Equal(t,
-			*dsoptions.ToRelationship(partitions[0].UpperBound),
-			*dsoptions.ToRelationship(partitions[1].LowerBound),
-		)
+		require.Nil(t, partitions[0].UpperBound)
 	})
 
-	t.Run("3 boundaries produce 4 partitions when K=4", func(t *testing.T) {
+	t.Run("equal-sized ranges split into K partitions", func(t *testing.T) {
 		boundaries := []dsoptions.Cursor{
 			makeBoundary("a", "0", "r", "u", "0", "..."),
 			makeBoundary("b", "0", "r", "u", "0", "..."),
 			makeBoundary("c", "0", "r", "u", "0", "..."),
+			makeBoundary("d", "0", "r", "u", "0", "..."),
 		}
-		partitions := groupBoundaries(boundaries, 4)
+		// 4 ranges, target = 4/4 = 1; greedy splits before each successor.
+		partitions := groupRanges(t.Context(), equalSizeRanges(boundaries...), 4)
 		require.Len(t, partitions, 4)
 
 		require.Nil(t, partitions[0].LowerBound)
 		require.Nil(t, partitions[3].UpperBound)
-
-		// All adjacent boundaries match.
 		for i := 1; i < len(partitions); i++ {
 			require.Equal(t,
 				*dsoptions.ToRelationship(partitions[i-1].UpperBound),
@@ -533,27 +471,26 @@ func TestPlanPartitionsLogic(t *testing.T) {
 		}
 	})
 
-	t.Run("K larger than boundaries+1 is capped", func(t *testing.T) {
-		boundaries := []dsoptions.Cursor{
-			makeBoundary("a", "0", "r", "u", "0", "..."),
-		}
-		partitions := groupBoundaries(boundaries, 100)
-		require.Len(t, partitions, 2) // 1 boundary → max 2 partitions
+	t.Run("partition count caps at usable splits", func(t *testing.T) {
+		// 1 range, K=100: nothing to split on, single partition.
+		b := makeBoundary("a", "0", "r", "u", "0", "...")
+		partitions := groupRanges(t.Context(), equalSizeRanges(b), 100)
+		require.Len(t, partitions, 1)
 	})
 
-	t.Run("many boundaries with small K downsamples", func(t *testing.T) {
+	t.Run("many equal ranges with small K balances by size", func(t *testing.T) {
 		boundaries := make([]dsoptions.Cursor, 20)
 		for i := range boundaries {
 			boundaries[i] = makeBoundary(
 				fmt.Sprintf("ns%02d", i), "0", "r", "u", "0", "...",
 			)
 		}
-		partitions := groupBoundaries(boundaries, 4)
+		// 20 ranges of size 1, K=4 → target 5 → splits every 5 ranges.
+		partitions := groupRanges(t.Context(), equalSizeRanges(boundaries...), 4)
 		require.Len(t, partitions, 4)
 
 		require.Nil(t, partitions[0].LowerBound)
 		require.Nil(t, partitions[3].UpperBound)
-
 		for i := 1; i < len(partitions); i++ {
 			require.Equal(t,
 				*dsoptions.ToRelationship(partitions[i-1].UpperBound),
@@ -562,12 +499,103 @@ func TestPlanPartitionsLogic(t *testing.T) {
 		}
 	})
 
-	t.Run("empty boundaries returns single partition", func(t *testing.T) {
-		partitions := groupBoundaries([]dsoptions.Cursor{}, 4)
+	t.Run("skewed sizes yield fewer but balanced partitions", func(t *testing.T) {
+		// Sizes [10, 1, 1, 1, 1] (total 14), K=3, target = 4. The heavy
+		// first range clears the target on its own, so we split right after
+		// it; the remaining tiny ranges never reach 4 again, so they all
+		// merge into the trailing partition. Result: 2 partitions of sizes
+		// 10 and 4 — fewer than the 3 requested, but each close to its fair
+		// share. This is the behavior trade-off of simple greedy: balance
+		// over partition count.
+		boundaries := make([]dsoptions.Cursor, 5)
+		for i := range boundaries {
+			boundaries[i] = makeBoundary(
+				fmt.Sprintf("ns%02d", i), "0", "r", "u", "0", "...",
+			)
+		}
+		ranges := []rangeInfo{
+			{cursor: boundaries[0], size: 10},
+			{cursor: boundaries[1], size: 1},
+			{cursor: boundaries[2], size: 1},
+			{cursor: boundaries[3], size: 1},
+			{cursor: boundaries[4], size: 1},
+		}
+		partitions := groupRanges(t.Context(), ranges, 3)
+		require.Len(t, partitions, 2)
+		require.Equal(t,
+			*dsoptions.ToRelationship(boundaries[1]),
+			*dsoptions.ToRelationship(partitions[0].UpperBound),
+		)
+	})
+
+	t.Run("empty ranges returns single partition", func(t *testing.T) {
+		partitions := groupRanges(t.Context(), nil, 4)
 		require.Len(t, partitions, 1)
 		require.Nil(t, partitions[0].LowerBound)
 		require.Nil(t, partitions[0].UpperBound)
 	})
+
+	t.Run("size-aware packing skews splits toward heavy ranges", func(t *testing.T) {
+		// 5 ranges, the first carrying 90% of the data:
+		//   R0 [b0 .. b1)  size=900
+		//   R1 [b1 .. b2)  size= 25
+		//   R2 [b2 .. b3)  size= 25
+		//   R3 [b3 .. b4)  size= 25
+		//   R4 [b4 .. -)   size= 25
+		// Total=1000, K=2, target=500. The algorithm must split right after
+		// the heavy first range — i.e., at b1 — even though that's the very
+		// first usable boundary, which the old index-based algorithm would
+		// never pick.
+		b0 := makeBoundary("a", "0", "r", "u", "0", "...")
+		b1 := makeBoundary("b", "0", "r", "u", "0", "...")
+		b2 := makeBoundary("c", "0", "r", "u", "0", "...")
+		b3 := makeBoundary("d", "0", "r", "u", "0", "...")
+		b4 := makeBoundary("e", "0", "r", "u", "0", "...")
+		ranges := []rangeInfo{
+			{cursor: b0, size: 900},
+			{cursor: b1, size: 25},
+			{cursor: b2, size: 25},
+			{cursor: b3, size: 25},
+			{cursor: b4, size: 25},
+		}
+
+		partitions := groupRanges(t.Context(), ranges, 2)
+		require.Len(t, partitions, 2)
+		require.Nil(t, partitions[0].LowerBound)
+		require.NotNil(t, partitions[0].UpperBound)
+		require.Equal(t,
+			*dsoptions.ToRelationship(b1),
+			*dsoptions.ToRelationship(partitions[0].UpperBound),
+			"split should land at b1, isolating the heavy first range",
+		)
+		require.Nil(t, partitions[1].UpperBound)
+	})
+
+	t.Run("zero total size falls back to per-boundary splits", func(t *testing.T) {
+		// Pathological case: every range reports size 0. We should still
+		// produce K partitions from the available split points rather than
+		// dividing by zero or collapsing to one partition.
+		ranges := []rangeInfo{
+			{cursor: makeBoundary("a", "0", "r", "u", "0", "..."), size: 0},
+			{cursor: makeBoundary("b", "0", "r", "u", "0", "..."), size: 0},
+			{cursor: makeBoundary("c", "0", "r", "u", "0", "..."), size: 0},
+			{cursor: makeBoundary("d", "0", "r", "u", "0", "..."), size: 0},
+		}
+		partitions := groupRanges(t.Context(), ranges, 4)
+		require.Len(t, partitions, 4)
+	})
+}
+
+// equalSizeRanges builds a rangeInfo slice modeling N ranges of equal size,
+// each keyed by one of the supplied boundaries. With N parseable boundaries
+// only N-1 of them are usable as split points (the first is the lower bound
+// of range 0), so groupRanges produces at most N partitions.
+func equalSizeRanges(boundaries ...dsoptions.Cursor) []rangeInfo {
+	ranges := make([]rangeInfo, 0, len(boundaries))
+	for _, b := range boundaries {
+		ranges = append(ranges, rangeInfo{cursor: b, size: 1})
+	}
+	return ranges
 }
 
 // TestPartitionerPrimaryKeyAssumptions verifies that the primary key of the


### PR DESCRIPTION
Balance partitions by total range bytes from SHOW RANGES ... WITH DETAILS instead of by range count, so workers process roughly equal amounts of data when range sizes are uneven. Uses a simple greedy: walk ranges in order, accumulating size, and split at the next boundary once a target of totalSize/K is reached. Skewed inputs may yield fewer than K partitions, but each one stays close to its fair share.

Falls back to range-count balancing (logged) when CRDB reports zero range_size for every range, e.g. on tables too fresh to have been sized.

<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

<!--
Why do we need this PR? Any implementation details worth mentioning here?
-->

## Testing

<!--
How did you test this and how can reviewers test this?
-->

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->