### PR TITLE
feat: registry for the iterators

### DIFF
--- a/pkg/query/alias.go
+++ b/pkg/query/alias.go
@@ -1,6 +1,28 @@
 package query
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: AliasIteratorType,
+		Name: "Alias",
+		ConstructWithArgs: func(args *IteratorArgs, subs []Iterator, key CanonicalKey) (Iterator, error) {
+			if len(subs) != 1 {
+				return nil, fmt.Errorf("AliasIterator requires exactly 1 subiterator, got %d", len(subs))
+			}
+			if args == nil || args.RelationName == "" {
+				return nil, errors.New("AliasIterator requires RelationName in Args")
+			}
+			alias := NewAliasIteratorWithChain(args.DefinitionName, args.RelationName, args.AliasedAs, subs[0])
+			alias.canonicalKey = key
+			return alias, nil
+		},
+	})
+}
 
 // AliasIterator is an iterator that rewrites the Resource's Relation field of all paths
 // streamed from the sub-iterator.

--- a/pkg/query/arrow.go
+++ b/pkg/query/arrow.go
@@ -9,6 +9,21 @@ import (
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: ArrowIteratorType,
+		Name: "Arrow",
+		ConstructWithArgs: func(_ *IteratorArgs, subs []Iterator, key CanonicalKey) (Iterator, error) {
+			if len(subs) != 2 {
+				return nil, fmt.Errorf("ArrowIterator requires exactly 2 subiterators, got %d", len(subs))
+			}
+			arrow := NewArrowIterator(subs[0], subs[1])
+			arrow.canonicalKey = key
+			return arrow, nil
+		},
+	})
+}
+
 // arrowDirection specifies which direction to execute the arrow check
 type arrowDirection int
 

--- a/pkg/query/caveat.go
+++ b/pkg/query/caveat.go
@@ -9,6 +9,24 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: CaveatIteratorType,
+		Name: "Caveat",
+		ConstructWithArgs: func(args *IteratorArgs, subs []Iterator, key CanonicalKey) (Iterator, error) {
+			if len(subs) != 1 {
+				return nil, fmt.Errorf("CaveatIterator requires exactly 1 subiterator, got %d", len(subs))
+			}
+			if args == nil || args.Caveat == nil {
+				return nil, errors.New("CaveatIterator requires Caveat in Args")
+			}
+			caveat := NewCaveatIterator(subs[0], args.Caveat)
+			caveat.canonicalKey = key
+			return caveat, nil
+		},
+	})
+}
+
 // CaveatIterator wraps another iterator and applies caveat evaluation to its results.
 // It checks caveat conditions on relationships during iteration and only yields
 // relationships that satisfy the caveat constraints.

--- a/pkg/query/datastore.go
+++ b/pkg/query/datastore.go
@@ -1,12 +1,28 @@
 package query
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/authzed/spicedb/pkg/schema/v2"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
+
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: DatastoreIteratorType,
+		Name: "Datastore",
+		ConstructWithArgs: func(args *IteratorArgs, _ []Iterator, key CanonicalKey) (Iterator, error) {
+			if args == nil || args.Relation == nil {
+				return nil, errors.New("DatastoreIterator requires Relation in Args")
+			}
+			ds := NewDatastoreIterator(args.Relation)
+			ds.canonicalKey = key
+			return ds, nil
+		},
+	})
+}
 
 // DatastoreIterator is a common leaf iterator. It represents the set of all
 // relationships of the given schema.BaseRelation, ie, relations that have a

--- a/pkg/query/exclusion.go
+++ b/pkg/query/exclusion.go
@@ -1,9 +1,26 @@
 package query
 
 import (
+	"fmt"
+
 	"github.com/authzed/spicedb/internal/caveats"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
+
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: ExclusionIteratorType,
+		Name: "Exclusion",
+		ConstructWithArgs: func(_ *IteratorArgs, subs []Iterator, key CanonicalKey) (Iterator, error) {
+			if len(subs) != 2 {
+				return nil, fmt.Errorf("ExclusionIterator requires exactly 2 subiterators, got %d", len(subs))
+			}
+			exclusion := NewExclusionIterator(subs[0], subs[1])
+			exclusion.canonicalKey = key
+			return exclusion, nil
+		},
+	})
+}
 
 // ExclusionIterator represents the set of relations that are in the mainSet but not in the excluded set.
 // This is equivalent to `permission foo = bar - baz`

