### PR TITLE
feat: add prometheus metrics for DispatchQueryPlan

### DIFF
--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -40,6 +40,8 @@ type Dispatcher struct {
 	lookupResourcesFromCacheCounter prometheus.Counter
 	lookupSubjectsTotalCounter      prometheus.Counter
 	lookupSubjectsFromCacheCounter  prometheus.Counter
+	queryPlanTotalCounter           *prometheus.CounterVec
+	queryPlanFromCacheCounter       *prometheus.CounterVec
 }
 
 func DispatchTestCache(t testing.TB) cache.Cache[keys.DispatchCacheKey, any] {
@@ -97,6 +99,19 @@ func NewCachingDispatcher(cacheInst cache.Cache[keys.DispatchCacheKey, any], met
 		Help:      "Total number of LookupSubjects dispatch requests served directly from the dispatch cache.",
 	})
 
+	queryPlanTotalCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prometheusNamespace,
+		Subsystem: prometheusSubsystem,
+		Name:      "query_plan_total",
+		Help:      "Total number of DispatchQueryPlan requests processed, labelled by plan operation.",
+	}, []string{"operation"})
+	queryPlanFromCacheCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prometheusNamespace,
+		Subsystem: prometheusSubsystem,
+		Name:      "query_plan_from_cache_total",
+		Help:      "Total number of DispatchQueryPlan requests served directly from the dispatch cache, labelled by plan operation.",
+	}, []string{"operation"})
+
 	if metricsEnabled && prometheusSubsystem != "" {
 		err := prometheus.Register(checkTotalCounter)
 		if err != nil {
@@ -122,6 +137,14 @@ func NewCachingDispatcher(cacheInst cache.Cache[keys.DispatchCacheKey, any], met
 		if err != nil {
 			return nil, fmt.Errorf(errCachingInitialization, err)
 		}
+		err = prometheus.Register(queryPlanTotalCounter)
+		if err != nil {
+			return nil, fmt.Errorf(errCachingInitialization, err)
+		}
+		err = prometheus.Register(queryPlanFromCacheCounter)
+		if err != nil {
+			return nil, fmt.Errorf(errCachingInitialization, err)
+		}
 	}
 
 	if keyHandler == nil {
@@ -138,6 +161,8 @@ func NewCachingDispatcher(cacheInst cache.Cache[keys.DispatchCacheKey, any], met
 		lookupResourcesFromCacheCounter: lookupResourcesFromCacheCounter,
 		lookupSubjectsTotalCounter:      lookupSubjectsTotalCounter,
 		lookupSubjectsFromCacheCounter:  lookupSubjectsFromCacheCounter,
+		queryPlanTotalCounter:           queryPlanTotalCounter,
+		queryPlanFromCacheCounter:       queryPlanFromCacheCounter,
 	}, nil
 }
 
@@ -405,6 +430,8 @@ func (cd *Dispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsReque
 }
 
 func (cd *Dispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
+	cd.queryPlanTotalCounter.WithLabelValues(dispatch.PlanOperationLabel(req.Operation)).Inc()
+
 	switch req.Operation {
 	case v1.PlanOperation_PLAN_OPERATION_CHECK:
 		return cd.dispatchQueryPlanCheckCached(req, stream)
@@ -415,8 +442,6 @@ func (cd *Dispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream
 }
 
 func (cd *Dispatcher) dispatchQueryPlanCheckCached(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
-	cd.checkTotalCounter.Inc()
-
 	requestKey, err := cd.keyHandler.PlanCheckCacheKey(stream.Context(), req)
 	if err != nil {
 		return err
@@ -427,7 +452,7 @@ func (cd *Dispatcher) dispatchQueryPlanCheckCached(req *v1.DispatchQueryPlanRequ
 		if err := cachedPath.UnmarshalVT(cachedPathRaw.([]byte)); err != nil {
 			return err
 		}
-		cd.checkFromCacheCounter.Inc()
+		cd.queryPlanFromCacheCounter.WithLabelValues(dispatch.PlanOperationLabel(req.Operation)).Inc()
 		return stream.Publish(&v1.DispatchQueryPlanResponse{
 			Paths: []*v1.ResultPath{&cachedPath},
 		})
@@ -461,8 +486,10 @@ func (cd *Dispatcher) Close() error {
 	prometheus.Unregister(cd.checkFromCacheCounter)
 	prometheus.Unregister(cd.lookupResourcesTotalCounter)
 	prometheus.Unregister(cd.lookupResourcesFromCacheCounter)
-	prometheus.Unregister(cd.lookupSubjectsFromCacheCounter)
 	prometheus.Unregister(cd.lookupSubjectsTotalCounter)
+	prometheus.Unregister(cd.lookupSubjectsFromCacheCounter)
+	prometheus.Unregister(cd.queryPlanTotalCounter)
+	prometheus.Unregister(cd.queryPlanFromCacheCounter)
 	if cache := cd.c; cache != nil {
 		cache.Close()
 	}

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -2,10 +2,13 @@ package caching
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -223,6 +226,120 @@ func TestConcurrentDebugInfoAccess(t *testing.T) {
 	for err := range errors {
 		require.NoError(err)
 	}
+}
+
+// planDispatchMock is a minimal dispatch.Dispatcher used by the caching plan-metrics
+// test. It publishes a single DispatchQueryPlanResponse carrying one ResultPath so
+// the caching layer's cache-write path is exercised.
+type planDispatchMock struct {
+	delegateDispatchMock
+	calls atomic.Uint64
+}
+
+func (p *planDispatchMock) DispatchQueryPlan(_ *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
+	p.calls.Add(1)
+	return stream.Publish(&v1.DispatchQueryPlanResponse{
+		Metadata: &v1.ResponseMeta{DispatchCount: 1},
+		Paths: []*v1.ResultPath{{
+			ResourceType: "document",
+			ResourceId:   "doc1",
+			Relation:     "viewer",
+		}},
+	})
+}
+
+func sumOperationCounter(t *testing.T, gatherer prometheus.Gatherer, metricName, operationLabel string) float64 {
+	t.Helper()
+	families, err := gatherer.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() != metricName {
+			continue
+		}
+		var sum float64
+		for _, m := range mf.GetMetric() {
+			matched := operationLabel == ""
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "operation" && l.GetValue() == operationLabel {
+					matched = true
+				}
+			}
+			if matched {
+				sum += m.GetCounter().GetValue()
+			}
+		}
+		return sum
+	}
+	return 0
+}
+
+func sumPlainCounter(t *testing.T, gatherer prometheus.Gatherer, metricName string) float64 {
+	t.Helper()
+	families, err := gatherer.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() != metricName {
+			continue
+		}
+		var sum float64
+		for _, m := range mf.GetMetric() {
+			sum += m.GetCounter().GetValue()
+		}
+		return sum
+	}
+	return 0
+}
+
+func TestDispatchQueryPlanRecordsCachingMetrics(t *testing.T) {
+	// Use a unique subsystem so we don't collide with other tests in the global
+	// default Prometheus registry.
+	subsystem := fmt.Sprintf("test_caching_%d", time.Now().UnixNano())
+
+	dispatcher, err := NewCachingDispatcher(DispatchTestCache(t), true, subsystem, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dispatcher.Close() })
+
+	delegate := &planDispatchMock{delegateDispatchMock: delegateDispatchMock{&mock.Mock{}}}
+	dispatcher.SetDelegate(delegate)
+
+	req := &v1.DispatchQueryPlanRequest{
+		Operation:    v1.PlanOperation_PLAN_OPERATION_CHECK,
+		CanonicalKey: "document#viewer",
+		Resource:     tuple.ONRStringToCore("document", "doc1", "viewer"),
+		Subject:      tuple.ONRStringToCore("user", "alice", "..."),
+		PlanContext: &v1.PlanContext{
+			Revision:   "1",
+			SchemaHash: []byte(datalayer.NoSchemaHashForTesting),
+		},
+	}
+
+	// First call: cache miss; bumps query_plan_total.
+	stream := dispatch.NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](t.Context())
+	require.NoError(t, dispatcher.DispatchQueryPlan(req, stream))
+	require.Len(t, stream.Results(), 1)
+
+	// Give the cache a chance to converge before the second call.
+	time.Sleep(10 * time.Millisecond)
+
+	// Second call: cache hit; bumps both query_plan_total and query_plan_from_cache_total.
+	stream2 := dispatch.NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](t.Context())
+	require.NoError(t, dispatcher.DispatchQueryPlan(req, stream2))
+	require.Len(t, stream2.Results(), 1)
+
+	gatherer := prometheus.DefaultGatherer
+
+	totalCheck := sumOperationCounter(t, gatherer, "spicedb_"+subsystem+"_query_plan_total", "check")
+	require.InEpsilon(t, float64(2), totalCheck, 1e-9, "query_plan_total{operation=check} should bump for each plan dispatch")
+
+	fromCacheCheck := sumOperationCounter(t, gatherer, "spicedb_"+subsystem+"_query_plan_from_cache_total", "check")
+	require.InEpsilon(t, float64(1), fromCacheCheck, 1e-9, "query_plan_from_cache_total{operation=check} should bump only on cache hit")
+
+	// Ensure the plan path no longer inflates the classic DispatchCheck counter.
+	checkTotal := sumPlainCounter(t, gatherer, "spicedb_"+subsystem+"_check_total")
+	require.Zero(t, checkTotal, "check_total must not be incremented from the plan path")
+
+	// The delegate is only consulted on the cache miss.
+	require.Equal(t, uint64(1), delegate.calls.Load(), "delegate should only be called once; second request must be served from cache")
 }
 
 type delegateDispatchMock struct {

--- a/internal/dispatch/planlabel.go
+++ b/internal/dispatch/planlabel.go
@@ -1,0 +1,24 @@
+package dispatch
+
+import (
+	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+)
+
+// PlanOperationLabel returns a stable, lowercase snake_case label string for the
+// given plan operation, suitable for use as a Prometheus label value.
+func PlanOperationLabel(op v1.PlanOperation) string {
+	switch op {
+	case v1.PlanOperation_PLAN_OPERATION_CHECK:
+		return "check"
+	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES:
+		return "lookup_resources"
+	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS:
+		return "lookup_subjects"
+	case v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES:
+		return "check_many_resources"
+	case v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS:
+		return "check_many_subjects"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/dispatch/remote/cluster.go
+++ b/internal/dispatch/remote/cluster.go
@@ -881,6 +881,11 @@ func (cr *clusterDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest,
 		return err
 	}
 
+	// TODO: route through dispatchStreamingRequest once DispatchQueryPlanRequest
+	// implements streamingRequestMessage, so plan can also benefit from hedging
+	// and secondary-dispatch.
+	reqKind := "queryplan_" + dispatch.PlanOperationLabel(req.Operation)
+	firstResult := true
 	for {
 		resp, err := client.Recv()
 		if err != nil {
@@ -888,6 +893,10 @@ func (cr *clusterDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest,
 				return nil
 			}
 			return err
+		}
+		if firstResult {
+			dispatchCounter.WithLabelValues(reqKind, primaryDispatcher).Inc()
+			firstResult = false
 		}
 		if err := stream.Publish(resp); err != nil {
 			return err

--- a/internal/dispatch/singleflight/singleflight.go
+++ b/internal/dispatch/singleflight/singleflight.go
@@ -147,6 +147,10 @@ func (d *Dispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsReques
 }
 
 func (d *Dispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
+	// Plan dispatches are not currently grouped via singleflight; record the
+	// passthrough so the metric series exists and can be compared against the
+	// other dispatch methods.
+	singleFlightCount.WithLabelValues("DispatchQueryPlan", "passthrough").Inc()
 	return d.delegate.DispatchQueryPlan(req, stream)
 }
 

--- a/internal/dispatch/singleflight/singleflight_test.go
+++ b/internal/dispatch/singleflight/singleflight_test.go
@@ -326,6 +326,23 @@ func TestSingleFlightDispatcherExpandBypassesIfMissingBloomFiler(t *testing.T) {
 	assertCounterWithLabel(t, reg, 1, "spicedb_dispatch_single_flight_total", "missing")
 }
 
+func TestDispatchQueryPlanRecordsSingleflightMetric(t *testing.T) {
+	singleFlightCount = prometheus.NewCounterVec(singleFlightCountConfig, []string{"method", "shared"})
+	reg := registerMetricInGatherer(singleFlightCount)
+
+	disp := New(mockDispatcher{f: func() {}}, &keys.DirectKeyHandler{})
+
+	req := &v1.DispatchQueryPlanRequest{
+		Operation: v1.PlanOperation_PLAN_OPERATION_CHECK,
+	}
+	stream := dispatch.NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](t.Context())
+
+	err := disp.DispatchQueryPlan(req, stream)
+	require.NoError(t, err)
+
+	assertCounterWithLabel(t, reg, 1, "spicedb_dispatch_single_flight_total", "DispatchQueryPlan")
+}
+
 func registerMetricInGatherer(collector prometheus.Collector) prometheus.Gatherer {
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collector)


### PR DESCRIPTION
## Description

We weren't keeping track of Prometheus dispatch metrics for DispatchQueryPlan in our load testing. This adds them, and separable by operation.
