### PR TITLE
ci: save benchmarks to cache on main

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -49,10 +49,9 @@ jobs:
           tool: "go"
           # Where the output from the benchmark tool is stored
           output-file-path: "bench_output.txt"
-          # Where the benchmarks in main are (to compare)
+          # Where we store the results
           external-data-json-path: "./cache/benchmark-data.json"
-          # Do not save the data
-          save-data-file: false
+          save-data-file: true
           # Alert when current run is >= 2x worse than HEAD~1
           alert-threshold: "200%"
           # Workflow will fail when an alert happens
@@ -76,7 +75,7 @@ jobs:
 
       - name: "Save benchmark JSON"
         # Run even if the compare step failed on a regression, so the next run has a baseline.
-        if: "${{ !cancelled() }}"
+        if: "${{ !cancelled() || failure() }}"
         uses: "actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306" # v5.0.3
         with:
           path: "./cache/benchmark-data.json"


### PR DESCRIPTION
Benchmarks aren't being cached! https://github.com/authzed/spicedb/actions/runs/25526206235/job/74928995063


```
Run actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
  with:
    path: ./cache/benchmark-data.json
    key: 42f15998956d28b27415b20c1cbca8caad3f65d7-Linux-go-benchmark
    enableCrossOsArchive: false
  env:
    GOTOOLCHAIN: local
>>>> Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
>>>> Warning: Cache save failed.
```

the consequence is that the regression alerts silently stopped firing.