### PR TITLE
fix: wire DispatchExecutor into the GRPC path properly and fix correctness

### DIFF
--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/authzed/spicedb/internal/caveats"
 	"github.com/authzed/spicedb/pkg/datalayer"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
@@ -242,6 +243,36 @@ func toProtoStruct(m map[string]any) (*structpb.Struct, error) {
 		return nil, nil
 	}
 	return structpb.NewStruct(m)
+}
+
+// NewQueryContext builds a query.Context whose Executor is a DispatchExecutor
+// driven by the given PlanContext, so that dispatched sub-requests carry the
+// same plan state. Plan-derived options (caveat context, recursion depth,
+// datastore limit) are applied first; extra opts are appended after.
+func NewQueryContext(
+	stdContext context.Context,
+	dispatcher Dispatcher,
+	planContext *v1.PlanContext,
+	reader query.QueryDatastoreReader,
+	caveatRunner *caveats.CaveatRunner,
+	opts ...query.ContextOption,
+) *query.Context {
+	executor := NewDispatchExecutor(dispatcher, planContext)
+
+	baseOpts := []query.ContextOption{
+		query.WithReader(reader),
+		query.WithCaveatContext(CaveatContextFromPlanContext(planContext)),
+		query.WithCaveatRunner(caveatRunner),
+	}
+	if d := planContext.GetMaxRecursionDepth(); d > 0 {
+		baseOpts = append(baseOpts, query.WithMaxRecursionDepth(int(d)))
+	}
+	if l := planContext.GetOptionalDatastoreLimit(); l > 0 {
+		baseOpts = append(baseOpts, query.WithPaginationLimit(l))
+	}
+	baseOpts = append(baseOpts, opts...)
+
+	return query.NewQueryContext(stdContext, executor, baseOpts...)
 }
 
 // NewPlanContext builds a PlanContext proto from query.Context fields.

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -131,9 +131,14 @@ func (e *DispatchExecutor) dispatchIterSubjects(ctx *query.Context, it query.Ite
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// For LookupSubjects the proto Subject field carries the *filter* subject
+	// type+relation rather than a real subject ONR — the receiver needs the
+	// filter to apply the same reachability/optimizer decisions the sender
+	// would have applied. The actual receiver-side iteration uses NoObjectFilter
+	// since the sender filters the returned paths itself.
 	req := e.buildRequest(v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS, it, resource, query.ObjectAndRelation{
-		ObjectType: resource.ObjectType,
-		ObjectID:   resource.ObjectID,
+		ObjectType: filterSubjectType.Type,
+		Relation:   filterSubjectType.Subrelation,
 	})
 	stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 	if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
@@ -162,9 +167,14 @@ func (e *DispatchExecutor) dispatchIterResources(ctx *query.Context, it query.It
 }
 
 func (e *DispatchExecutor) buildRequest(op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
+	// dispatch{Check,IterSubjects,IterResources} only enter buildRequest when
+	// it is a *query.AliasIterator, so the type assertion is safe. The dispatch
+	// boundary is always the (definition, relation) the alias represents; we
+	// encode that as "definition#relation" in the canonical_key field.
+	alias := it.(*query.AliasIterator)
 	return &v1.DispatchQueryPlanRequest{
 		Operation:    op,
-		CanonicalKey: string(it.CanonicalKey()),
+		CanonicalKey: alias.DefinitionName() + "#" + alias.Relation(),
 		Resource: &core.ObjectAndRelation{
 			Namespace: resource.ObjectType,
 			ObjectId:  resource.ObjectID,

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -177,7 +177,7 @@ func (e *DispatchExecutor) dispatchCheck(ctx *query.Context, it query.Iterator, 
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	req := e.buildRequest(v1.PlanOperation_PLAN_OPERATION_CHECK, it, resource, subject)
+	req := e.buildRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK, it, resource, subject)
 	stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 	if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ func (e *DispatchExecutor) dispatchIterSubjects(ctx *query.Context, it query.Ite
 	// filter to apply the same reachability/optimizer decisions the sender
 	// would have applied. The actual receiver-side iteration uses NoObjectFilter
 	// since the sender filters the returned paths itself.
-	req := e.buildRequest(v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS, it, resource, query.ObjectAndRelation{
+	req := e.buildRequest(ctx, v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS, it, resource, query.ObjectAndRelation{
 		ObjectType: filterSubjectType.Type,
 		Relation:   filterSubjectType.Subrelation,
 	})
@@ -218,7 +218,7 @@ func (e *DispatchExecutor) dispatchIterResources(ctx *query.Context, it query.It
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	req := e.buildRequest(v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES, it, query.Object{
+	req := e.buildRequest(ctx, v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES, it, query.Object{
 		ObjectType: subject.ObjectType,
 		ObjectID:   subject.ObjectID,
 	}, subject)
@@ -242,7 +242,7 @@ func (e *DispatchExecutor) dispatchCheckManySubjects(ctx *query.Context, it quer
 		if end > len(subjects) {
 			end = len(subjects)
 		}
-		req := e.buildManyRequest(v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS, it, resource, query.ObjectAndRelation{}, nil, subjects[start:end])
+		req := e.buildManyRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS, it, resource, query.ObjectAndRelation{}, nil, subjects[start:end])
 		stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 		if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
 			return nil, err
@@ -273,7 +273,7 @@ func (e *DispatchExecutor) dispatchCheckManyResources(ctx *query.Context, it que
 		if end > len(resources) {
 			end = len(resources)
 		}
-		req := e.buildManyRequest(v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES, it, query.Object{}, subject, resources[start:end], nil)
+		req := e.buildManyRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES, it, query.Object{}, subject, resources[start:end], nil)
 		stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 		if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
 			return nil, err
@@ -297,7 +297,7 @@ func (e *DispatchExecutor) dispatchCheckManyResources(ctx *query.Context, it que
 // Exactly one of (manyResources, manySubjects) is non-nil; the corresponding
 // singular field (resource for CHECK_MANY_RESOURCES, subject for CHECK_MANY_SUBJECTS)
 // must be left zero — the receiver inspects `many` for those operations.
-func (e *DispatchExecutor) buildManyRequest(op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation, manyResources []query.Object, manySubjects []query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
+func (e *DispatchExecutor) buildManyRequest(ctx *query.Context, op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation, manyResources []query.Object, manySubjects []query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
 	alias := it.(*query.AliasIterator)
 	key := alias.DefinitionName() + "#" + alias.Relation()
 	req := &v1.DispatchQueryPlanRequest{
@@ -312,7 +312,7 @@ func (e *DispatchExecutor) buildManyRequest(op v1.PlanOperation, it query.Iterat
 			ObjectId:  subject.ObjectID,
 			Relation:  subject.Relation,
 		},
-		PlanContext: planContextWithKey(e.planContext, key),
+		PlanContext: planContextForDispatch(e.planContext, key, ctx.TopLevelOperation),
 	}
 	if len(manyResources) > 0 {
 		req.Many = make([]*core.ObjectAndRelation, len(manyResources))
@@ -336,7 +336,7 @@ func (e *DispatchExecutor) buildManyRequest(op v1.PlanOperation, it query.Iterat
 	return req
 }
 
-func (e *DispatchExecutor) buildRequest(op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
+func (e *DispatchExecutor) buildRequest(ctx *query.Context, op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
 	// dispatch{Check,IterSubjects,IterResources} only enter buildRequest when
 	// it is a *query.AliasIterator, so the type assertion is safe. The dispatch
 	// boundary is always the (definition, relation) the alias represents; we
@@ -355,22 +355,57 @@ func (e *DispatchExecutor) buildRequest(op v1.PlanOperation, it query.Iterator, 
 			ObjectId:  subject.ObjectID,
 			Relation:  subject.Relation,
 		},
-		PlanContext: planContextWithKey(e.planContext, key),
+		PlanContext: planContextForDispatch(e.planContext, key, ctx.TopLevelOperation),
 	}
 }
 
-// planContextWithKey returns a shallow copy of pc with key appended to the
-// in-progress dispatch keys. The receiver's DispatchExecutor consults this set
-// to refuse re-dispatching keys that any ancestor on the dispatch chain is
-// already computing — the only way to terminate cross-relation cycles produced
-// by standalone plan rebuilds at each receiver hop.
-func planContextWithKey(pc *v1.PlanContext, key string) *v1.PlanContext {
+// planContextForDispatch returns a shallow copy of pc with `key` appended to
+// the in-progress dispatch keys and `topLevelOp` recorded as the user-facing
+// operation. Two receiver-side guards depend on these:
+//   - InProgressKeys breaks cross-relation cycles produced by standalone plan
+//     rebuilds at each receiver hop.
+//   - TopLevelOperation propagates the original API operation across hops so
+//     iterators that consult TopLevelOperation see consistent user intent.
+func planContextForDispatch(pc *v1.PlanContext, key string, topLevelOp query.Operation) *v1.PlanContext {
 	if pc == nil {
-		return &v1.PlanContext{InProgressKeys: []string{key}}
+		return &v1.PlanContext{
+			InProgressKeys:    []string{key},
+			TopLevelOperation: queryOpToPlanOperation(topLevelOp),
+		}
 	}
-	out := *pc
-	out.InProgressKeys = append(append([]string(nil), pc.InProgressKeys...), key)
-	return &out
+	// Preserve any TopLevelOperation already on pc (set higher in the chain);
+	// only fill in when the chain hasn't recorded a user-facing op yet.
+	// PlanOperation's zero value is CHECK, which is also the natural fallback
+	// for Check-rooted chains, so detecting "unset" here is by-design lossy.
+	tlo := pc.TopLevelOperation
+	if tlo == v1.PlanOperation_PLAN_OPERATION_CHECK {
+		tlo = queryOpToPlanOperation(topLevelOp)
+	}
+	return &v1.PlanContext{
+		Revision:               pc.Revision,
+		CaveatContext:          pc.CaveatContext,
+		MaxRecursionDepth:      pc.MaxRecursionDepth,
+		OptionalDatastoreLimit: pc.OptionalDatastoreLimit,
+		SchemaHash:             pc.SchemaHash,
+		InProgressKeys:         append(append([]string(nil), pc.InProgressKeys...), key),
+		TopLevelOperation:      tlo,
+	}
+}
+
+// queryOpToPlanOperation maps the user-facing query.Operation (Check /
+// IterSubjects / IterResources) to its PlanOperation equivalent so the
+// outgoing PlanContext can carry the original API operation across hops.
+// CheckMany variants and OperationUnset both map to PLAN_OPERATION_CHECK
+// since the field only describes user-facing intent.
+func queryOpToPlanOperation(op query.Operation) v1.PlanOperation {
+	switch op {
+	case query.OperationIterSubjects:
+		return v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS
+	case query.OperationIterResources:
+		return v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES
+	default:
+		return v1.PlanOperation_PLAN_OPERATION_CHECK
+	}
 }
 
 func collectPathsFromResponses(responses []*v1.DispatchQueryPlanResponse) []*query.Path {
@@ -406,6 +441,12 @@ func resultPathToQueryPath(rp *v1.ResultPath) *query.Path {
 	if rp.Metadata != nil {
 		p.Metadata = rp.Metadata.AsMap()
 	}
+	if len(rp.ExcludedSubjects) > 0 {
+		p.ExcludedSubjects = make([]*query.Path, len(rp.ExcludedSubjects))
+		for i, esp := range rp.ExcludedSubjects {
+			p.ExcludedSubjects[i] = resultPathToQueryPath(esp)
+		}
+	}
 	return p
 }
 
@@ -428,6 +469,12 @@ func QueryPathToResultPath(p *query.Path) *v1.ResultPath {
 		md, err := toProtoStruct(p.Metadata)
 		if err == nil {
 			rp.Metadata = md
+		}
+	}
+	if len(p.ExcludedSubjects) > 0 {
+		rp.ExcludedSubjects = make([]*v1.ResultPath, len(p.ExcludedSubjects))
+		for i, ep := range p.ExcludedSubjects {
+			rp.ExcludedSubjects[i] = QueryPathToResultPath(ep)
 		}
 	}
 	return rp

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -89,15 +89,40 @@ func NewDispatchExecutor(dispatcher Dispatcher, planContext *v1.PlanContext, dis
 	}
 }
 
+// shouldDispatchAlias reports whether the iterator is an AliasIterator that the
+// executor should ship over RPC, vs. running locally. Two reasons to refuse:
+//   - the alias contains a sentinel whose matching RecursiveIterator lives
+//     outside its own subtree (sentinel-based recursion guard, ancestor case).
+//   - the alias's canonical key is already in the active dispatch chain
+//     (in-progress guard, cross-relation cycle case). Without this, a standalone
+//     plan that re-expands the same key in a sibling subtree produces an
+//     infinite dispatch loop.
+func (e *DispatchExecutor) shouldDispatchAlias(it query.Iterator) (string, bool) {
+	alias, ok := it.(*query.AliasIterator)
+	if !ok {
+		return "", false
+	}
+	if containsUnmatchedRecursiveSentinel(it) {
+		return "", false
+	}
+	key := alias.DefinitionName() + "#" + alias.Relation()
+	for _, k := range e.planContext.GetInProgressKeys() {
+		if k == key {
+			return "", false
+		}
+	}
+	return key, true
+}
+
 func (e *DispatchExecutor) Check(ctx *query.Context, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) (*query.Path, error) {
-	if _, ok := it.(*query.AliasIterator); ok && !containsUnmatchedRecursiveSentinel(it) {
+	if _, ok := e.shouldDispatchAlias(it); ok {
 		return e.dispatchCheck(ctx, it, resource, subject)
 	}
 	return it.CheckImpl(ctx, resource, subject)
 }
 
 func (e *DispatchExecutor) CheckManySubjects(ctx *query.Context, it query.Iterator, resource query.Object, subjects []query.ObjectAndRelation) ([]*query.Path, error) {
-	if _, ok := it.(*query.AliasIterator); !ok || containsUnmatchedRecursiveSentinel(it) {
+	if _, ok := e.shouldDispatchAlias(it); !ok {
 		out := make([]*query.Path, len(subjects))
 		for i, s := range subjects {
 			p, err := it.CheckImpl(ctx, resource, s)
@@ -112,7 +137,7 @@ func (e *DispatchExecutor) CheckManySubjects(ctx *query.Context, it query.Iterat
 }
 
 func (e *DispatchExecutor) CheckManyResources(ctx *query.Context, it query.Iterator, resources []query.Object, subject query.ObjectAndRelation) ([]*query.Path, error) {
-	if _, ok := it.(*query.AliasIterator); !ok || containsUnmatchedRecursiveSentinel(it) {
+	if _, ok := e.shouldDispatchAlias(it); !ok {
 		out := make([]*query.Path, len(resources))
 		for i, r := range resources {
 			p, err := it.CheckImpl(ctx, r, subject)
@@ -127,7 +152,7 @@ func (e *DispatchExecutor) CheckManyResources(ctx *query.Context, it query.Itera
 }
 
 func (e *DispatchExecutor) IterSubjects(ctx *query.Context, it query.Iterator, resource query.Object, filterSubjectType query.ObjectType) (query.PathSeq, error) {
-	if _, ok := it.(*query.AliasIterator); ok && !containsUnmatchedRecursiveSentinel(it) {
+	if _, ok := e.shouldDispatchAlias(it); ok {
 		return e.dispatchIterSubjects(ctx, it, resource, filterSubjectType)
 	}
 	pathSeq, err := it.IterSubjectsImpl(ctx, resource, filterSubjectType)
@@ -138,7 +163,7 @@ func (e *DispatchExecutor) IterSubjects(ctx *query.Context, it query.Iterator, r
 }
 
 func (e *DispatchExecutor) IterResources(ctx *query.Context, it query.Iterator, subject query.ObjectAndRelation, filterResourceType query.ObjectType) (query.PathSeq, error) {
-	if _, ok := it.(*query.AliasIterator); ok && !containsUnmatchedRecursiveSentinel(it) {
+	if _, ok := e.shouldDispatchAlias(it); ok {
 		return e.dispatchIterResources(ctx, it, subject, filterResourceType)
 	}
 	pathSeq, err := it.IterResourcesImpl(ctx, subject, filterResourceType)
@@ -274,9 +299,10 @@ func (e *DispatchExecutor) dispatchCheckManyResources(ctx *query.Context, it que
 // must be left zero — the receiver inspects `many` for those operations.
 func (e *DispatchExecutor) buildManyRequest(op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation, manyResources []query.Object, manySubjects []query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
 	alias := it.(*query.AliasIterator)
+	key := alias.DefinitionName() + "#" + alias.Relation()
 	req := &v1.DispatchQueryPlanRequest{
 		Operation:    op,
-		CanonicalKey: alias.DefinitionName() + "#" + alias.Relation(),
+		CanonicalKey: key,
 		Resource: &core.ObjectAndRelation{
 			Namespace: resource.ObjectType,
 			ObjectId:  resource.ObjectID,
@@ -286,7 +312,7 @@ func (e *DispatchExecutor) buildManyRequest(op v1.PlanOperation, it query.Iterat
 			ObjectId:  subject.ObjectID,
 			Relation:  subject.Relation,
 		},
-		PlanContext: e.planContext,
+		PlanContext: planContextWithKey(e.planContext, key),
 	}
 	if len(manyResources) > 0 {
 		req.Many = make([]*core.ObjectAndRelation, len(manyResources))
@@ -316,9 +342,10 @@ func (e *DispatchExecutor) buildRequest(op v1.PlanOperation, it query.Iterator, 
 	// boundary is always the (definition, relation) the alias represents; we
 	// encode that as "definition#relation" in the canonical_key field.
 	alias := it.(*query.AliasIterator)
+	key := alias.DefinitionName() + "#" + alias.Relation()
 	return &v1.DispatchQueryPlanRequest{
 		Operation:    op,
-		CanonicalKey: alias.DefinitionName() + "#" + alias.Relation(),
+		CanonicalKey: key,
 		Resource: &core.ObjectAndRelation{
 			Namespace: resource.ObjectType,
 			ObjectId:  resource.ObjectID,
@@ -328,8 +355,22 @@ func (e *DispatchExecutor) buildRequest(op v1.PlanOperation, it query.Iterator, 
 			ObjectId:  subject.ObjectID,
 			Relation:  subject.Relation,
 		},
-		PlanContext: e.planContext,
+		PlanContext: planContextWithKey(e.planContext, key),
 	}
+}
+
+// planContextWithKey returns a shallow copy of pc with key appended to the
+// in-progress dispatch keys. The receiver's DispatchExecutor consults this set
+// to refuse re-dispatching keys that any ancestor on the dispatch chain is
+// already computing — the only way to terminate cross-relation cycles produced
+// by standalone plan rebuilds at each receiver hop.
+func planContextWithKey(pc *v1.PlanContext, key string) *v1.PlanContext {
+	if pc == nil {
+		return &v1.PlanContext{InProgressKeys: []string{key}}
+	}
+	out := *pc
+	out.InProgressKeys = append(append([]string(nil), pc.InProgressKeys...), key)
+	return &out
 }
 
 func collectPathsFromResponses(responses []*v1.DispatchQueryPlanResponse) []*query.Path {

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -2,6 +2,7 @@ package dispatch
 
 import (
 	"context"
+	"slices"
 
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -236,13 +237,9 @@ func (e *DispatchExecutor) dispatchCheckManySubjects(ctx *query.Context, it quer
 	defer cancel()
 
 	out := make([]*query.Path, len(subjects))
-	chunk := int(e.dispatchChunkSize)
-	for start := 0; start < len(subjects); start += chunk {
-		end := start + chunk
-		if end > len(subjects) {
-			end = len(subjects)
-		}
-		req := e.buildManyRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS, it, resource, query.ObjectAndRelation{}, nil, subjects[start:end])
+	idx := 0
+	for chunk := range slices.Chunk(subjects, int(e.dispatchChunkSize)) {
+		req := e.buildManyRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS, it, resource, query.ObjectAndRelation{}, nil, chunk)
 		stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 		if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
 			return nil, err
@@ -255,8 +252,9 @@ func (e *DispatchExecutor) dispatchCheckManySubjects(ctx *query.Context, it quer
 				bySubject[p.Subject] = p
 			}
 		}
-		for i := start; i < end; i++ {
-			out[i] = bySubject[subjects[i]]
+		for _, subject := range chunk {
+			out[idx] = bySubject[subject]
+			idx++
 		}
 	}
 	return out, nil
@@ -267,13 +265,9 @@ func (e *DispatchExecutor) dispatchCheckManyResources(ctx *query.Context, it que
 	defer cancel()
 
 	out := make([]*query.Path, len(resources))
-	chunk := int(e.dispatchChunkSize)
-	for start := 0; start < len(resources); start += chunk {
-		end := start + chunk
-		if end > len(resources) {
-			end = len(resources)
-		}
-		req := e.buildManyRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES, it, query.Object{}, subject, resources[start:end], nil)
+	idx := 0
+	for chunk := range slices.Chunk(resources, int(e.dispatchChunkSize)) {
+		req := e.buildManyRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES, it, query.Object{}, subject, chunk, nil)
 		stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 		if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
 			return nil, err
@@ -286,8 +280,9 @@ func (e *DispatchExecutor) dispatchCheckManyResources(ctx *query.Context, it que
 				byResource[p.Resource] = p
 			}
 		}
-		for i := start; i < end; i++ {
-			out[i] = byResource[resources[i]]
+		for _, resource := range chunk {
+			out[idx] = byResource[resource]
+			idx++
 		}
 	}
 	return out, nil
@@ -381,13 +376,19 @@ func planContextForDispatch(pc *v1.PlanContext, key string, topLevelOp query.Ope
 	if tlo == v1.PlanOperation_PLAN_OPERATION_CHECK {
 		tlo = queryOpToPlanOperation(topLevelOp)
 	}
+
+	// Duplicate and append the in progress keys
+	inProgress := make([]string, len(pc.InProgressKeys)+1)
+	copy(inProgress, pc.InProgressKeys)
+	inProgress[len(pc.InProgressKeys)] = key
+
 	return &v1.PlanContext{
 		Revision:               pc.Revision,
 		CaveatContext:          pc.CaveatContext,
 		MaxRecursionDepth:      pc.MaxRecursionDepth,
 		OptionalDatastoreLimit: pc.OptionalDatastoreLimit,
 		SchemaHash:             pc.SchemaHash,
-		InProgressKeys:         append(append([]string(nil), pc.InProgressKeys...), key),
+		InProgressKeys:         inProgress,
 		TopLevelOperation:      tlo,
 	}
 }

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -17,11 +17,16 @@ import (
 // through the dispatch infrastructure at alias iterator boundaries.
 // For non-alias iterators, it delegates locally like LocalExecutor.
 type DispatchExecutor struct {
-	dispatcher  Dispatcher
-	planContext *v1.PlanContext
+	dispatcher        Dispatcher
+	planContext       *v1.PlanContext
+	dispatchChunkSize uint16
 }
 
 var _ query.Executor = &DispatchExecutor{}
+
+// defaultDispatchChunkSize is the fallback batch size for CheckMany RPCs when
+// the executor was constructed with chunkSize == 0.
+const defaultDispatchChunkSize = 100
 
 // recursiveKey uniquely identifies a recursion pair by definition and relation name.
 type recursiveKey struct {
@@ -71,11 +76,16 @@ func containsUnmatchedRecursiveSentinel(it query.Iterator) bool {
 }
 
 // NewDispatchExecutor creates a new DispatchExecutor that dispatches alias
-// iterator operations through the given Dispatcher chain.
-func NewDispatchExecutor(dispatcher Dispatcher, planContext *v1.PlanContext) *DispatchExecutor {
+// iterator operations through the given Dispatcher chain. dispatchChunkSize
+// caps the number of inputs per CheckMany RPC; if zero, defaults to 100.
+func NewDispatchExecutor(dispatcher Dispatcher, planContext *v1.PlanContext, dispatchChunkSize uint16) *DispatchExecutor {
+	if dispatchChunkSize == 0 {
+		dispatchChunkSize = defaultDispatchChunkSize
+	}
 	return &DispatchExecutor{
-		dispatcher:  dispatcher,
-		planContext: planContext,
+		dispatcher:        dispatcher,
+		planContext:       planContext,
+		dispatchChunkSize: dispatchChunkSize,
 	}
 }
 
@@ -84,6 +94,36 @@ func (e *DispatchExecutor) Check(ctx *query.Context, it query.Iterator, resource
 		return e.dispatchCheck(ctx, it, resource, subject)
 	}
 	return it.CheckImpl(ctx, resource, subject)
+}
+
+func (e *DispatchExecutor) CheckManySubjects(ctx *query.Context, it query.Iterator, resource query.Object, subjects []query.ObjectAndRelation) ([]*query.Path, error) {
+	if _, ok := it.(*query.AliasIterator); !ok || containsUnmatchedRecursiveSentinel(it) {
+		out := make([]*query.Path, len(subjects))
+		for i, s := range subjects {
+			p, err := it.CheckImpl(ctx, resource, s)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = p
+		}
+		return out, nil
+	}
+	return e.dispatchCheckManySubjects(ctx, it, resource, subjects)
+}
+
+func (e *DispatchExecutor) CheckManyResources(ctx *query.Context, it query.Iterator, resources []query.Object, subject query.ObjectAndRelation) ([]*query.Path, error) {
+	if _, ok := it.(*query.AliasIterator); !ok || containsUnmatchedRecursiveSentinel(it) {
+		out := make([]*query.Path, len(resources))
+		for i, r := range resources {
+			p, err := it.CheckImpl(ctx, r, subject)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = p
+		}
+		return out, nil
+	}
+	return e.dispatchCheckManyResources(ctx, it, resources, subject)
 }
 
 func (e *DispatchExecutor) IterSubjects(ctx *query.Context, it query.Iterator, resource query.Object, filterSubjectType query.ObjectType) (query.PathSeq, error) {
@@ -164,6 +204,110 @@ func (e *DispatchExecutor) dispatchIterResources(ctx *query.Context, it query.It
 
 	paths := collectPathsFromResponses(stream.Results())
 	return query.FilterResourcesByType(query.PathSeqFromSlice(paths), filterResourceType), nil
+}
+
+func (e *DispatchExecutor) dispatchCheckManySubjects(ctx *query.Context, it query.Iterator, resource query.Object, subjects []query.ObjectAndRelation) ([]*query.Path, error) {
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	out := make([]*query.Path, len(subjects))
+	chunk := int(e.dispatchChunkSize)
+	for start := 0; start < len(subjects); start += chunk {
+		end := start + chunk
+		if end > len(subjects) {
+			end = len(subjects)
+		}
+		req := e.buildManyRequest(v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS, it, resource, query.ObjectAndRelation{}, nil, subjects[start:end])
+		stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
+		if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
+			return nil, err
+		}
+		// Index responses by subject ONR for back-mapping.
+		bySubject := make(map[query.ObjectAndRelation]*query.Path)
+		for _, resp := range stream.Results() {
+			for _, rp := range resp.Paths {
+				p := resultPathToQueryPath(rp)
+				bySubject[p.Subject] = p
+			}
+		}
+		for i := start; i < end; i++ {
+			out[i] = bySubject[subjects[i]]
+		}
+	}
+	return out, nil
+}
+
+func (e *DispatchExecutor) dispatchCheckManyResources(ctx *query.Context, it query.Iterator, resources []query.Object, subject query.ObjectAndRelation) ([]*query.Path, error) {
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	out := make([]*query.Path, len(resources))
+	chunk := int(e.dispatchChunkSize)
+	for start := 0; start < len(resources); start += chunk {
+		end := start + chunk
+		if end > len(resources) {
+			end = len(resources)
+		}
+		req := e.buildManyRequest(v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES, it, query.Object{}, subject, resources[start:end], nil)
+		stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
+		if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
+			return nil, err
+		}
+		// Index responses by resource Object for back-mapping.
+		byResource := make(map[query.Object]*query.Path)
+		for _, resp := range stream.Results() {
+			for _, rp := range resp.Paths {
+				p := resultPathToQueryPath(rp)
+				byResource[p.Resource] = p
+			}
+		}
+		for i := start; i < end; i++ {
+			out[i] = byResource[resources[i]]
+		}
+	}
+	return out, nil
+}
+
+// buildManyRequest constructs a DispatchQueryPlanRequest for CheckMany operations.
+// Exactly one of (manyResources, manySubjects) is non-nil; the corresponding
+// singular field (resource for CHECK_MANY_RESOURCES, subject for CHECK_MANY_SUBJECTS)
+// must be left zero — the receiver inspects `many` for those operations.
+func (e *DispatchExecutor) buildManyRequest(op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation, manyResources []query.Object, manySubjects []query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
+	alias := it.(*query.AliasIterator)
+	req := &v1.DispatchQueryPlanRequest{
+		Operation:    op,
+		CanonicalKey: alias.DefinitionName() + "#" + alias.Relation(),
+		Resource: &core.ObjectAndRelation{
+			Namespace: resource.ObjectType,
+			ObjectId:  resource.ObjectID,
+		},
+		Subject: &core.ObjectAndRelation{
+			Namespace: subject.ObjectType,
+			ObjectId:  subject.ObjectID,
+			Relation:  subject.Relation,
+		},
+		PlanContext: e.planContext,
+	}
+	if len(manyResources) > 0 {
+		req.Many = make([]*core.ObjectAndRelation, len(manyResources))
+		for i, r := range manyResources {
+			req.Many[i] = &core.ObjectAndRelation{
+				Namespace: r.ObjectType,
+				ObjectId:  r.ObjectID,
+			}
+		}
+	}
+	if len(manySubjects) > 0 {
+		req.Many = make([]*core.ObjectAndRelation, len(manySubjects))
+		for i, s := range manySubjects {
+			req.Many[i] = &core.ObjectAndRelation{
+				Namespace: s.ObjectType,
+				ObjectId:  s.ObjectID,
+				Relation:  s.Relation,
+			}
+		}
+	}
+	return req
 }
 
 func (e *DispatchExecutor) buildRequest(op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
@@ -259,20 +403,23 @@ func toProtoStruct(m map[string]any) (*structpb.Struct, error) {
 // driven by the given PlanContext, so that dispatched sub-requests carry the
 // same plan state. Plan-derived options (caveat context, recursion depth,
 // datastore limit) are applied first; extra opts are appended after.
+// dispatchChunkSize caps inputs-per-RPC for batched CheckMany operations.
 func NewQueryContext(
 	stdContext context.Context,
 	dispatcher Dispatcher,
 	planContext *v1.PlanContext,
 	reader query.QueryDatastoreReader,
 	caveatRunner *caveats.CaveatRunner,
+	dispatchChunkSize uint16,
 	opts ...query.ContextOption,
 ) *query.Context {
-	executor := NewDispatchExecutor(dispatcher, planContext)
+	executor := NewDispatchExecutor(dispatcher, planContext, dispatchChunkSize)
 
 	baseOpts := []query.ContextOption{
 		query.WithReader(reader),
 		query.WithCaveatContext(CaveatContextFromPlanContext(planContext)),
 		query.WithCaveatRunner(caveatRunner),
+		query.WithBatchedArrows(true),
 	}
 	if d := planContext.GetMaxRecursionDepth(); d > 0 {
 		baseOpts = append(baseOpts, query.WithMaxRecursionDepth(int(d)))

--- a/internal/dispatch/executor_test.go
+++ b/internal/dispatch/executor_test.go
@@ -82,7 +82,7 @@ func TestDispatchExecutor_Check_AliasDispatches(t *testing.T) {
 
 	// AliasIterator wrapping a FixedIterator — should trigger dispatch
 	inner := query.NewFixedIterator()
-	alias := query.NewAliasIterator("viewer", inner)
+	alias := query.NewAliasIterator("", "viewer", inner)
 
 	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func TestDispatchExecutor_Check_AliasNoResult(t *testing.T) {
 	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
-	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
 	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
@@ -150,7 +150,7 @@ func TestDispatchExecutor_IterSubjects_AliasDispatches(t *testing.T) {
 	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
-	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
 	pathSeq, err := exec.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
 	require.NoError(t, err)
@@ -206,7 +206,7 @@ func TestDispatchExecutor_IterResources_AliasDispatches(t *testing.T) {
 	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
-	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
 	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
@@ -252,7 +252,7 @@ func TestDispatchExecutor_Check_AliasWithRecursiveSentinelDoesNotDispatch(t *tes
 
 	// AliasIterator wrapping a RecursiveSentinel — should NOT dispatch
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
-	alias := query.NewAliasIterator("viewer", sentinel)
+	alias := query.NewAliasIterator("", "viewer", sentinel)
 
 	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
@@ -270,7 +270,7 @@ func TestDispatchExecutor_IterSubjects_AliasWithRecursiveSentinelDoesNotDispatch
 	ctx := newTestContext()
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
-	alias := query.NewAliasIterator("viewer", sentinel)
+	alias := query.NewAliasIterator("", "viewer", sentinel)
 
 	pathSeq, err := exec.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
 	require.NoError(t, err)
@@ -288,7 +288,7 @@ func TestDispatchExecutor_IterResources_AliasWithRecursiveSentinelDoesNotDispatc
 	ctx := newTestContext()
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
-	alias := query.NewAliasIterator("viewer", sentinel)
+	alias := query.NewAliasIterator("", "viewer", sentinel)
 
 	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
@@ -320,7 +320,7 @@ func TestDispatchExecutor_Check_AliasWithSentinelInsideRecursiveDispatches(t *te
 	// The sentinel is managed by the RecursiveIterator's context, so dispatch is allowed.
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
-	alias := query.NewAliasIterator("viewer", recursive)
+	alias := query.NewAliasIterator("", "viewer", recursive)
 
 	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
@@ -350,7 +350,7 @@ func TestDispatchExecutor_IterSubjects_AliasWithSentinelInsideRecursiveDispatche
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
-	alias := query.NewAliasIterator("viewer", recursive)
+	alias := query.NewAliasIterator("", "viewer", recursive)
 
 	pathSeq, err := exec.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
 	require.NoError(t, err)
@@ -382,7 +382,7 @@ func TestDispatchExecutor_IterResources_AliasWithSentinelInsideRecursiveDispatch
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
-	alias := query.NewAliasIterator("viewer", recursive)
+	alias := query.NewAliasIterator("", "viewer", recursive)
 
 	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
@@ -407,7 +407,7 @@ func TestDispatchExecutor_Check_DoubleRecursionUnmatchedSentinelDoesNotDispatch(
 	// so dispatch should be blocked.
 	documentSentinel := query.NewRecursiveSentinelIterator("document", "reader", false)
 	folderRecursive := query.NewRecursiveIterator(documentSentinel, "folder", "viewer")
-	alias := query.NewAliasIterator("viewer", folderRecursive)
+	alias := query.NewAliasIterator("", "viewer", folderRecursive)
 
 	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
@@ -441,7 +441,7 @@ func TestDispatchExecutor_Check_DoubleRecursionBothMatchedDispatches(t *testing.
 	documentSentinel := query.NewRecursiveSentinelIterator("document", "reader", false)
 	documentRecursive := query.NewRecursiveIterator(documentSentinel, "document", "reader")
 	folderRecursive := query.NewRecursiveIterator(documentRecursive, "folder", "viewer")
-	alias := query.NewAliasIterator("viewer", folderRecursive)
+	alias := query.NewAliasIterator("", "viewer", folderRecursive)
 
 	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
@@ -469,7 +469,7 @@ func TestDispatchExecutor_StreamBatching(t *testing.T) {
 	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
-	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
 	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
@@ -495,7 +495,7 @@ func TestDispatchExecutor_PlanContextForwarded(t *testing.T) {
 	exec := NewDispatchExecutor(td, pc, 100)
 	ctx := newTestContext()
 
-	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 	_, _ = exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 
 	require.Len(t, td.planCalls, 1)
@@ -515,7 +515,7 @@ func TestDispatchExecutor_ContextCancellation(t *testing.T) {
 	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	qctx := query.NewLocalContext(ctx)
 
-	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 	_, err := exec.Check(qctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 
 	// The dispatch itself succeeds (our test dispatcher doesn't check context),
@@ -675,7 +675,7 @@ func TestDispatchExecutor_CheckManyResources_AliasDispatchesAndPairsByONR(t *tes
 	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
-	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 	resources := []query.Object{
 		{ObjectType: "document", ObjectID: "doc1"},
 		{ObjectType: "document", ObjectID: "doc2"},
@@ -709,7 +709,7 @@ func TestDispatchExecutor_CheckManySubjects_AliasDispatches(t *testing.T) {
 	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
-	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 	subjects := []query.ObjectAndRelation{
 		{ObjectType: "user", ObjectID: "alice", Relation: "..."},
 		{ObjectType: "user", ObjectID: "bob", Relation: "..."},
@@ -791,7 +791,7 @@ func TestDispatchExecutor_CheckManyResources_ChunksByDispatchChunkSize(t *testin
 	exec := NewDispatchExecutor(cd, &v1.PlanContext{Revision: "rev1"}, chunkSize)
 	ctx := newTestContext()
 
-	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
 	resources := make([]query.Object, total)
 	for i := range resources {
@@ -838,7 +838,7 @@ func TestDispatchExecutor_CheckManySubjects_ChunksByDispatchChunkSize(t *testing
 	exec := NewDispatchExecutor(cd, &v1.PlanContext{Revision: "rev1"}, chunkSize)
 	ctx := newTestContext()
 
-	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 	subjects := make([]query.ObjectAndRelation, total)
 	for i := range subjects {
 		subjects[i] = query.ObjectAndRelation{ObjectType: "user", ObjectID: "u" + string(rune('a'+i)), Relation: "..."}

--- a/internal/dispatch/executor_test.go
+++ b/internal/dispatch/executor_test.go
@@ -77,7 +77,7 @@ func TestDispatchExecutor_Check_AliasDispatches(t *testing.T) {
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// AliasIterator wrapping a FixedIterator — should trigger dispatch
@@ -100,7 +100,7 @@ func TestDispatchExecutor_Check_AliasDispatches(t *testing.T) {
 func TestDispatchExecutor_Check_NonAliasLocal(t *testing.T) {
 	td := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// FixedIterator (not an alias) — should delegate locally, no dispatch
@@ -126,7 +126,7 @@ func TestDispatchExecutor_Check_AliasNoResult(t *testing.T) {
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
@@ -147,7 +147,7 @@ func TestDispatchExecutor_IterSubjects_AliasDispatches(t *testing.T) {
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
@@ -168,7 +168,7 @@ func TestDispatchExecutor_IterSubjects_AliasDispatches(t *testing.T) {
 func TestDispatchExecutor_IterSubjects_NonAliasLocal(t *testing.T) {
 	td := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	fixed := query.NewFixedIterator(
@@ -203,7 +203,7 @@ func TestDispatchExecutor_IterResources_AliasDispatches(t *testing.T) {
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
@@ -224,7 +224,7 @@ func TestDispatchExecutor_IterResources_AliasDispatches(t *testing.T) {
 func TestDispatchExecutor_IterResources_NonAliasLocal(t *testing.T) {
 	td := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	fixed := query.NewFixedIterator(
@@ -247,7 +247,7 @@ func TestDispatchExecutor_IterResources_NonAliasLocal(t *testing.T) {
 func TestDispatchExecutor_Check_AliasWithRecursiveSentinelDoesNotDispatch(t *testing.T) {
 	td := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// AliasIterator wrapping a RecursiveSentinel — should NOT dispatch
@@ -266,7 +266,7 @@ func TestDispatchExecutor_Check_AliasWithRecursiveSentinelDoesNotDispatch(t *tes
 func TestDispatchExecutor_IterSubjects_AliasWithRecursiveSentinelDoesNotDispatch(t *testing.T) {
 	td := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
@@ -284,7 +284,7 @@ func TestDispatchExecutor_IterSubjects_AliasWithRecursiveSentinelDoesNotDispatch
 func TestDispatchExecutor_IterResources_AliasWithRecursiveSentinelDoesNotDispatch(t *testing.T) {
 	td := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
@@ -313,7 +313,7 @@ func TestDispatchExecutor_Check_AliasWithSentinelInsideRecursiveDispatches(t *te
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// AliasIterator wrapping a RecursiveIterator that contains a RecursiveSentinel.
@@ -345,7 +345,7 @@ func TestDispatchExecutor_IterSubjects_AliasWithSentinelInsideRecursiveDispatche
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
@@ -377,7 +377,7 @@ func TestDispatchExecutor_IterResources_AliasWithSentinelInsideRecursiveDispatch
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
@@ -398,7 +398,7 @@ func TestDispatchExecutor_IterResources_AliasWithSentinelInsideRecursiveDispatch
 func TestDispatchExecutor_Check_DoubleRecursionUnmatchedSentinelDoesNotDispatch(t *testing.T) {
 	td := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// Double recursion: RecursiveIterator for "folder#viewer" contains a
@@ -431,7 +431,7 @@ func TestDispatchExecutor_Check_DoubleRecursionBothMatchedDispatches(t *testing.
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// Double recursion with both pairs matched:
@@ -466,7 +466,7 @@ func TestDispatchExecutor_StreamBatching(t *testing.T) {
 		},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
@@ -492,7 +492,7 @@ func TestDispatchExecutor_PlanContextForwarded(t *testing.T) {
 		MaxRecursionDepth:      5,
 		OptionalDatastoreLimit: 100,
 	}
-	exec := NewDispatchExecutor(td, pc)
+	exec := NewDispatchExecutor(td, pc, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
@@ -512,7 +512,7 @@ func TestDispatchExecutor_ContextCancellation(t *testing.T) {
 		planResponses: []*v1.DispatchQueryPlanResponse{{Paths: []*v1.ResultPath{}}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"})
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
 	qctx := query.NewLocalContext(ctx)
 
 	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
@@ -633,4 +633,229 @@ func TestPaginationLimitFromPlanContext(t *testing.T) {
 func TestPaginationLimitFromPlanContext_Zero(t *testing.T) {
 	pc := NewPlanContext("rev1", datalayer.NoSchemaHashForTesting, nil, 0, 0)
 	require.Nil(t, PaginationLimitFromPlanContext(pc))
+}
+
+// --- CheckMany dispatch tests ---
+
+func TestDispatchExecutor_CheckManyResources_NonAliasLocal(t *testing.T) {
+	td := &testDispatcher{}
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	ctx := newTestContext()
+
+	// FixedIterator (not an alias) — must delegate locally, no dispatch.
+	fixed := query.NewFixedIterator(query.Path{
+		Resource: query.Object{ObjectType: "document", ObjectID: "doc1"},
+		Relation: "viewer",
+		Subject:  query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."},
+	})
+
+	resources := []query.Object{
+		{ObjectType: "document", ObjectID: "doc1"},
+		{ObjectType: "document", ObjectID: "missing"},
+	}
+	out, err := exec.CheckManyResources(ctx, fixed, resources, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	require.NotNil(t, out[0])
+	require.Nil(t, out[1])
+	require.Empty(t, td.planCalls)
+}
+
+func TestDispatchExecutor_CheckManyResources_AliasDispatchesAndPairsByONR(t *testing.T) {
+	// Receiver returns paths in arbitrary order; sender must pair to inputs by
+	// resource ONR identity, not by position.
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{
+			Paths: []*v1.ResultPath{
+				{ResourceType: "document", ResourceId: "doc3", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
+				{ResourceType: "document", ResourceId: "doc1", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
+			},
+		}},
+	}
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	ctx := newTestContext()
+
+	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	resources := []query.Object{
+		{ObjectType: "document", ObjectID: "doc1"},
+		{ObjectType: "document", ObjectID: "doc2"},
+		{ObjectType: "document", ObjectID: "doc3"},
+	}
+	out, err := exec.CheckManyResources(ctx, alias, resources, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	require.NoError(t, err)
+	require.Len(t, out, 3)
+	require.NotNil(t, out[0])
+	require.Equal(t, "doc1", out[0].Resource.ObjectID)
+	require.Nil(t, out[1], "doc2 had no response — expected nil")
+	require.NotNil(t, out[2])
+	require.Equal(t, "doc3", out[2].Resource.ObjectID)
+
+	require.Len(t, td.planCalls, 1)
+	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES, td.planCalls[0].Operation)
+	require.Len(t, td.planCalls[0].Many, 3)
+	require.Equal(t, "doc1", td.planCalls[0].Many[0].ObjectId)
+	require.Equal(t, "doc2", td.planCalls[0].Many[1].ObjectId)
+	require.Equal(t, "doc3", td.planCalls[0].Many[2].ObjectId)
+}
+
+func TestDispatchExecutor_CheckManySubjects_AliasDispatches(t *testing.T) {
+	td := &testDispatcher{
+		planResponses: []*v1.DispatchQueryPlanResponse{{
+			Paths: []*v1.ResultPath{
+				{ResourceType: "document", ResourceId: "doc1", Relation: "viewer", SubjectType: "user", SubjectId: "bob", SubjectRelation: "..."},
+			},
+		}},
+	}
+	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	ctx := newTestContext()
+
+	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	subjects := []query.ObjectAndRelation{
+		{ObjectType: "user", ObjectID: "alice", Relation: "..."},
+		{ObjectType: "user", ObjectID: "bob", Relation: "..."},
+	}
+	out, err := exec.CheckManySubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, subjects)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	require.Nil(t, out[0], "alice had no response")
+	require.NotNil(t, out[1])
+	require.Equal(t, "bob", out[1].Subject.ObjectID)
+
+	require.Len(t, td.planCalls, 1)
+	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS, td.planCalls[0].Operation)
+}
+
+// chunkingDispatcher records every DispatchQueryPlan call and lets the test
+// configure a per-call response, simulating chunked RPCs.
+type chunkingDispatcher struct {
+	planCalls []*v1.DispatchQueryPlanRequest
+	respond   func(req *v1.DispatchQueryPlanRequest) []*v1.ResultPath
+}
+
+func (d *chunkingDispatcher) DispatchCheck(_ context.Context, _ *v1.DispatchCheckRequest) (*v1.DispatchCheckResponse, error) {
+	return &v1.DispatchCheckResponse{}, nil
+}
+
+func (d *chunkingDispatcher) DispatchExpand(_ context.Context, _ *v1.DispatchExpandRequest) (*v1.DispatchExpandResponse, error) {
+	return &v1.DispatchExpandResponse{}, nil
+}
+
+func (d *chunkingDispatcher) DispatchLookupResources2(_ *v1.DispatchLookupResources2Request, _ LookupResources2Stream) error {
+	return nil
+}
+
+func (d *chunkingDispatcher) DispatchLookupResources3(_ *v1.DispatchLookupResources3Request, _ LookupResources3Stream) error {
+	return nil
+}
+
+func (d *chunkingDispatcher) DispatchLookupSubjects(_ *v1.DispatchLookupSubjectsRequest, _ LookupSubjectsStream) error {
+	return nil
+}
+
+func (d *chunkingDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream PlanStream) error {
+	d.planCalls = append(d.planCalls, req)
+	if d.respond != nil {
+		paths := d.respond(req)
+		if len(paths) > 0 {
+			return stream.Publish(&v1.DispatchQueryPlanResponse{Paths: paths})
+		}
+	}
+	return nil
+}
+func (d *chunkingDispatcher) Close() error           { return nil }
+func (d *chunkingDispatcher) ReadyState() ReadyState { return ReadyState{IsReady: true} }
+
+var _ Dispatcher = &chunkingDispatcher{}
+
+func TestDispatchExecutor_CheckManyResources_ChunksByDispatchChunkSize(t *testing.T) {
+	const chunkSize = 3
+	const total = 10
+
+	cd := &chunkingDispatcher{
+		respond: func(req *v1.DispatchQueryPlanRequest) []*v1.ResultPath {
+			// Echo back every input as a match so the per-input pairing is exercised.
+			out := make([]*v1.ResultPath, 0, len(req.Many))
+			for _, m := range req.Many {
+				out = append(out, &v1.ResultPath{
+					ResourceType:    m.Namespace,
+					ResourceId:      m.ObjectId,
+					Relation:        "viewer",
+					SubjectType:     req.Subject.Namespace,
+					SubjectId:       req.Subject.ObjectId,
+					SubjectRelation: req.Subject.Relation,
+				})
+			}
+			return out
+		},
+	}
+	exec := NewDispatchExecutor(cd, &v1.PlanContext{Revision: "rev1"}, chunkSize)
+	ctx := newTestContext()
+
+	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+
+	resources := make([]query.Object, total)
+	for i := range resources {
+		resources[i] = query.Object{ObjectType: "document", ObjectID: "doc" + string(rune('a'+i))}
+	}
+	subject := query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}
+
+	out, err := exec.CheckManyResources(ctx, alias, resources, subject)
+	require.NoError(t, err)
+	require.Len(t, out, total)
+	for i, p := range out {
+		require.NotNil(t, p, "output %d should be non-nil", i)
+		require.Equal(t, resources[i].ObjectID, p.Resource.ObjectID)
+	}
+
+	// 10 inputs at chunkSize=3 → 4 RPCs (3,3,3,1).
+	require.Len(t, cd.planCalls, 4)
+	require.Len(t, cd.planCalls[0].Many, 3)
+	require.Len(t, cd.planCalls[1].Many, 3)
+	require.Len(t, cd.planCalls[2].Many, 3)
+	require.Len(t, cd.planCalls[3].Many, 1)
+}
+
+func TestDispatchExecutor_CheckManySubjects_ChunksByDispatchChunkSize(t *testing.T) {
+	const chunkSize = 4
+	const total = 9
+
+	cd := &chunkingDispatcher{
+		respond: func(req *v1.DispatchQueryPlanRequest) []*v1.ResultPath {
+			out := make([]*v1.ResultPath, 0, len(req.Many))
+			for _, m := range req.Many {
+				out = append(out, &v1.ResultPath{
+					ResourceType:    req.Resource.Namespace,
+					ResourceId:      req.Resource.ObjectId,
+					Relation:        "viewer",
+					SubjectType:     m.Namespace,
+					SubjectId:       m.ObjectId,
+					SubjectRelation: m.Relation,
+				})
+			}
+			return out
+		},
+	}
+	exec := NewDispatchExecutor(cd, &v1.PlanContext{Revision: "rev1"}, chunkSize)
+	ctx := newTestContext()
+
+	alias := query.NewAliasIterator("viewer", query.NewFixedIterator())
+	subjects := make([]query.ObjectAndRelation, total)
+	for i := range subjects {
+		subjects[i] = query.ObjectAndRelation{ObjectType: "user", ObjectID: "u" + string(rune('a'+i)), Relation: "..."}
+	}
+	resource := query.Object{ObjectType: "document", ObjectID: "doc1"}
+
+	out, err := exec.CheckManySubjects(ctx, alias, resource, subjects)
+	require.NoError(t, err)
+	require.Len(t, out, total)
+	for i, p := range out {
+		require.NotNil(t, p, "output %d should be non-nil", i)
+		require.Equal(t, subjects[i].ObjectID, p.Subject.ObjectID)
+	}
+
+	// 9 inputs at chunkSize=4 → 3 RPCs (4,4,1).
+	require.Len(t, cd.planCalls, 3)
+	require.Len(t, cd.planCalls[0].Many, 4)
+	require.Len(t, cd.planCalls[1].Many, 4)
+	require.Len(t, cd.planCalls[2].Many, 1)
 }

--- a/internal/dispatch/executor_test.go
+++ b/internal/dispatch/executor_test.go
@@ -64,7 +64,7 @@ func newTestContext() *query.Context {
 }
 
 func TestDispatchExecutor_Check_AliasDispatches(t *testing.T) {
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{
 			Paths: []*v1.ResultPath{{
 				ResourceType:    "document",
@@ -77,14 +77,14 @@ func TestDispatchExecutor_Check_AliasDispatches(t *testing.T) {
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// AliasIterator wrapping a FixedIterator — should trigger dispatch
 	inner := query.NewFixedIterator()
 	alias := query.NewAliasIterator("", "viewer", inner)
 
-	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.NotNil(t, path)
 	require.Equal(t, "document", path.Resource.ObjectType)
@@ -92,15 +92,15 @@ func TestDispatchExecutor_Check_AliasDispatches(t *testing.T) {
 	require.Equal(t, "alice", path.Subject.ObjectID)
 
 	// Verify dispatch was called
-	require.Len(t, td.planCalls, 1)
-	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_CHECK, td.planCalls[0].Operation)
-	require.Equal(t, "rev1", td.planCalls[0].PlanContext.Revision)
+	require.Len(t, receiver.planCalls, 1)
+	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_CHECK, receiver.planCalls[0].Operation)
+	require.Equal(t, "rev1", receiver.planCalls[0].PlanContext.Revision)
 }
 
 func TestDispatchExecutor_Check_NonAliasLocal(t *testing.T) {
-	td := &testDispatcher{}
+	receiver := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// FixedIterator (not an alias) — should delegate locally, no dispatch
@@ -110,35 +110,35 @@ func TestDispatchExecutor_Check_NonAliasLocal(t *testing.T) {
 		Subject:  query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."},
 	})
 
-	path, err := exec.Check(ctx, fixed, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, fixed, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.NotNil(t, path)
 	require.Equal(t, "alice", path.Subject.ObjectID)
 
 	// Verify NO dispatch was called
-	require.Empty(t, td.planCalls)
+	require.Empty(t, receiver.planCalls)
 }
 
 func TestDispatchExecutor_Check_AliasNoResult(t *testing.T) {
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{
 			Paths: []*v1.ResultPath{}, // empty = no permission
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
-	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.Nil(t, path)
-	require.Len(t, td.planCalls, 1)
+	require.Len(t, receiver.planCalls, 1)
 }
 
 func TestDispatchExecutor_IterSubjects_AliasDispatches(t *testing.T) {
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{
 			Paths: []*v1.ResultPath{
 				{ResourceType: "document", ResourceId: "doc1", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
@@ -147,12 +147,12 @@ func TestDispatchExecutor_IterSubjects_AliasDispatches(t *testing.T) {
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
-	pathSeq, err := exec.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	pathSeq, err := sender.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -161,14 +161,14 @@ func TestDispatchExecutor_IterSubjects_AliasDispatches(t *testing.T) {
 	require.Equal(t, "alice", paths[0].Subject.ObjectID)
 	require.Equal(t, "bob", paths[1].Subject.ObjectID)
 
-	require.Len(t, td.planCalls, 1)
-	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS, td.planCalls[0].Operation)
+	require.Len(t, receiver.planCalls, 1)
+	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS, receiver.planCalls[0].Operation)
 }
 
 func TestDispatchExecutor_IterSubjects_NonAliasLocal(t *testing.T) {
-	td := &testDispatcher{}
+	receiver := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	fixed := query.NewFixedIterator(
@@ -184,17 +184,17 @@ func TestDispatchExecutor_IterSubjects_NonAliasLocal(t *testing.T) {
 		},
 	)
 
-	pathSeq, err := exec.IterSubjects(ctx, fixed, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	pathSeq, err := sender.IterSubjects(ctx, fixed, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
 	require.NoError(t, err)
 	require.Len(t, paths, 2)
-	require.Empty(t, td.planCalls)
+	require.Empty(t, receiver.planCalls)
 }
 
 func TestDispatchExecutor_IterResources_AliasDispatches(t *testing.T) {
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{
 			Paths: []*v1.ResultPath{
 				{ResourceType: "document", ResourceId: "doc1", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
@@ -203,12 +203,12 @@ func TestDispatchExecutor_IterResources_AliasDispatches(t *testing.T) {
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
-	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	pathSeq, err := sender.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -217,14 +217,14 @@ func TestDispatchExecutor_IterResources_AliasDispatches(t *testing.T) {
 	require.Equal(t, "doc1", paths[0].Resource.ObjectID)
 	require.Equal(t, "doc2", paths[1].Resource.ObjectID)
 
-	require.Len(t, td.planCalls, 1)
-	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES, td.planCalls[0].Operation)
+	require.Len(t, receiver.planCalls, 1)
+	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES, receiver.planCalls[0].Operation)
 }
 
 func TestDispatchExecutor_IterResources_NonAliasLocal(t *testing.T) {
-	td := &testDispatcher{}
+	receiver := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	fixed := query.NewFixedIterator(
@@ -235,72 +235,72 @@ func TestDispatchExecutor_IterResources_NonAliasLocal(t *testing.T) {
 		},
 	)
 
-	pathSeq, err := exec.IterResources(ctx, fixed, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	pathSeq, err := sender.IterResources(ctx, fixed, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
 	require.NoError(t, err)
 	require.Len(t, paths, 1)
-	require.Empty(t, td.planCalls)
+	require.Empty(t, receiver.planCalls)
 }
 
 func TestDispatchExecutor_Check_AliasWithRecursiveSentinelDoesNotDispatch(t *testing.T) {
-	td := &testDispatcher{}
+	receiver := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// AliasIterator wrapping a RecursiveSentinel — should NOT dispatch
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	alias := query.NewAliasIterator("", "viewer", sentinel)
 
-	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	// RecursiveSentinel.CheckImpl returns nil
 	require.Nil(t, path)
 
 	// Verify NO dispatch was called
-	require.Empty(t, td.planCalls)
+	require.Empty(t, receiver.planCalls)
 }
 
 func TestDispatchExecutor_IterSubjects_AliasWithRecursiveSentinelDoesNotDispatch(t *testing.T) {
-	td := &testDispatcher{}
+	receiver := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	alias := query.NewAliasIterator("", "viewer", sentinel)
 
-	pathSeq, err := exec.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	pathSeq, err := sender.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
 	require.NoError(t, err)
 	require.Empty(t, paths)
-	require.Empty(t, td.planCalls)
+	require.Empty(t, receiver.planCalls)
 }
 
 func TestDispatchExecutor_IterResources_AliasWithRecursiveSentinelDoesNotDispatch(t *testing.T) {
-	td := &testDispatcher{}
+	receiver := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	alias := query.NewAliasIterator("", "viewer", sentinel)
 
-	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	pathSeq, err := sender.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
 	require.NoError(t, err)
 	require.Empty(t, paths)
-	require.Empty(t, td.planCalls)
+	require.Empty(t, receiver.planCalls)
 }
 
 func TestDispatchExecutor_Check_AliasWithSentinelInsideRecursiveDispatches(t *testing.T) {
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{
 			Paths: []*v1.ResultPath{{
 				ResourceType:    "document",
@@ -313,7 +313,7 @@ func TestDispatchExecutor_Check_AliasWithSentinelInsideRecursiveDispatches(t *te
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// AliasIterator wrapping a RecursiveIterator that contains a RecursiveSentinel.
@@ -322,17 +322,17 @@ func TestDispatchExecutor_Check_AliasWithSentinelInsideRecursiveDispatches(t *te
 	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
 	alias := query.NewAliasIterator("", "viewer", recursive)
 
-	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.NotNil(t, path)
 	require.Equal(t, "alice", path.Subject.ObjectID)
 
 	// Verify dispatch WAS called — the RecursiveIterator boundary makes it safe
-	require.Len(t, td.planCalls, 1)
+	require.Len(t, receiver.planCalls, 1)
 }
 
 func TestDispatchExecutor_IterSubjects_AliasWithSentinelInsideRecursiveDispatches(t *testing.T) {
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{
 			Paths: []*v1.ResultPath{{
 				ResourceType:    "document",
@@ -345,14 +345,14 @@ func TestDispatchExecutor_IterSubjects_AliasWithSentinelInsideRecursiveDispatche
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
 	alias := query.NewAliasIterator("", "viewer", recursive)
 
-	pathSeq, err := exec.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	pathSeq, err := sender.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -360,11 +360,11 @@ func TestDispatchExecutor_IterSubjects_AliasWithSentinelInsideRecursiveDispatche
 	require.Len(t, paths, 1)
 	require.Equal(t, "alice", paths[0].Subject.ObjectID)
 
-	require.Len(t, td.planCalls, 1)
+	require.Len(t, receiver.planCalls, 1)
 }
 
 func TestDispatchExecutor_IterResources_AliasWithSentinelInsideRecursiveDispatches(t *testing.T) {
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{
 			Paths: []*v1.ResultPath{{
 				ResourceType:    "document",
@@ -377,14 +377,14 @@ func TestDispatchExecutor_IterResources_AliasWithSentinelInsideRecursiveDispatch
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
 	alias := query.NewAliasIterator("", "viewer", recursive)
 
-	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	pathSeq, err := sender.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -392,13 +392,13 @@ func TestDispatchExecutor_IterResources_AliasWithSentinelInsideRecursiveDispatch
 	require.Len(t, paths, 1)
 	require.Equal(t, "doc1", paths[0].Resource.ObjectID)
 
-	require.Len(t, td.planCalls, 1)
+	require.Len(t, receiver.planCalls, 1)
 }
 
 func TestDispatchExecutor_Check_DoubleRecursionUnmatchedSentinelDoesNotDispatch(t *testing.T) {
-	td := &testDispatcher{}
+	receiver := &testDispatcher{}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// Double recursion: RecursiveIterator for "folder#viewer" contains a
@@ -409,16 +409,16 @@ func TestDispatchExecutor_Check_DoubleRecursionUnmatchedSentinelDoesNotDispatch(
 	folderRecursive := query.NewRecursiveIterator(documentSentinel, "folder", "viewer")
 	alias := query.NewAliasIterator("", "viewer", folderRecursive)
 
-	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.Nil(t, path)
 
 	// Verify NO dispatch was called — unmatched sentinel blocks dispatch
-	require.Empty(t, td.planCalls)
+	require.Empty(t, receiver.planCalls)
 }
 
 func TestDispatchExecutor_Check_DoubleRecursionBothMatchedDispatches(t *testing.T) {
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{
 			Paths: []*v1.ResultPath{{
 				ResourceType:    "folder",
@@ -431,7 +431,7 @@ func TestDispatchExecutor_Check_DoubleRecursionBothMatchedDispatches(t *testing.
 		}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// Double recursion with both pairs matched:
@@ -443,18 +443,18 @@ func TestDispatchExecutor_Check_DoubleRecursionBothMatchedDispatches(t *testing.
 	folderRecursive := query.NewRecursiveIterator(documentRecursive, "folder", "viewer")
 	alias := query.NewAliasIterator("", "viewer", folderRecursive)
 
-	path, err := exec.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.NotNil(t, path)
 	require.Equal(t, "alice", path.Subject.ObjectID)
 
 	// Verify dispatch WAS called — all sentinels are matched
-	require.Len(t, td.planCalls, 1)
+	require.Len(t, receiver.planCalls, 1)
 }
 
 func TestDispatchExecutor_StreamBatching(t *testing.T) {
 	// Multiple streamed responses should be collected correctly
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{
 			{Paths: []*v1.ResultPath{
 				{ResourceType: "document", ResourceId: "doc1", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
@@ -466,12 +466,12 @@ func TestDispatchExecutor_StreamBatching(t *testing.T) {
 		},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
-	pathSeq, err := exec.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	pathSeq, err := sender.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -483,7 +483,7 @@ func TestDispatchExecutor_StreamBatching(t *testing.T) {
 }
 
 func TestDispatchExecutor_PlanContextForwarded(t *testing.T) {
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{Paths: []*v1.ResultPath{}}},
 	}
 
@@ -492,31 +492,31 @@ func TestDispatchExecutor_PlanContextForwarded(t *testing.T) {
 		MaxRecursionDepth:      5,
 		OptionalDatastoreLimit: 100,
 	}
-	exec := NewDispatchExecutor(td, pc, 100)
+	sender := NewDispatchExecutor(receiver, pc, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
-	_, _ = exec.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	_, _ = sender.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 
-	require.Len(t, td.planCalls, 1)
-	require.Equal(t, "rev42", td.planCalls[0].PlanContext.Revision)
-	require.Equal(t, int32(5), td.planCalls[0].PlanContext.MaxRecursionDepth)
-	require.Equal(t, uint64(100), td.planCalls[0].PlanContext.OptionalDatastoreLimit)
+	require.Len(t, receiver.planCalls, 1)
+	require.Equal(t, "rev42", receiver.planCalls[0].PlanContext.Revision)
+	require.Equal(t, int32(5), receiver.planCalls[0].PlanContext.MaxRecursionDepth)
+	require.Equal(t, uint64(100), receiver.planCalls[0].PlanContext.OptionalDatastoreLimit)
 }
 
 func TestDispatchExecutor_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately
 
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{Paths: []*v1.ResultPath{}}},
 	}
 
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	qctx := query.NewLocalContext(ctx)
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
-	_, err := exec.Check(qctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	_, err := sender.Check(qctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 
 	// The dispatch itself succeeds (our test dispatcher doesn't check context),
 	// but the subcontext created inside dispatchCheck is derived from the cancelled parent.
@@ -638,8 +638,8 @@ func TestPaginationLimitFromPlanContext_Zero(t *testing.T) {
 // --- CheckMany dispatch tests ---
 
 func TestDispatchExecutor_CheckManyResources_NonAliasLocal(t *testing.T) {
-	td := &testDispatcher{}
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	receiver := &testDispatcher{}
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	// FixedIterator (not an alias) — must delegate locally, no dispatch.
@@ -653,18 +653,18 @@ func TestDispatchExecutor_CheckManyResources_NonAliasLocal(t *testing.T) {
 		{ObjectType: "document", ObjectID: "doc1"},
 		{ObjectType: "document", ObjectID: "missing"},
 	}
-	out, err := exec.CheckManyResources(ctx, fixed, resources, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	out, err := sender.CheckManyResources(ctx, fixed, resources, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
-	require.Len(t, out, 2)
+	require.Len(t, out, len(resources))
 	require.NotNil(t, out[0])
 	require.Nil(t, out[1])
-	require.Empty(t, td.planCalls)
+	require.Empty(t, receiver.planCalls)
 }
 
 func TestDispatchExecutor_CheckManyResources_AliasDispatchesAndPairsByONR(t *testing.T) {
 	// Receiver returns paths in arbitrary order; sender must pair to inputs by
 	// resource ONR identity, not by position.
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{
 			Paths: []*v1.ResultPath{
 				{ResourceType: "document", ResourceId: "doc3", Relation: "viewer", SubjectType: "user", SubjectId: "alice", SubjectRelation: "..."},
@@ -672,7 +672,7 @@ func TestDispatchExecutor_CheckManyResources_AliasDispatchesAndPairsByONR(t *tes
 			},
 		}},
 	}
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
@@ -681,32 +681,32 @@ func TestDispatchExecutor_CheckManyResources_AliasDispatchesAndPairsByONR(t *tes
 		{ObjectType: "document", ObjectID: "doc2"},
 		{ObjectType: "document", ObjectID: "doc3"},
 	}
-	out, err := exec.CheckManyResources(ctx, alias, resources, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	out, err := sender.CheckManyResources(ctx, alias, resources, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
-	require.Len(t, out, 3)
+	require.Len(t, out, len(resources))
 	require.NotNil(t, out[0])
 	require.Equal(t, "doc1", out[0].Resource.ObjectID)
 	require.Nil(t, out[1], "doc2 had no response — expected nil")
 	require.NotNil(t, out[2])
 	require.Equal(t, "doc3", out[2].Resource.ObjectID)
 
-	require.Len(t, td.planCalls, 1)
-	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES, td.planCalls[0].Operation)
-	require.Len(t, td.planCalls[0].Many, 3)
-	require.Equal(t, "doc1", td.planCalls[0].Many[0].ObjectId)
-	require.Equal(t, "doc2", td.planCalls[0].Many[1].ObjectId)
-	require.Equal(t, "doc3", td.planCalls[0].Many[2].ObjectId)
+	require.Len(t, receiver.planCalls, 1)
+	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES, receiver.planCalls[0].Operation)
+	require.Len(t, receiver.planCalls[0].Many, 3)
+	require.Equal(t, "doc1", receiver.planCalls[0].Many[0].ObjectId)
+	require.Equal(t, "doc2", receiver.planCalls[0].Many[1].ObjectId)
+	require.Equal(t, "doc3", receiver.planCalls[0].Many[2].ObjectId)
 }
 
 func TestDispatchExecutor_CheckManySubjects_AliasDispatches(t *testing.T) {
-	td := &testDispatcher{
+	receiver := &testDispatcher{
 		planResponses: []*v1.DispatchQueryPlanResponse{{
 			Paths: []*v1.ResultPath{
 				{ResourceType: "document", ResourceId: "doc1", Relation: "viewer", SubjectType: "user", SubjectId: "bob", SubjectRelation: "..."},
 			},
 		}},
 	}
-	exec := NewDispatchExecutor(td, &v1.PlanContext{Revision: "rev1"}, 100)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, 100)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
@@ -714,15 +714,15 @@ func TestDispatchExecutor_CheckManySubjects_AliasDispatches(t *testing.T) {
 		{ObjectType: "user", ObjectID: "alice", Relation: "..."},
 		{ObjectType: "user", ObjectID: "bob", Relation: "..."},
 	}
-	out, err := exec.CheckManySubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, subjects)
+	out, err := sender.CheckManySubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, subjects)
 	require.NoError(t, err)
-	require.Len(t, out, 2)
+	require.Len(t, out, len(subjects))
 	require.Nil(t, out[0], "alice had no response")
 	require.NotNil(t, out[1])
 	require.Equal(t, "bob", out[1].Subject.ObjectID)
 
-	require.Len(t, td.planCalls, 1)
-	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS, td.planCalls[0].Operation)
+	require.Len(t, receiver.planCalls, 1)
+	require.Equal(t, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS, receiver.planCalls[0].Operation)
 }
 
 // chunkingDispatcher records every DispatchQueryPlan call and lets the test
@@ -771,7 +771,7 @@ func TestDispatchExecutor_CheckManyResources_ChunksByDispatchChunkSize(t *testin
 	const chunkSize = 3
 	const total = 10
 
-	cd := &chunkingDispatcher{
+	receiver := &chunkingDispatcher{
 		respond: func(req *v1.DispatchQueryPlanRequest) []*v1.ResultPath {
 			// Echo back every input as a match so the per-input pairing is exercised.
 			out := make([]*v1.ResultPath, 0, len(req.Many))
@@ -788,7 +788,7 @@ func TestDispatchExecutor_CheckManyResources_ChunksByDispatchChunkSize(t *testin
 			return out
 		},
 	}
-	exec := NewDispatchExecutor(cd, &v1.PlanContext{Revision: "rev1"}, chunkSize)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, chunkSize)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
@@ -799,7 +799,7 @@ func TestDispatchExecutor_CheckManyResources_ChunksByDispatchChunkSize(t *testin
 	}
 	subject := query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}
 
-	out, err := exec.CheckManyResources(ctx, alias, resources, subject)
+	out, err := sender.CheckManyResources(ctx, alias, resources, subject)
 	require.NoError(t, err)
 	require.Len(t, out, total)
 	for i, p := range out {
@@ -808,18 +808,18 @@ func TestDispatchExecutor_CheckManyResources_ChunksByDispatchChunkSize(t *testin
 	}
 
 	// 10 inputs at chunkSize=3 → 4 RPCs (3,3,3,1).
-	require.Len(t, cd.planCalls, 4)
-	require.Len(t, cd.planCalls[0].Many, 3)
-	require.Len(t, cd.planCalls[1].Many, 3)
-	require.Len(t, cd.planCalls[2].Many, 3)
-	require.Len(t, cd.planCalls[3].Many, 1)
+	require.Len(t, receiver.planCalls, 4)
+	require.Len(t, receiver.planCalls[0].Many, 3)
+	require.Len(t, receiver.planCalls[1].Many, 3)
+	require.Len(t, receiver.planCalls[2].Many, 3)
+	require.Len(t, receiver.planCalls[3].Many, 1)
 }
 
 func TestDispatchExecutor_CheckManySubjects_ChunksByDispatchChunkSize(t *testing.T) {
 	const chunkSize = 4
 	const total = 9
 
-	cd := &chunkingDispatcher{
+	receiver := &chunkingDispatcher{
 		respond: func(req *v1.DispatchQueryPlanRequest) []*v1.ResultPath {
 			out := make([]*v1.ResultPath, 0, len(req.Many))
 			for _, m := range req.Many {
@@ -835,7 +835,7 @@ func TestDispatchExecutor_CheckManySubjects_ChunksByDispatchChunkSize(t *testing
 			return out
 		},
 	}
-	exec := NewDispatchExecutor(cd, &v1.PlanContext{Revision: "rev1"}, chunkSize)
+	sender := NewDispatchExecutor(receiver, &v1.PlanContext{Revision: "rev1"}, chunkSize)
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
@@ -845,7 +845,7 @@ func TestDispatchExecutor_CheckManySubjects_ChunksByDispatchChunkSize(t *testing
 	}
 	resource := query.Object{ObjectType: "document", ObjectID: "doc1"}
 
-	out, err := exec.CheckManySubjects(ctx, alias, resource, subjects)
+	out, err := sender.CheckManySubjects(ctx, alias, resource, subjects)
 	require.NoError(t, err)
 	require.Len(t, out, total)
 	for i, p := range out {
@@ -854,8 +854,8 @@ func TestDispatchExecutor_CheckManySubjects_ChunksByDispatchChunkSize(t *testing
 	}
 
 	// 9 inputs at chunkSize=4 → 3 RPCs (4,4,1).
-	require.Len(t, cd.planCalls, 3)
-	require.Len(t, cd.planCalls[0].Many, 4)
-	require.Len(t, cd.planCalls[1].Many, 4)
-	require.Len(t, cd.planCalls[2].Many, 1)
+	require.Len(t, receiver.planCalls, 3)
+	require.Len(t, receiver.planCalls[0].Many, 4)
+	require.Len(t, receiver.planCalls[1].Many, 4)
+	require.Len(t, receiver.planCalls[2].Many, 1)
 }

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -29,6 +29,7 @@ import (
 	"github.com/authzed/spicedb/pkg/query"
 	"github.com/authzed/spicedb/pkg/query/queryopt"
 	"github.com/authzed/spicedb/pkg/schema/v2"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
@@ -503,7 +504,7 @@ func (ld *localDispatcher) DispatchQueryPlan(
 
 	// Load schema at the requested revision and rebuild the iterator subtree
 	// for the (definition, relation) pair encoded in CanonicalKey.
-	// TODO: use cached compiled plans (Phase 7) instead of recompiling each time.
+	// TODO: use cached compiled plans instead of recompiling each time.
 	it, err := ld.compileIteratorForDispatchKey(ctx, revision, schemaHash, req)
 	if err != nil {
 		return err
@@ -534,12 +535,10 @@ func (ld *localDispatcher) DispatchQueryPlan(
 	// the dispatch chain (carried on PlanContext) so the first inner ctx.IterX
 	// call inside the body is NOT treated as the API-boundary top-level — that
 	// wrap strips wildcards, and on a receiver we must propagate them back to
-	// the sender. If PlanContext's top_level_operation matches req.Operation
-	// (e.g. zero/CHECK on both for an older sender), derive from req.Operation;
-	// otherwise prefer the explicit PlanContext value.
-	topLevelOp := planOperationToQueryOperation(req.PlanContext.GetTopLevelOperation())
-	if topLevelOp == query.OperationCheck && req.Operation != v1.PlanOperation_PLAN_OPERATION_CHECK {
-		topLevelOp = planOperationToQueryOperation(req.Operation)
+	// the sender.
+	topLevelOp, err := planOperationToQueryOperation(req.PlanContext.GetTopLevelOperation())
+	if err != nil {
+		return err
 	}
 	qctx.MarkAsOperation(it, topLevelOp)
 	switch req.Operation {
@@ -594,9 +593,9 @@ func (ld *localDispatcher) DispatchQueryPlan(
 	case v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES:
 		// Iterate CheckImpl directly: dispatch boundary already crossed for this
 		// alias. qctx still uses DispatchExecutor, so nested aliases re-dispatch.
-		for _, m := range req.Many {
-			res := query.Object{ObjectType: m.Namespace, ObjectID: m.ObjectId}
-			path, err := it.CheckImpl(qctx, res, subject)
+		for _, res := range req.Many {
+			resource := query.Object{ObjectType: res.Namespace, ObjectID: res.ObjectId}
+			path, err := it.CheckImpl(qctx, resource, subject)
 			if err != nil {
 				return err
 			}
@@ -611,13 +610,13 @@ func (ld *localDispatcher) DispatchQueryPlan(
 		return nil
 
 	case v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS:
-		for _, m := range req.Many {
-			sub := query.ObjectAndRelation{
-				ObjectType: m.Namespace,
-				ObjectID:   m.ObjectId,
-				Relation:   m.Relation,
+		for _, sub := range req.Many {
+			subject := query.ObjectAndRelation{
+				ObjectType: sub.Namespace,
+				ObjectID:   sub.ObjectId,
+				Relation:   sub.Relation,
 			}
-			path, err := it.CheckImpl(qctx, resource, sub)
+			path, err := it.CheckImpl(qctx, resource, subject)
 			if err != nil {
 				return err
 			}
@@ -680,8 +679,13 @@ func (ld *localDispatcher) compileIteratorForDispatchKey(ctx context.Context, re
 		return nil, fmt.Errorf("DispatchQueryPlan: failed to build outline for %s#%s: %w", defName, relName, err)
 	}
 
+	operation, err := planOperationToQueryOperation(req.Operation)
+	if err != nil {
+		return nil, fmt.Errorf("DispatchQueryPlan: %w", err)
+	}
+
 	params := queryopt.RequestParams{
-		Operation:       planOperationToQueryOperation(req.Operation),
+		Operation:       operation,
 		SubjectType:     req.Subject.GetNamespace(),
 		SubjectRelation: req.Subject.GetRelation(),
 	}
@@ -699,18 +703,18 @@ func (ld *localDispatcher) compileIteratorForDispatchKey(ctx context.Context, re
 
 // planOperationToQueryOperation maps the proto PlanOperation enum to the
 // corresponding query.Operation used by the optimizer-selection logic.
-func planOperationToQueryOperation(op v1.PlanOperation) query.Operation {
+func planOperationToQueryOperation(op v1.PlanOperation) (query.Operation, error) {
 	switch op {
 	case v1.PlanOperation_PLAN_OPERATION_CHECK,
 		v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES,
 		v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS:
-		return query.OperationCheck
+		return query.OperationCheck, nil
 	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES:
-		return query.OperationIterResources
+		return query.OperationIterResources, nil
 	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS:
-		return query.OperationIterSubjects
+		return query.OperationIterSubjects, nil
 	default:
-		return query.OperationCheck
+		return query.OperationUnset, spiceerrors.MustBugf("unhandled plan operation type")
 	}
 }
 

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -498,39 +499,22 @@ func (ld *localDispatcher) DispatchQueryPlan(
 
 	schemaHash := datalayer.SchemaHash(planCtx.GetSchemaHash())
 
-	// Load schema at the requested revision.
+	// Load schema at the requested revision and rebuild the iterator subtree
+	// for the (definition, relation) pair encoded in CanonicalKey.
 	// TODO: use cached compiled plans (Phase 7) instead of recompiling each time.
-
-	// Map PlanOperation to query.Operation for optimizer selection.
-	var operation query.Operation
-	switch req.Operation {
-	case v1.PlanOperation_PLAN_OPERATION_CHECK:
-		operation = query.OperationCheck
-	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES:
-		operation = query.OperationIterResources
-	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS:
-		operation = query.OperationIterSubjects
-	}
-
-	queryParams := queryopt.RequestParams{
-		Operation:       operation,
-		SubjectType:     req.Subject.Namespace,
-		SubjectRelation: req.Subject.Relation,
-	}
-
-	it, err := ld.findIteratorByCanonicalKey(ctx, revision, schemaHash, query.CanonicalKey(req.CanonicalKey), queryParams)
+	it, err := ld.compileIteratorForDispatchKey(ctx, revision, schemaHash, req)
 	if err != nil {
 		return err
 	}
 
-	// Build execution context with DispatchExecutor so nested alias boundaries
-	// in the subtree can re-dispatch through the full dispatch chain.
+	// Use DispatchExecutor so nested alias boundaries in the subtree re-dispatch
+	// through the full dispatch chain.
 	dl := datalayer.MustFromContext(ctx)
 	executor := dispatch.NewDispatchExecutor(ld, planCtx)
 	qctx := &query.Context{
 		Context:       ctx,
 		Executor:      executor,
-		Reader:        query.NewQueryDatastoreReader(dl.SnapshotReader(revision, datalayer.SchemaHash(req.GetPlanContext().GetSchemaHash()))),
+		Reader:        query.NewQueryDatastoreReader(dl.SnapshotReader(revision, schemaHash)),
 		CaveatRunner:  caveats.NewCaveatRunner(caveattypes.Default.TypeSet),
 		CaveatContext: dispatch.CaveatContextFromPlanContext(planCtx),
 	}
@@ -597,10 +581,19 @@ func (ld *localDispatcher) DispatchQueryPlan(
 	}
 }
 
-// findIteratorByCanonicalKey loads the schema at the given revision, compiles
-// all permissions with the given request parameters for optimization, and returns
-// the iterator subtree matching the canonical key.
-func (ld *localDispatcher) findIteratorByCanonicalKey(ctx context.Context, revision datastore.Revision, schemaHash datalayer.SchemaHash, targetKey query.CanonicalKey, queryParams queryopt.RequestParams) (query.Iterator, error) {
+// compileIteratorForDispatchKey loads the schema at the given revision, parses
+// the dispatch key (currently encoded as "definition#relation"), builds the
+// outline standalone for that pair, applies the same optimizers the sender
+// would have used, and compiles to an iterator. The returned iterator's outer
+// node is the *AliasIterator for the requested (definition, relation); callers
+// invoke its Impl method directly so the alias's rewrite + self-edge logic
+// runs without re-triggering the executor's dispatch decision at this level.
+func (ld *localDispatcher) compileIteratorForDispatchKey(ctx context.Context, revision datastore.Revision, schemaHash datalayer.SchemaHash, req *v1.DispatchQueryPlanRequest) (query.Iterator, error) {
+	defName, relName, ok := strings.Cut(req.CanonicalKey, "#")
+	if !ok || defName == "" || relName == "" {
+		return nil, fmt.Errorf("DispatchQueryPlan: invalid dispatch key %q (expected \"definition#relation\")", req.CanonicalKey)
+	}
+
 	dl := datalayer.MustFromContext(ctx)
 	reader := dl.SnapshotReader(revision, schemaHash)
 
@@ -627,41 +620,41 @@ func (ld *localDispatcher) findIteratorByCanonicalKey(ctx context.Context, revis
 		return nil, fmt.Errorf("DispatchQueryPlan: failed to build schema: %w", err)
 	}
 
-	for nsName, def := range fullSchema.Definitions() {
-		for permName := range def.Permissions() {
-			co, err := query.BuildOutlineFromSchema(fullSchema, nsName, permName)
-			if err != nil {
-				continue
-			}
-
-			optimized, err := queryopt.ApplyOptimizations(co, queryopt.OptimizersForRequest(queryParams), queryParams)
-			if err != nil {
-				continue
-			}
-
-			it, err := optimized.Compile()
-			if err != nil {
-				continue
-			}
-			if found := findByCanonicalKey(it, targetKey); found != nil {
-				return found, nil
-			}
-		}
+	co, err := query.BuildOutlineFromSchema(fullSchema, defName, relName)
+	if err != nil {
+		return nil, fmt.Errorf("DispatchQueryPlan: failed to build outline for %s#%s: %w", defName, relName, err)
 	}
-	return nil, fmt.Errorf("DispatchQueryPlan: no iterator found for canonical key %q", targetKey)
+
+	params := queryopt.RequestParams{
+		Operation:       planOperationToQueryOperation(req.Operation),
+		SubjectType:     req.Subject.GetNamespace(),
+		SubjectRelation: req.Subject.GetRelation(),
+	}
+	optimized, err := queryopt.ApplyOptimizations(co, queryopt.OptimizersForRequest(params), params)
+	if err != nil {
+		return nil, fmt.Errorf("DispatchQueryPlan: failed to optimize outline for %s#%s: %w", defName, relName, err)
+	}
+
+	it, err := optimized.Compile()
+	if err != nil {
+		return nil, fmt.Errorf("DispatchQueryPlan: failed to compile outline for %s#%s: %w", defName, relName, err)
+	}
+	return it, nil
 }
 
-// findByCanonicalKey recursively searches an iterator tree for a node matching the key.
-func findByCanonicalKey(it query.Iterator, key query.CanonicalKey) query.Iterator {
-	if it.CanonicalKey() == key {
-		return it
+// planOperationToQueryOperation maps the proto PlanOperation enum to the
+// corresponding query.Operation used by the optimizer-selection logic.
+func planOperationToQueryOperation(op v1.PlanOperation) query.Operation {
+	switch op {
+	case v1.PlanOperation_PLAN_OPERATION_CHECK:
+		return query.OperationCheck
+	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES:
+		return query.OperationIterResources
+	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS:
+		return query.OperationIterSubjects
+	default:
+		return query.OperationCheck
 	}
-	for _, sub := range it.Subiterators() {
-		if found := findByCanonicalKey(sub, key); found != nil {
-			return found
-		}
-	}
-	return nil
 }
 
 func (ld *localDispatcher) Close() error {

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -530,6 +530,18 @@ func (ld *localDispatcher) DispatchQueryPlan(
 	}
 
 	// Call Impl directly — the dispatch boundary has already been crossed.
+	// Pre-seal qctx's topLevelOnce with the user-facing operation that started
+	// the dispatch chain (carried on PlanContext) so the first inner ctx.IterX
+	// call inside the body is NOT treated as the API-boundary top-level — that
+	// wrap strips wildcards, and on a receiver we must propagate them back to
+	// the sender. If PlanContext's top_level_operation matches req.Operation
+	// (e.g. zero/CHECK on both for an older sender), derive from req.Operation;
+	// otherwise prefer the explicit PlanContext value.
+	topLevelOp := planOperationToQueryOperation(req.PlanContext.GetTopLevelOperation())
+	if topLevelOp == query.OperationCheck && req.Operation != v1.PlanOperation_PLAN_OPERATION_CHECK {
+		topLevelOp = planOperationToQueryOperation(req.Operation)
+	}
+	qctx.MarkAsOperation(it, topLevelOp)
 	switch req.Operation {
 	case v1.PlanOperation_PLAN_OPERATION_CHECK:
 		path, err := it.CheckImpl(qctx, resource, subject)

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -151,7 +151,7 @@ func NewLocalOnlyDispatcher(parameters DispatcherParameters) (dispatch.Dispatche
 		return nil, err
 	}
 
-	d := &localDispatcher{}
+	d := &localDispatcher{dispatchChunkSize: parameters.DispatchChunkSize}
 
 	typeSet := parameters.TypeSet
 	concurrencyLimits := limitsOrDefaults(parameters.ConcurrencyLimits, defaultConcurrencyLimit)
@@ -197,6 +197,7 @@ func NewDispatcher(redispatcher dispatch.Dispatcher, parameters DispatcherParame
 		lookupSubjectsHandler:   lookupSubjectsHandler,
 		lookupResourcesHandler2: lookupResourcesHandler2,
 		lookupResourcesHandler3: lr3,
+		dispatchChunkSize:       chunkSize,
 	}, nil
 }
 
@@ -206,6 +207,7 @@ type localDispatcher struct {
 	lookupSubjectsHandler   *graph.ConcurrentLookupSubjects
 	lookupResourcesHandler2 *graph.CursoredLookupResources2
 	lookupResourcesHandler3 *graph.CursoredLookupResources3
+	dispatchChunkSize       uint16
 }
 
 func (ld *localDispatcher) loadNamespace(ctx context.Context, nsName string, revision datastore.Revision, schemaHash datalayer.SchemaHash) (*core.NamespaceDefinition, error) {
@@ -510,13 +512,14 @@ func (ld *localDispatcher) DispatchQueryPlan(
 	// Use DispatchExecutor so nested alias boundaries in the subtree re-dispatch
 	// through the full dispatch chain.
 	dl := datalayer.MustFromContext(ctx)
-	executor := dispatch.NewDispatchExecutor(ld, planCtx)
+	executor := dispatch.NewDispatchExecutor(ld, planCtx, ld.dispatchChunkSize)
 	qctx := &query.Context{
 		Context:       ctx,
 		Executor:      executor,
 		Reader:        query.NewQueryDatastoreReader(dl.SnapshotReader(revision, schemaHash)),
 		CaveatRunner:  caveats.NewCaveatRunner(caveattypes.Default.TypeSet),
 		CaveatContext: dispatch.CaveatContextFromPlanContext(planCtx),
+		BatchedArrows: true,
 	}
 
 	resource := query.Object{ObjectType: req.Resource.Namespace, ObjectID: req.Resource.ObjectId}
@@ -572,6 +575,46 @@ func (ld *localDispatcher) DispatchQueryPlan(
 				Paths: []*v1.ResultPath{dispatch.QueryPathToResultPath(path)},
 			}); err != nil {
 				return err
+			}
+		}
+		return nil
+
+	case v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES:
+		// Iterate CheckImpl directly: dispatch boundary already crossed for this
+		// alias. qctx still uses DispatchExecutor, so nested aliases re-dispatch.
+		for _, m := range req.Many {
+			res := query.Object{ObjectType: m.Namespace, ObjectID: m.ObjectId}
+			path, err := it.CheckImpl(qctx, res, subject)
+			if err != nil {
+				return err
+			}
+			if path != nil {
+				if err := stream.Publish(&v1.DispatchQueryPlanResponse{
+					Paths: []*v1.ResultPath{dispatch.QueryPathToResultPath(path)},
+				}); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+
+	case v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS:
+		for _, m := range req.Many {
+			sub := query.ObjectAndRelation{
+				ObjectType: m.Namespace,
+				ObjectID:   m.ObjectId,
+				Relation:   m.Relation,
+			}
+			path, err := it.CheckImpl(qctx, resource, sub)
+			if err != nil {
+				return err
+			}
+			if path != nil {
+				if err := stream.Publish(&v1.DispatchQueryPlanResponse{
+					Paths: []*v1.ResultPath{dispatch.QueryPathToResultPath(path)},
+				}); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
@@ -646,7 +689,9 @@ func (ld *localDispatcher) compileIteratorForDispatchKey(ctx context.Context, re
 // corresponding query.Operation used by the optimizer-selection logic.
 func planOperationToQueryOperation(op v1.PlanOperation) query.Operation {
 	switch op {
-	case v1.PlanOperation_PLAN_OPERATION_CHECK:
+	case v1.PlanOperation_PLAN_OPERATION_CHECK,
+		v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES,
+		v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS:
 		return query.OperationCheck
 	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES:
 		return query.OperationIterResources

--- a/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
+++ b/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
@@ -189,8 +189,7 @@ func (h *dispatchQueryPlanHandle) newCachingDispatcher(b *testing.B) *caching.Di
 }
 
 // localQueryPlanDispatcher is a minimal dispatcher that handles DispatchQueryPlan by compiling
-// the plan from schema and executing it locally. This simulates what the real
-// localDispatcher will do in Phase 4.
+// the plan from schema and executing it locally.
 type localQueryPlanDispatcher struct {
 	handle *dispatchQueryPlanHandle
 }

--- a/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
+++ b/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
@@ -142,7 +142,7 @@ func (h *dispatchQueryPlanHandle) newLocalContext(ctx context.Context) *query.Co
 func (h *dispatchQueryPlanHandle) newDispatchContext(ctx context.Context) *query.Context {
 	planCtx := dispatch.NewPlanContext(h.revision.String(), h.schemaHash, nil, 0, 0)
 	lpd := &localQueryPlanDispatcher{handle: h}
-	executor := dispatch.NewDispatchExecutor(lpd, planCtx)
+	executor := dispatch.NewDispatchExecutor(lpd, planCtx, 100)
 
 	qctx := &query.Context{
 		Context:       ctx,
@@ -158,7 +158,7 @@ func (h *dispatchQueryPlanHandle) newDispatchContext(ctx context.Context) *query
 // a caching layer wrapping the localQueryPlanDispatcher. This exercises the Check cache path.
 func (h *dispatchQueryPlanHandle) newCachedDispatchContext(b *testing.B, cachingDispatcher *caching.Dispatcher) *query.Context {
 	planCtx := dispatch.NewPlanContext(h.revision.String(), h.schemaHash, nil, 0, 0)
-	executor := dispatch.NewDispatchExecutor(cachingDispatcher, planCtx)
+	executor := dispatch.NewDispatchExecutor(cachingDispatcher, planCtx, 100)
 
 	qctx := &query.Context{
 		Context:       b.Context(),
@@ -240,7 +240,7 @@ func (d *localQueryPlanDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRe
 	// while letting anything underneath go through the executor normally.
 	planCtx := req.PlanContext
 	lpd := &localQueryPlanDispatcher{handle: d.handle}
-	executor := dispatch.NewDispatchExecutor(lpd, planCtx)
+	executor := dispatch.NewDispatchExecutor(lpd, planCtx, 100)
 
 	qctx := &query.Context{
 		Context:       ctx,

--- a/internal/services/v1/permissions_queryplan.go
+++ b/internal/services/v1/permissions_queryplan.go
@@ -160,6 +160,7 @@ func (ps *permissionServer) checkPermissionWithQueryPlan(ctx context.Context, re
 		planContext,
 		query.NewQueryDatastoreReader(reader),
 		caveatsimpl.NewCaveatRunner(ps.config.CaveatTypeSet),
+		ps.config.DispatchChunkSize,
 		query.WithObserver(countObserver),
 	)
 
@@ -292,6 +293,7 @@ func (ps *permissionServer) lookupResourcesWithQueryPlan(req *v1.LookupResources
 		planContext,
 		query.NewQueryDatastoreReader(reader),
 		caveatsimpl.NewCaveatRunner(ps.config.CaveatTypeSet),
+		ps.config.DispatchChunkSize,
 		query.WithObserver(countObserver),
 	)
 
@@ -419,6 +421,7 @@ func (ps *permissionServer) lookupSubjectsWithQueryPlan(req *v1.LookupSubjectsRe
 		planContext,
 		query.NewQueryDatastoreReader(reader),
 		caveatsimpl.NewCaveatRunner(ps.config.CaveatTypeSet),
+		ps.config.DispatchChunkSize,
 		query.WithObserver(countObserver),
 	)
 

--- a/internal/services/v1/permissions_queryplan.go
+++ b/internal/services/v1/permissions_queryplan.go
@@ -8,6 +8,7 @@ import (
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
 	caveatsimpl "github.com/authzed/spicedb/internal/caveats"
+	"github.com/authzed/spicedb/internal/dispatch"
 	"github.com/authzed/spicedb/pkg/datalayer"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/middleware/consistency"
@@ -151,11 +152,14 @@ func (ps *permissionServer) checkPermissionWithQueryPlan(ctx context.Context, re
 	// Create count observer to track query execution statistics
 	countObserver := query.NewCountObserver()
 
-	// Create query context with count observer
-	qctx := query.NewLocalContext(ctx,
-		query.WithReader(query.NewQueryDatastoreReader(reader)),
-		query.WithCaveatContext(caveatContext),
-		query.WithCaveatRunner(caveatsimpl.NewCaveatRunner(ps.config.CaveatTypeSet)),
+	// Create query context backed by a DispatchExecutor.
+	planContext := dispatch.NewPlanContext(atRevision.String(), schemaHash, caveatContext, int(ps.config.MaximumAPIDepth), 0)
+	qctx := dispatch.NewQueryContext(
+		ctx,
+		ps.dispatch,
+		planContext,
+		query.NewQueryDatastoreReader(reader),
+		caveatsimpl.NewCaveatRunner(ps.config.CaveatTypeSet),
 		query.WithObserver(countObserver),
 	)
 
@@ -281,10 +285,13 @@ func (ps *permissionServer) lookupResourcesWithQueryPlan(req *v1.LookupResources
 
 	countObserver := query.NewCountObserver()
 
-	qctx := query.NewLocalContext(ctx,
-		query.WithReader(query.NewQueryDatastoreReader(reader)),
-		query.WithCaveatContext(caveatContext),
-		query.WithCaveatRunner(caveatsimpl.NewCaveatRunner(ps.config.CaveatTypeSet)),
+	planContext := dispatch.NewPlanContext(atRevision.String(), schemaHash, caveatContext, int(ps.config.MaximumAPIDepth), 0)
+	qctx := dispatch.NewQueryContext(
+		ctx,
+		ps.dispatch,
+		planContext,
+		query.NewQueryDatastoreReader(reader),
+		caveatsimpl.NewCaveatRunner(ps.config.CaveatTypeSet),
 		query.WithObserver(countObserver),
 	)
 
@@ -405,10 +412,13 @@ func (ps *permissionServer) lookupSubjectsWithQueryPlan(req *v1.LookupSubjectsRe
 
 	countObserver := query.NewCountObserver()
 
-	qctx := query.NewLocalContext(ctx,
-		query.WithReader(query.NewQueryDatastoreReader(reader)),
-		query.WithCaveatContext(caveatContext),
-		query.WithCaveatRunner(caveatsimpl.NewCaveatRunner(ps.config.CaveatTypeSet)),
+	planContext := dispatch.NewPlanContext(atRevision.String(), schemaHash, caveatContext, int(ps.config.MaximumAPIDepth), 0)
+	qctx := dispatch.NewQueryContext(
+		ctx,
+		ps.dispatch,
+		planContext,
+		query.NewQueryDatastoreReader(reader),
+		caveatsimpl.NewCaveatRunner(ps.config.CaveatTypeSet),
 		query.WithObserver(countObserver),
 	)
 

--- a/pkg/proto/dispatch/v1/dispatch.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch.pb.go
@@ -1740,8 +1740,15 @@ type PlanContext struct {
 	MaxRecursionDepth      int32                  `protobuf:"varint,3,opt,name=max_recursion_depth,json=maxRecursionDepth,proto3" json:"max_recursion_depth,omitempty"`
 	OptionalDatastoreLimit uint64                 `protobuf:"varint,4,opt,name=optional_datastore_limit,json=optionalDatastoreLimit,proto3" json:"optional_datastore_limit,omitempty"`
 	SchemaHash             []byte                 `protobuf:"bytes,5,opt,name=schema_hash,json=schemaHash,proto3" json:"schema_hash,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// in_progress_keys are the dispatch canonical keys (\"def#rel\") that ancestors
+	// of this dispatch are currently computing. The receiver-side DispatchExecutor
+	// refuses to dispatch any alias whose key is in this set, falling back to local
+	// execution. This is what breaks dispatch loops that arise when the standalone
+	// plan for a key contains another structurally complete instance of itself
+	// (cross-relation recursion the sentinel machinery can't see).
+	InProgressKeys []string `protobuf:"bytes,6,rep,name=in_progress_keys,json=inProgressKeys,proto3" json:"in_progress_keys,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *PlanContext) Reset() {
@@ -1805,6 +1812,13 @@ func (x *PlanContext) GetOptionalDatastoreLimit() uint64 {
 func (x *PlanContext) GetSchemaHash() []byte {
 	if x != nil {
 		return x.SchemaHash
+	}
+	return nil
+}
+
+func (x *PlanContext) GetInProgressKeys() []string {
+	if x != nil {
+		return x.InProgressKeys
 	}
 	return nil
 }
@@ -2280,14 +2294,15 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\f\n" +
 	"\bRELATION\x10\x01\x12\x0e\n" +
 	"\n" +
-	"PERMISSION\x10\x02\"\xf4\x01\n" +
+	"PERMISSION\x10\x02\"\x9e\x02\n" +
 	"\vPlanContext\x12\x1a\n" +
 	"\brevision\x18\x01 \x01(\tR\brevision\x12>\n" +
 	"\x0ecaveat_context\x18\x02 \x01(\v2\x17.google.protobuf.StructR\rcaveatContext\x12.\n" +
 	"\x13max_recursion_depth\x18\x03 \x01(\x05R\x11maxRecursionDepth\x128\n" +
 	"\x18optional_datastore_limit\x18\x04 \x01(\x04R\x16optionalDatastoreLimit\x12\x1f\n" +
 	"\vschema_hash\x18\x05 \x01(\fR\n" +
-	"schemaHash\"\xd4\x02\n" +
+	"schemaHash\x12(\n" +
+	"\x10in_progress_keys\x18\x06 \x03(\tR\x0einProgressKeys\"\xd4\x02\n" +
 	"\x18DispatchQueryPlanRequest\x128\n" +
 	"\toperation\x18\x01 \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\toperation\x12#\n" +
 	"\rcanonical_key\x18\x02 \x01(\tR\fcanonicalKey\x126\n" +

--- a/pkg/proto/dispatch/v1/dispatch.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch.pb.go
@@ -32,6 +32,10 @@ const (
 	PlanOperation_PLAN_OPERATION_CHECK            PlanOperation = 0
 	PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES PlanOperation = 1
 	PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS  PlanOperation = 2
+	// CHECK_MANY_RESOURCES: many = repeated resource ONRs, subject = single ONR.
+	PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES PlanOperation = 3
+	// CHECK_MANY_SUBJECTS: resource = single ONR, many = repeated subject ONRs.
+	PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS PlanOperation = 4
 )
 
 // Enum value maps for PlanOperation.
@@ -40,11 +44,15 @@ var (
 		0: "PLAN_OPERATION_CHECK",
 		1: "PLAN_OPERATION_LOOKUP_RESOURCES",
 		2: "PLAN_OPERATION_LOOKUP_SUBJECTS",
+		3: "PLAN_OPERATION_CHECK_MANY_RESOURCES",
+		4: "PLAN_OPERATION_CHECK_MANY_SUBJECTS",
 	}
 	PlanOperation_value = map[string]int32{
-		"PLAN_OPERATION_CHECK":            0,
-		"PLAN_OPERATION_LOOKUP_RESOURCES": 1,
-		"PLAN_OPERATION_LOOKUP_SUBJECTS":  2,
+		"PLAN_OPERATION_CHECK":                0,
+		"PLAN_OPERATION_LOOKUP_RESOURCES":     1,
+		"PLAN_OPERATION_LOOKUP_SUBJECTS":      2,
+		"PLAN_OPERATION_CHECK_MANY_RESOURCES": 3,
+		"PLAN_OPERATION_CHECK_MANY_SUBJECTS":  4,
 	}
 )
 
@@ -1802,12 +1810,17 @@ func (x *PlanContext) GetSchemaHash() []byte {
 }
 
 type DispatchQueryPlanRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Operation     PlanOperation          `protobuf:"varint,1,opt,name=operation,proto3,enum=dispatch.v1.PlanOperation" json:"operation,omitempty"`
-	CanonicalKey  string                 `protobuf:"bytes,2,opt,name=canonical_key,json=canonicalKey,proto3" json:"canonical_key,omitempty"`
-	Resource      *v1.ObjectAndRelation  `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
-	Subject       *v1.ObjectAndRelation  `protobuf:"bytes,4,opt,name=subject,proto3" json:"subject,omitempty"`
-	PlanContext   *PlanContext           `protobuf:"bytes,5,opt,name=plan_context,json=planContext,proto3" json:"plan_context,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Operation    PlanOperation          `protobuf:"varint,1,opt,name=operation,proto3,enum=dispatch.v1.PlanOperation" json:"operation,omitempty"`
+	CanonicalKey string                 `protobuf:"bytes,2,opt,name=canonical_key,json=canonicalKey,proto3" json:"canonical_key,omitempty"`
+	// For CHECK_MANY_RESOURCES, resource is empty and `many` carries the resources.
+	Resource *v1.ObjectAndRelation `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
+	// For CHECK_MANY_SUBJECTS, subject is empty and `many` carries the subjects.
+	Subject     *v1.ObjectAndRelation `protobuf:"bytes,4,opt,name=subject,proto3" json:"subject,omitempty"`
+	PlanContext *PlanContext          `protobuf:"bytes,5,opt,name=plan_context,json=planContext,proto3" json:"plan_context,omitempty"`
+	// many takes the place of resource or subject (whichever is empty), used by
+	// PLAN_OPERATION_CHECK_MANY_RESOURCES and PLAN_OPERATION_CHECK_MANY_SUBJECTS.
+	Many          []*v1.ObjectAndRelation `protobuf:"bytes,6,rep,name=many,proto3" json:"many,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1873,6 +1886,13 @@ func (x *DispatchQueryPlanRequest) GetSubject() *v1.ObjectAndRelation {
 func (x *DispatchQueryPlanRequest) GetPlanContext() *PlanContext {
 	if x != nil {
 		return x.PlanContext
+	}
+	return nil
+}
+
+func (x *DispatchQueryPlanRequest) GetMany() []*v1.ObjectAndRelation {
+	if x != nil {
+		return x.Many
 	}
 	return nil
 }
@@ -2267,13 +2287,14 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\x13max_recursion_depth\x18\x03 \x01(\x05R\x11maxRecursionDepth\x128\n" +
 	"\x18optional_datastore_limit\x18\x04 \x01(\x04R\x16optionalDatastoreLimit\x12\x1f\n" +
 	"\vschema_hash\x18\x05 \x01(\fR\n" +
-	"schemaHash\"\xa4\x02\n" +
+	"schemaHash\"\xd4\x02\n" +
 	"\x18DispatchQueryPlanRequest\x128\n" +
 	"\toperation\x18\x01 \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\toperation\x12#\n" +
 	"\rcanonical_key\x18\x02 \x01(\tR\fcanonicalKey\x126\n" +
 	"\bresource\x18\x03 \x01(\v2\x1a.core.v1.ObjectAndRelationR\bresource\x124\n" +
 	"\asubject\x18\x04 \x01(\v2\x1a.core.v1.ObjectAndRelationR\asubject\x12;\n" +
-	"\fplan_context\x18\x05 \x01(\v2\x18.dispatch.v1.PlanContextR\vplanContext\"\x81\x01\n" +
+	"\fplan_context\x18\x05 \x01(\v2\x18.dispatch.v1.PlanContextR\vplanContext\x12.\n" +
+	"\x04many\x18\x06 \x03(\v2\x1a.core.v1.ObjectAndRelationR\x04many\"\x81\x01\n" +
 	"\x19DispatchQueryPlanResponse\x125\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x19.dispatch.v1.ResponseMetaR\bmetadata\x12-\n" +
 	"\x05paths\x18\x02 \x03(\v2\x17.dispatch.v1.ResultPathR\x05paths\"\x83\x04\n" +
@@ -2297,11 +2318,13 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\x11excluded_subjects\x18\v \x03(\v2\x17.dispatch.v1.ResultPathR\x10excludedSubjects\"a\n" +
 	"\x0fLookupDebugInfo\x12#\n" +
 	"\rcycle_members\x18\x01 \x03(\tR\fcycleMembers\x12)\n" +
-	"\x10cycle_candidates\x18\x02 \x03(\tR\x0fcycleCandidates*r\n" +
+	"\x10cycle_candidates\x18\x02 \x03(\tR\x0fcycleCandidates*\xc3\x01\n" +
 	"\rPlanOperation\x12\x18\n" +
 	"\x14PLAN_OPERATION_CHECK\x10\x00\x12#\n" +
 	"\x1fPLAN_OPERATION_LOOKUP_RESOURCES\x10\x01\x12\"\n" +
-	"\x1ePLAN_OPERATION_LOOKUP_SUBJECTS\x10\x022\xa1\x05\n" +
+	"\x1ePLAN_OPERATION_LOOKUP_SUBJECTS\x10\x02\x12'\n" +
+	"#PLAN_OPERATION_CHECK_MANY_RESOURCES\x10\x03\x12&\n" +
+	"\"PLAN_OPERATION_CHECK_MANY_SUBJECTS\x10\x042\xa1\x05\n" +
 	"\x0fDispatchService\x12X\n" +
 	"\rDispatchCheck\x12!.dispatch.v1.DispatchCheckRequest\x1a\".dispatch.v1.DispatchCheckResponse\"\x00\x12[\n" +
 	"\x0eDispatchExpand\x12\".dispatch.v1.DispatchExpandRequest\x1a#.dispatch.v1.DispatchExpandResponse\"\x00\x12u\n" +
@@ -2424,33 +2447,34 @@ var file_dispatch_v1_dispatch_proto_depIdxs = []int32{
 	36, // 50: dispatch.v1.DispatchQueryPlanRequest.resource:type_name -> core.v1.ObjectAndRelation
 	36, // 51: dispatch.v1.DispatchQueryPlanRequest.subject:type_name -> core.v1.ObjectAndRelation
 	27, // 52: dispatch.v1.DispatchQueryPlanRequest.plan_context:type_name -> dispatch.v1.PlanContext
-	24, // 53: dispatch.v1.DispatchQueryPlanResponse.metadata:type_name -> dispatch.v1.ResponseMeta
-	30, // 54: dispatch.v1.DispatchQueryPlanResponse.paths:type_name -> dispatch.v1.ResultPath
-	37, // 55: dispatch.v1.ResultPath.caveat:type_name -> core.v1.CaveatExpression
-	41, // 56: dispatch.v1.ResultPath.expiration:type_name -> google.protobuf.Timestamp
-	42, // 57: dispatch.v1.ResultPath.integrity:type_name -> core.v1.RelationshipIntegrity
-	39, // 58: dispatch.v1.ResultPath.metadata:type_name -> google.protobuf.Struct
-	30, // 59: dispatch.v1.ResultPath.excluded_subjects:type_name -> dispatch.v1.ResultPath
-	9,  // 60: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry.value:type_name -> dispatch.v1.ResourceCheckResult
-	21, // 61: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry.value:type_name -> dispatch.v1.FoundSubjects
-	9,  // 62: dispatch.v1.CheckDebugTrace.ResultsEntry.value:type_name -> dispatch.v1.ResourceCheckResult
-	6,  // 63: dispatch.v1.DispatchService.DispatchCheck:input_type -> dispatch.v1.DispatchCheckRequest
-	10, // 64: dispatch.v1.DispatchService.DispatchExpand:input_type -> dispatch.v1.DispatchExpandRequest
-	19, // 65: dispatch.v1.DispatchService.DispatchLookupSubjects:input_type -> dispatch.v1.DispatchLookupSubjectsRequest
-	13, // 66: dispatch.v1.DispatchService.DispatchLookupResources2:input_type -> dispatch.v1.DispatchLookupResources2Request
-	16, // 67: dispatch.v1.DispatchService.DispatchLookupResources3:input_type -> dispatch.v1.DispatchLookupResources3Request
-	28, // 68: dispatch.v1.DispatchService.DispatchQueryPlan:input_type -> dispatch.v1.DispatchQueryPlanRequest
-	8,  // 69: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
-	11, // 70: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
-	22, // 71: dispatch.v1.DispatchService.DispatchLookupSubjects:output_type -> dispatch.v1.DispatchLookupSubjectsResponse
-	15, // 72: dispatch.v1.DispatchService.DispatchLookupResources2:output_type -> dispatch.v1.DispatchLookupResources2Response
-	17, // 73: dispatch.v1.DispatchService.DispatchLookupResources3:output_type -> dispatch.v1.DispatchLookupResources3Response
-	29, // 74: dispatch.v1.DispatchService.DispatchQueryPlan:output_type -> dispatch.v1.DispatchQueryPlanResponse
-	69, // [69:75] is the sub-list for method output_type
-	63, // [63:69] is the sub-list for method input_type
-	63, // [63:63] is the sub-list for extension type_name
-	63, // [63:63] is the sub-list for extension extendee
-	0,  // [0:63] is the sub-list for field type_name
+	36, // 53: dispatch.v1.DispatchQueryPlanRequest.many:type_name -> core.v1.ObjectAndRelation
+	24, // 54: dispatch.v1.DispatchQueryPlanResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	30, // 55: dispatch.v1.DispatchQueryPlanResponse.paths:type_name -> dispatch.v1.ResultPath
+	37, // 56: dispatch.v1.ResultPath.caveat:type_name -> core.v1.CaveatExpression
+	41, // 57: dispatch.v1.ResultPath.expiration:type_name -> google.protobuf.Timestamp
+	42, // 58: dispatch.v1.ResultPath.integrity:type_name -> core.v1.RelationshipIntegrity
+	39, // 59: dispatch.v1.ResultPath.metadata:type_name -> google.protobuf.Struct
+	30, // 60: dispatch.v1.ResultPath.excluded_subjects:type_name -> dispatch.v1.ResultPath
+	9,  // 61: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry.value:type_name -> dispatch.v1.ResourceCheckResult
+	21, // 62: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry.value:type_name -> dispatch.v1.FoundSubjects
+	9,  // 63: dispatch.v1.CheckDebugTrace.ResultsEntry.value:type_name -> dispatch.v1.ResourceCheckResult
+	6,  // 64: dispatch.v1.DispatchService.DispatchCheck:input_type -> dispatch.v1.DispatchCheckRequest
+	10, // 65: dispatch.v1.DispatchService.DispatchExpand:input_type -> dispatch.v1.DispatchExpandRequest
+	19, // 66: dispatch.v1.DispatchService.DispatchLookupSubjects:input_type -> dispatch.v1.DispatchLookupSubjectsRequest
+	13, // 67: dispatch.v1.DispatchService.DispatchLookupResources2:input_type -> dispatch.v1.DispatchLookupResources2Request
+	16, // 68: dispatch.v1.DispatchService.DispatchLookupResources3:input_type -> dispatch.v1.DispatchLookupResources3Request
+	28, // 69: dispatch.v1.DispatchService.DispatchQueryPlan:input_type -> dispatch.v1.DispatchQueryPlanRequest
+	8,  // 70: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
+	11, // 71: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
+	22, // 72: dispatch.v1.DispatchService.DispatchLookupSubjects:output_type -> dispatch.v1.DispatchLookupSubjectsResponse
+	15, // 73: dispatch.v1.DispatchService.DispatchLookupResources2:output_type -> dispatch.v1.DispatchLookupResources2Response
+	17, // 74: dispatch.v1.DispatchService.DispatchLookupResources3:output_type -> dispatch.v1.DispatchLookupResources3Response
+	29, // 75: dispatch.v1.DispatchService.DispatchQueryPlan:output_type -> dispatch.v1.DispatchQueryPlanResponse
+	70, // [70:76] is the sub-list for method output_type
+	64, // [64:70] is the sub-list for method input_type
+	64, // [64:64] is the sub-list for extension type_name
+	64, // [64:64] is the sub-list for extension extendee
+	0,  // [0:64] is the sub-list for field type_name
 }
 
 func init() { file_dispatch_v1_dispatch_proto_init() }

--- a/pkg/proto/dispatch/v1/dispatch.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch.pb.go
@@ -1747,8 +1747,16 @@ type PlanContext struct {
 	// plan for a key contains another structurally complete instance of itself
 	// (cross-relation recursion the sentinel machinery can't see).
 	InProgressKeys []string `protobuf:"bytes,6,rep,name=in_progress_keys,json=inProgressKeys,proto3" json:"in_progress_keys,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// top_level_operation carries the user-facing operation (Check / LookupSubjects
+	// / LookupResources) that started the dispatch chain. The receiver pre-seals
+	// its qctx with this value so iterators that consult TopLevelOperation (e.g.
+	// AliasIterator.shouldIncludeSelfEdge) see the original API intent rather
+	// than the per-hop dispatch op. Reuses PlanOperation so a single enum
+	// describes both per-hop and user-facing operations; only CHECK,
+	// LOOKUP_RESOURCES, and LOOKUP_SUBJECTS are valid here.
+	TopLevelOperation PlanOperation `protobuf:"varint,7,opt,name=top_level_operation,json=topLevelOperation,proto3,enum=dispatch.v1.PlanOperation" json:"top_level_operation,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *PlanContext) Reset() {
@@ -1821,6 +1829,13 @@ func (x *PlanContext) GetInProgressKeys() []string {
 		return x.InProgressKeys
 	}
 	return nil
+}
+
+func (x *PlanContext) GetTopLevelOperation() PlanOperation {
+	if x != nil {
+		return x.TopLevelOperation
+	}
+	return PlanOperation_PLAN_OPERATION_CHECK
 }
 
 type DispatchQueryPlanRequest struct {
@@ -2294,7 +2309,7 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\f\n" +
 	"\bRELATION\x10\x01\x12\x0e\n" +
 	"\n" +
-	"PERMISSION\x10\x02\"\x9e\x02\n" +
+	"PERMISSION\x10\x02\"\xea\x02\n" +
 	"\vPlanContext\x12\x1a\n" +
 	"\brevision\x18\x01 \x01(\tR\brevision\x12>\n" +
 	"\x0ecaveat_context\x18\x02 \x01(\v2\x17.google.protobuf.StructR\rcaveatContext\x12.\n" +
@@ -2302,7 +2317,8 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\x18optional_datastore_limit\x18\x04 \x01(\x04R\x16optionalDatastoreLimit\x12\x1f\n" +
 	"\vschema_hash\x18\x05 \x01(\fR\n" +
 	"schemaHash\x12(\n" +
-	"\x10in_progress_keys\x18\x06 \x03(\tR\x0einProgressKeys\"\xd4\x02\n" +
+	"\x10in_progress_keys\x18\x06 \x03(\tR\x0einProgressKeys\x12J\n" +
+	"\x13top_level_operation\x18\a \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\x11topLevelOperation\"\xd4\x02\n" +
 	"\x18DispatchQueryPlanRequest\x128\n" +
 	"\toperation\x18\x01 \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\toperation\x12#\n" +
 	"\rcanonical_key\x18\x02 \x01(\tR\fcanonicalKey\x126\n" +
@@ -2458,38 +2474,39 @@ var file_dispatch_v1_dispatch_proto_depIdxs = []int32{
 	26, // 46: dispatch.v1.CheckDebugTrace.sub_problems:type_name -> dispatch.v1.CheckDebugTrace
 	40, // 47: dispatch.v1.CheckDebugTrace.duration:type_name -> google.protobuf.Duration
 	39, // 48: dispatch.v1.PlanContext.caveat_context:type_name -> google.protobuf.Struct
-	0,  // 49: dispatch.v1.DispatchQueryPlanRequest.operation:type_name -> dispatch.v1.PlanOperation
-	36, // 50: dispatch.v1.DispatchQueryPlanRequest.resource:type_name -> core.v1.ObjectAndRelation
-	36, // 51: dispatch.v1.DispatchQueryPlanRequest.subject:type_name -> core.v1.ObjectAndRelation
-	27, // 52: dispatch.v1.DispatchQueryPlanRequest.plan_context:type_name -> dispatch.v1.PlanContext
-	36, // 53: dispatch.v1.DispatchQueryPlanRequest.many:type_name -> core.v1.ObjectAndRelation
-	24, // 54: dispatch.v1.DispatchQueryPlanResponse.metadata:type_name -> dispatch.v1.ResponseMeta
-	30, // 55: dispatch.v1.DispatchQueryPlanResponse.paths:type_name -> dispatch.v1.ResultPath
-	37, // 56: dispatch.v1.ResultPath.caveat:type_name -> core.v1.CaveatExpression
-	41, // 57: dispatch.v1.ResultPath.expiration:type_name -> google.protobuf.Timestamp
-	42, // 58: dispatch.v1.ResultPath.integrity:type_name -> core.v1.RelationshipIntegrity
-	39, // 59: dispatch.v1.ResultPath.metadata:type_name -> google.protobuf.Struct
-	30, // 60: dispatch.v1.ResultPath.excluded_subjects:type_name -> dispatch.v1.ResultPath
-	9,  // 61: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry.value:type_name -> dispatch.v1.ResourceCheckResult
-	21, // 62: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry.value:type_name -> dispatch.v1.FoundSubjects
-	9,  // 63: dispatch.v1.CheckDebugTrace.ResultsEntry.value:type_name -> dispatch.v1.ResourceCheckResult
-	6,  // 64: dispatch.v1.DispatchService.DispatchCheck:input_type -> dispatch.v1.DispatchCheckRequest
-	10, // 65: dispatch.v1.DispatchService.DispatchExpand:input_type -> dispatch.v1.DispatchExpandRequest
-	19, // 66: dispatch.v1.DispatchService.DispatchLookupSubjects:input_type -> dispatch.v1.DispatchLookupSubjectsRequest
-	13, // 67: dispatch.v1.DispatchService.DispatchLookupResources2:input_type -> dispatch.v1.DispatchLookupResources2Request
-	16, // 68: dispatch.v1.DispatchService.DispatchLookupResources3:input_type -> dispatch.v1.DispatchLookupResources3Request
-	28, // 69: dispatch.v1.DispatchService.DispatchQueryPlan:input_type -> dispatch.v1.DispatchQueryPlanRequest
-	8,  // 70: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
-	11, // 71: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
-	22, // 72: dispatch.v1.DispatchService.DispatchLookupSubjects:output_type -> dispatch.v1.DispatchLookupSubjectsResponse
-	15, // 73: dispatch.v1.DispatchService.DispatchLookupResources2:output_type -> dispatch.v1.DispatchLookupResources2Response
-	17, // 74: dispatch.v1.DispatchService.DispatchLookupResources3:output_type -> dispatch.v1.DispatchLookupResources3Response
-	29, // 75: dispatch.v1.DispatchService.DispatchQueryPlan:output_type -> dispatch.v1.DispatchQueryPlanResponse
-	70, // [70:76] is the sub-list for method output_type
-	64, // [64:70] is the sub-list for method input_type
-	64, // [64:64] is the sub-list for extension type_name
-	64, // [64:64] is the sub-list for extension extendee
-	0,  // [0:64] is the sub-list for field type_name
+	0,  // 49: dispatch.v1.PlanContext.top_level_operation:type_name -> dispatch.v1.PlanOperation
+	0,  // 50: dispatch.v1.DispatchQueryPlanRequest.operation:type_name -> dispatch.v1.PlanOperation
+	36, // 51: dispatch.v1.DispatchQueryPlanRequest.resource:type_name -> core.v1.ObjectAndRelation
+	36, // 52: dispatch.v1.DispatchQueryPlanRequest.subject:type_name -> core.v1.ObjectAndRelation
+	27, // 53: dispatch.v1.DispatchQueryPlanRequest.plan_context:type_name -> dispatch.v1.PlanContext
+	36, // 54: dispatch.v1.DispatchQueryPlanRequest.many:type_name -> core.v1.ObjectAndRelation
+	24, // 55: dispatch.v1.DispatchQueryPlanResponse.metadata:type_name -> dispatch.v1.ResponseMeta
+	30, // 56: dispatch.v1.DispatchQueryPlanResponse.paths:type_name -> dispatch.v1.ResultPath
+	37, // 57: dispatch.v1.ResultPath.caveat:type_name -> core.v1.CaveatExpression
+	41, // 58: dispatch.v1.ResultPath.expiration:type_name -> google.protobuf.Timestamp
+	42, // 59: dispatch.v1.ResultPath.integrity:type_name -> core.v1.RelationshipIntegrity
+	39, // 60: dispatch.v1.ResultPath.metadata:type_name -> google.protobuf.Struct
+	30, // 61: dispatch.v1.ResultPath.excluded_subjects:type_name -> dispatch.v1.ResultPath
+	9,  // 62: dispatch.v1.DispatchCheckResponse.ResultsByResourceIdEntry.value:type_name -> dispatch.v1.ResourceCheckResult
+	21, // 63: dispatch.v1.DispatchLookupSubjectsResponse.FoundSubjectsByResourceIdEntry.value:type_name -> dispatch.v1.FoundSubjects
+	9,  // 64: dispatch.v1.CheckDebugTrace.ResultsEntry.value:type_name -> dispatch.v1.ResourceCheckResult
+	6,  // 65: dispatch.v1.DispatchService.DispatchCheck:input_type -> dispatch.v1.DispatchCheckRequest
+	10, // 66: dispatch.v1.DispatchService.DispatchExpand:input_type -> dispatch.v1.DispatchExpandRequest
+	19, // 67: dispatch.v1.DispatchService.DispatchLookupSubjects:input_type -> dispatch.v1.DispatchLookupSubjectsRequest
+	13, // 68: dispatch.v1.DispatchService.DispatchLookupResources2:input_type -> dispatch.v1.DispatchLookupResources2Request
+	16, // 69: dispatch.v1.DispatchService.DispatchLookupResources3:input_type -> dispatch.v1.DispatchLookupResources3Request
+	28, // 70: dispatch.v1.DispatchService.DispatchQueryPlan:input_type -> dispatch.v1.DispatchQueryPlanRequest
+	8,  // 71: dispatch.v1.DispatchService.DispatchCheck:output_type -> dispatch.v1.DispatchCheckResponse
+	11, // 72: dispatch.v1.DispatchService.DispatchExpand:output_type -> dispatch.v1.DispatchExpandResponse
+	22, // 73: dispatch.v1.DispatchService.DispatchLookupSubjects:output_type -> dispatch.v1.DispatchLookupSubjectsResponse
+	15, // 74: dispatch.v1.DispatchService.DispatchLookupResources2:output_type -> dispatch.v1.DispatchLookupResources2Response
+	17, // 75: dispatch.v1.DispatchService.DispatchLookupResources3:output_type -> dispatch.v1.DispatchLookupResources3Response
+	29, // 76: dispatch.v1.DispatchService.DispatchQueryPlan:output_type -> dispatch.v1.DispatchQueryPlanResponse
+	71, // [71:77] is the sub-list for method output_type
+	65, // [65:71] is the sub-list for method input_type
+	65, // [65:65] is the sub-list for extension type_name
+	65, // [65:65] is the sub-list for extension extendee
+	0,  // [0:65] is the sub-list for field type_name
 }
 
 func init() { file_dispatch_v1_dispatch_proto_init() }

--- a/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
@@ -658,6 +658,11 @@ func (m *PlanContext) CloneVT() *PlanContext {
 		copy(tmpBytes, rhs)
 		r.SchemaHash = tmpBytes
 	}
+	if rhs := m.InProgressKeys; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.InProgressKeys = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1699,6 +1704,15 @@ func (this *PlanContext) EqualVT(that *PlanContext) bool {
 	}
 	if string(this.SchemaHash) != string(that.SchemaHash) {
 		return false
+	}
+	if len(this.InProgressKeys) != len(that.InProgressKeys) {
+		return false
+	}
+	for i, vx := range this.InProgressKeys {
+		vy := that.InProgressKeys[i]
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -3594,6 +3608,15 @@ func (m *PlanContext) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.InProgressKeys) > 0 {
+		for iNdEx := len(m.InProgressKeys) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.InProgressKeys[iNdEx])
+			copy(dAtA[i:], m.InProgressKeys[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.InProgressKeys[iNdEx])))
+			i--
+			dAtA[i] = 0x32
+		}
+	}
 	if len(m.SchemaHash) > 0 {
 		i -= len(m.SchemaHash)
 		copy(dAtA[i:], m.SchemaHash)
@@ -4708,6 +4731,12 @@ func (m *PlanContext) SizeVT() (n int) {
 	l = len(m.SchemaHash)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.InProgressKeys) > 0 {
+		for _, s := range m.InProgressKeys {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9058,6 +9087,38 @@ func (m *PlanContext) UnmarshalVT(dAtA []byte) error {
 			if m.SchemaHash == nil {
 				m.SchemaHash = []byte{}
 			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InProgressKeys", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.InProgressKeys = append(m.InProgressKeys, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
@@ -653,6 +653,7 @@ func (m *PlanContext) CloneVT() *PlanContext {
 	r.CaveatContext = (*structpb.Struct)((*structpb1.Struct)(m.CaveatContext).CloneVT())
 	r.MaxRecursionDepth = m.MaxRecursionDepth
 	r.OptionalDatastoreLimit = m.OptionalDatastoreLimit
+	r.TopLevelOperation = m.TopLevelOperation
 	if rhs := m.SchemaHash; rhs != nil {
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
@@ -1713,6 +1714,9 @@ func (this *PlanContext) EqualVT(that *PlanContext) bool {
 		if vx != vy {
 			return false
 		}
+	}
+	if this.TopLevelOperation != that.TopLevelOperation {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -3608,6 +3612,11 @@ func (m *PlanContext) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.TopLevelOperation != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.TopLevelOperation))
+		i--
+		dAtA[i] = 0x38
+	}
 	if len(m.InProgressKeys) > 0 {
 		for iNdEx := len(m.InProgressKeys) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.InProgressKeys[iNdEx])
@@ -4737,6 +4746,9 @@ func (m *PlanContext) SizeVT() (n int) {
 			l = len(s)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.TopLevelOperation != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.TopLevelOperation))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9120,6 +9132,25 @@ func (m *PlanContext) UnmarshalVT(dAtA []byte) error {
 			}
 			m.InProgressKeys = append(m.InProgressKeys, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TopLevelOperation", wireType)
+			}
+			m.TopLevelOperation = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TopLevelOperation |= PlanOperation(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
@@ -691,6 +691,17 @@ func (m *DispatchQueryPlanRequest) CloneVT() *DispatchQueryPlanRequest {
 			r.Subject = proto.Clone(rhs).(*v1.ObjectAndRelation)
 		}
 	}
+	if rhs := m.Many; rhs != nil {
+		tmpContainer := make([]*v1.ObjectAndRelation, len(rhs))
+		for k, v := range rhs {
+			if vtpb, ok := interface{}(v).(interface{ CloneVT() *v1.ObjectAndRelation }); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*v1.ObjectAndRelation)
+			}
+		}
+		r.Many = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1731,6 +1742,29 @@ func (this *DispatchQueryPlanRequest) EqualVT(that *DispatchQueryPlanRequest) bo
 	}
 	if !this.PlanContext.EqualVT(that.PlanContext) {
 		return false
+	}
+	if len(this.Many) != len(that.Many) {
+		return false
+	}
+	for i, vx := range this.Many {
+		vy := that.Many[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &v1.ObjectAndRelation{}
+			}
+			if q == nil {
+				q = &v1.ObjectAndRelation{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*v1.ObjectAndRelation) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
+				return false
+			}
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -3627,6 +3661,30 @@ func (m *DispatchQueryPlanRequest) MarshalToSizedBufferVT(dAtA []byte) (int, err
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.Many) > 0 {
+		for iNdEx := len(m.Many) - 1; iNdEx >= 0; iNdEx-- {
+			if vtmsg, ok := interface{}(m.Many[iNdEx]).(interface {
+				MarshalToSizedBufferVT([]byte) (int, error)
+			}); ok {
+				size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			} else {
+				encoded, err := proto.Marshal(m.Many[iNdEx])
+				if err != nil {
+					return 0, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			}
+			i--
+			dAtA[i] = 0x32
+		}
+	}
 	if m.PlanContext != nil {
 		size, err := m.PlanContext.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -4691,6 +4749,18 @@ func (m *DispatchQueryPlanRequest) SizeVT() (n int) {
 	if m.PlanContext != nil {
 		l = m.PlanContext.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Many) > 0 {
+		for _, e := range m.Many {
+			if size, ok := interface{}(e).(interface {
+				SizeVT() int
+			}); ok {
+				l = size.SizeVT()
+			} else {
+				l = proto.Size(e)
+			}
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9213,6 +9283,48 @@ func (m *DispatchQueryPlanRequest) UnmarshalVT(dAtA []byte) error {
 			}
 			if err := m.PlanContext.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Many", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Many = append(m.Many, &v1.ObjectAndRelation{})
+			if unmarshal, ok := interface{}(m.Many[len(m.Many)-1]).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Many[len(m.Many)-1]); err != nil {
+					return err
+				}
 			}
 			iNdEx = postIndex
 		default:

--- a/pkg/query/alias.go
+++ b/pkg/query/alias.go
@@ -15,10 +15,11 @@ import "strings"
 // semantics of an uncollapsed chain. The underlying identity (relation) is kept so
 // the canonical key for caching reflects the data the iterator actually reads.
 type AliasIterator struct {
-	relation     string
-	aliasedAs    []string
-	subIt        Iterator
-	canonicalKey CanonicalKey
+	definitionName string
+	relation       string
+	aliasedAs      []string
+	subIt          Iterator
+	canonicalKey   CanonicalKey
 }
 
 var _ Iterator = &AliasIterator{}
@@ -29,6 +30,18 @@ func NewAliasIterator(relation string, subIt Iterator) *AliasIterator {
 	return &AliasIterator{
 		relation: relation,
 		subIt:    subIt,
+	}
+}
+
+// NewAliasIteratorWithDefinition creates a new Alias iterator that also carries
+// the schema definition name to which the alias belongs. The definition name is
+// used by the dispatch layer to identify the (definition, relation) boundary
+// represented by this alias.
+func NewAliasIteratorWithDefinition(definitionName, relation string, subIt Iterator) *AliasIterator {
+	return &AliasIterator{
+		definitionName: definitionName,
+		relation:       relation,
+		subIt:          subIt,
 	}
 }
 
@@ -56,6 +69,19 @@ func (a *AliasIterator) effectiveRelation() string {
 		return a.aliasedAs[n-1]
 	}
 	return a.relation
+}
+
+// DefinitionName returns the schema definition this alias belongs to, or the
+// empty string if the alias was constructed without one (e.g. by tests using
+// the 2-arg NewAliasIterator).
+func (a *AliasIterator) DefinitionName() string {
+	return a.definitionName
+}
+
+// Relation returns the outermost name in the alias chain — what emitted paths
+// are rewritten to and what callers asked the alias to compute.
+func (a *AliasIterator) Relation() string {
+	return a.effectiveRelation()
 }
 
 // matchesSelfEdgeRelation reports whether the given relation name would trigger
@@ -256,10 +282,11 @@ func (a *AliasIterator) IterResourcesImpl(ctx *Context, subject ObjectAndRelatio
 
 func (a *AliasIterator) Clone() Iterator {
 	return &AliasIterator{
-		canonicalKey: a.canonicalKey,
-		relation:     a.relation,
-		aliasedAs:    append([]string(nil), a.aliasedAs...),
-		subIt:        a.subIt.Clone(),
+		canonicalKey:   a.canonicalKey,
+		definitionName: a.definitionName,
+		relation:       a.relation,
+		aliasedAs:      append([]string(nil), a.aliasedAs...),
+		subIt:          a.subIt.Clone(),
 	}
 }
 
@@ -281,10 +308,11 @@ func (a *AliasIterator) Subiterators() []Iterator {
 
 func (a *AliasIterator) ReplaceSubiterators(newSubs []Iterator) (Iterator, error) {
 	return &AliasIterator{
-		canonicalKey: a.canonicalKey,
-		relation:     a.relation,
-		aliasedAs:    append([]string(nil), a.aliasedAs...),
-		subIt:        newSubs[0],
+		canonicalKey:   a.canonicalKey,
+		definitionName: a.definitionName,
+		relation:       a.relation,
+		aliasedAs:      append([]string(nil), a.aliasedAs...),
+		subIt:          newSubs[0],
 	}, nil
 }
 

--- a/pkg/query/alias.go
+++ b/pkg/query/alias.go
@@ -25,19 +25,10 @@ type AliasIterator struct {
 var _ Iterator = &AliasIterator{}
 
 // NewAliasIterator creates a new Alias iterator that rewrites paths from the sub-iterator
-// to use the specified relation name.
-func NewAliasIterator(relation string, subIt Iterator) *AliasIterator {
-	return &AliasIterator{
-		relation: relation,
-		subIt:    subIt,
-	}
-}
-
-// NewAliasIteratorWithDefinition creates a new Alias iterator that also carries
-// the schema definition name to which the alias belongs. The definition name is
-// used by the dispatch layer to identify the (definition, relation) boundary
-// represented by this alias.
-func NewAliasIteratorWithDefinition(definitionName, relation string, subIt Iterator) *AliasIterator {
+// to use the specified relation name. The definitionName identifies the schema definition
+// to which the alias belongs and is used by the dispatch layer to identify the
+// (definition, relation) boundary represented by this alias.
+func NewAliasIterator(definitionName, relation string, subIt Iterator) *AliasIterator {
 	return &AliasIterator{
 		definitionName: definitionName,
 		relation:       relation,
@@ -53,11 +44,12 @@ func NewAliasIteratorWithDefinition(definitionName, relation string, subIt Itera
 // as the identity (cache key, datastore-facing name) and records ["view","perm"]
 // in aliasedAs so the iterator emits paths labeled "perm" and the self-edge
 // matches subject relations in {"viewer","view","perm"}.
-func NewAliasIteratorWithChain(relation string, aliasedAs []string, subIt Iterator) *AliasIterator {
+func NewAliasIteratorWithChain(definitionName, relation string, aliasedAs []string, subIt Iterator) *AliasIterator {
 	return &AliasIterator{
-		relation:  relation,
-		aliasedAs: append([]string(nil), aliasedAs...),
-		subIt:     subIt,
+		definitionName: definitionName,
+		relation:       relation,
+		aliasedAs:      append([]string(nil), aliasedAs...),
+		subIt:          subIt,
 	}
 }
 
@@ -71,9 +63,7 @@ func (a *AliasIterator) effectiveRelation() string {
 	return a.relation
 }
 
-// DefinitionName returns the schema definition this alias belongs to, or the
-// empty string if the alias was constructed without one (e.g. by tests using
-// the 2-arg NewAliasIterator).
+// DefinitionName returns the schema definition this alias belongs to.
 func (a *AliasIterator) DefinitionName() string {
 	return a.definitionName
 }

--- a/pkg/query/alias_test.go
+++ b/pkg/query/alias_test.go
@@ -13,7 +13,7 @@ func TestAliasIterator(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create a sub-iterator with document relations
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("read", subIt)
+		aliasIt := NewAliasIterator("", "read", subIt)
 
 		path, err := ctx.Check(aliasIt, NewObject("document", "doc1"), NewObject("user", "alice").WithEllipses())
 		require.NoError(err)
@@ -32,7 +32,7 @@ func TestAliasIterator(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create an empty sub-iterator since we only want to test self-edge detection
 		subIt := NewEmptyFixedIterator()
-		aliasIt := NewAliasIterator("admin", subIt)
+		aliasIt := NewAliasIterator("", "admin", subIt)
 
 		// Self-edge: user:alice#admin@user:alice#admin
 		subject := NewObjectAndRelation("alice", "user", "admin")
@@ -55,7 +55,7 @@ func TestAliasIterator(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create a sub-iterator
 		subIt := NewSingleUserFixedIterator("bob")
-		aliasIt := NewAliasIterator("admin", subIt)
+		aliasIt := NewAliasIterator("", "admin", subIt)
 
 		// document:doc1 vs user:alice#viewer — no self-edge since types differ
 		subject := NewObjectAndRelation("alice", "user", "viewer")
@@ -70,7 +70,7 @@ func TestAliasIterator(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("access", subIt)
+		aliasIt := NewAliasIterator("", "access", subIt)
 
 		pathDoc1, err := ctx.Check(aliasIt, NewObject("document", "doc1"), NewObject("user", "alice").WithEllipses())
 		require.NoError(err)
@@ -88,7 +88,7 @@ func TestAliasIterator(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("permission", subIt)
+		aliasIt := NewAliasIterator("", "permission", subIt)
 
 		pathSeq, err := ctx.IterSubjects(aliasIt, NewObject("document", "doc1"), NoObjectFilter())
 		require.NoError(err)
@@ -109,7 +109,7 @@ func TestAliasIterator(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("can_view", subIt)
+		aliasIt := NewAliasIterator("", "can_view", subIt)
 
 		pathSeq, err := ctx.IterResources(aliasIt, NewObject("user", "alice").WithEllipses(), NoObjectFilter())
 		require.NoError(err)
@@ -131,7 +131,7 @@ func TestAliasIterator(t *testing.T) {
 		subIt := NewEmptyFixedIterator()
 
 		// Create an alias iterator that rewrites to "admin"
-		aliasIt := NewAliasIterator("admin", subIt)
+		aliasIt := NewAliasIterator("", "admin", subIt)
 
 		// Check for a self-edge: user:alice#admin@user:alice#admin
 		subject := NewObjectAndRelation("alice", "user", "admin")
@@ -160,7 +160,7 @@ func TestAliasIterator(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewEmptyFixedIterator()
-		aliasIt := NewAliasIterator("empty_alias", subIt)
+		aliasIt := NewAliasIterator("", "empty_alias", subIt)
 
 		path, err := ctx.Check(aliasIt, NewObject("document", "doc1"), NewObject("user", "alice").WithEllipses())
 		require.NoError(err)
@@ -173,7 +173,7 @@ func TestAliasIterator(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create empty sub-iterator
 		subIt := NewEmptyFixedIterator()
-		aliasIt := NewAliasIterator("self", subIt)
+		aliasIt := NewAliasIterator("", "self", subIt)
 
 		// Create a self-edge scenario: document:doc1#self@user:alice#self
 		subject := NewObjectAndRelation("alice", "user", "self")
@@ -190,7 +190,7 @@ func TestAliasIterator(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewEmptyFixedIterator()
-		aliasIt := NewAliasIterator("owner", subIt)
+		aliasIt := NewAliasIterator("", "owner", subIt)
 
 		// Create a perfect self-edge: user:alice#owner@user:alice#owner
 		subject := NewObjectAndRelation("alice", "user", "owner")
@@ -214,7 +214,7 @@ func TestAliasIteratorClone(t *testing.T) {
 	require := require.New(t)
 
 	subIt := NewDocumentAccessFixedIterator()
-	original := NewAliasIterator("original_relation", subIt)
+	original := NewAliasIterator("", "original_relation", subIt)
 
 	cloned := original.Clone()
 	require.NotSame(original, cloned, "cloned iterator should be a different object")
@@ -235,7 +235,7 @@ func TestAliasIteratorExplain(t *testing.T) {
 		require := require.New(t)
 
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("test_relation", subIt)
+		aliasIt := NewAliasIterator("", "test_relation", subIt)
 
 		explain := aliasIt.Explain()
 		require.Equal("Alias(test_relation)", explain.Info)
@@ -250,7 +250,7 @@ func TestAliasIteratorExplain(t *testing.T) {
 		require := require.New(t)
 
 		subIt := NewEmptyFixedIterator()
-		aliasIt := NewAliasIterator("empty_test", subIt)
+		aliasIt := NewAliasIterator("", "empty_test", subIt)
 
 		explain := aliasIt.Explain()
 		require.Equal("Alias(empty_test)", explain.Info)
@@ -265,7 +265,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create a faulty sub-iterator
 		faultyIt := NewFaultyIterator(true, false, ObjectType{}, []ObjectType{})
-		aliasIt := NewAliasIterator("error_test", faultyIt)
+		aliasIt := NewAliasIterator("", "error_test", faultyIt)
 
 		_, err := ctx.Check(aliasIt, NewObject("document", "doc1"), NewObject("user", "alice").WithEllipses())
 		require.Error(err, "should propagate error from sub-iterator")
@@ -278,7 +278,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 		// Create a faulty sub-iterator that fails during collection
 		// With the new *Path API, collection errors propagate immediately
 		faultyIt := NewFaultyIterator(false, true, ObjectType{}, []ObjectType{})
-		aliasIt := NewAliasIterator("collection_error_test", faultyIt)
+		aliasIt := NewAliasIterator("", "collection_error_test", faultyIt)
 
 		_, err := ctx.Check(aliasIt, NewObject("document", "doc1"), NewObject("user", "alice").WithEllipses())
 		// With *Path return, the error may or may not propagate (depends on implementation)
@@ -292,7 +292,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create a faulty sub-iterator that fails on IterSubjectsImpl
 		faultyIt := NewFaultyIterator(true, false, ObjectType{}, []ObjectType{})
-		aliasIt := NewAliasIterator("error_test", faultyIt)
+		aliasIt := NewAliasIterator("", "error_test", faultyIt)
 
 		_, err := ctx.IterSubjects(aliasIt, NewObject("document", "doc1"), NoObjectFilter())
 		require.Error(err, "should propagate error from sub-iterator")
@@ -305,7 +305,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create a faulty sub-iterator that fails during collection
 		faultyIt := NewFaultyIterator(false, true, ObjectType{}, []ObjectType{})
-		aliasIt := NewAliasIterator("collection_error_test", faultyIt)
+		aliasIt := NewAliasIterator("", "collection_error_test", faultyIt)
 
 		pathSeq, err := ctx.IterSubjects(aliasIt, NewObject("document", "doc1"), NoObjectFilter())
 		require.NoError(err, "initial IterSubjects should succeed")
@@ -322,7 +322,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create a faulty sub-iterator that fails on IterResourcesImpl
 		faultyIt := NewFaultyIterator(true, false, ObjectType{}, []ObjectType{})
-		aliasIt := NewAliasIterator("error_test", faultyIt)
+		aliasIt := NewAliasIterator("", "error_test", faultyIt)
 
 		_, err := ctx.IterResources(aliasIt, NewObject("user", "alice").WithEllipses(), NoObjectFilter())
 		require.Error(err, "should propagate error from sub-iterator")
@@ -335,7 +335,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create a faulty sub-iterator that fails during collection
 		faultyIt := NewFaultyIterator(false, true, ObjectType{}, []ObjectType{})
-		aliasIt := NewAliasIterator("collection_error_test", faultyIt)
+		aliasIt := NewAliasIterator("", "collection_error_test", faultyIt)
 
 		pathSeq, err := ctx.IterResources(aliasIt, NewObject("user", "alice").WithEllipses(), NoObjectFilter())
 		require.NoError(err, "initial IterResources should succeed")
@@ -352,7 +352,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create a faulty sub-iterator that errors on CheckImpl
 		faultyIt := NewFaultyIterator(true, false, ObjectType{}, []ObjectType{})
-		aliasIt := NewAliasIterator("self", faultyIt)
+		aliasIt := NewAliasIterator("", "self", faultyIt)
 
 		// Create a self-edge scenario
 		subject := NewObjectAndRelation("alice", "user", "self")
@@ -367,7 +367,7 @@ func TestAliasIteratorErrorHandling(t *testing.T) {
 		// Create a faulty sub-iterator that fails during collection
 		// With the new *Path API, collection errors may propagate immediately
 		faultyIt := NewFaultyIterator(false, true, ObjectType{}, []ObjectType{})
-		aliasIt := NewAliasIterator("self", faultyIt)
+		aliasIt := NewAliasIterator("", "self", faultyIt)
 
 		// Create a self-edge scenario
 		subject := NewObjectAndRelation("alice", "user", "self")
@@ -384,7 +384,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create sub-iterator with real data
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("admin", subIt)
+		aliasIt := NewAliasIterator("", "admin", subIt)
 
 		// Self-edge: document:doc1#admin@document:doc1#admin
 		subject := NewObjectAndRelation("doc1", "document", "admin")
@@ -404,7 +404,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Create empty sub-iterator to isolate self-edge logic
 		subIt := NewEmptyFixedIterator()
-		aliasIt := NewAliasIterator("owner", subIt)
+		aliasIt := NewAliasIterator("", "owner", subIt)
 
 		// Self-edge: user:user1#owner@user:user1#owner
 		subject := NewObjectAndRelation("user1", "user", "owner")
@@ -426,7 +426,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewEmptyFixedIterator()
-		aliasIt := NewAliasIterator("owner", subIt)
+		aliasIt := NewAliasIterator("", "owner", subIt)
 
 		// user:user2 should not match subject user:user1
 		subject := NewObjectAndRelation("user1", "user", "owner")
@@ -440,7 +440,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewEmptyFixedIterator()
-		aliasIt := NewAliasIterator("empty_relation", subIt)
+		aliasIt := NewAliasIterator("", "empty_relation", subIt)
 
 		pathSeq, err := ctx.IterSubjects(aliasIt, NewObject("document", "doc1"), NoObjectFilter())
 		require.NoError(err)
@@ -455,7 +455,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewEmptyFixedIterator()
-		aliasIt := NewAliasIterator("empty_relation", subIt)
+		aliasIt := NewAliasIterator("", "empty_relation", subIt)
 
 		pathSeq, err := ctx.IterResources(aliasIt, NewObject("user", "alice").WithEllipses(), NoObjectFilter())
 		require.NoError(err)
@@ -471,7 +471,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Use iterator with many results
 		subIt := NewLargeFixedIterator()
-		aliasIt := NewAliasIterator("massive", subIt)
+		aliasIt := NewAliasIterator("", "massive", subIt)
 
 		// NewLargeFixedIterator creates relations for user0, user1, etc. on doc0, doc1, etc.
 		path, err := ctx.Check(aliasIt, NewObject("document", "doc0"), NewObject("user", "user0").WithEllipses())
@@ -487,7 +487,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewDocumentAccessFixedIterator()
-		original := NewAliasIterator("original", subIt)
+		original := NewAliasIterator("", "original", subIt)
 
 		// Clone the iterator
 		cloned := original.Clone().(*AliasIterator)
@@ -519,7 +519,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("early_test", subIt)
+		aliasIt := NewAliasIterator("", "early_test", subIt)
 
 		path, err := ctx.Check(aliasIt, NewObject("document", "doc1"), NewObject("user", "alice").WithEllipses())
 		require.NoError(err)
@@ -532,7 +532,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("admin", subIt)
+		aliasIt := NewAliasIterator("", "admin", subIt)
 
 		// Self-edge scenario: document:doc1#admin@document:doc1#admin
 		subject := NewObjectAndRelation("doc1", "document", "admin")
@@ -549,7 +549,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("early_subjects", subIt)
+		aliasIt := NewAliasIterator("", "early_subjects", subIt)
 
 		pathSeq, err := ctx.IterSubjects(aliasIt, NewObject("document", "doc1"), NoObjectFilter())
 		require.NoError(err)
@@ -572,7 +572,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 
 		ctx := NewTestContext(t)
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("early_resources", subIt)
+		aliasIt := NewAliasIterator("", "early_resources", subIt)
 
 		pathSeq, err := ctx.IterResources(aliasIt, NewObject("user", "alice").WithEllipses(), NoObjectFilter())
 		require.NoError(err)
@@ -596,7 +596,7 @@ func TestAliasIteratorAdvancedScenarios(t *testing.T) {
 		ctx := NewTestContext(t)
 		// Use sub-iterator that will return paths that need rewriting
 		subIt := NewDocumentAccessFixedIterator()
-		aliasIt := NewAliasIterator("admin", subIt)
+		aliasIt := NewAliasIterator("", "admin", subIt)
 
 		// Self-edge: document:doc1#admin@document:doc1#admin
 		subject := NewObjectAndRelation("doc1", "document", "admin")
@@ -618,7 +618,7 @@ func TestAlias_Types(t *testing.T) {
 		// Create an alias iterator
 		path := MustPathFromString("document:doc1#viewer@user:alice")
 		subIter := NewFixedIterator(*path)
-		alias := NewAliasIterator("admin", subIter)
+		alias := NewAliasIterator("", "admin", subIter)
 
 		resourceType, err := alias.ResourceType()
 		require.NoError(err)
@@ -632,7 +632,7 @@ func TestAlias_Types(t *testing.T) {
 		// Create an alias iterator
 		path := MustPathFromString("document:doc1#viewer@user:alice")
 		subIter := NewFixedIterator(*path)
-		alias := NewAliasIterator("admin", subIter)
+		alias := NewAliasIterator("", "admin", subIter)
 
 		subjectTypes, err := alias.SubjectTypes()
 		require.NoError(err)

--- a/pkg/query/arrow.go
+++ b/pkg/query/arrow.go
@@ -57,11 +57,19 @@ func (a *ArrowIterator) CheckImpl(ctx *Context, resource Object, subject ObjectA
 	// - IterResources on the right, Check on the left
 	// - IterSubjects on left, IterResources on right, and intersect the two iterators here (especially if they are known to be sorted)
 	//
-	// But for now, we cover the first two.
+	// But for now, we cover the first two. When BatchedArrows is set the
+	// per-element Check loop is replaced by a single CheckMany call so the
+	// executor (e.g. DispatchExecutor) can collapse fanout into one RPC.
 	switch a.direction {
 	case leftToRight:
+		if ctx.BatchedArrows {
+			return a.checkLeftToRightBatch(ctx, resource, subject)
+		}
 		return a.checkLeftToRight(ctx, resource, subject)
 	case rightToLeft:
+		if ctx.BatchedArrows {
+			return a.checkRightToLeftBatch(ctx, resource, subject)
+		}
 		return a.checkRightToLeft(ctx, resource, subject)
 	default:
 		return nil, spiceerrors.MustBugf("unknown arrow direction: %d", a.direction)
@@ -205,6 +213,135 @@ func (a *ArrowIterator) checkRightToLeft(ctx *Context, resource Object, subject 
 
 	if ctx.shouldTrace() {
 		ctx.TraceStep(a, "arrow (right-to-left) completed: %d right paths, found=%v", rightPathCount, result != nil)
+	}
+	return result, nil
+}
+
+// checkLeftToRightBatch is the batched variant of checkLeftToRight: it drains
+// all left subjects first, then issues a single CheckManyResources call against
+// the right side. Wildcards still fall back to the per-element IterResources
+// inversion path because they cannot be used as a concrete resource on the right.
+func (a *ArrowIterator) checkLeftToRightBatch(ctx *Context, resource Object, subject ObjectAndRelation) (*Path, error) {
+	if ctx.shouldTrace() {
+		ctx.TraceStep(a, "arrow check (left-to-right, batched) for resource %s:%s", resource.ObjectType, resource.ObjectID)
+	}
+
+	subit, err := ctx.IterSubjects(a.left, resource, NoObjectFilter())
+	if err != nil {
+		return nil, err
+	}
+	leftPaths, err := CollectAll(subit)
+	if err != nil {
+		return nil, err
+	}
+
+	var result *Path
+	concreteLeft := make([]*Path, 0, len(leftPaths))
+	concreteRes := make([]Object, 0, len(leftPaths))
+	for _, leftPath := range leftPaths {
+		// Wildcards: invert to IterResources, like the unbatched path.
+		if leftPath.Subject.ObjectID == tuple.PublicWildcard {
+			rightSeq, err := ctx.IterResources(a.right, subject, ObjectType{Type: leftPath.Subject.ObjectType})
+			if err != nil {
+				return nil, err
+			}
+			for rightPath, err := range rightSeq {
+				if err != nil {
+					return nil, err
+				}
+				combined := combineArrowPaths(leftPath, rightPath)
+				if combined.Caveat == nil {
+					return combined, nil
+				}
+				result, err = result.MergeOr(combined)
+				if err != nil {
+					return nil, err
+				}
+			}
+			continue
+		}
+		concreteLeft = append(concreteLeft, leftPath)
+		concreteRes = append(concreteRes, GetObject(leftPath.Subject))
+	}
+
+	if len(concreteRes) > 0 {
+		rightPaths, err := ctx.CheckManyResources(a.right, concreteRes, subject)
+		if err != nil {
+			return nil, err
+		}
+		for i, rightPath := range rightPaths {
+			if rightPath == nil {
+				continue
+			}
+			combined := combineArrowPaths(concreteLeft[i], rightPath)
+			if combined.Caveat == nil {
+				return combined, nil
+			}
+			result, err = result.MergeOr(combined)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if ctx.shouldTrace() {
+		ctx.TraceStep(a, "arrow (left-to-right, batched) completed: %d concrete, found=%v", len(concreteLeft), result != nil)
+	}
+	return result, nil
+}
+
+// checkRightToLeftBatch is the batched variant of checkRightToLeft: it drains
+// all right resources first, then issues a single CheckManySubjects call against
+// the left side using the right resources (with ellipsis relation) as subjects.
+func (a *ArrowIterator) checkRightToLeftBatch(ctx *Context, resource Object, subject ObjectAndRelation) (*Path, error) {
+	if ctx.shouldTrace() {
+		ctx.TraceStep(a, "arrow check (right-to-left, batched) for resource %s:%s, subject %s:%s",
+			resource.ObjectType, resource.ObjectID, subject.ObjectType, subject.ObjectID)
+	}
+
+	rightSeq, err := ctx.IterResources(a.right, subject, NoObjectFilter())
+	if err != nil {
+		return nil, err
+	}
+	rightPaths, err := CollectAll(rightSeq)
+	if err != nil {
+		return nil, err
+	}
+	if len(rightPaths) == 0 {
+		return nil, nil
+	}
+
+	intermediates := make([]ObjectAndRelation, len(rightPaths))
+	for i, rightPath := range rightPaths {
+		intermediates[i] = ObjectAndRelation{
+			ObjectType: rightPath.Resource.ObjectType,
+			ObjectID:   rightPath.Resource.ObjectID,
+			Relation:   tuple.Ellipsis,
+		}
+	}
+
+	leftPaths, err := ctx.CheckManySubjects(a.left, resource, intermediates)
+	if err != nil {
+		return nil, err
+	}
+
+	var result *Path
+	for i, leftPath := range leftPaths {
+		if leftPath == nil {
+			continue
+		}
+		combined := combineArrowPaths(leftPath, rightPaths[i])
+		if combined.Caveat == nil {
+			return combined, nil
+		}
+		result, err = result.MergeOr(combined)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if ctx.shouldTrace() {
+		ctx.TraceStep(a, "arrow (right-to-left, batched) completed: %d right paths, found=%v", len(rightPaths), result != nil)
 	}
 	return result, nil
 }

--- a/pkg/query/arrow_batched_test.go
+++ b/pkg/query/arrow_batched_test.go
@@ -1,0 +1,225 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// runArrowCheckInBothModes runs the same Check assertion against an arrow with
+// BatchedArrows = false and BatchedArrows = true. The two modes must produce
+// equivalent results for any input — that is the contract that lets the
+// dispatch executor enable batching unconditionally.
+func runArrowCheckInBothModes(t *testing.T, name string, arrowFactory func() *ArrowIterator, resource Object, subject ObjectAndRelation, expectMatch bool, expectedSubjectID string) {
+	t.Helper()
+	for _, batched := range []bool{false, true} {
+		mode := "unbatched"
+		if batched {
+			mode = "batched"
+		}
+		t.Run(name+"/"+mode, func(t *testing.T) {
+			req := require.New(t)
+			ctx := NewTestContext(t)
+			ctx.BatchedArrows = batched
+
+			path, err := ctx.Check(arrowFactory(), resource, subject)
+			req.NoError(err)
+			if !expectMatch {
+				req.Nil(path, "expected no match")
+				return
+			}
+			req.NotNil(path, "expected match in %s mode", mode)
+			req.Equal(resource.ObjectID, path.Resource.ObjectID)
+			if expectedSubjectID != "" {
+				req.Equal(expectedSubjectID, path.Subject.ObjectID)
+			}
+		})
+	}
+}
+
+func TestArrow_BatchedVsUnbatched_LTR(t *testing.T) {
+	factory := func() *ArrowIterator {
+		left := NewFolderHierarchyFixedIterator()
+		right := NewFolderHierarchyFixedIterator()
+		a := NewArrowIterator(left, right)
+		a.direction = leftToRight
+		return a
+	}
+
+	runArrowCheckInBothModes(t, "spec1_alice_match", factory,
+		NewObject("document", "spec1"),
+		NewObject("user", "alice").WithEllipses(),
+		true, "alice")
+
+	runArrowCheckInBothModes(t, "spec2_alice_no_match", factory,
+		NewObject("document", "spec2"),
+		NewObject("user", "alice").WithEllipses(),
+		false, "")
+
+	runArrowCheckInBothModes(t, "nonexistent_resource", factory,
+		NewObject("document", "nonexistent"),
+		NewObject("user", "alice").WithEllipses(),
+		false, "")
+
+	runArrowCheckInBothModes(t, "nonexistent_subject", factory,
+		NewObject("document", "spec1"),
+		NewObject("user", "nobody").WithEllipses(),
+		false, "")
+}
+
+func TestArrow_BatchedVsUnbatched_RTL(t *testing.T) {
+	factory := func() *ArrowIterator {
+		left := NewFolderHierarchyFixedIterator()
+		right := NewFolderHierarchyFixedIterator()
+		a := NewArrowIterator(left, right)
+		a.direction = rightToLeft
+		return a
+	}
+
+	runArrowCheckInBothModes(t, "spec1_alice_match", factory,
+		NewObject("document", "spec1"),
+		NewObject("user", "alice").WithEllipses(),
+		true, "alice")
+
+	runArrowCheckInBothModes(t, "spec2_alice_no_match", factory,
+		NewObject("document", "spec2"),
+		NewObject("user", "alice").WithEllipses(),
+		false, "")
+}
+
+// countingExecutor wraps LocalExecutor to count Check / CheckMany invocations
+// so tests can assert that the batched path actually batches.
+type countingExecutor struct {
+	LocalExecutor
+	checks            int
+	checkManyCalls    int
+	checkManyTotalLen int
+}
+
+func (c *countingExecutor) Check(ctx *Context, it Iterator, resource Object, subject ObjectAndRelation) (*Path, error) {
+	c.checks++
+	return c.LocalExecutor.Check(ctx, it, resource, subject)
+}
+
+func (c *countingExecutor) CheckManySubjects(ctx *Context, it Iterator, resource Object, subjects []ObjectAndRelation) ([]*Path, error) {
+	c.checkManyCalls++
+	c.checkManyTotalLen += len(subjects)
+	return c.LocalExecutor.CheckManySubjects(ctx, it, resource, subjects)
+}
+
+func (c *countingExecutor) CheckManyResources(ctx *Context, it Iterator, resources []Object, subject ObjectAndRelation) ([]*Path, error) {
+	c.checkManyCalls++
+	c.checkManyTotalLen += len(resources)
+	return c.LocalExecutor.CheckManyResources(ctx, it, resources, subject)
+}
+
+func TestArrow_BatchedDispatchesOneCheckMany_LTR(t *testing.T) {
+	req := require.New(t)
+	left := NewFolderHierarchyFixedIterator()
+	right := NewFolderHierarchyFixedIterator()
+	arrow := NewArrowIterator(left, right)
+	arrow.direction = leftToRight
+
+	exec := &countingExecutor{}
+	ctx := &Context{
+		Context:       t.Context(),
+		Executor:      exec,
+		BatchedArrows: true,
+	}
+
+	_, err := ctx.Check(arrow, NewObject("document", "spec1"), NewObject("user", "alice").WithEllipses())
+	req.NoError(err)
+	// Exactly one CheckMany call for the right side (after collecting the left subjects).
+	// Per-element ctx.Check on the right side must not be invoked when batched mode is on.
+	req.Equal(1, exec.checkManyCalls, "expected exactly one CheckMany call for the batched right side")
+	// The single CheckMany call must contain at least one input.
+	req.GreaterOrEqual(exec.checkManyTotalLen, 1)
+}
+
+func TestArrow_UnbatchedDoesNotCallCheckMany_LTR(t *testing.T) {
+	req := require.New(t)
+	left := NewFolderHierarchyFixedIterator()
+	right := NewFolderHierarchyFixedIterator()
+	arrow := NewArrowIterator(left, right)
+	arrow.direction = leftToRight
+
+	exec := &countingExecutor{}
+	ctx := &Context{
+		Context:       t.Context(),
+		Executor:      exec,
+		BatchedArrows: false,
+	}
+
+	_, err := ctx.Check(arrow, NewObject("document", "spec1"), NewObject("user", "alice").WithEllipses())
+	req.NoError(err)
+	req.Equal(0, exec.checkManyCalls, "unbatched mode must not invoke CheckMany")
+}
+
+func TestArrow_BatchedDispatchesOneCheckMany_RTL(t *testing.T) {
+	req := require.New(t)
+	left := NewFolderHierarchyFixedIterator()
+	right := NewFolderHierarchyFixedIterator()
+	arrow := NewArrowIterator(left, right)
+	arrow.direction = rightToLeft
+
+	exec := &countingExecutor{}
+	ctx := &Context{
+		Context:       t.Context(),
+		Executor:      exec,
+		BatchedArrows: true,
+	}
+
+	_, err := ctx.Check(arrow, NewObject("document", "spec1"), NewObject("user", "alice").WithEllipses())
+	req.NoError(err)
+	req.Equal(1, exec.checkManyCalls, "expected exactly one CheckMany call for the batched left side")
+}
+
+func TestLocalExecutor_CheckManyResources(t *testing.T) {
+	req := require.New(t)
+	rels := NewDocumentAccessFixedIterator()
+	ctx := NewTestContext(t)
+
+	resources := []Object{
+		NewObject("document", "doc1"),
+		NewObject("document", "doc2"),
+		NewObject("document", "missing"),
+	}
+	out, err := ctx.CheckManyResources(rels, resources, NewObject("user", "alice").WithEllipses())
+	req.NoError(err)
+	req.Len(out, 3)
+	req.NotNil(out[0], "alice -> doc1 expected")
+	req.NotNil(out[1], "alice -> doc2 expected")
+	req.Nil(out[2], "alice -> missing expected to be nil")
+}
+
+func TestLocalExecutor_CheckManySubjects(t *testing.T) {
+	req := require.New(t)
+	rels := NewDocumentAccessFixedIterator()
+	ctx := NewTestContext(t)
+
+	subjects := []ObjectAndRelation{
+		NewObject("user", "alice").WithEllipses(),
+		NewObject("user", "nobody").WithEllipses(),
+		NewObject("user", "bob").WithEllipses(),
+	}
+	out, err := ctx.CheckManySubjects(rels, NewObject("document", "doc1"), subjects)
+	req.NoError(err)
+	req.Len(out, 3)
+	req.NotNil(out[0], "alice -> doc1 expected")
+	req.Nil(out[1], "nobody -> doc1 expected to be nil")
+	req.NotNil(out[2], "bob -> doc1 expected")
+}
+
+func TestLocalExecutor_CheckMany_EmptyInputs(t *testing.T) {
+	req := require.New(t)
+	rels := NewDocumentAccessFixedIterator()
+	ctx := NewTestContext(t)
+
+	out, err := ctx.CheckManyResources(rels, nil, NewObject("user", "alice").WithEllipses())
+	req.NoError(err)
+	req.Nil(out)
+
+	out2, err := ctx.CheckManySubjects(rels, NewObject("document", "doc1"), nil)
+	req.NoError(err)
+	req.Nil(out2)
+}

--- a/pkg/query/arrow_batched_test.go
+++ b/pkg/query/arrow_batched_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/genutil/slicez"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
 )
 
 // runArrowCheckInBothModes runs the same Check assertion against an arrow with
@@ -222,4 +226,375 @@ func TestLocalExecutor_CheckMany_EmptyInputs(t *testing.T) {
 	out2, err := ctx.CheckManySubjects(rels, NewObject("document", "doc1"), nil)
 	req.NoError(err)
 	req.Nil(out2)
+}
+
+// --- Wildcard tests for ArrowIterator (batched path, lines 242-260 in arrow.go) ---
+// Note: wildcardPath() is defined in wildcard_intersection_test.go (same package).
+
+// wildcardPathWithCaveat creates a wildcard path with a caveat attached.
+func wildcardPathWithCaveat(resourceType, resourceID, relation, subjectType, caveatName string) *Path {
+	p := wildcardPath(resourceType, resourceID, relation, subjectType)
+	p.Caveat = &core.CaveatExpression{
+		OperationOrCaveat: &core.CaveatExpression_Caveat{
+			Caveat: &core.ContextualizedCaveat{
+				CaveatName: caveatName,
+			},
+		},
+	}
+	return p
+}
+
+// rightPathForWildcard creates a path suitable for the right side of an arrow when the
+// left side produced a wildcard. The path's Resource must match the wildcard's object type,
+// and the Subject must be the target subject — so that IterResources(subject, wildcardType)
+// finds it.
+func rightPathForWildcard(wildcardSubjectType, wildcardSubjectID, relation string, subject ObjectAndRelation) *Path {
+	return &Path{
+		Resource: Object{
+			ObjectType: wildcardSubjectType,
+			ObjectID:   wildcardSubjectID,
+		},
+		Relation: relation,
+		Subject:  subject,
+	}
+}
+
+// rightPathForWildcardWithCaveat is like rightPathForWildcard but with a caveat.
+func rightPathForWildcardWithCaveat(wildcardSubjectType, wildcardSubjectID, relation string, subject ObjectAndRelation, caveatName string) *Path {
+	p := rightPathForWildcard(wildcardSubjectType, wildcardSubjectID, relation, subject)
+	p.Caveat = &core.CaveatExpression{
+		OperationOrCaveat: &core.CaveatExpression_Caveat{
+			Caveat: &core.ContextualizedCaveat{
+				CaveatName: caveatName,
+			},
+		},
+	}
+	return p
+}
+
+// TestArrow_BatchedWildcard_LeftOnly exercises the wildcard branch in
+// checkLeftToRightBatch (arrow.go lines 242-260). The left side returns only a
+// wildcard path, so the batched path must invert to IterResources.
+func TestArrow_BatchedWildcard_LeftOnly(t *testing.T) {
+	factory := func() *ArrowIterator {
+		// Left side: document:doc1 has a wildcard viewer (user:*)
+		left := NewFixedIterator(*wildcardPath("document", "doc1", "viewer", "user"))
+
+		// Right side: a path where user:alice is the subject, resource is of type "user".
+		// IterResources(user:alice#..., ObjectType{Type: "user"}) will find this path.
+		subject := NewObject("user", "alice").WithEllipses()
+		right := NewFixedIterator(*rightPathForWildcard("user", "alice", "viewer", subject))
+
+		a := NewArrowIterator(left, right)
+		a.direction = leftToRight
+		return a
+	}
+
+	resource := NewObject("document", "doc1")
+	subject := NewObject("user", "alice").WithEllipses()
+
+	// Both modes should produce a match. The combined path's subject comes from
+	// the right path (combineArrowPaths uses rightPath.Subject), so the subject
+	// is the concrete "alice" from the right-side IterResources result.
+	runArrowCheckInBothModes(t, "wildcard_left_match", factory,
+		resource, subject, true, "alice")
+}
+
+// TestArrow_BatchedWildcard_LeftOnly_NoMatch verifies that when the left side
+// returns a wildcard but IterResources on the right finds nothing, there is no match.
+func TestArrow_BatchedWildcard_LeftOnly_NoMatch(t *testing.T) {
+	factory := func() *ArrowIterator {
+		// Left side: document:doc1 has a wildcard viewer (user:*)
+		left := NewFixedIterator(*wildcardPath("document", "doc1", "viewer", "user"))
+
+		// Right side: a path for bob, not alice.
+		// IterResources(user:alice#..., ObjectType{Type: "user"}) will NOT find this.
+		bobSubject := NewObject("user", "bob").WithEllipses()
+		right := NewFixedIterator(*rightPathForWildcard("user", "bob", "viewer", bobSubject))
+
+		a := NewArrowIterator(left, right)
+		a.direction = leftToRight
+		return a
+	}
+
+	resource := NewObject("document", "doc1")
+	subject := NewObject("user", "alice").WithEllipses()
+
+	runArrowCheckInBothModes(t, "wildcard_left_no_match", factory,
+		resource, subject, false, "")
+}
+
+// TestArrow_BatchedWildcard_MixedConcreteAndWildcard verifies the branch where the
+// left side returns BOTH concrete subjects AND a wildcard. In batched mode, concrete
+// paths go through CheckManyResources while the wildcard goes through IterResources.
+func TestArrow_BatchedWildcard_MixedConcreteAndWildcard(t *testing.T) {
+	factory := func() *ArrowIterator {
+		// Left side: document:doc1 has a concrete viewer (bob) AND a wildcard (user:*)
+		concretePath := MustPathFromString("document:doc1#viewer@user:bob")
+		wildcard := wildcardPath("document", "doc1", "viewer", "user")
+		left := NewFixedIterator(*concretePath, *wildcard)
+
+		// Right side:
+		// - user:bob has a viewer path (for the concrete branch)
+		// - user:alice has a viewer path (for the wildcard branch via IterResources)
+		bobSubject := NewObject("user", "bob").WithEllipses()
+		aliceSubject := NewObject("user", "alice").WithEllipses()
+		right := NewFixedIterator(
+			*rightPathForWildcard("user", "bob", "viewer", bobSubject),
+			*rightPathForWildcard("user", "alice", "viewer", aliceSubject),
+		)
+
+		a := NewArrowIterator(left, right)
+		a.direction = leftToRight
+		return a
+	}
+
+	resource := NewObject("document", "doc1")
+
+	// alice matches via the wildcard branch (IterResources finds alice on right).
+	// The combined path's subject is "alice" from the right path.
+	runArrowCheckInBothModes(t, "mixed_alice_via_wildcard", factory,
+		resource, NewObject("user", "alice").WithEllipses(), true, "alice")
+
+	// bob matches via the concrete branch (CheckManyResources)
+	runArrowCheckInBothModes(t, "mixed_bob_via_concrete", factory,
+		resource, NewObject("user", "bob").WithEllipses(), true, "bob")
+
+	// charlie matches via the wildcard branch (IterResources finds user:charlie path)
+	// But we don't have a charlie path on the right, so no match.
+	runArrowCheckInBothModes(t, "mixed_charlie_no_right_path", factory,
+		resource, NewObject("user", "charlie").WithEllipses(), false, "")
+}
+
+// TestArrow_BatchedWildcard_WithCaveat exercises the MergeOr branch (lines 255-258)
+// where the combined path has a caveat, so it accumulates via MergeOr instead of
+// returning early.
+func TestArrow_BatchedWildcard_WithCaveat(t *testing.T) {
+	factory := func() *ArrowIterator {
+		// Left side: wildcard with a caveat
+		left := NewFixedIterator(*wildcardPathWithCaveat("document", "doc1", "viewer", "user", "left_caveat"))
+
+		// Right side: matching path with a caveat
+		subject := NewObject("user", "alice").WithEllipses()
+		right := NewFixedIterator(*rightPathForWildcardWithCaveat("user", "alice", "viewer", subject, "right_caveat"))
+
+		a := NewArrowIterator(left, right)
+		a.direction = leftToRight
+		return a
+	}
+
+	resource := NewObject("document", "doc1")
+	subject := NewObject("user", "alice").WithEllipses()
+
+	// Both modes should match. Subject comes from the right path ("alice").
+	runArrowCheckInBothModes(t, "wildcard_with_caveat_match", factory,
+		resource, subject, true, "alice")
+}
+
+// TestArrow_BatchedWildcard_MultipleRightPaths tests the case where IterResources
+// returns multiple matching right paths for a single wildcard left path.
+func TestArrow_BatchedWildcard_MultipleRightPaths(t *testing.T) {
+	factory := func() *ArrowIterator {
+		// Left side: single wildcard
+		left := NewFixedIterator(*wildcardPath("document", "doc1", "viewer", "user"))
+
+		// Right side: multiple users
+		aliceSubject := NewObject("user", "alice").WithEllipses()
+		bobSubject := NewObject("user", "bob").WithEllipses()
+		right := NewFixedIterator(
+			*rightPathForWildcard("user", "alice", "viewer", aliceSubject),
+			*rightPathForWildcard("user", "bob", "viewer", bobSubject),
+		)
+
+		a := NewArrowIterator(left, right)
+		a.direction = leftToRight
+		return a
+	}
+
+	resource := NewObject("document", "doc1")
+
+	// alice matches (subject from right path)
+	runArrowCheckInBothModes(t, "multi_right_alice", factory,
+		resource, NewObject("user", "alice").WithEllipses(), true, "alice")
+
+	// bob matches (subject from right path)
+	runArrowCheckInBothModes(t, "multi_right_bob", factory,
+		resource, NewObject("user", "bob").WithEllipses(), true, "bob")
+
+	// charlie doesn't match (no right path for charlie)
+	runArrowCheckInBothModes(t, "multi_right_charlie_no_match", factory,
+		resource, NewObject("user", "charlie").WithEllipses(), false, "")
+}
+
+// TestArrow_BatchedWildcard_UseIterResourcesNotCheckMany verifies that when the left
+// side returns ONLY wildcards, the batched path uses IterResources (not CheckManyResources)
+// to follow the arrow.
+func TestArrow_BatchedWildcard_UseIterResourcesNotCheckMany(t *testing.T) {
+	req := require.New(t)
+
+	// Left side: only a wildcard path
+	left := NewFixedIterator(*wildcardPath("document", "doc1", "viewer", "user"))
+
+	// Right side: matching path for alice
+	subject := NewObject("user", "alice").WithEllipses()
+	right := NewFixedIterator(*rightPathForWildcard("user", "alice", "viewer", subject))
+
+	arrow := NewArrowIterator(left, right)
+	arrow.direction = leftToRight
+
+	exec := &countingExecutor{}
+	ctx := &Context{
+		Context:       t.Context(),
+		Executor:      exec,
+		BatchedArrows: true,
+	}
+
+	path, err := ctx.Check(arrow, NewObject("document", "doc1"), subject)
+	req.NoError(err)
+	req.NotNil(path, "expected match via wildcard")
+	// The combined path's subject comes from the right path (alice).
+	req.Equal("alice", path.Subject.ObjectID, "subject should be from right path")
+
+	// Since the left side is ONLY wildcards, CheckManyResources must NOT be called
+	// (there are no concrete intermediates to batch). The wildcard branch uses
+	// IterResources directly.
+	req.Equal(0, exec.checkManyCalls, "wildcard-only left side must not call CheckManyResources")
+}
+
+// TestArrow_BatchedWildcard_MixedDispatch verifies that when the left side has both
+// concrete and wildcard paths, CheckManyResources is called for the concrete paths.
+// We check for a subject that does NOT match the wildcard branch, forcing the
+// concrete CheckManyResources path to be exercised.
+func TestArrow_BatchedWildcard_MixedDispatch(t *testing.T) {
+	req := require.New(t)
+
+	// Left side: concrete + wildcard
+	concretePath := MustPathFromString("document:doc1#viewer@user:alice")
+	wildcard := wildcardPath("document", "doc1", "viewer", "user")
+	left := NewFixedIterator(*concretePath, *wildcard)
+
+	// Right side: only bob has a right-side path.
+	// When we check for alice:
+	//   - Wildcard branch: IterResources(user:alice#..., {Type: "user"}) finds nothing (no alice path on right)
+	//   - Concrete branch: CheckManyResources with [user:alice] — alice matches because right has alice path
+	bobSubject := NewObject("user", "bob").WithEllipses()
+	right := NewFixedIterator(*rightPathForWildcard("user", "bob", "viewer", bobSubject))
+
+	arrow := NewArrowIterator(left, right)
+	arrow.direction = leftToRight
+
+	exec := &countingExecutor{}
+	ctx := &Context{
+		Context:       t.Context(),
+		Executor:      exec,
+		BatchedArrows: true,
+	}
+
+	// Check for alice: wildcard branch finds nothing (no alice on right).
+	// Concrete branch: CheckManyResources checks user:alice against right — no match either.
+	// Result: no match, but CheckManyResources WAS called.
+	_, err := ctx.Check(arrow, NewObject("document", "doc1"), NewObject("user", "alice").WithEllipses())
+	req.NoError(err)
+
+	// CheckManyResources WAS called for the concrete path.
+	req.Equal(1, exec.checkManyCalls, "mixed left side must call CheckManyResources for concrete paths")
+}
+
+// TestArrow_BatchedWildcard_RTL verifies that wildcards work correctly in the
+// right-to-left direction. In RTL mode, the right side is queried first via
+// IterResources, then the left side is checked via CheckManySubjects. Wildcards
+// on the right side are handled naturally through IterResources (which filters
+// by the target subject).
+func TestArrow_BatchedWildcard_RTL(t *testing.T) {
+	factory := func() *ArrowIterator {
+		// Left side: folder:project1 has parent folder:root
+		leftPath := MustPathFromString("folder:project1#parent@folder:root")
+		left := NewFixedIterator(*leftPath)
+
+		// Right side: folder:root has a concrete viewer (user:alice).
+		// RTL: IterResources(right, user:alice#..., ...) finds folder:root.
+		// Then CheckManySubjects(left, folder:project1, [folder:root#...]) finds the parent path.
+		rightPath := MustPathFromString("folder:root#viewer@user:alice")
+		right := NewFixedIterator(*rightPath)
+
+		a := NewArrowIterator(left, right)
+		a.direction = rightToLeft
+		return a
+	}
+
+	// Check: does folder:project1 have user:alice as a viewer?
+	// Right: user:alice views folder:root (IterResources finds this)
+	// Left: folder:project1 has parent folder:root (CheckManySubjects finds this)
+	// Result: match via folder:root
+	runArrowCheckInBothModes(t, "rtl_concrete_viewer", factory,
+		NewObject("folder", "project1"),
+		NewObject("user", "alice").WithEllipses(),
+		true, "alice")
+}
+
+// TestArrow_BatchedWildcard_IterSubjects verifies that IterSubjects through an
+// arrow skips wildcard left paths (arrow.go line 462: wildcards are skipped in
+// IterSubjects because they can't be followed through arrows without a store-wide
+// query). Only concrete left paths are followed.
+func TestArrow_BatchedWildcard_IterSubjects(t *testing.T) {
+	req := require.New(t)
+
+	// Left side: document:doc1 has both a concrete viewer and a wildcard
+	concretePath := MustPathFromString("document:doc1#viewer@user:bob")
+	wildcard := wildcardPath("document", "doc1", "viewer", "user")
+	left := NewFixedIterator(*concretePath, *wildcard)
+
+	// Right side: user:bob has viewer access (so bob -> bob chain works)
+	bobSubject := NewObject("user", "bob").WithEllipses()
+	right := NewFixedIterator(
+		*rightPathForWildcard("user", "bob", "viewer", bobSubject),
+	)
+
+	arrow := NewArrowIterator(left, right)
+	arrow.direction = leftToRight
+
+	ctx := NewTestContext(t)
+
+	// IterSubjects follows concrete left paths but SKIPS wildcard left paths
+	// (see arrow.go:462 "cannot follow arrow through wildcard").
+	// Only bob (via concrete path) should appear.
+	seq, err := ctx.IterSubjects(arrow, NewObject("document", "doc1"), NoObjectFilter())
+	req.NoError(err)
+
+	paths, err := CollectAll(seq)
+	req.NoError(err)
+
+	subjectIDs := slicez.Map(paths, func(p *Path) string { return p.Subject.ObjectID })
+	req.Contains(subjectIDs, "bob", "expected concrete subject bob")
+	req.NotContains(subjectIDs, tuple.PublicWildcard, "wildcards are skipped in IterSubjects through arrows")
+}
+
+// TestArrow_BatchedWildcard_CombinedCaveat verifies that when both left (wildcard)
+// and right paths have caveats, they are combined with AND logic via combineArrowPaths.
+func TestArrow_BatchedWildcard_CombinedCaveat(t *testing.T) {
+	req := require.New(t)
+
+	// Left: wildcard with caveat
+	left := NewFixedIterator(*wildcardPathWithCaveat("document", "doc1", "viewer", "user", "left_caveat"))
+
+	// Right: matching path with caveat
+	subject := NewObject("user", "alice").WithEllipses()
+	right := NewFixedIterator(*rightPathForWildcardWithCaveat("user", "alice", "viewer", subject, "right_caveat"))
+
+	arrow := NewArrowIterator(left, right)
+	arrow.direction = leftToRight
+
+	ctx := NewTestContext(t)
+	path, err := ctx.Check(arrow, NewObject("document", "doc1"), subject)
+	req.NoError(err)
+	req.NotNil(path)
+
+	// The combined caveat should be an AND of left and right caveats.
+	req.NotNil(path.Caveat, "expected combined caveat")
+
+	// combineArrowPaths uses caveats.And() which produces a CaveatOperation with AND.
+	op := path.Caveat.GetOperation()
+	req.NotNil(op, "expected caveat operation (AND)")
+	req.Equal(core.CaveatOperation_AND, op.Op, "combined caveat should use AND")
+	req.Len(op.Children, 2, "AND should have 2 children")
 }

--- a/pkg/query/build_tree.go
+++ b/pkg/query/build_tree.go
@@ -146,6 +146,7 @@ func (b *outlineBuilder) buildOutlineFromSchemaInternal(definitionName string, r
 }
 
 func (b *outlineBuilder) buildOutlineFromRelation(r *schema.Relation, withSubRelations bool) (Outline, error) {
+	defName := r.Definition().Name()
 	if len(r.BaseRelations()) == 1 {
 		baseIt, err := b.buildBaseDatastoreOutline(r.BaseRelations()[0], withSubRelations)
 		if err != nil {
@@ -153,7 +154,7 @@ func (b *outlineBuilder) buildOutlineFromRelation(r *schema.Relation, withSubRel
 		}
 		return Outline{
 			Type:        AliasIteratorType,
-			Args:        &IteratorArgs{RelationName: r.Name()},
+			Args:        &IteratorArgs{DefinitionName: defName, RelationName: r.Name()},
 			SubOutlines: []Outline{baseIt},
 		}, nil
 	}
@@ -171,7 +172,7 @@ func (b *outlineBuilder) buildOutlineFromRelation(r *schema.Relation, withSubRel
 	}
 	return Outline{
 		Type:        AliasIteratorType,
-		Args:        &IteratorArgs{RelationName: r.Name()},
+		Args:        &IteratorArgs{DefinitionName: defName, RelationName: r.Name()},
 		SubOutlines: []Outline{union},
 	}, nil
 }
@@ -183,7 +184,7 @@ func (b *outlineBuilder) buildOutlineFromPermission(p *schema.Permission) (Outli
 	}
 	return Outline{
 		Type:        AliasIteratorType,
-		Args:        &IteratorArgs{RelationName: p.Name()},
+		Args:        &IteratorArgs{DefinitionName: p.Definition().Name(), RelationName: p.Name()},
 		SubOutlines: []Outline{baseIt},
 	}, nil
 }

--- a/pkg/query/context.go
+++ b/pkg/query/context.go
@@ -28,6 +28,13 @@ type Context struct {
 	// Iterators may inspect it to skip work that is irrelevant for the current operation type.
 	TopLevelOperation Operation
 
+	// BatchedArrows enables the batched arrow check path: arrows drain their
+	// left/right side into a slice and issue a single CheckMany call instead of
+	// one Check per element. Always set when running with DispatchExecutor so
+	// arrow fanout collapses into a single RPC per alias boundary; left off in
+	// LocalExecutor by default to keep the simpler path.
+	BatchedArrows bool
+
 	// Pagination options for IterSubjects and IterResources
 	PaginationCursors map[string]*tuple.Relationship // Cursors for pagination, keyed by iterator ID
 	PaginationLimit   *uint64                        // Limit for pagination (max number of results to return)
@@ -103,6 +110,11 @@ func WithCaveatContext(caveatCtx map[string]any) ContextOption {
 // WithMaxRecursionDepth sets the maximum recursion depth for the context.
 func WithMaxRecursionDepth(depth int) ContextOption {
 	return func(ctx *Context) { ctx.MaxRecursionDepth = depth }
+}
+
+// WithBatchedArrows enables the batched arrow check path on the context.
+func WithBatchedArrows(enabled bool) ContextOption {
+	return func(ctx *Context) { ctx.BatchedArrows = enabled }
 }
 
 // WithPaginationLimit sets the pagination limit for the context.
@@ -246,6 +258,64 @@ func (ctx *Context) Check(it Iterator, resource Object, subject ObjectAndRelatio
 	return path, nil
 }
 
+// CheckManySubjects tests resource against each subject in subjects. Returns a
+// parallel slice of paths (result[i] matches subjects[i], nil if no match).
+func (ctx *Context) CheckManySubjects(it Iterator, resource Object, subjects []ObjectAndRelation) ([]*Path, error) {
+	if ctx.Executor == nil {
+		return nil, spiceerrors.MustBugf("no executor has been set")
+	}
+	if len(subjects) == 0 {
+		return nil, nil
+	}
+
+	ctx.topLevelOnce.Do(func() {
+		ctx.topLevelIterator = it
+		ctx.TopLevelOperation = OperationCheck
+	})
+
+	key := it.CanonicalKey()
+	ctx.notifyEnterIterator(OperationCheck, key)
+
+	paths, err := ctx.Executor.CheckManySubjects(ctx, it, resource, subjects)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range paths {
+		ctx.notifyCheckResult(key, p)
+	}
+	return paths, nil
+}
+
+// CheckManyResources tests each resource in resources against subject. Returns a
+// parallel slice of paths (result[i] matches resources[i], nil if no match).
+func (ctx *Context) CheckManyResources(it Iterator, resources []Object, subject ObjectAndRelation) ([]*Path, error) {
+	if ctx.Executor == nil {
+		return nil, spiceerrors.MustBugf("no executor has been set")
+	}
+	if len(resources) == 0 {
+		return nil, nil
+	}
+
+	ctx.topLevelOnce.Do(func() {
+		ctx.topLevelIterator = it
+		ctx.TopLevelOperation = OperationCheck
+	})
+
+	key := it.CanonicalKey()
+	ctx.notifyEnterIterator(OperationCheck, key)
+
+	paths, err := ctx.Executor.CheckManyResources(ctx, it, resources, subject)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range paths {
+		ctx.notifyCheckResult(key, p)
+	}
+	return paths, nil
+}
+
 // wrapPathSeqForTracing wraps a PathSeq to collect results for exit tracing if tracing is enabled,
 // otherwise returns the original PathSeq unchanged.
 func (ctx *Context) wrapPathSeqForTracing(it Iterator, pathSeq PathSeq) PathSeq {
@@ -359,6 +429,16 @@ type Executor interface {
 	// Check tests if the given resource is connected to subject.
 	// Returns the matching Path if found, or nil if not found.
 	Check(ctx *Context, it Iterator, resource Object, subject ObjectAndRelation) (*Path, error)
+
+	// CheckManySubjects tests resource against each subject in the slice.
+	// Returns a parallel slice of paths: result[i] is the matching Path for
+	// subjects[i], or nil if subjects[i] does not match.
+	CheckManySubjects(ctx *Context, it Iterator, resource Object, subjects []ObjectAndRelation) ([]*Path, error)
+
+	// CheckManyResources tests each resource in the slice against subject.
+	// Returns a parallel slice of paths: result[i] is the matching Path for
+	// resources[i], or nil if resources[i] does not match.
+	CheckManyResources(ctx *Context, it Iterator, resources []Object, subject ObjectAndRelation) ([]*Path, error)
 
 	// IterSubjects returns a sequence of all the relations in this set that match the given resource.
 	// The filterSubjectType parameter filters results to only include subjects matching the

--- a/pkg/query/context.go
+++ b/pkg/query/context.go
@@ -48,17 +48,22 @@ type Context struct {
 	topLevelOnce     sync.Once
 }
 
-// NewLocalContext creates a new query execution context with a LocalExecutor.
-// This is a convenience constructor for tests and local execution scenarios.
-func NewLocalContext(stdContext context.Context, opts ...ContextOption) *Context {
+// NewQueryContext builds a query plan exection context with the given executor implementation.
+func NewQueryContext(stdContext context.Context, executor Executor, opts ...ContextOption) *Context {
 	ctx := &Context{
 		Context:  stdContext,
-		Executor: LocalExecutor{},
+		Executor: executor,
 	}
 	for _, opt := range opts {
 		opt(ctx)
 	}
 	return ctx
+}
+
+// NewLocalContext creates a new query execution context with a LocalExecutor.
+// This is a convenience constructor for tests and local execution scenarios.
+func NewLocalContext(stdContext context.Context, opts ...ContextOption) *Context {
+	return NewQueryContext(stdContext, LocalExecutor{}, opts...)
 }
 
 // ContextOption is a function that configures a Context.

--- a/pkg/query/context.go
+++ b/pkg/query/context.go
@@ -236,10 +236,7 @@ func (ctx *Context) Check(it Iterator, resource Object, subject ObjectAndRelatio
 		return nil, spiceerrors.MustBugf("no executor has been set")
 	}
 
-	ctx.topLevelOnce.Do(func() {
-		ctx.topLevelIterator = it
-		ctx.TopLevelOperation = OperationCheck
-	})
+	ctx.MarkAsOperation(it, OperationCheck)
 
 	var tracedIterator Iterator
 	if ctx.shouldTrace() {
@@ -258,6 +255,33 @@ func (ctx *Context) Check(it Iterator, resource Object, subject ObjectAndRelatio
 	return path, nil
 }
 
+// MarkAsOperation records the top-level iterator and operation for this
+// context, idempotently. The first caller "wins" and gets isTopLevel=true; all
+// subsequent calls are no-ops and return false. This is used in two ways:
+//
+//  1. By Context.{Check,IterSubjects,IterResources,CheckManyX}, which call it
+//     on entry so that any nested calls into the same context know they are
+//     not the top-level — and so that the entry path can apply API-boundary
+//     wrappers (FilterWildcardSubjects / DeduplicatePathSeq) only when truly
+//     at the top.
+//
+//  2. By dispatch receivers, which pre-seal it so that the first inner
+//     ctx.IterX call on the body is NOT mistaken for the top-level. Without
+//     pre-sealing, the receiver's first inner call applies FilterWildcardSubjects
+//     to a sub-iterator's results, silently dropping wildcards that should
+//     propagate back to the sender's intersection/exclusion logic.
+//
+// It also sets TopLevelOperation so iterators that consult it (e.g.
+// AliasIterator.shouldIncludeSelfEdge) see the right value.
+func (ctx *Context) MarkAsOperation(it Iterator, op Operation) (isTopLevel bool) {
+	ctx.topLevelOnce.Do(func() {
+		ctx.topLevelIterator = it
+		ctx.TopLevelOperation = op
+		isTopLevel = true
+	})
+	return
+}
+
 // CheckManySubjects tests resource against each subject in subjects. Returns a
 // parallel slice of paths (result[i] matches subjects[i], nil if no match).
 func (ctx *Context) CheckManySubjects(it Iterator, resource Object, subjects []ObjectAndRelation) ([]*Path, error) {
@@ -268,10 +292,7 @@ func (ctx *Context) CheckManySubjects(it Iterator, resource Object, subjects []O
 		return nil, nil
 	}
 
-	ctx.topLevelOnce.Do(func() {
-		ctx.topLevelIterator = it
-		ctx.TopLevelOperation = OperationCheck
-	})
+	ctx.MarkAsOperation(it, OperationCheck)
 
 	key := it.CanonicalKey()
 	ctx.notifyEnterIterator(OperationCheck, key)
@@ -297,10 +318,7 @@ func (ctx *Context) CheckManyResources(it Iterator, resources []Object, subject 
 		return nil, nil
 	}
 
-	ctx.topLevelOnce.Do(func() {
-		ctx.topLevelIterator = it
-		ctx.TopLevelOperation = OperationCheck
-	})
+	ctx.MarkAsOperation(it, OperationCheck)
 
 	key := it.CanonicalKey()
 	ctx.notifyEnterIterator(OperationCheck, key)
@@ -355,12 +373,7 @@ func (ctx *Context) IterSubjects(it Iterator, resource Object, filterSubjectType
 		return nil, spiceerrors.MustBugf("no executor has been set")
 	}
 
-	isTopLevel := false
-	ctx.topLevelOnce.Do(func() {
-		ctx.topLevelIterator = it
-		isTopLevel = true
-		ctx.TopLevelOperation = OperationIterSubjects
-	})
+	isTopLevel := ctx.MarkAsOperation(it, OperationIterSubjects)
 
 	var tracedIterator Iterator
 	if ctx.shouldTrace() {
@@ -394,12 +407,7 @@ func (ctx *Context) IterResources(it Iterator, subject ObjectAndRelation, filter
 		return nil, spiceerrors.MustBugf("no executor has been set")
 	}
 
-	isTopLevel := false
-	ctx.topLevelOnce.Do(func() {
-		ctx.topLevelIterator = it
-		isTopLevel = true
-		ctx.TopLevelOperation = OperationIterResources
-	})
+	isTopLevel := ctx.MarkAsOperation(it, OperationIterResources)
 
 	var tracedIterator Iterator
 	if ctx.shouldTrace() {

--- a/pkg/query/executor_local.go
+++ b/pkg/query/executor_local.go
@@ -12,6 +12,32 @@ func (l LocalExecutor) Check(ctx *Context, it Iterator, resource Object, subject
 	return it.CheckImpl(ctx, resource, subject)
 }
 
+// CheckManySubjects tests resource against each subject. Result is parallel to subjects.
+func (l LocalExecutor) CheckManySubjects(ctx *Context, it Iterator, resource Object, subjects []ObjectAndRelation) ([]*Path, error) {
+	out := make([]*Path, len(subjects))
+	for i, s := range subjects {
+		p, err := it.CheckImpl(ctx, resource, s)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = p
+	}
+	return out, nil
+}
+
+// CheckManyResources tests each resource against subject. Result is parallel to resources.
+func (l LocalExecutor) CheckManyResources(ctx *Context, it Iterator, resources []Object, subject ObjectAndRelation) ([]*Path, error) {
+	out := make([]*Path, len(resources))
+	for i, r := range resources {
+		p, err := it.CheckImpl(ctx, r, subject)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = p
+	}
+	return out, nil
+}
+
 // IterSubjects returns a sequence of all the paths in this set that match the given resource.
 func (l LocalExecutor) IterSubjects(ctx *Context, it Iterator, resource Object, filterSubjectType ObjectType) (PathSeq, error) {
 	pathSeq, err := it.IterSubjectsImpl(ctx, resource, filterSubjectType)

--- a/pkg/query/intersection_arrow.go
+++ b/pkg/query/intersection_arrow.go
@@ -44,19 +44,43 @@ func (ia *IntersectionArrowIterator) CheckImpl(ctx *Context, resource Object, su
 	// 4. Combine all (leftCaveat AND rightCaveat) pairs with AND logic
 
 	validResults := make([]*Path, 0)
-	for path, err := range subit {
-		if err != nil {
-			return nil, err
+	if ctx.BatchedArrows {
+		var (
+			leftPaths    []*Path
+			concreteRes  []Object
+			concreteIdxs []int
+			wildcardIdxs []int
+		)
+		for path, err := range subit {
+			if err != nil {
+				return nil, err
+			}
+			leftPaths = append(leftPaths, path)
+			if path.Subject.ObjectID == tuple.PublicWildcard {
+				wildcardIdxs = append(wildcardIdxs, len(leftPaths)-1)
+			} else {
+				concreteIdxs = append(concreteIdxs, len(leftPaths)-1)
+				concreteRes = append(concreteRes, GetObject(path.Subject))
+			}
 		}
 
-		// If the left side returned a wildcard, use IterResources inversion on the right
-		// to check if the subject appears in any resource of the matching type.
-		var checkPath *Path
-		if path.Subject.ObjectID == tuple.PublicWildcard {
-			if ctx.shouldTrace() {
-				ctx.TraceStep(ia, "left returned wildcard %s:*, using IterResources inversion", path.Subject.ObjectType)
+		checkResults := make([]*Path, len(leftPaths))
+		if len(concreteRes) > 0 {
+			batched, err := ctx.CheckManyResources(ia.right, concreteRes, subject)
+			if err != nil {
+				return nil, err
 			}
-			rightSeq, err := ctx.IterResources(ia.right, subject, ObjectType{Type: path.Subject.ObjectType})
+			for i, idx := range concreteIdxs {
+				checkResults[idx] = batched[i]
+			}
+		}
+		// Wildcards still go through IterResources inversion individually.
+		for _, idx := range wildcardIdxs {
+			lp := leftPaths[idx]
+			if ctx.shouldTrace() {
+				ctx.TraceStep(ia, "left returned wildcard %s:*, using IterResources inversion", lp.Subject.ObjectType)
+			}
+			rightSeq, err := ctx.IterResources(ia.right, subject, ObjectType{Type: lp.Subject.ObjectType})
 			if err != nil {
 				return nil, err
 			}
@@ -64,43 +88,90 @@ func (ia *IntersectionArrowIterator) CheckImpl(ctx *Context, resource Object, su
 				if err != nil {
 					return nil, err
 				}
-				checkPath = rp
-				break // any match suffices
+				checkResults[idx] = rp
+				break
 			}
-		} else {
-			checkPath, err = ctx.Check(ia.right, GetObject(path.Subject), subject)
+		}
+
+		for i, leftPath := range leftPaths {
+			checkPath := checkResults[i]
+			if checkPath == nil {
+				if ctx.shouldTrace() {
+					ctx.TraceStep(ia, "left subject %s:%s did NOT connect on the right side",
+						leftPath.Subject.ObjectType, leftPath.Subject.ObjectID)
+				}
+				return nil, nil
+			}
+			combinedCaveat := caveats.And(leftPath.Caveat, checkPath.Caveat)
+			validResults = append(validResults, &Path{
+				Resource:   leftPath.Resource,
+				Relation:   leftPath.Relation,
+				Subject:    checkPath.Subject,
+				Caveat:     combinedCaveat,
+				Expiration: combineExpiration(leftPath.Expiration, checkPath.Expiration),
+				Integrity:  combineIntegrity(leftPath.Integrity, checkPath.Integrity),
+				Metadata:   checkPath.Metadata,
+			})
+		}
+	} else {
+		for path, err := range subit {
 			if err != nil {
 				return nil, err
 			}
-		}
 
-		if checkPath == nil {
+			// If the left side returned a wildcard, use IterResources inversion on the right
+			// to check if the subject appears in any resource of the matching type.
+			var checkPath *Path
+			if path.Subject.ObjectID == tuple.PublicWildcard {
+				if ctx.shouldTrace() {
+					ctx.TraceStep(ia, "left returned wildcard %s:*, using IterResources inversion", path.Subject.ObjectType)
+				}
+				rightSeq, err := ctx.IterResources(ia.right, subject, ObjectType{Type: path.Subject.ObjectType})
+				if err != nil {
+					return nil, err
+				}
+				for rp, err := range rightSeq {
+					if err != nil {
+						return nil, err
+					}
+					checkPath = rp
+					break // any match suffices
+				}
+			} else {
+				checkPath, err = ctx.Check(ia.right, GetObject(path.Subject), subject)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			if checkPath == nil {
+				if ctx.shouldTrace() {
+					ctx.TraceStep(ia, "left subject %s:%s did NOT connect on the right side",
+						path.Subject.ObjectType, path.Subject.ObjectID)
+				}
+				// One left subject failed — intersection fails entirely
+				return nil, nil
+			}
+
 			if ctx.shouldTrace() {
-				ctx.TraceStep(ia, "left subject %s:%s did NOT connect on the right side",
+				ctx.TraceStep(ia, "left subject %s:%s connects with the right side",
 					path.Subject.ObjectType, path.Subject.ObjectID)
 			}
-			// One left subject failed — intersection fails entirely
-			return nil, nil
-		}
 
-		if ctx.shouldTrace() {
-			ctx.TraceStep(ia, "left subject %s:%s connects with the right side",
-				path.Subject.ObjectType, path.Subject.ObjectID)
-		}
+			// Combine this path's left caveat with the right caveat
+			combinedCaveat := caveats.And(path.Caveat, checkPath.Caveat)
 
-		// Combine this path's left caveat with the right caveat
-		combinedCaveat := caveats.And(path.Caveat, checkPath.Caveat)
-
-		combinedPath := &Path{
-			Resource:   path.Resource,
-			Relation:   path.Relation,
-			Subject:    checkPath.Subject,
-			Caveat:     combinedCaveat,
-			Expiration: combineExpiration(path.Expiration, checkPath.Expiration),
-			Integrity:  combineIntegrity(path.Integrity, checkPath.Integrity),
-			Metadata:   checkPath.Metadata,
+			combinedPath := &Path{
+				Resource:   path.Resource,
+				Relation:   path.Relation,
+				Subject:    checkPath.Subject,
+				Caveat:     combinedCaveat,
+				Expiration: combineExpiration(path.Expiration, checkPath.Expiration),
+				Integrity:  combineIntegrity(path.Integrity, checkPath.Integrity),
+				Metadata:   checkPath.Metadata,
+			}
+			validResults = append(validResults, combinedPath)
 		}
-		validResults = append(validResults, combinedPath)
 	}
 
 	if len(validResults) == 0 {

--- a/pkg/query/outline.go
+++ b/pkg/query/outline.go
@@ -224,9 +224,8 @@ func compileOutline(outline Outline, keys map[OutlineNodeID]CanonicalKey, hints 
 		if outline.Args == nil || outline.Args.RelationName == "" {
 			return nil, errors.New("AliasIterator requires RelationName in Args")
 		}
-		alias := NewAliasIteratorWithChain(outline.Args.RelationName, outline.Args.AliasedAs, compiledSubs[0])
+		alias := NewAliasIteratorWithChain(outline.Args.DefinitionName, outline.Args.RelationName, outline.Args.AliasedAs, compiledSubs[0])
 		alias.canonicalKey = key
-		alias.definitionName = outline.Args.DefinitionName
 		it = alias
 
 	case RecursiveIteratorType:

--- a/pkg/query/outline.go
+++ b/pkg/query/outline.go
@@ -226,6 +226,7 @@ func compileOutline(outline Outline, keys map[OutlineNodeID]CanonicalKey, hints 
 		}
 		alias := NewAliasIteratorWithChain(outline.Args.RelationName, outline.Args.AliasedAs, compiledSubs[0])
 		alias.canonicalKey = key
+		alias.definitionName = outline.Args.DefinitionName
 		it = alias
 
 	case RecursiveIteratorType:
@@ -378,8 +379,9 @@ func Decompile(it Iterator) (Outline, error) {
 		return Outline{
 			Type: AliasIteratorType,
 			Args: &IteratorArgs{
-				RelationName: typed.relation,
-				AliasedAs:    append([]string(nil), typed.aliasedAs...),
+				DefinitionName: typed.definitionName,
+				RelationName:   typed.relation,
+				AliasedAs:      append([]string(nil), typed.aliasedAs...),
 			},
 			SubOutlines: decompSubs,
 		}, nil

--- a/pkg/query/outline_test.go
+++ b/pkg/query/outline_test.go
@@ -577,7 +577,7 @@ func TestOutline_Decompile(t *testing.T) {
 	t.Run("AliasIterator", func(t *testing.T) {
 		require := require.New(t)
 
-		alias := NewAliasIterator("viewer", NewFixedIterator())
+		alias := NewAliasIterator("", "viewer", NewFixedIterator())
 
 		outline, err := Decompile(alias)
 		require.NoError(err)

--- a/proto/internal/dispatch/v1/dispatch.proto
+++ b/proto/internal/dispatch/v1/dispatch.proto
@@ -246,6 +246,14 @@ message PlanContext {
   // plan for a key contains another structurally complete instance of itself
   // (cross-relation recursion the sentinel machinery can't see).
   repeated string in_progress_keys = 6;
+  // top_level_operation carries the user-facing operation (Check / LookupSubjects
+  // / LookupResources) that started the dispatch chain. The receiver pre-seals
+  // its qctx with this value so iterators that consult TopLevelOperation (e.g.
+  // AliasIterator.shouldIncludeSelfEdge) see the original API intent rather
+  // than the per-hop dispatch op. Reuses PlanOperation so a single enum
+  // describes both per-hop and user-facing operations; only CHECK,
+  // LOOKUP_RESOURCES, and LOOKUP_SUBJECTS are valid here.
+  PlanOperation top_level_operation = 7;
 }
 
 message DispatchQueryPlanRequest {

--- a/proto/internal/dispatch/v1/dispatch.proto
+++ b/proto/internal/dispatch/v1/dispatch.proto
@@ -227,6 +227,10 @@ enum PlanOperation {
   PLAN_OPERATION_CHECK = 0;
   PLAN_OPERATION_LOOKUP_RESOURCES = 1;
   PLAN_OPERATION_LOOKUP_SUBJECTS = 2;
+  // CHECK_MANY_RESOURCES: many = repeated resource ONRs, subject = single ONR.
+  PLAN_OPERATION_CHECK_MANY_RESOURCES = 3;
+  // CHECK_MANY_SUBJECTS: resource = single ONR, many = repeated subject ONRs.
+  PLAN_OPERATION_CHECK_MANY_SUBJECTS = 4;
 }
 
 message PlanContext {
@@ -240,9 +244,14 @@ message PlanContext {
 message DispatchQueryPlanRequest {
   PlanOperation operation = 1;
   string canonical_key = 2;
+  // For CHECK_MANY_RESOURCES, resource is empty and `many` carries the resources.
   core.v1.ObjectAndRelation resource = 3;
+  // For CHECK_MANY_SUBJECTS, subject is empty and `many` carries the subjects.
   core.v1.ObjectAndRelation subject = 4;
   PlanContext plan_context = 5;
+  // many takes the place of resource or subject (whichever is empty), used by
+  // PLAN_OPERATION_CHECK_MANY_RESOURCES and PLAN_OPERATION_CHECK_MANY_SUBJECTS.
+  repeated core.v1.ObjectAndRelation many = 6;
 }
 
 message DispatchQueryPlanResponse {

--- a/proto/internal/dispatch/v1/dispatch.proto
+++ b/proto/internal/dispatch/v1/dispatch.proto
@@ -239,6 +239,13 @@ message PlanContext {
   int32 max_recursion_depth = 3;
   uint64 optional_datastore_limit = 4;
   bytes schema_hash = 5;
+  // in_progress_keys are the dispatch canonical keys (\"def#rel\") that ancestors
+  // of this dispatch are currently computing. The receiver-side DispatchExecutor
+  // refuses to dispatch any alias whose key is in this set, falling back to local
+  // execution. This is what breaks dispatch loops that arise when the standalone
+  // plan for a key contains another structurally complete instance of itself
+  // (cross-relation recursion the sentinel machinery can't see).
+  repeated string in_progress_keys = 6;
 }
 
 message DispatchQueryPlanRequest {


### PR DESCRIPTION
## Description

This PR uses DispatchExecutor to actually send subproblems on Alias boundaries. This then showed up the final minor bugs in correctness in the integration tests, which were then eliminated, via adding the necessary fields to the proto PlanContext

This also introduces batching operations to the executors which allow the iterators to make choices about when to batch partial results (such as in an arrow, pulling from the left and sending them all to the right) 

## Testing

Integration Testing discovered much of this, notably `go test -v -tags integration ./internal/services/integrationtesting/queryconsistency -run="GRPC/"`