--- a/pkg/query/fixed.go
+++ b/pkg/query/fixed.go
@@ -8,6 +8,34 @@ import (
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
+func init() {
+	// NullIteratorType and FixedIteratorType both produce a FixedIterator;
+	// the Null form is just the empty-paths case (see Decompile).
+	MustRegisterIterator(IteratorSpec{
+		Type: NullIteratorType,
+		Name: "Null",
+		ConstructWithArgs: func(_ *IteratorArgs, _ []Iterator, key CanonicalKey) (Iterator, error) {
+			fixed := NewFixedIterator()
+			fixed.canonicalKey = key
+			return fixed, nil
+		},
+	})
+	MustRegisterIterator(IteratorSpec{
+		Type: FixedIteratorType,
+		Name: "Fixed",
+		ConstructWithArgs: func(args *IteratorArgs, _ []Iterator, key CanonicalKey) (Iterator, error) {
+			var fixed *FixedIterator
+			if args != nil {
+				fixed = NewFixedIterator(args.FixedPaths...)
+			} else {
+				fixed = NewFixedIterator()
+			}
+			fixed.canonicalKey = key
+			return fixed, nil
+		},
+	})
+}
+
 // sortObjectTypes sorts a slice of ObjectType for deterministic ordering.
 // This prevents test flakiness from nondeterministic map iteration.
 func sortObjectTypes(types []ObjectType) {

--- a/pkg/query/intersection.go
+++ b/pkg/query/intersection.go
@@ -6,6 +6,24 @@ import (
 	"github.com/authzed/spicedb/pkg/tuple"
 )
 
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: IntersectionIteratorType,
+		Name: "Intersection",
+		ConstructWithArgs: func(_ *IteratorArgs, subs []Iterator, key CanonicalKey) (Iterator, error) {
+			it := NewIntersectionIterator(subs...)
+			// NewIntersectionIterator returns a FixedIterator when subs is empty.
+			switch v := it.(type) {
+			case *IntersectionIterator:
+				v.canonicalKey = key
+			case *FixedIterator:
+				v.canonicalKey = key
+			}
+			return it, nil
+		},
+	})
+}
+
 // IntersectionIterator the set of paths that are in all of underlying subiterators.
 // This is equivalent to `permission foo = bar & baz`
 type IntersectionIterator struct {

--- a/pkg/query/intersection_arrow.go
+++ b/pkg/query/intersection_arrow.go
@@ -1,11 +1,28 @@
 package query
 
 import (
+	"fmt"
+
 	"github.com/authzed/spicedb/internal/caveats"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
+
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: IntersectionArrowIteratorType,
+		Name: "IntersectionArrow",
+		ConstructWithArgs: func(_ *IteratorArgs, subs []Iterator, key CanonicalKey) (Iterator, error) {
+			if len(subs) != 2 {
+				return nil, fmt.Errorf("IntersectionArrowIterator requires exactly 2 subiterators, got %d", len(subs))
+			}
+			ia := NewIntersectionArrowIterator(subs[0], subs[1])
+			ia.canonicalKey = key
+			return ia, nil
+		},
+	})
+}
 
 // IntersectionArrowIterator is an iterator that represents the set of relations that
 // follow from a walk in the graph where ALL subjects on the left must satisfy

--- a/pkg/query/outline.go
+++ b/pkg/query/outline.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -10,28 +9,6 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/schema/v2"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
-)
-
-// IteratorType is an enum to represent each basic type of iterator by a
-// well-known byte.
-//
-// Remember to also update  the allIteratorTypes list below when adding a new one.
-type IteratorType byte
-
-const (
-	NullIteratorType              IteratorType = '0'
-	DatastoreIteratorType         IteratorType = 'D'
-	UnionIteratorType             IteratorType = '|'
-	IntersectionIteratorType      IteratorType = '&'
-	FixedIteratorType             IteratorType = 'F'
-	ArrowIteratorType             IteratorType = '>'
-	ExclusionIteratorType         IteratorType = 'X'
-	CaveatIteratorType            IteratorType = 'C'
-	AliasIteratorType             IteratorType = '@'
-	RecursiveIteratorType         IteratorType = 'R'
-	RecursiveSentinelIteratorType IteratorType = 'r'
-	IntersectionArrowIteratorType IteratorType = 'A'
-	SelfIteratorType              IteratorType = '='
 )
 
 // CanonicalKey is a unique string identifier for a canonical Outline subtree.
