### PR TITLE
fix: postgres implementation of HeadRevision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Watch consumers that request `WatchCheckpoints` now eventually observe every revision returned by `WriteRelationships` as a checkpoint. MemDB regressed this in https://github.com/authzed/spicedb/pull/2578 for no-op writes and MySQL never emitted checkpoints at all prior to now. Both now emit a checkpoint at the new revision. (https://github.com/authzed/spicedb/pull/3114)
 - When Query Planner evaluates a union, short-circuit if one of the branches yields a positive un-caveated result (https://github.com/authzed/spicedb/pull/3120)
 - DispatchQueryPlan previously did not try to use the singleflight middleware for check calls. (https://github.com/authzed/spicedb/pull/3119)
+- Fixed regression introduced in 1.53.0. Postgres `HeadRevision` no longer allocates a new transaction ID on every call (https://github.com/authzed/spicedb/pull/3127)
 
 ## [1.53.0] - 2026-05-13
 ### Added

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -1147,8 +1147,10 @@ func HeadRevisionDoesNotConsumeXIDTest(t *testing.T, ds datastore.Datastore) {
 
 	nextXID := func() uint64 {
 		var x uint64
-		require.NoError(t, pds.readPool.QueryRow(ctx,
-			`SELECT pg_snapshot_xmax(pg_current_snapshot())::text::bigint`).Scan(&x))
+		// pg_snapshot_xmax returns the first not-yet-assigned xid at the time the snapshot
+		// was taken; reading it observes the xid counter without consuming an xid itself.
+		err := pds.readPool.QueryRow(ctx, `SELECT pg_snapshot_xmax(pg_current_snapshot())::text::bigint`).Scan(&x)
+		require.NoError(t, err)
 		return x
 	}
 
@@ -1160,8 +1162,7 @@ func HeadRevisionDoesNotConsumeXIDTest(t *testing.T, ds datastore.Datastore) {
 	}
 	after := nextXID()
 
-	require.Equal(t, before, after,
-		"HeadRevision burned %d xid(s) over %d calls; expected 0", after-before, iterations)
+	require.Equal(t, before, after, "HeadRevision burned %d xid(s) over %d calls; expected 0", after-before, iterations)
 }
 
 // ConcurrentRevisionWatchTest uses goroutines and channels to intentionally set up a pair of

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -175,6 +175,17 @@ func testPostgresDatastore(t *testing.T, config postgresTestConfig) {
 				MigrationPhase(config.migrationPhase),
 			))
 
+			t.Run("HeadRevisionDoesNotConsumeXID", createDatastoreTest(
+				b,
+				HeadRevisionDoesNotConsumeXIDTest,
+				RevisionQuantization(0),
+				GCWindow(1*time.Millisecond),
+				GCInterval(veryLargeGCInterval),
+				WatchBufferLength(1),
+				MigrationPhase(config.migrationPhase),
+				WithRevisionHeartbeat(false),
+			))
+
 			t.Run("ConcurrentRevisionWatch", createDatastoreTest(
 				b,
 				ConcurrentRevisionWatchTest,
@@ -1126,6 +1137,31 @@ func ConcurrentRevisionHeadTest(t *testing.T, ds datastore.Datastore) {
 	found, err := datastore.IteratorToSlice(it)
 	require.NoError(err)
 	require.Len(found, 2, "missing relationships in %v", found)
+}
+
+// HeadRevisionDoesNotConsumeXIDTest verifies that calling HeadRevision does not allocate a
+// new Postgres transaction ID.
+func HeadRevisionDoesNotConsumeXIDTest(t *testing.T, ds datastore.Datastore) {
+	pds := ds.(*pgDatastore)
+	ctx := t.Context()
+
+	nextXID := func() uint64 {
+		var x uint64
+		require.NoError(t, pds.readPool.QueryRow(ctx,
+			`SELECT pg_snapshot_xmax(pg_current_snapshot())::text::bigint`).Scan(&x))
+		return x
+	}
+
+	const iterations = 10
+	before := nextXID()
+	for i := 0; i < iterations; i++ {
+		_, err := ds.HeadRevision(ctx)
+		require.NoError(t, err)
+	}
+	after := nextXID()
+
+	require.Equal(t, before, after,
+		"HeadRevision burned %d xid(s) over %d calls; expected 0", after-before, iterations)
 }
 
 // ConcurrentRevisionWatchTest uses goroutines and channels to intentionally set up a pair of

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -40,6 +40,18 @@ const (
         LIMIT 1
 	);`
 
+	// schemaHashForSelectedXID looks up the schema hash visible at `selected.xid`.
+	// When `selected.xid` is NULL, it falls back to the currently-live row (deleted_xid = max_xid8).
+	// Returns an empty bytea when no row matches.
+	schemaHashForSelectedXID = `
+	COALESCE(
+		(SELECT hash FROM schema_revision
+		 WHERE (selected.xid IS NOT NULL AND created_xid <= selected.xid AND deleted_xid > selected.xid)
+		    OR (selected.xid IS NULL AND deleted_xid = '9223372036854775807'::xid8)
+		 ORDER BY created_xid DESC LIMIT 1),
+		''::bytea
+	)`
+
 	// querySelectRevision will round the database's timestamp down to the nearest
 	// quantization period, and then find the first transaction (and its active xmin)
 	// after that. If there are no transactions newer than the quantization period,
@@ -62,13 +74,7 @@ const (
 	SELECT selected.xid,
 	COALESCE((SELECT %[5]s FROM %[2]s WHERE %[1]s = selected.xid), (SELECT pg_current_snapshot())),
 	%[4]d - CAST(EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'utc') * 1000000000 as bigint) %% %[4]d,
-	COALESCE(
-		(SELECT hash FROM schema_revision
-		 WHERE (selected.xid IS NOT NULL AND created_xid <= selected.xid AND deleted_xid > selected.xid)
-		    OR (selected.xid IS NULL AND deleted_xid = '9223372036854775807'::xid8)
-		 ORDER BY created_xid DESC LIMIT 1),
-		''::bytea
-	)
+	` + schemaHashForSelectedXID + `
 	FROM selected;`
 
 	// queryValidTransaction will return a single row with three values:
@@ -108,14 +114,15 @@ const (
 	) AS candidates
 	ORDER BY %[3]s ASC
 	LIMIT 1;`
+	// queryCurrentSnapshotWithHash returns the current snapshot alongside the schema hash
+	// visible at the current xid. Uses pg_current_xact_id_if_assigned() so a read-only
+	// HeadRevision call does not allocate a fresh xid.
 	queryCurrentSnapshotWithHash = `
-	WITH current_xid AS (
+	WITH selected AS (
 		SELECT pg_current_xact_id_if_assigned() as xid, pg_current_snapshot() as snapshot
 	)
-	SELECT
-		current_xid.snapshot,
-		COALESCE((SELECT hash FROM schema_revision WHERE created_xid <= current_xid.xid AND deleted_xid > current_xid.xid ORDER BY created_xid DESC LIMIT 1), ''::bytea)
-	FROM current_xid;`
+	SELECT selected.snapshot, ` + schemaHashForSelectedXID + `
+	FROM selected;`
 
 	queryCurrentTransactionID = `SELECT pg_current_xact_id()::text::integer;`
 	queryLatestXID            = `SELECT max(xid)::text::integer FROM relation_tuple_transaction;`

--- a/internal/datastore/postgres/revisions.go
+++ b/internal/datastore/postgres/revisions.go
@@ -110,7 +110,7 @@ const (
 	LIMIT 1;`
 	queryCurrentSnapshotWithHash = `
 	WITH current_xid AS (
-		SELECT pg_current_xact_id() as xid, pg_current_snapshot() as snapshot
+		SELECT pg_current_xact_id_if_assigned() as xid, pg_current_snapshot() as snapshot
 	)
 	SELECT
 		current_xid.snapshot,


### PR DESCRIPTION
Fixes a regression wherein a call to `postgres.HeadRevision` was inadvertently moving forward the transaction ID, which means that calling `HeadRevision` on a loop returns different revisions every time.

