### PR TITLE
fix: Watch checkpointing in memdb and mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Watch consumers that request `WatchCheckpoints` now eventually observe every revision returned by `WriteRelationships` as a checkpoint. MemDB regressed this in https://github.com/authzed/spicedb/pull/2578 for no-op writes and MySQL never emitted checkpoints at all prior to now. Both now emit a checkpoint at the new revision. (https://github.com/authzed/spicedb/pull/3114)
+
+## [1.53.0] - 2026-05-13
 ### Added
 - Add DispatchExecutor, a query plan executor that is Dispatch-aware and sends subproblems on Alias boundaries (https://github.com/authzed/spicedb/pull/3074)
 - Implement Dispatch caching for query plan execution (https://github.com/authzed/spicedb/pull/3079)
@@ -3615,7 +3619,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - First release.
 
-[Unreleased]: https://github.com/authzed/spicedb/compare/v1.52.0...HEAD
+[Unreleased]: https://github.com/authzed/spicedb/compare/v1.53.0...HEAD
+[1.53.0]: https://github.com/authzed/spicedb/compare/v1.52.0...v1.53.0
 [1.52.0]: https://github.com/authzed/spicedb/compare/v1.51.1...v1.52.0
 [1.51.1]: https://github.com/authzed/spicedb/compare/v1.51.0...v1.51.1
 [1.51.0]: https://github.com/authzed/spicedb/compare/v1.50.0...v1.51.0

--- a/internal/datastore/memdb/memdb.go
+++ b/internal/datastore/memdb/memdb.go
@@ -313,13 +313,13 @@ func (mdb *memdbDatastore) ReadWriteTx(
 			}
 
 			changes := tracked.AsRevisionChanges(revisions.TimestampIDKeyLessThanFunc)
-			isFirstChange := true
+			wroteChangelog := false
 			for rc, err := range changes {
 				if err != nil {
 					return datastore.NoRevision, err
 				}
 
-				if !isFirstChange {
+				if wroteChangelog {
 					return datastore.NoRevision, spiceerrors.MustBugf("unexpected MemDB transaction with multiple revision changes")
 				}
 
@@ -331,7 +331,22 @@ func (mdb *memdbDatastore) ReadWriteTx(
 					return datastore.NoRevision, fmt.Errorf("error writing changelog: %w", err)
 				}
 
-				isFirstChange = false
+				wroteChangelog = true
+			}
+
+			// Always emit a changelog entry for the committed revision, even
+			// when the transaction produced no observable changes (e.g., a
+			// TOUCH that matched the existing relationship). The changes
+			// payload is intentionally empty — the watch goroutine constructs the
+			// checkpoint event itself based on each consumer's options.
+			if !wroteChangelog {
+				change := &changelog{
+					revisionNanos: newRevision.TimestampNanoSec(),
+					changes:       datastore.RevisionChanges{},
+				}
+				if err := tx.Insert(tableChangelog, change); err != nil {
+					return datastore.NoRevision, fmt.Errorf("error writing changelog: %w", err)
+				}
 			}
 
 			tx.Commit()

--- a/internal/datastore/mysql/datastore_test.go
+++ b/internal/datastore/mysql/datastore_test.go
@@ -118,7 +118,7 @@ func TestMySQLDatastoreDSNWithoutParseTime(t *testing.T) {
 func TestMySQL8Datastore(t *testing.T) {
 	b := testdatastore.RunMySQLForTestingWithOptions(t, testdatastore.MySQLTesterOptions{MigrateForNewDatastore: true}, "")
 	dst := datastoreTester{b: b}
-	test.AllWithExceptions(t, mysqlFactory.NewTester(test.DatastoreTesterFunc(dst.createDatastore)), test.WithCategories(test.WatchSchemaCategory, test.WatchCheckpointsCategory))
+	test.AllWithExceptions(t, mysqlFactory.NewTester(test.DatastoreTesterFunc(dst.createDatastore)), test.WithCategories(test.WatchSchemaCategory))
 	additionalMySQLTests(t, b)
 }
 

--- a/internal/datastore/mysql/watch.go
+++ b/internal/datastore/mysql/watch.go
@@ -96,6 +96,7 @@ func (mds *mysqlDatastore) Watch(ctx context.Context, afterRevisionRaw datastore
 				}
 				return
 			}
+			previousTxn := currentTxn
 			currentTxn = ctxn
 
 			// Write the staged updates to the channel
@@ -110,6 +111,19 @@ func (mds *mysqlDatastore) Watch(ctx context.Context, afterRevisionRaw datastore
 					return
 				}
 				changeCount++
+			}
+
+			// Emit a checkpoint at the latest revision whenever HEAD
+			// advances (even even when the transaction produced no observable changes)
+			// and the consumer asked for checkpoints.
+			if currentTxn > previousTxn &&
+				options.Content&datastore.WatchCheckpoints == datastore.WatchCheckpoints {
+				if !sendChange(datastore.RevisionChanges{
+					Revision:     revisions.NewForTransactionID(currentTxn),
+					IsCheckpoint: true,
+				}) {
+					return
+				}
 			}
 
 			// If there were no changes, sleep a bit

--- a/pkg/datastore/test/datastore.go
+++ b/pkg/datastore/test/datastore.go
@@ -211,11 +211,16 @@ func AllWithExceptions(t *testing.T, tester DatastoreTester, except Categories) 
 
 	if !except.Watch() && !except.WatchSchema() {
 		t.Run("TestWatchSchema", runner(tester, WatchSchemaTest))
-		t.Run("TestWatchAll", runner(tester, WatchAllTest))
+		t.Run("TestWatchRelationshipsAndSchemaChanges", runner(tester, WatchRelationshipsAndSchemaChangesTest))
 	}
 
 	if !except.Watch() && !except.WatchCheckpoints() {
-		t.Run("TestWatchCheckpoints", runner(tester, WatchCheckpointsTest))
+		t.Run("TestWatchObservesEveryReturnedRevision", runner(tester, WatchObservesEveryReturnedRevisionTest))
+		t.Run("TestWatchEmitsCheckpointAfterWriteWithChanges", runner(tester, WatchEmitsCheckpointAfterWriteWithChangesTest))
+	}
+
+	if !except.Watch() && !except.WatchCheckpoints() && !except.WatchSchema() {
+		t.Run("TestWatchRelationshipsAndSchemaAndCheckpoints", runner(tester, WatchRelationshipsAndSchemaAndCheckpointsTest))
 	}
 
 	if !except.Transaction() {

--- a/pkg/datastore/test/watch.go
+++ b/pkg/datastore/test/watch.go
@@ -661,7 +661,7 @@ func WatchSchemaTest(t *testing.T, tester DatastoreTester) {
 	}, changes, errchan, false)
 }
 
-func WatchAllTest(t *testing.T, tester DatastoreTester) {
+func WatchRelationshipsAndSchemaChangesTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
 	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
@@ -794,7 +794,7 @@ func verifyMixedUpdates(
 	require.False(expectDisconnect, "all changes verified without expected disconnect")
 }
 
-func WatchCheckpointsTest(t *testing.T, tester DatastoreTester) {
+func WatchRelationshipsAndSchemaAndCheckpointsTest(t *testing.T, tester DatastoreTester) {
 	require := require.New(t)
 
 	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
@@ -916,6 +916,111 @@ func WatchEmissionStrategyTest(t *testing.T, tester DatastoreTester) {
 		}
 
 		if relTouchEmitted && metadataEmitted && checkpointEmitted {
+			return
+		}
+	}
+}
+
+// WatchObservesEveryReturnedRevisionTest verifies this contract: if
+// WriteRelationships returns revision X, a watch consumer eventually observes
+// revision X on the watch stream — even when the write produced no actual
+// changes (e.g., a TOUCH that exactly matches an existing relationship).
+func WatchObservesEveryReturnedRevisionTest(t *testing.T, tester DatastoreTester) {
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
+	require.NoError(t, err)
+
+	setupDatastore(t, ds)
+
+	// First TOUCH creates the relationship.
+	afterCreateRevision, err := common.WriteRelationships(t.Context(), ds, tuple.UpdateOperationTouch,
+		tuple.MustParse("document:firstdoc#viewer@user:tom"),
+	)
+	require.NoError(t, err)
+
+	// Start watching from after the create.
+	changes, errchan := ds.Watch(t.Context(), afterCreateRevision, datastore.WatchOptions{
+		Content:            datastore.WatchRelationships | datastore.WatchCheckpoints,
+		CheckpointInterval: 100 * time.Millisecond,
+	})
+	require.Empty(t, errchan)
+
+	// Second TOUCH of the same relationship is a no-op (no actual changes),
+	secondRevision, err := common.WriteRelationships(t.Context(), ds, tuple.UpdateOperationTouch,
+		tuple.MustParse("document:firstdoc#viewer@user:tom"),
+	)
+	require.NoError(t, err)
+
+	verifyWatchReachesRevision(t, secondRevision, changes, errchan)
+}
+
+func verifyWatchReachesRevision(
+	t *testing.T,
+	targetRevision datastore.Revision,
+	changes <-chan datastore.RevisionChanges,
+	errchan <-chan error,
+) {
+	for {
+		select {
+		case change, ok := <-changes:
+			require.True(t, ok, "watch stream closed before observing revision %s", targetRevision)
+			if change.Revision != nil &&
+				(change.Revision.Equal(targetRevision) || change.Revision.GreaterThan(targetRevision)) {
+				return
+			}
+		case err := <-errchan:
+			require.NoError(t, err, "unexpected watch error while waiting for revision %s", targetRevision)
+		case <-time.After(waitForChangesTimeout):
+			require.Fail(t, "Timed out waiting for watch to reach revision", "target: %s", targetRevision)
+			return
+		}
+	}
+}
+
+// WatchEmitsCheckpointAfterWriteWithChangesTest verifies that when a consumer asks for checkpoints,
+// every revision returned by WriteRelationships must eventually be observable as a checkpoint.
+func WatchEmitsCheckpointAfterWriteWithChangesTest(t *testing.T, tester DatastoreTester) {
+	ds, err := tester.New(t, 0, veryLargeGCInterval, veryLargeGCWindow, 16)
+	require.NoError(t, err)
+
+	setupDatastore(t, ds)
+
+	startingRevisionResult, err := ds.HeadRevision(t.Context())
+	require.NoError(t, err)
+	startingRevision := startingRevisionResult.Revision
+
+	changes, errchan := ds.Watch(t.Context(), startingRevision, datastore.WatchOptions{
+		Content:            datastore.WatchRelationships | datastore.WatchCheckpoints,
+		CheckpointInterval: 100 * time.Millisecond,
+	})
+	require.Empty(t, errchan)
+
+	// A TOUCH that produces a real change.
+	afterWriteRevision, err := common.WriteRelationships(t.Context(), ds, tuple.UpdateOperationTouch,
+		tuple.MustParse("document:firstdoc#viewer@user:tom"),
+	)
+	require.NoError(t, err)
+
+	verifyWatchEmitsCheckpoint(t, afterWriteRevision, changes, errchan)
+}
+
+func verifyWatchEmitsCheckpoint(
+	t *testing.T,
+	targetRevision datastore.Revision,
+	changes <-chan datastore.RevisionChanges,
+	errchan <-chan error,
+) {
+	for {
+		select {
+		case change, ok := <-changes:
+			require.True(t, ok, "watch stream closed before observing checkpoint at revision %s", targetRevision)
+			if change.IsCheckpoint && change.Revision != nil &&
+				(change.Revision.Equal(targetRevision) || change.Revision.GreaterThan(targetRevision)) {
+				return
+			}
+		case err := <-errchan:
+			require.NoError(t, err, "unexpected watch error while waiting for checkpoint at revision %s", targetRevision)
+		case <-time.After(waitForChangesTimeout):
+			require.Fail(t, "Timed out waiting for checkpoint", "target: %s", targetRevision)
 			return
 		}
 	}


### PR DESCRIPTION
Both of these should pass now:

```
--- FAIL: TestMemdbDatastore (49.71s)
    --- FAIL: TestMemdbDatastore/TestWatchObservesEveryReturnedRevision (20.02s)
        watch.go:973: 
            	Error Trace:	/home/runner/work/spicedb/spicedb/pkg/datastore/test/watch.go:973
            	            				/home/runner/work/spicedb/spicedb/pkg/datastore/test/watch.go:953
            	            				/home/runner/work/spicedb/spicedb/pkg/datastore/test/datastore.go:114
            	Error:      	Timed out waiting for watch to reach revision
            	Test:       	TestMemdbDatastore/TestWatchObservesEveryReturnedRevision
            	Messages:   	target: 1778700019952040216
FAIL
```

```
--- FAIL: TestMySQL8Datastore (153.08s)
    --- FAIL: TestMySQL8Datastore/TestWatchObservesEveryReturnedRevision (20.17s)
        watch.go:973: 
            	Error Trace:	/home/runner/work/spicedb/spicedb/pkg/datastore/test/watch.go:973
            	            				/home/runner/work/spicedb/spicedb/pkg/datastore/test/watch.go:953
            	            				/home/runner/work/spicedb/spicedb/pkg/datastore/test/datastore.go:114
            	Error:      	Timed out waiting for watch to reach revision
            	Test:       	TestMySQL8Datastore/TestWatchObservesEveryReturnedRevision
            	Messages:   	target: 4
FAIL
```