@@ -138,13 +115,14 @@ func (co CanonicalOutline) Compile() (Iterator, error) {
 
 // compileOutline recursively builds an Iterator tree from an Outline,
 // looking up each node's CanonicalKey from the provided map and applying hints.
+// The concrete iterator for each node comes from the registry — see
+// MustRegisterIterator and the init() in each iterator's file.
 func compileOutline(outline Outline, keys map[OutlineNodeID]CanonicalKey, hints map[OutlineNodeID][]Hint) (Iterator, error) {
 	key, ok := keys[outline.ID]
 	if !ok {
 		return nil, spiceerrors.MustBugf("outline node ID %d not found in CanonicalKeys map - outline must come from a CanonicalOutline", outline.ID)
 	}
 
-	// First, recursively compile all subiterators (bottom-up)
 	compiledSubs := make([]Iterator, len(outline.SubOutlines))
 	for i, sub := range outline.SubOutlines {
 		compiled, err := compileOutline(sub, keys, hints)
@@ -154,121 +132,11 @@ func compileOutline(outline Outline, keys map[OutlineNodeID]CanonicalKey, hints 
 		compiledSubs[i] = compiled
 	}
 
-	// Now construct the iterator based on type and set canonical key
-	var it Iterator
-	switch outline.Type {
-	case NullIteratorType:
-		fixed := NewFixedIterator()
-		fixed.canonicalKey = key
-		it = fixed
-
-	case DatastoreIteratorType:
-		if outline.Args == nil || outline.Args.Relation == nil {
-			return nil, errors.New("DatastoreIterator requires Relation in Args")
-		}
-		ds := NewDatastoreIterator(outline.Args.Relation)
-		ds.canonicalKey = key
-		it = ds
-
-	case UnionIteratorType:
-		union := NewUnionIterator(compiledSubs...)
-		union.(*UnionIterator).canonicalKey = key
-		it = union
-
-	case IntersectionIteratorType:
-		intersection := NewIntersectionIterator(compiledSubs...)
-		intersection.(*IntersectionIterator).canonicalKey = key
-		it = intersection
-
-	case FixedIteratorType:
-		var fixed *FixedIterator
-		if outline.Args != nil {
-			fixed = NewFixedIterator(outline.Args.FixedPaths...)
-		} else {
-			fixed = NewFixedIterator()
-		}
-		fixed.canonicalKey = key
-		it = fixed
-
-	case ArrowIteratorType:
-		if len(compiledSubs) != 2 {
-			return nil, fmt.Errorf("ArrowIterator requires exactly 2 subiterators, got %d", len(compiledSubs))
-		}
-		arrow := NewArrowIterator(compiledSubs[0], compiledSubs[1])
-		arrow.canonicalKey = key
-		it = arrow
-
-	case ExclusionIteratorType:
-		if len(compiledSubs) != 2 {
-			return nil, fmt.Errorf("ExclusionIterator requires exactly 2 subiterators, got %d", len(compiledSubs))
-		}
-		exclusion := NewExclusionIterator(compiledSubs[0], compiledSubs[1])
-		exclusion.canonicalKey = key
-		it = exclusion
-
-	case CaveatIteratorType:
-		if len(compiledSubs) != 1 {
-			return nil, fmt.Errorf("CaveatIterator requires exactly 1 subiterator, got %d", len(compiledSubs))
-		}
-		if outline.Args == nil || outline.Args.Caveat == nil {
-			return nil, errors.New("CaveatIterator requires Caveat in Args")
-		}
-		caveat := NewCaveatIterator(compiledSubs[0], outline.Args.Caveat)
-		caveat.canonicalKey = key
-		it = caveat
-
-	case AliasIteratorType:
-		if len(compiledSubs) != 1 {
-			return nil, fmt.Errorf("AliasIterator requires exactly 1 subiterator, got %d", len(compiledSubs))
-		}
-		if outline.Args == nil || outline.Args.RelationName == "" {
-			return nil, errors.New("AliasIterator requires RelationName in Args")
-		}
-		alias := NewAliasIteratorWithChain(outline.Args.DefinitionName, outline.Args.RelationName, outline.Args.AliasedAs, compiledSubs[0])
-		alias.canonicalKey = key
-		it = alias
-
-	case RecursiveIteratorType:
-		if len(compiledSubs) != 1 {
-			return nil, fmt.Errorf("RecursiveIterator requires exactly 1 subiterator, got %d", len(compiledSubs))
-		}
-		if outline.Args == nil || outline.Args.DefinitionName == "" || outline.Args.RelationName == "" {
-			return nil, errors.New("RecursiveIterator requires DefinitionName and RelationName in Args")
-		}
-		recursive := NewRecursiveIterator(compiledSubs[0], outline.Args.DefinitionName, outline.Args.RelationName)
-		recursive.canonicalKey = key
-		it = recursive
-
-	case RecursiveSentinelIteratorType:
-		if outline.Args == nil || outline.Args.DefinitionName == "" || outline.Args.RelationName == "" {
-			return nil, errors.New("RecursiveSentinelIterator requires DefinitionName and RelationName in Args")
-		}
-		// withSubRelations defaults to false for now
-		sentinel := NewRecursiveSentinelIterator(outline.Args.DefinitionName, outline.Args.RelationName, false)
-		sentinel.canonicalKey = key
-		it = sentinel
-
-	case IntersectionArrowIteratorType:
-		if len(compiledSubs) != 2 {
-			return nil, fmt.Errorf("IntersectionArrowIterator requires exactly 2 subiterators, got %d", len(compiledSubs))
-		}
-		intersectionArrow := NewIntersectionArrowIterator(compiledSubs[0], compiledSubs[1])
-		intersectionArrow.canonicalKey = key
-		it = intersectionArrow
-
-	case SelfIteratorType:
-		if outline.Args == nil || outline.Args.RelationName == "" || outline.Args.DefinitionName == "" {
-			return nil, errors.New("SelfIterator requires RelationName and DefinitionName in Args")
-		}
-		self := NewSelfIterator(outline.Args.RelationName, outline.Args.DefinitionName)
-		self.canonicalKey = key
-		it = self
-
-	default:
-		return nil, fmt.Errorf("unknown iterator type: %c", outline.Type)
+	it, err := MakeIterator(outline.Type, outline.Args, compiledSubs, key)
+	if err != nil {
+		return nil, err
 	}
 
-	// Apply hints to the constructed iterator
 	if hints != nil {
 		for _, hint := range hints[outline.ID] {
 			if err := hint(it); err != nil {

--- a/pkg/query/outline_test.go
+++ b/pkg/query/outline_test.go
@@ -462,15 +462,17 @@ func TestOutline_Compile(t *testing.T) {
 		require := require.New(t)
 
 		outline := Outline{
-			Type: IteratorType('Z'), // Unknown type
+			Type: IteratorType('\n'), // Unknown type — no init() registered it.
 		}
 
 		canonical, err := CanonicalizeOutline(outline)
 		require.NoError(err)
 
-		_, err = canonical.Compile()
-		require.Error(err)
-		require.Contains(err.Error(), "unknown iterator type")
+		// An unregistered iterator type indicates a missing init() registration,
+		// which is a programmer bug — MakeIterator panics via MustBugf under tests.
+		require.PanicsWithValue("cannot find iterator of type `\n`", func() {
+			_, _ = canonical.Compile()
+		})
 	})
 }
 

--- a/pkg/query/recursive.go
+++ b/pkg/query/recursive.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -8,6 +9,24 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
+
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: RecursiveIteratorType,
+		Name: "Recursive",
+		ConstructWithArgs: func(args *IteratorArgs, subs []Iterator, key CanonicalKey) (Iterator, error) {
+			if len(subs) != 1 {
+				return nil, fmt.Errorf("RecursiveIterator requires exactly 1 subiterator, got %d", len(subs))
+			}
+			if args == nil || args.DefinitionName == "" || args.RelationName == "" {
+				return nil, errors.New("RecursiveIterator requires DefinitionName and RelationName in Args")
+			}
+			recursive := NewRecursiveIterator(subs[0], args.DefinitionName, args.RelationName)
+			recursive.canonicalKey = key
+			return recursive, nil
+		},
+	})
+}
 
 // frontierEntry is a lightweight frontier node for BFS IterSubjects.
 // It carries only the fields needed to combine with the next hop's path —

--- a/pkg/query/recursive_sentinel.go
+++ b/pkg/query/recursive_sentinel.go
@@ -1,11 +1,28 @@
 package query
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
+
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: RecursiveSentinelIteratorType,
+		Name: "RecursiveSentinel",
+		ConstructWithArgs: func(args *IteratorArgs, _ []Iterator, key CanonicalKey) (Iterator, error) {
+			if args == nil || args.DefinitionName == "" || args.RelationName == "" {
+				return nil, errors.New("RecursiveSentinelIterator requires DefinitionName and RelationName in Args")
+			}
+			// withSubRelations defaults to false; the outline does not yet carry it.
+			sentinel := NewRecursiveSentinelIterator(args.DefinitionName, args.RelationName, false)
+			sentinel.canonicalKey = key
+			return sentinel, nil
+		},
+	})
+}
 
 var _ Iterator = &RecursiveSentinelIterator{}
 

--- a/pkg/query/registry.go
+++ b/pkg/query/registry.go
@@ -1,0 +1,57 @@
+package query
+
+import "github.com/authzed/spicedb/pkg/spiceerrors"
+
+// IteratorType is an enum to represent each basic type of iterator by a
+// well-known byte.
+//
+// Remember to also update  the allIteratorTypes list below when adding a new one.
+type IteratorType byte
+
+const (
+	NullIteratorType              IteratorType = '0'
+	DatastoreIteratorType         IteratorType = 'D'
+	UnionIteratorType             IteratorType = '|'
+	IntersectionIteratorType      IteratorType = '&'
+	FixedIteratorType             IteratorType = 'F'
+	ArrowIteratorType             IteratorType = '>'
+	ExclusionIteratorType         IteratorType = 'X'
+	CaveatIteratorType            IteratorType = 'C'
+	AliasIteratorType             IteratorType = '@'
+	RecursiveIteratorType         IteratorType = 'R'
+	RecursiveSentinelIteratorType IteratorType = 'r'
+	IntersectionArrowIteratorType IteratorType = 'A'
+	SelfIteratorType              IteratorType = '='
+)
+
+// IteratorSpec describes how to construct a single concrete Iterator type from
+// an Outline node. Each iterator implementation registers a spec via
+// MustRegisterIterator in its file's init(), which lets the compile step build
+// iterator trees without knowing the concrete types involved. External packages
+// can register their own iterators by adding a spec for a new IteratorType.
+type IteratorSpec struct {
+	Type              IteratorType
+	Name              string
+	ConstructWithArgs func(args *IteratorArgs, subIterators []Iterator, key CanonicalKey) (Iterator, error)
+}
+
+var iteratorRegistry = make(map[IteratorType]IteratorSpec)
+
+// MustRegisterIterator registers an IteratorSpec for a given IteratorType. It
+// panics if a spec is already registered for that type, which is what we want
+// at init() time so collisions are caught at startup.
+func MustRegisterIterator(spec IteratorSpec) {
+	if _, ok := iteratorRegistry[spec.Type]; ok {
+		spiceerrors.MustPanicf("writing twice to the iteratorRegistry! type:`%s`, name:`%s`", string(spec.Type), spec.Name)
+	}
+	iteratorRegistry[spec.Type] = spec
+}
+
+// MakeIterator constructs an Iterator of the given type using the registered
+// spec, threading the canonical key through to the constructor.
+func MakeIterator(t IteratorType, args *IteratorArgs, subs []Iterator, key CanonicalKey) (Iterator, error) {
+	if v, ok := iteratorRegistry[t]; ok {
+		return v.ConstructWithArgs(args, subs, key)
+	}
+	return nil, spiceerrors.MustBugf("cannot find iterator of type `%s`", string(t))
+}

--- a/pkg/query/self.go
+++ b/pkg/query/self.go
@@ -1,9 +1,26 @@
 package query
 
 import (
+	"errors"
+
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
+
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: SelfIteratorType,
+		Name: "Self",
+		ConstructWithArgs: func(args *IteratorArgs, _ []Iterator, key CanonicalKey) (Iterator, error) {
+			if args == nil || args.RelationName == "" || args.DefinitionName == "" {
+				return nil, errors.New("SelfIterator requires RelationName and DefinitionName in Args")
+			}
+			self := NewSelfIterator(args.RelationName, args.DefinitionName)
+			self.canonicalKey = key
+			return self, nil
+		},
+	})
+}
 
 // SelfIterator is an iterator that produces a synthetic relation for every
 // Resource in the subiterator that connects it to

--- a/pkg/query/union.go
+++ b/pkg/query/union.go
@@ -4,6 +4,24 @@ import (
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
 )
 
+func init() {
+	MustRegisterIterator(IteratorSpec{
+		Type: UnionIteratorType,
+		Name: "Union",
+		ConstructWithArgs: func(_ *IteratorArgs, subs []Iterator, key CanonicalKey) (Iterator, error) {
+			it := NewUnionIterator(subs...)
+			// NewUnionIterator returns a FixedIterator when subs is empty.
+			switch v := it.(type) {
+			case *UnionIterator:
+				v.canonicalKey = key
+			case *FixedIterator:
+				v.canonicalKey = key
+			}
+			return it, nil
+		},
+	})
+}
+
 // UnionIterator the set of paths that are in any of underlying subiterators.
 // This is equivalent to `permission foo = bar | baz`
 type UnionIterator struct {


### PR DESCRIPTION
## Description

Adds a registry for new iterator implementations, along with their logical symbols and instantiation.

Importantly, this allows for new iterators outside of `pkg/query` (for example, a custom dispatch iterator, to denote a dispatch boundary)