### PR TITLE
feat: use serialized plans in dispatch

### DIFF
--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -429,6 +429,43 @@ func (cd *Dispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsReque
 	return nil
 }
 
+// LookupPlanCheck probes the cache for a Plan-Check answer using a lightweight
+// descriptor. This is the cache-hit fast path that avoids serializing the
+// iterator subtree on the sender side: the executor calls this first, and only
+// builds a full DispatchQueryPlanRequest (which is what forces plan
+// serialization) when this misses.
+//
+// On a hit we increment both queryPlanTotal and queryPlanFromCache so the cache
+// hit ratio across LookupPlanCheck + DispatchQueryPlan stays sensible; on a
+// miss we *do not* increment queryPlanTotal here — the caller will issue the
+// full DispatchQueryPlan next, which counts the dispatch itself.
+//
+// We also forward to the delegate on miss so a chain of caching dispatchers
+// (rare today, but allowed by the layering) all get probed.
+func (cd *Dispatcher) LookupPlanCheck(ctx context.Context, lookup dispatch.PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	if lookup.PlanContext == nil {
+		return cd.d.LookupPlanCheck(ctx, lookup)
+	}
+	cacheKey := keys.PlanCheckLookupKey(
+		lookup.PlanContext.Revision,
+		lookup.CanonicalKey,
+		lookup.Resource,
+		lookup.Subject,
+		lookup.PlanContext.CaveatContext,
+	)
+	if cachedRaw, found := cd.c.Get(cacheKey); found {
+		var cachedPath v1.ResultPath
+		if err := cachedPath.UnmarshalVT(cachedRaw.([]byte)); err != nil {
+			return nil, false, err
+		}
+		op := dispatch.PlanOperationLabel(v1.PlanOperation_PLAN_OPERATION_CHECK)
+		cd.queryPlanTotalCounter.WithLabelValues(op).Inc()
+		cd.queryPlanFromCacheCounter.WithLabelValues(op).Inc()
+		return &cachedPath, true, nil
+	}
+	return cd.d.LookupPlanCheck(ctx, lookup)
+}
+
 func (cd *Dispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
 	cd.queryPlanTotalCounter.WithLabelValues(dispatch.PlanOperationLabel(req.Operation)).Inc()
 

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -371,6 +371,10 @@ func (ddm delegateDispatchMock) DispatchQueryPlan(_ *v1.DispatchQueryPlanRequest
 	return nil
 }
 
+func (ddm delegateDispatchMock) LookupPlanCheck(_ context.Context, _ dispatch.PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return nil, false, nil
+}
+
 func (ddm delegateDispatchMock) Close() error {
 	return nil
 }

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -303,13 +303,13 @@ func TestDispatchQueryPlanRecordsCachingMetrics(t *testing.T) {
 	dispatcher.SetDelegate(delegate)
 
 	req := &v1.DispatchQueryPlanRequest{
-		Operation:    v1.PlanOperation_PLAN_OPERATION_CHECK,
-		CanonicalKey: "document#viewer",
-		Resource:     tuple.ONRStringToCore("document", "doc1", "viewer"),
-		Subject:      tuple.ONRStringToCore("user", "alice", "..."),
+		Operation: v1.PlanOperation_PLAN_OPERATION_CHECK,
+		Resource:  tuple.ONRStringToCore("document", "doc1", "viewer"),
+		Subject:   tuple.ONRStringToCore("user", "alice", "..."),
 		PlanContext: &v1.PlanContext{
-			Revision:   "1",
-			SchemaHash: []byte(datalayer.NoSchemaHashForTesting),
+			Revision:       "1",
+			SchemaHash:     []byte(datalayer.NoSchemaHashForTesting),
+			InProgressKeys: []string{"document#viewer"},
 		},
 	}
 

--- a/internal/dispatch/caching/delegate.go
+++ b/internal/dispatch/caching/delegate.go
@@ -44,4 +44,8 @@ func (fd fakeDelegate) DispatchQueryPlan(_ *v1.DispatchQueryPlanRequest, _ dispa
 	return spiceerrors.MustBugf(errMessage)
 }
 
+func (fd fakeDelegate) LookupPlanCheck(_ context.Context, _ dispatch.PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return nil, false, spiceerrors.MustBugf(errMessage)
+}
+
 var _ dispatch.Dispatcher = fakeDelegate{}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog"
 
 	log "github.com/authzed/spicedb/internal/logging"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 )
 
@@ -83,6 +84,19 @@ type LookupSubjects interface {
 // PlanStream is an alias for the stream to which plan results will be written.
 type PlanStream = Stream[*v1.DispatchQueryPlanResponse]
 
+// PlanCheckLookup is the small, cheap-to-construct descriptor a caller passes
+// to LookupPlanCheck to consult dispatcher caches before paying to serialize a
+// full iterator subtree into a DispatchQueryPlanRequest. The fields mirror the
+// inputs the Plan-Check cache key hashes over (see keys.PlanCheckLookupKey):
+// callers that produce identical descriptors for the same underlying problem
+// will hit the same cache entry as the corresponding DispatchQueryPlan call.
+type PlanCheckLookup struct {
+	CanonicalKey string
+	Resource     *core.ObjectAndRelation
+	Subject      *core.ObjectAndRelation
+	PlanContext  *v1.PlanContext
+}
+
 // Plan interface describes the methods required to dispatch plan-based query planner requests.
 type Plan interface {
 	// DispatchQueryPlan submits a plan-based query request, writing its results to the specified stream.
@@ -90,6 +104,15 @@ type Plan interface {
 		req *v1.DispatchQueryPlanRequest,
 		stream PlanStream,
 	) error
+
+	// LookupPlanCheck consults any caches in the dispatcher chain for a
+	// Plan-Check answer matching lookup, without forcing the caller to
+	// serialize the iterator subtree first. Returns (path, true, nil) on a
+	// cache hit; (nil, false, nil) on a miss (caller should proceed to
+	// DispatchQueryPlan); error on a cache I/O failure. Implementations that
+	// hold no cache return (nil, false, nil) and should forward to any wrapped
+	// delegate so chained caches all get probed.
+	LookupPlanCheck(ctx context.Context, lookup PlanCheckLookup) (*v1.ResultPath, bool, error)
 }
 
 // DispatchableRequest is an interface for requests.

--- a/internal/dispatch/dispatch_iterator.go
+++ b/internal/dispatch/dispatch_iterator.go
@@ -1,0 +1,113 @@
+package dispatch
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/authzed/spicedb/pkg/query"
+)
+
+// DispatchIteratorType is the wire/registry byte for DispatchIterator. It uses
+// lowercase 'd' so it does not collide with DatastoreIteratorType ('D').
+const DispatchIteratorType query.IteratorType = 'd'
+
+func init() {
+	query.MustRegisterIterator(query.IteratorSpec{
+		Type: DispatchIteratorType,
+		Name: "Dispatch",
+		ConstructWithArgs: func(_ *query.IteratorArgs, subs []query.Iterator, key query.CanonicalKey) (query.Iterator, error) {
+			if len(subs) != 1 {
+				return nil, fmt.Errorf("DispatchIterator requires exactly 1 subiterator, got %d", len(subs))
+			}
+			d := NewDispatchIterator(subs[0])
+			d.canonicalKey = key
+			return d, nil
+		},
+		Deserialize: deserializeDispatch,
+	})
+}
+
+// DispatchIterator is a single-child passthrough: every Plan method delegates
+// straight to its sub-iterator. It carries no state of its own beyond a
+// canonical key and the wrapped child, and exists as a marker node in the
+// iterator tree that the dispatch layer can recognize and act on.
+type DispatchIterator struct {
+	subIt        query.Iterator
+	canonicalKey query.CanonicalKey
+}
+
+var _ query.Iterator = &DispatchIterator{}
+
+// NewDispatchIterator wraps sub in a passthrough DispatchIterator.
+func NewDispatchIterator(sub query.Iterator) *DispatchIterator {
+	return &DispatchIterator{subIt: sub}
+}
+
+func (d *DispatchIterator) CheckImpl(ctx *query.Context, resource query.Object, subject query.ObjectAndRelation) (*query.Path, error) {
+	return ctx.Check(d.subIt, resource, subject)
+}
+
+func (d *DispatchIterator) IterSubjectsImpl(ctx *query.Context, resource query.Object, filterSubjectType query.ObjectType) (query.PathSeq, error) {
+	return ctx.IterSubjects(d.subIt, resource, filterSubjectType)
+}
+
+func (d *DispatchIterator) IterResourcesImpl(ctx *query.Context, subject query.ObjectAndRelation, filterResourceType query.ObjectType) (query.PathSeq, error) {
+	return ctx.IterResources(d.subIt, subject, filterResourceType)
+}
+
+func (d *DispatchIterator) Clone() query.Iterator {
+	return &DispatchIterator{
+		subIt:        d.subIt.Clone(),
+		canonicalKey: d.canonicalKey,
+	}
+}
+
+func (d *DispatchIterator) Explain() query.Explain {
+	return query.Explain{
+		Name:       "Dispatch",
+		Info:       "Dispatch",
+		SubExplain: []query.Explain{d.subIt.Explain()},
+	}
+}
+
+func (d *DispatchIterator) Subiterators() []query.Iterator {
+	return []query.Iterator{d.subIt}
+}
+
+func (d *DispatchIterator) ReplaceSubiterators(newSubs []query.Iterator) (query.Iterator, error) {
+	if len(newSubs) != 1 {
+		return nil, fmt.Errorf("DispatchIterator requires exactly 1 subiterator, got %d", len(newSubs))
+	}
+	return &DispatchIterator{
+		subIt:        newSubs[0],
+		canonicalKey: d.canonicalKey,
+	}, nil
+}
+
+func (d *DispatchIterator) CanonicalKey() query.CanonicalKey {
+	return d.canonicalKey
+}
+
+func (d *DispatchIterator) ResourceType() ([]query.ObjectType, error) {
+	return d.subIt.ResourceType()
+}
+
+func (d *DispatchIterator) SubjectTypes() ([]query.ObjectType, error) {
+	return d.subIt.SubjectTypes()
+}
+
+func (d *DispatchIterator) Serialize(w io.Writer) error {
+	return query.SerializeWithHeader(w, DispatchIteratorType, d.canonicalKey, func(buf io.Writer) error {
+		return d.subIt.Serialize(buf)
+	})
+}
+
+func deserializeDispatch(body io.Reader, key query.CanonicalKey, dctx *query.DeserializeContext) (query.Iterator, error) {
+	sub, err := query.Deserialize(body, dctx)
+	if err != nil {
+		return nil, fmt.Errorf("dispatch sub: %w", err)
+	}
+	d := NewDispatchIterator(sub)
+	d.canonicalKey = key
+	return d, nil
+}

--- a/internal/dispatch/dispatch_iterator_test.go
+++ b/internal/dispatch/dispatch_iterator_test.go
@@ -1,0 +1,108 @@
+package dispatch
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/query"
+)
+
+func makePath(resourceID, subjectID string) query.Path {
+	return query.Path{
+		Resource: query.Object{ObjectType: "document", ObjectID: resourceID},
+		Relation: "viewer",
+		Subject: query.ObjectAndRelation{
+			ObjectType: "user",
+			ObjectID:   subjectID,
+			Relation:   "...",
+		},
+	}
+}
+
+// TestDispatchIteratorPassthrough confirms the wrapper forwards Check,
+// IterSubjects and IterResources untouched to its sub-iterator.
+func TestDispatchIteratorPassthrough(t *testing.T) {
+	paths := []query.Path{
+		makePath("doc1", "alice"),
+		makePath("doc2", "bob"),
+	}
+	sub := query.NewFixedIterator(paths...)
+	d := NewDispatchIterator(sub)
+
+	ctx := query.NewLocalContext(t.Context())
+
+	t.Run("check hit", func(t *testing.T) {
+		p, err := d.CheckImpl(ctx,
+			query.Object{ObjectType: "document", ObjectID: "doc1"},
+			query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		require.Equal(t, "doc1", p.Resource.ObjectID)
+	})
+
+	t.Run("check miss", func(t *testing.T) {
+		p, err := d.CheckImpl(ctx,
+			query.Object{ObjectType: "document", ObjectID: "doc1"},
+			query.ObjectAndRelation{ObjectType: "user", ObjectID: "nobody", Relation: "..."})
+		require.NoError(t, err)
+		require.Nil(t, p)
+	})
+
+	t.Run("iter subjects", func(t *testing.T) {
+		seq, err := d.IterSubjectsImpl(ctx,
+			query.Object{ObjectType: "document", ObjectID: "doc1"},
+			query.NoObjectFilter())
+		require.NoError(t, err)
+		var ids []string
+		for p, err := range seq {
+			require.NoError(t, err)
+			ids = append(ids, p.Subject.ObjectID)
+		}
+		require.Equal(t, []string{"alice"}, ids)
+	})
+
+	t.Run("subiterators and replace", func(t *testing.T) {
+		subs := d.Subiterators()
+		require.Len(t, subs, 1)
+
+		replacement := query.NewFixedIterator(makePath("doc3", "carol"))
+		swapped, err := d.ReplaceSubiterators([]query.Iterator{replacement})
+		require.NoError(t, err)
+
+		p, err := swapped.CheckImpl(ctx,
+			query.Object{ObjectType: "document", ObjectID: "doc3"},
+			query.ObjectAndRelation{ObjectType: "user", ObjectID: "carol", Relation: "..."})
+		require.NoError(t, err)
+		require.NotNil(t, p)
+
+		_, err = d.ReplaceSubiterators(nil)
+		require.Error(t, err)
+	})
+}
+
+// TestDispatchIteratorRoundtrip verifies the registered Serialize/Deserialize
+// pair produces a structurally identical iterator with matching canonical keys.
+func TestDispatchIteratorRoundtrip(t *testing.T) {
+	sub := query.NewFixedIterator(makePath("doc1", "alice"))
+	d := NewDispatchIterator(sub)
+
+	var buf bytes.Buffer
+	require.NoError(t, d.Serialize(&buf))
+
+	got, err := query.Deserialize(&buf, &query.DeserializeContext{})
+	require.NoError(t, err)
+	require.Equal(t, 0, buf.Len(), "decoder must consume the entire wire payload")
+
+	gotD, ok := got.(*DispatchIterator)
+	require.True(t, ok, "expected *DispatchIterator, got %T", got)
+	require.Equal(t, d.CanonicalKey(), gotD.CanonicalKey())
+
+	ctx := query.NewLocalContext(t.Context())
+	p, err := gotD.CheckImpl(ctx,
+		query.Object{ObjectType: "document", ObjectID: "doc1"},
+		query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	require.NoError(t, err)
+	require.NotNil(t, p)
+}

--- a/internal/dispatch/dispatch_optimizer.go
+++ b/internal/dispatch/dispatch_optimizer.go
@@ -1,0 +1,108 @@
+package dispatch
+
+import (
+	"github.com/authzed/spicedb/pkg/query"
+	"github.com/authzed/spicedb/pkg/query/queryopt"
+)
+
+// DispatchWrapAliasOptimizationName is the registry name for the
+// dispatch-wrap-alias optimization. Callers fetch the registered Optimizer by
+// this name when they want to apply the wrap as a standalone step after the
+// usual queryopt.OptimizersForRequest set.
+const DispatchWrapAliasOptimizationName = "dispatch-wrap-alias"
+
+func init() {
+	queryopt.MustRegisterOptimization(queryopt.Optimizer{
+		Name: DispatchWrapAliasOptimizationName,
+		Description: `
+		Wraps every AliasIteratorType node in a DispatchIteratorType passthrough
+		so the dispatch layer can recognize the (definition, relation) boundary
+		as a dispatch candidate without re-deriving it at runtime. Aliases whose
+		subtree contains an unmatched RecursiveSentinel are left unwrapped — the
+		sentinel must execute inside the collection context established by its
+		matching RecursiveIterator, which is broken by an RPC hop.
+		`,
+		NewTransform: func(_ queryopt.RequestParams) queryopt.OutlineTransform {
+			return func(outline query.Outline) query.Outline {
+				return query.MutateOutline(outline, []query.OutlineMutation{wrapAliasWithDispatch})
+			}
+		},
+	})
+}
+
+// wrapAliasWithDispatch is a bottom-up OutlineMutation that wraps each
+// AliasIteratorType node in a DispatchIteratorType node. The wrap is the
+// static portion of the old DispatchExecutor.shouldDispatchAlias check:
+//   - the "is this an alias" test becomes "is this outline node an alias?"
+//   - the sentinel-recursion guard runs over the outline subtree
+//
+// The remaining runtime guard (in-progress dispatch-key cycle break) cannot
+// be made static and stays in the executor.
+func wrapAliasWithDispatch(outline query.Outline) query.Outline {
+	if outline.Type != query.AliasIteratorType {
+		return outline
+	}
+	if containsUnmatchedRecursiveSentinelOutline(outline) {
+		return outline
+	}
+	// New node has ID==0; ApplyOptimizations runs FillMissingNodeIDs after the
+	// transform, which assigns it a fresh ID and records its canonical key.
+	return query.Outline{
+		Type:        DispatchIteratorType,
+		SubOutlines: []query.Outline{outline},
+	}
+}
+
+// containsUnmatchedRecursiveSentinelOutline is the outline-time mirror of
+// containsUnmatchedRecursiveSentinel (executor.go): it walks an outline
+// subtree and reports whether any RecursiveSentinel has no RecursiveIterator
+// with the same (definition, relation) key in the same subtree. An unmatched
+// sentinel means dispatching this subtree would sever the sentinel from the
+// collection context its iterator establishes.
+func containsUnmatchedRecursiveSentinelOutline(root query.Outline) bool {
+	var iteratorKeys map[recursiveKey]struct{}
+	var sentinelKeys map[recursiveKey]struct{}
+
+	var walk func(query.Outline)
+	walk = func(node query.Outline) {
+		switch node.Type {
+		case query.RecursiveIteratorType:
+			if node.Args != nil {
+				if iteratorKeys == nil {
+					iteratorKeys = make(map[recursiveKey]struct{})
+				}
+				iteratorKeys[recursiveKey{node.Args.DefinitionName, node.Args.RelationName}] = struct{}{}
+			}
+		case query.RecursiveSentinelIteratorType:
+			if node.Args != nil {
+				if sentinelKeys == nil {
+					sentinelKeys = make(map[recursiveKey]struct{})
+				}
+				sentinelKeys[recursiveKey{node.Args.DefinitionName, node.Args.RelationName}] = struct{}{}
+			}
+		}
+		for _, sub := range node.SubOutlines {
+			walk(sub)
+		}
+	}
+	walk(root)
+
+	for k := range sentinelKeys {
+		if _, managed := iteratorKeys[k]; !managed {
+			return true
+		}
+	}
+	return false
+}
+
+// ApplyDispatchWrap runs only the dispatch-wrap-alias optimization on the
+// given CanonicalOutline. It exists for callers (dispatch service handlers,
+// query plan compilers) that already ran queryopt.OptimizersForRequest and
+// want to bolt on the dispatch wrap as a final pass.
+func ApplyDispatchWrap(co query.CanonicalOutline, params queryopt.RequestParams) (query.CanonicalOutline, error) {
+	opt, err := queryopt.GetOptimization(DispatchWrapAliasOptimizationName)
+	if err != nil {
+		return query.CanonicalOutline{}, err
+	}
+	return queryopt.ApplyOptimizations(co, []queryopt.Optimizer{opt}, params)
+}

--- a/internal/dispatch/dispatch_optimizer_test.go
+++ b/internal/dispatch/dispatch_optimizer_test.go
@@ -1,0 +1,170 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/query"
+	"github.com/authzed/spicedb/pkg/query/queryopt"
+	"github.com/authzed/spicedb/pkg/schema/v2"
+)
+
+func aliasOutline(defName, relName string, child query.Outline) query.Outline {
+	return query.Outline{
+		Type: query.AliasIteratorType,
+		Args: &query.IteratorArgs{
+			DefinitionName: defName,
+			RelationName:   relName,
+		},
+		SubOutlines: []query.Outline{child},
+	}
+}
+
+func recursiveOutline(defName, relName string, child query.Outline) query.Outline {
+	return query.Outline{
+		Type: query.RecursiveIteratorType,
+		Args: &query.IteratorArgs{
+			DefinitionName: defName,
+			RelationName:   relName,
+		},
+		SubOutlines: []query.Outline{child},
+	}
+}
+
+func sentinelOutline(defName, relName string) query.Outline {
+	return query.Outline{
+		Type: query.RecursiveSentinelIteratorType,
+		Args: &query.IteratorArgs{
+			DefinitionName: defName,
+			RelationName:   relName,
+		},
+	}
+}
+
+func dsOutline() query.Outline {
+	rel := schema.NewTestBaseRelationWithFeatures("document", "viewer", "user", "", "", false)
+	return query.Outline{
+		Type: query.DatastoreIteratorType,
+		Args: &query.IteratorArgs{Relation: rel},
+	}
+}
+
+// runDispatchWrap canonicalizes outline then runs only the dispatch-wrap
+// optimization on it, returning the resulting root outline.
+func runDispatchWrap(t *testing.T, outline query.Outline) query.Outline {
+	t.Helper()
+	co, err := query.CanonicalizeOutline(outline)
+	require.NoError(t, err)
+	res, err := ApplyDispatchWrap(co, queryopt.RequestParams{})
+	require.NoError(t, err)
+	return res.Root
+}
+
+func TestDispatchWrapOptimizer(t *testing.T) {
+	t.Run("wraps a single alias", func(t *testing.T) {
+		input := aliasOutline("document", "viewer", dsOutline())
+		got := runDispatchWrap(t, input)
+
+		require.Equal(t, DispatchIteratorType, got.Type)
+		require.Len(t, got.SubOutlines, 1)
+		require.Equal(t, query.AliasIteratorType, got.SubOutlines[0].Type)
+		require.Equal(t, "viewer", got.SubOutlines[0].Args.RelationName)
+		// child unchanged
+		require.Len(t, got.SubOutlines[0].SubOutlines, 1)
+		require.Equal(t, query.DatastoreIteratorType, got.SubOutlines[0].SubOutlines[0].Type)
+	})
+
+	t.Run("leaves non-alias outlines alone", func(t *testing.T) {
+		input := dsOutline()
+		got := runDispatchWrap(t, input)
+		require.Equal(t, query.DatastoreIteratorType, got.Type)
+	})
+
+	t.Run("wraps nested aliases at every level", func(t *testing.T) {
+		// Alias("perm")(Union[ Alias("view")(DS), DS ])
+		inner := aliasOutline("document", "view", dsOutline())
+		union := query.Outline{
+			Type:        query.UnionIteratorType,
+			SubOutlines: []query.Outline{inner, dsOutline()},
+		}
+		input := aliasOutline("document", "perm", union)
+
+		got := runDispatchWrap(t, input)
+
+		// Outer alias is wrapped
+		require.Equal(t, DispatchIteratorType, got.Type)
+		outerAlias := got.SubOutlines[0]
+		require.Equal(t, query.AliasIteratorType, outerAlias.Type)
+		require.Equal(t, "perm", outerAlias.Args.RelationName)
+
+		// Inner alias inside the union is also wrapped
+		gotUnion := outerAlias.SubOutlines[0]
+		require.Equal(t, query.UnionIteratorType, gotUnion.Type)
+		require.Len(t, gotUnion.SubOutlines, 2)
+		require.Equal(t, DispatchIteratorType, gotUnion.SubOutlines[0].Type)
+		require.Equal(t, query.AliasIteratorType, gotUnion.SubOutlines[0].SubOutlines[0].Type)
+		require.Equal(t, "view", gotUnion.SubOutlines[0].SubOutlines[0].Args.RelationName)
+	})
+
+	t.Run("wraps alias whose subtree has a matched sentinel/iterator pair", func(t *testing.T) {
+		// Alias("view")(Recursive("folder","viewer")(Sentinel("folder","viewer")))
+		// The recursive iterator inside the alias matches the sentinel's key, so
+		// the dispatch boundary is safe.
+		input := aliasOutline("document", "view",
+			recursiveOutline("folder", "viewer", sentinelOutline("folder", "viewer")),
+		)
+		got := runDispatchWrap(t, input)
+		require.Equal(t, DispatchIteratorType, got.Type, "expected wrap; matched sentinel/iterator pair is dispatch-safe")
+	})
+
+	t.Run("does NOT wrap alias whose subtree contains an unmatched sentinel", func(t *testing.T) {
+		// Alias("view")(Union[ Sentinel("folder","viewer"), DS ])
+		// No RecursiveIterator with key folder#viewer exists in the alias's
+		// subtree, so dispatching the alias would sever the sentinel from its
+		// collection context.
+		input := aliasOutline("document", "view",
+			query.Outline{
+				Type: query.UnionIteratorType,
+				SubOutlines: []query.Outline{
+					sentinelOutline("folder", "viewer"),
+					dsOutline(),
+				},
+			},
+		)
+		got := runDispatchWrap(t, input)
+		require.Equal(t, query.AliasIteratorType, got.Type,
+			"alias with unmatched sentinel should remain unwrapped to preserve sentinel collection context")
+	})
+
+	t.Run("assigns IDs and canonical keys to newly-wrapped nodes", func(t *testing.T) {
+		input := aliasOutline("document", "viewer", dsOutline())
+		co, err := query.CanonicalizeOutline(input)
+		require.NoError(t, err)
+		res, err := ApplyDispatchWrap(co, queryopt.RequestParams{})
+		require.NoError(t, err)
+
+		require.NotZero(t, res.Root.ID, "Dispatch root must have an ID assigned by FillMissingNodeIDs")
+		key, ok := res.CanonicalKeys[res.Root.ID]
+		require.True(t, ok, "Dispatch root must have a canonical key recorded")
+		require.NotEmpty(t, key)
+	})
+
+	t.Run("optimized outline compiles to DispatchIterator above AliasIterator", func(t *testing.T) {
+		input := aliasOutline("document", "viewer", dsOutline())
+		co, err := query.CanonicalizeOutline(input)
+		require.NoError(t, err)
+		res, err := ApplyDispatchWrap(co, queryopt.RequestParams{})
+		require.NoError(t, err)
+
+		it, err := res.Compile()
+		require.NoError(t, err)
+
+		d, ok := it.(*DispatchIterator)
+		require.True(t, ok, "expected root to compile to *DispatchIterator, got %T", it)
+		subs := d.Subiterators()
+		require.Len(t, subs, 1)
+		_, ok = subs[0].(*query.AliasIterator)
+		require.True(t, ok, "expected DispatchIterator child to be *query.AliasIterator, got %T", subs[0])
+	})
+}

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -92,16 +92,42 @@ func NewDispatchExecutor(dispatcher Dispatcher, planContext *v1.PlanContext, dis
 	}
 }
 
-// shouldDispatchAlias reports whether the iterator is an AliasIterator that the
-// executor should ship over RPC, vs. running locally. Two reasons to refuse:
-//   - the alias contains a sentinel whose matching RecursiveIterator lives
+// wrappedAlias extracts the AliasIterator wrapped by a DispatchIterator. The
+// dispatch-wrap optimizer (internal/dispatch/dispatch_optimizer.go) always
+// builds DispatchIterator(Alias(...)), so the assertion is normally safe; we
+// still return ok=false for any other shape so a future caller handing us an
+// odd tree doesn't panic the executor.
+func wrappedAlias(it query.Iterator) (*query.AliasIterator, bool) {
+	disp, ok := it.(*DispatchIterator)
+	if !ok {
+		return nil, false
+	}
+	subs := disp.Subiterators()
+	if len(subs) != 1 {
+		return nil, false
+	}
+	alias, ok := subs[0].(*query.AliasIterator)
+	if !ok {
+		return nil, false
+	}
+	return alias, true
+}
+
+// shouldDispatch reports whether the iterator is a DispatchIterator-wrapped
+// alias that the executor should ship over RPC, vs. running locally. Two
+// reasons to refuse:
+//   - the wrap contains a sentinel whose matching RecursiveIterator lives
 //     outside its own subtree (sentinel-based recursion guard, ancestor case).
 //   - the alias's canonical key is already in the active dispatch chain
 //     (in-progress guard, cross-relation cycle case). Without this, a standalone
 //     plan that re-expands the same key in a sibling subtree produces an
 //     infinite dispatch loop.
-func (e *DispatchExecutor) shouldDispatchAlias(it query.Iterator) (string, bool) {
-	alias, ok := it.(*query.AliasIterator)
+//
+// The wrap itself is the authoritative dispatch boundary — bare AliasIterators
+// produced by the planner are intentionally not dispatched. The optimizer
+// decides which alias positions get a wrap; this predicate just consults it.
+func (e *DispatchExecutor) shouldDispatch(it query.Iterator) (string, bool) {
+	alias, ok := wrappedAlias(it)
 	if !ok {
 		return "", false
 	}
@@ -118,14 +144,14 @@ func (e *DispatchExecutor) shouldDispatchAlias(it query.Iterator) (string, bool)
 }
 
 func (e *DispatchExecutor) Check(ctx *query.Context, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) (*query.Path, error) {
-	if _, ok := e.shouldDispatchAlias(it); ok {
+	if _, ok := e.shouldDispatch(it); ok {
 		return e.dispatchCheck(ctx, it, resource, subject)
 	}
 	return it.CheckImpl(ctx, resource, subject)
 }
 
 func (e *DispatchExecutor) CheckManySubjects(ctx *query.Context, it query.Iterator, resource query.Object, subjects []query.ObjectAndRelation) ([]*query.Path, error) {
-	if _, ok := e.shouldDispatchAlias(it); !ok {
+	if _, ok := e.shouldDispatch(it); !ok {
 		out := make([]*query.Path, len(subjects))
 		for i, s := range subjects {
 			p, err := it.CheckImpl(ctx, resource, s)
@@ -140,7 +166,7 @@ func (e *DispatchExecutor) CheckManySubjects(ctx *query.Context, it query.Iterat
 }
 
 func (e *DispatchExecutor) CheckManyResources(ctx *query.Context, it query.Iterator, resources []query.Object, subject query.ObjectAndRelation) ([]*query.Path, error) {
-	if _, ok := e.shouldDispatchAlias(it); !ok {
+	if _, ok := e.shouldDispatch(it); !ok {
 		out := make([]*query.Path, len(resources))
 		for i, r := range resources {
 			p, err := it.CheckImpl(ctx, r, subject)
@@ -155,7 +181,7 @@ func (e *DispatchExecutor) CheckManyResources(ctx *query.Context, it query.Itera
 }
 
 func (e *DispatchExecutor) IterSubjects(ctx *query.Context, it query.Iterator, resource query.Object, filterSubjectType query.ObjectType) (query.PathSeq, error) {
-	if _, ok := e.shouldDispatchAlias(it); ok {
+	if _, ok := e.shouldDispatch(it); ok {
 		return e.dispatchIterSubjects(ctx, it, resource, filterSubjectType)
 	}
 	pathSeq, err := it.IterSubjectsImpl(ctx, resource, filterSubjectType)
@@ -166,7 +192,7 @@ func (e *DispatchExecutor) IterSubjects(ctx *query.Context, it query.Iterator, r
 }
 
 func (e *DispatchExecutor) IterResources(ctx *query.Context, it query.Iterator, subject query.ObjectAndRelation, filterResourceType query.ObjectType) (query.PathSeq, error) {
-	if _, ok := e.shouldDispatchAlias(it); ok {
+	if _, ok := e.shouldDispatch(it); ok {
 		return e.dispatchIterResources(ctx, it, subject, filterResourceType)
 	}
 	pathSeq, err := it.IterResourcesImpl(ctx, subject, filterResourceType)
@@ -182,11 +208,11 @@ func (e *DispatchExecutor) dispatchCheck(ctx *query.Context, it query.Iterator, 
 
 	// Probe the dispatcher chain for a cached Plan-Check answer before paying
 	// to serialize the iterator. The lookup descriptor is cheap to build —
-	// just the alias's (def, rel) plus the resource/subject ONRs and parent
-	// plan context — and the cache key it produces is identical to the one
-	// DispatchQueryPlan would compute (see keys.PlanCheckLookupKey), so a hit
-	// here is the same hit the slow path would have found.
-	alias := it.(*query.AliasIterator)
+	// just the wrapped alias's (def, rel) plus the resource/subject ONRs and
+	// parent plan context — and the cache key it produces is identical to the
+	// one DispatchQueryPlan would compute (see keys.PlanCheckLookupKey), so a
+	// hit here is the same hit the slow path would have found.
+	alias, _ := wrappedAlias(it)
 	canonicalKey := alias.DefinitionName() + "#" + alias.Relation()
 	resourceONR := &core.ObjectAndRelation{
 		Namespace: resource.ObjectType,
@@ -338,9 +364,16 @@ func (e *DispatchExecutor) dispatchCheckManyResources(ctx *query.Context, it que
 // singular field (resource for CHECK_MANY_RESOURCES, subject for CHECK_MANY_SUBJECTS)
 // must be left zero — the receiver inspects `many` for those operations.
 func (e *DispatchExecutor) buildManyRequest(ctx *query.Context, op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation, manyResources []query.Object, manySubjects []query.ObjectAndRelation) (*v1.DispatchQueryPlanRequest, error) {
-	alias := it.(*query.AliasIterator)
+	// it is a *DispatchIterator wrapping the alias the executor decided to
+	// ship — see shouldDispatch. Serialize only the inner alias subtree: the
+	// receiver runs it locally (its executor won't re-dispatch a bare alias),
+	// and we save a small handful of header bytes per request.
+	alias, ok := wrappedAlias(it)
+	if !ok {
+		return nil, fmt.Errorf("DispatchQueryPlan: buildManyRequest expected DispatchIterator(Alias), got %T", it)
+	}
 	key := alias.DefinitionName() + "#" + alias.Relation()
-	plan, err := serializePlan(it)
+	plan, err := serializePlan(alias)
 	if err != nil {
 		return nil, err
 	}
@@ -396,16 +429,19 @@ func serializePlan(it query.Iterator) ([]byte, error) {
 }
 
 func (e *DispatchExecutor) buildRequest(ctx *query.Context, op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) (*v1.DispatchQueryPlanRequest, error) {
-	// dispatch{Check,IterSubjects,IterResources} only enter buildRequest when
-	// it is a *query.AliasIterator, so the type assertion is safe. The dispatch
-	// boundary is always the (definition, relation) the alias represents; we
-	// encode that as "definition#relation" and append it to
-	// PlanContext.InProgressKeys (planContextForDispatch). Cache/routing key
-	// computation pulls the current dispatch's canonical key back out of that
-	// slice — there is no top-level canonical_key field on the request anymore.
-	alias := it.(*query.AliasIterator)
+	// dispatch{Check,IterSubjects,IterResources} only enter buildRequest after
+	// shouldDispatch accepted `it` as a DispatchIterator(Alias). Unwrap the
+	// wrap and serialize the inner alias — the receiver runs it locally without
+	// re-dispatching, and we keep the wire shape identical to what shipped
+	// before the wrap became authoritative. The dispatch boundary's "def#rel"
+	// is appended to PlanContext.InProgressKeys via planContextForDispatch;
+	// receiver-side cache key computation pulls it back out of that slice.
+	alias, ok := wrappedAlias(it)
+	if !ok {
+		return nil, fmt.Errorf("DispatchQueryPlan: buildRequest expected DispatchIterator(Alias), got %T", it)
+	}
 	key := alias.DefinitionName() + "#" + alias.Relation()
-	plan, err := serializePlan(it)
+	plan, err := serializePlan(alias)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -344,9 +344,12 @@ func (e *DispatchExecutor) buildManyRequest(ctx *query.Context, op v1.PlanOperat
 	if err != nil {
 		return nil, err
 	}
+	// The current dispatch's canonical key rides on PlanContext.InProgressKeys
+	// (appended by planContextForDispatch). Receiver-side cache key computation
+	// reads it back from the last entry there; there is no top-level
+	// canonical_key field on the request anymore.
 	req := &v1.DispatchQueryPlanRequest{
-		Operation:    op,
-		CanonicalKey: key,
+		Operation: op,
 		Resource: &core.ObjectAndRelation{
 			Namespace: resource.ObjectType,
 			ObjectId:  resource.ObjectID,
@@ -396,7 +399,10 @@ func (e *DispatchExecutor) buildRequest(ctx *query.Context, op v1.PlanOperation,
 	// dispatch{Check,IterSubjects,IterResources} only enter buildRequest when
 	// it is a *query.AliasIterator, so the type assertion is safe. The dispatch
 	// boundary is always the (definition, relation) the alias represents; we
-	// encode that as "definition#relation" in the canonical_key field.
+	// encode that as "definition#relation" and append it to
+	// PlanContext.InProgressKeys (planContextForDispatch). Cache/routing key
+	// computation pulls the current dispatch's canonical key back out of that
+	// slice — there is no top-level canonical_key field on the request anymore.
 	alias := it.(*query.AliasIterator)
 	key := alias.DefinitionName() + "#" + alias.Relation()
 	plan, err := serializePlan(it)
@@ -404,8 +410,7 @@ func (e *DispatchExecutor) buildRequest(ctx *query.Context, op v1.PlanOperation,
 		return nil, err
 	}
 	return &v1.DispatchQueryPlanRequest{
-		Operation:    op,
-		CanonicalKey: key,
+		Operation: op,
 		Resource: &core.ObjectAndRelation{
 			Namespace: resource.ObjectType,
 			ObjectId:  resource.ObjectID,

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -180,6 +180,34 @@ func (e *DispatchExecutor) dispatchCheck(ctx *query.Context, it query.Iterator, 
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// Probe the dispatcher chain for a cached Plan-Check answer before paying
+	// to serialize the iterator. The lookup descriptor is cheap to build —
+	// just the alias's (def, rel) plus the resource/subject ONRs and parent
+	// plan context — and the cache key it produces is identical to the one
+	// DispatchQueryPlan would compute (see keys.PlanCheckLookupKey), so a hit
+	// here is the same hit the slow path would have found.
+	alias := it.(*query.AliasIterator)
+	canonicalKey := alias.DefinitionName() + "#" + alias.Relation()
+	resourceONR := &core.ObjectAndRelation{
+		Namespace: resource.ObjectType,
+		ObjectId:  resource.ObjectID,
+	}
+	subjectONR := &core.ObjectAndRelation{
+		Namespace: subject.ObjectType,
+		ObjectId:  subject.ObjectID,
+		Relation:  subject.Relation,
+	}
+	if path, ok, err := e.dispatcher.LookupPlanCheck(subCtx, PlanCheckLookup{
+		CanonicalKey: canonicalKey,
+		Resource:     resourceONR,
+		Subject:      subjectONR,
+		PlanContext:  e.planContext,
+	}); err != nil {
+		return nil, err
+	} else if ok {
+		return resultPathToQueryPath(path), nil
+	}
+
 	req, err := e.buildRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK, it, resource, subject)
 	if err != nil {
 		return nil, err

--- a/internal/dispatch/executor.go
+++ b/internal/dispatch/executor.go
@@ -1,7 +1,9 @@
 package dispatch
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"slices"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -178,7 +180,10 @@ func (e *DispatchExecutor) dispatchCheck(ctx *query.Context, it query.Iterator, 
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	req := e.buildRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK, it, resource, subject)
+	req, err := e.buildRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK, it, resource, subject)
+	if err != nil {
+		return nil, err
+	}
 	stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 	if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
 		return nil, err
@@ -202,10 +207,13 @@ func (e *DispatchExecutor) dispatchIterSubjects(ctx *query.Context, it query.Ite
 	// filter to apply the same reachability/optimizer decisions the sender
 	// would have applied. The actual receiver-side iteration uses NoObjectFilter
 	// since the sender filters the returned paths itself.
-	req := e.buildRequest(ctx, v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS, it, resource, query.ObjectAndRelation{
+	req, err := e.buildRequest(ctx, v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS, it, resource, query.ObjectAndRelation{
 		ObjectType: filterSubjectType.Type,
 		Relation:   filterSubjectType.Subrelation,
 	})
+	if err != nil {
+		return nil, err
+	}
 	stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 	if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
 		return nil, err
@@ -219,10 +227,13 @@ func (e *DispatchExecutor) dispatchIterResources(ctx *query.Context, it query.It
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	req := e.buildRequest(ctx, v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES, it, query.Object{
+	req, err := e.buildRequest(ctx, v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES, it, query.Object{
 		ObjectType: subject.ObjectType,
 		ObjectID:   subject.ObjectID,
 	}, subject)
+	if err != nil {
+		return nil, err
+	}
 	stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 	if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
 		return nil, err
@@ -239,7 +250,10 @@ func (e *DispatchExecutor) dispatchCheckManySubjects(ctx *query.Context, it quer
 	out := make([]*query.Path, len(subjects))
 	idx := 0
 	for chunk := range slices.Chunk(subjects, int(e.dispatchChunkSize)) {
-		req := e.buildManyRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS, it, resource, query.ObjectAndRelation{}, nil, chunk)
+		req, err := e.buildManyRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_SUBJECTS, it, resource, query.ObjectAndRelation{}, nil, chunk)
+		if err != nil {
+			return nil, err
+		}
 		stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 		if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
 			return nil, err
@@ -267,7 +281,10 @@ func (e *DispatchExecutor) dispatchCheckManyResources(ctx *query.Context, it que
 	out := make([]*query.Path, len(resources))
 	idx := 0
 	for chunk := range slices.Chunk(resources, int(e.dispatchChunkSize)) {
-		req := e.buildManyRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES, it, query.Object{}, subject, chunk, nil)
+		req, err := e.buildManyRequest(ctx, v1.PlanOperation_PLAN_OPERATION_CHECK_MANY_RESOURCES, it, query.Object{}, subject, chunk, nil)
+		if err != nil {
+			return nil, err
+		}
 		stream := NewCollectingDispatchStream[*v1.DispatchQueryPlanResponse](subCtx)
 		if err := e.dispatcher.DispatchQueryPlan(req, stream); err != nil {
 			return nil, err
@@ -292,9 +309,13 @@ func (e *DispatchExecutor) dispatchCheckManyResources(ctx *query.Context, it que
 // Exactly one of (manyResources, manySubjects) is non-nil; the corresponding
 // singular field (resource for CHECK_MANY_RESOURCES, subject for CHECK_MANY_SUBJECTS)
 // must be left zero — the receiver inspects `many` for those operations.
-func (e *DispatchExecutor) buildManyRequest(ctx *query.Context, op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation, manyResources []query.Object, manySubjects []query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
+func (e *DispatchExecutor) buildManyRequest(ctx *query.Context, op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation, manyResources []query.Object, manySubjects []query.ObjectAndRelation) (*v1.DispatchQueryPlanRequest, error) {
 	alias := it.(*query.AliasIterator)
 	key := alias.DefinitionName() + "#" + alias.Relation()
+	plan, err := serializePlan(it)
+	if err != nil {
+		return nil, err
+	}
 	req := &v1.DispatchQueryPlanRequest{
 		Operation:    op,
 		CanonicalKey: key,
@@ -308,6 +329,7 @@ func (e *DispatchExecutor) buildManyRequest(ctx *query.Context, op v1.PlanOperat
 			Relation:  subject.Relation,
 		},
 		PlanContext: planContextForDispatch(e.planContext, key, ctx.TopLevelOperation),
+		Plan:        plan,
 	}
 	if len(manyResources) > 0 {
 		req.Many = make([]*core.ObjectAndRelation, len(manyResources))
@@ -328,16 +350,31 @@ func (e *DispatchExecutor) buildManyRequest(ctx *query.Context, op v1.PlanOperat
 			}
 		}
 	}
-	return req
+	return req, nil
 }
 
-func (e *DispatchExecutor) buildRequest(ctx *query.Context, op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) *v1.DispatchQueryPlanRequest {
+// serializePlan emits the iterator subtree using the pkg/query wire format so
+// the receiver can deserialize and execute it directly without rebuilding from
+// the (definition, relation) canonical key.
+func serializePlan(it query.Iterator) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := it.Serialize(&buf); err != nil {
+		return nil, fmt.Errorf("DispatchQueryPlan: serialize plan: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func (e *DispatchExecutor) buildRequest(ctx *query.Context, op v1.PlanOperation, it query.Iterator, resource query.Object, subject query.ObjectAndRelation) (*v1.DispatchQueryPlanRequest, error) {
 	// dispatch{Check,IterSubjects,IterResources} only enter buildRequest when
 	// it is a *query.AliasIterator, so the type assertion is safe. The dispatch
 	// boundary is always the (definition, relation) the alias represents; we
 	// encode that as "definition#relation" in the canonical_key field.
 	alias := it.(*query.AliasIterator)
 	key := alias.DefinitionName() + "#" + alias.Relation()
+	plan, err := serializePlan(it)
+	if err != nil {
+		return nil, err
+	}
 	return &v1.DispatchQueryPlanRequest{
 		Operation:    op,
 		CanonicalKey: key,
@@ -351,7 +388,8 @@ func (e *DispatchExecutor) buildRequest(ctx *query.Context, op v1.PlanOperation,
 			Relation:  subject.Relation,
 		},
 		PlanContext: planContextForDispatch(e.planContext, key, ctx.TopLevelOperation),
-	}
+		Plan:        plan,
+	}, nil
 }
 
 // planContextForDispatch returns a shallow copy of pc with `key` appended to

--- a/internal/dispatch/executor_test.go
+++ b/internal/dispatch/executor_test.go
@@ -88,7 +88,7 @@ func TestDispatchExecutor_Check_AliasDispatches(t *testing.T) {
 	inner := query.NewFixedIterator()
 	alias := query.NewAliasIterator("", "viewer", inner)
 
-	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.NotNil(t, path)
 	require.Equal(t, "document", path.Resource.ObjectType)
@@ -135,7 +135,7 @@ func TestDispatchExecutor_Check_AliasNoResult(t *testing.T) {
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
-	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.Nil(t, path)
 	require.Len(t, receiver.planCalls, 1)
@@ -156,7 +156,7 @@ func TestDispatchExecutor_IterSubjects_AliasDispatches(t *testing.T) {
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
-	pathSeq, err := sender.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	pathSeq, err := sender.IterSubjects(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -212,7 +212,7 @@ func TestDispatchExecutor_IterResources_AliasDispatches(t *testing.T) {
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
-	pathSeq, err := sender.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	pathSeq, err := sender.IterResources(ctx, NewDispatchIterator(alias), query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -258,7 +258,7 @@ func TestDispatchExecutor_Check_AliasWithRecursiveSentinelDoesNotDispatch(t *tes
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	alias := query.NewAliasIterator("", "viewer", sentinel)
 
-	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	// RecursiveSentinel.CheckImpl returns nil
 	require.Nil(t, path)
@@ -276,7 +276,7 @@ func TestDispatchExecutor_IterSubjects_AliasWithRecursiveSentinelDoesNotDispatch
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	alias := query.NewAliasIterator("", "viewer", sentinel)
 
-	pathSeq, err := sender.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	pathSeq, err := sender.IterSubjects(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -294,7 +294,7 @@ func TestDispatchExecutor_IterResources_AliasWithRecursiveSentinelDoesNotDispatc
 	sentinel := query.NewRecursiveSentinelIterator("document", "viewer", false)
 	alias := query.NewAliasIterator("", "viewer", sentinel)
 
-	pathSeq, err := sender.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	pathSeq, err := sender.IterResources(ctx, NewDispatchIterator(alias), query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -326,7 +326,7 @@ func TestDispatchExecutor_Check_AliasWithSentinelInsideRecursiveDispatches(t *te
 	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
 	alias := query.NewAliasIterator("", "viewer", recursive)
 
-	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.NotNil(t, path)
 	require.Equal(t, "alice", path.Subject.ObjectID)
@@ -356,7 +356,7 @@ func TestDispatchExecutor_IterSubjects_AliasWithSentinelInsideRecursiveDispatche
 	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
 	alias := query.NewAliasIterator("", "viewer", recursive)
 
-	pathSeq, err := sender.IterSubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
+	pathSeq, err := sender.IterSubjects(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "document", ObjectID: "doc1"}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -388,7 +388,7 @@ func TestDispatchExecutor_IterResources_AliasWithSentinelInsideRecursiveDispatch
 	recursive := query.NewRecursiveIterator(sentinel, "document", "viewer")
 	alias := query.NewAliasIterator("", "viewer", recursive)
 
-	pathSeq, err := sender.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	pathSeq, err := sender.IterResources(ctx, NewDispatchIterator(alias), query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -413,7 +413,7 @@ func TestDispatchExecutor_Check_DoubleRecursionUnmatchedSentinelDoesNotDispatch(
 	folderRecursive := query.NewRecursiveIterator(documentSentinel, "folder", "viewer")
 	alias := query.NewAliasIterator("", "viewer", folderRecursive)
 
-	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.Nil(t, path)
 
@@ -447,7 +447,7 @@ func TestDispatchExecutor_Check_DoubleRecursionBothMatchedDispatches(t *testing.
 	folderRecursive := query.NewRecursiveIterator(documentRecursive, "folder", "viewer")
 	alias := query.NewAliasIterator("", "viewer", folderRecursive)
 
-	path, err := sender.Check(ctx, alias, query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	path, err := sender.Check(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "folder", ObjectID: "f1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.NotNil(t, path)
 	require.Equal(t, "alice", path.Subject.ObjectID)
@@ -475,7 +475,7 @@ func TestDispatchExecutor_StreamBatching(t *testing.T) {
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
 
-	pathSeq, err := sender.IterResources(ctx, alias, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
+	pathSeq, err := sender.IterResources(ctx, NewDispatchIterator(alias), query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}, query.NoObjectFilter())
 	require.NoError(t, err)
 
 	paths, err := query.CollectAll(pathSeq)
@@ -500,7 +500,7 @@ func TestDispatchExecutor_PlanContextForwarded(t *testing.T) {
 	ctx := newTestContext()
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
-	_, _ = sender.Check(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	_, _ = sender.Check(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 
 	require.Len(t, receiver.planCalls, 1)
 	require.Equal(t, "rev42", receiver.planCalls[0].PlanContext.Revision)
@@ -520,7 +520,7 @@ func TestDispatchExecutor_ContextCancellation(t *testing.T) {
 	qctx := query.NewLocalContext(ctx)
 
 	alias := query.NewAliasIterator("", "viewer", query.NewFixedIterator())
-	_, err := sender.Check(qctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	_, err := sender.Check(qctx, NewDispatchIterator(alias), query.Object{ObjectType: "document", ObjectID: "doc1"}, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 
 	// The dispatch itself succeeds (our test dispatcher doesn't check context),
 	// but the subcontext created inside dispatchCheck is derived from the cancelled parent.
@@ -685,7 +685,7 @@ func TestDispatchExecutor_CheckManyResources_AliasDispatchesAndPairsByONR(t *tes
 		{ObjectType: "document", ObjectID: "doc2"},
 		{ObjectType: "document", ObjectID: "doc3"},
 	}
-	out, err := sender.CheckManyResources(ctx, alias, resources, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
+	out, err := sender.CheckManyResources(ctx, NewDispatchIterator(alias), resources, query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."})
 	require.NoError(t, err)
 	require.Len(t, out, len(resources))
 	require.NotNil(t, out[0])
@@ -718,7 +718,7 @@ func TestDispatchExecutor_CheckManySubjects_AliasDispatches(t *testing.T) {
 		{ObjectType: "user", ObjectID: "alice", Relation: "..."},
 		{ObjectType: "user", ObjectID: "bob", Relation: "..."},
 	}
-	out, err := sender.CheckManySubjects(ctx, alias, query.Object{ObjectType: "document", ObjectID: "doc1"}, subjects)
+	out, err := sender.CheckManySubjects(ctx, NewDispatchIterator(alias), query.Object{ObjectType: "document", ObjectID: "doc1"}, subjects)
 	require.NoError(t, err)
 	require.Len(t, out, len(subjects))
 	require.Nil(t, out[0], "alice had no response")
@@ -807,7 +807,7 @@ func TestDispatchExecutor_CheckManyResources_ChunksByDispatchChunkSize(t *testin
 	}
 	subject := query.ObjectAndRelation{ObjectType: "user", ObjectID: "alice", Relation: "..."}
 
-	out, err := sender.CheckManyResources(ctx, alias, resources, subject)
+	out, err := sender.CheckManyResources(ctx, NewDispatchIterator(alias), resources, subject)
 	require.NoError(t, err)
 	require.Len(t, out, total)
 	for i, p := range out {
@@ -853,7 +853,7 @@ func TestDispatchExecutor_CheckManySubjects_ChunksByDispatchChunkSize(t *testing
 	}
 	resource := query.Object{ObjectType: "document", ObjectID: "doc1"}
 
-	out, err := sender.CheckManySubjects(ctx, alias, resource, subjects)
+	out, err := sender.CheckManySubjects(ctx, NewDispatchIterator(alias), resource, subjects)
 	require.NoError(t, err)
 	require.Len(t, out, total)
 	for i, p := range out {

--- a/internal/dispatch/executor_test.go
+++ b/internal/dispatch/executor_test.go
@@ -54,6 +54,10 @@ func (d *testDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, str
 	}
 	return nil
 }
+
+func (d *testDispatcher) LookupPlanCheck(_ context.Context, _ PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return nil, false, nil
+}
 func (d *testDispatcher) Close() error           { return nil }
 func (d *testDispatcher) ReadyState() ReadyState { return ReadyState{IsReady: true} }
 
@@ -761,6 +765,10 @@ func (d *chunkingDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest,
 		}
 	}
 	return nil
+}
+
+func (d *chunkingDispatcher) LookupPlanCheck(_ context.Context, _ PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return nil, false, nil
 }
 func (d *chunkingDispatcher) Close() error           { return nil }
 func (d *chunkingDispatcher) ReadyState() ReadyState { return ReadyState{IsReady: true} }

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -722,6 +722,14 @@ func (ld *localDispatcher) compileIteratorForDispatchKey(ctx context.Context, re
 		return nil, fmt.Errorf("DispatchQueryPlan: failed to optimize outline for %s#%s: %w", defName, relName, err)
 	}
 
+	// Tag dispatch-eligible aliases by wrapping them in DispatchIterator. This
+	// runs after the standard optimizer set so the wrap sees the post-optimizer
+	// tree shape (e.g. collapsed alias chains).
+	optimized, err = dispatch.ApplyDispatchWrap(optimized, params)
+	if err != nil {
+		return nil, fmt.Errorf("DispatchQueryPlan: failed to apply dispatch wrap for %s#%s: %w", defName, relName, err)
+	}
+
 	// Apply the count-based advisor using the shared QueryPlanMetadata so the
 	// receiver-side compile benefits from stats accumulated by prior runs on
 	// either side of the dispatch boundary.

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -497,6 +497,12 @@ func (ld *localDispatcher) DispatchLookupSubjects(
 	)
 }
 
+// LookupPlanCheck is a no-op on the local dispatcher — there is no cache layer
+// at this level, so callers should fall through to DispatchQueryPlan.
+func (ld *localDispatcher) LookupPlanCheck(_ context.Context, _ dispatch.PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return nil, false, nil
+}
+
 // DispatchQueryPlan implements dispatch.Plan interface.
 // It loads the schema (needed to rehydrate DatastoreIterator subjects), then
 // deserializes the iterator subtree the sender shipped in req.Plan and runs

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -1,10 +1,10 @@
 package graph
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -27,7 +27,6 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/query"
-	"github.com/authzed/spicedb/pkg/query/queryopt"
 	"github.com/authzed/spicedb/pkg/schema/v2"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -499,10 +498,11 @@ func (ld *localDispatcher) DispatchLookupSubjects(
 }
 
 // DispatchQueryPlan implements dispatch.Plan interface.
-// It loads the schema, compiles the plan, finds the subtree by canonical key,
-// and executes it locally. The Impl method is called directly on the found
-// iterator to avoid re-triggering the executor's dispatch decision on the
-// same alias boundary that was already dispatched by the caller.
+// It loads the schema (needed to rehydrate DatastoreIterator subjects), then
+// deserializes the iterator subtree the sender shipped in req.Plan and runs
+// it locally. The Impl method is called directly on the deserialized iterator
+// to avoid re-triggering the executor's dispatch decision on the same alias
+// boundary that was already dispatched by the caller.
 func (ld *localDispatcher) DispatchQueryPlan(
 	req *v1.DispatchQueryPlanRequest,
 	stream dispatch.PlanStream,
@@ -521,10 +521,7 @@ func (ld *localDispatcher) DispatchQueryPlan(
 
 	schemaHash := datalayer.SchemaHash(planCtx.GetSchemaHash())
 
-	// Load schema at the requested revision and rebuild the iterator subtree
-	// for the (definition, relation) pair encoded in CanonicalKey.
-	// TODO: use cached compiled plans instead of recompiling each time.
-	it, err := ld.compileIteratorForDispatchKey(ctx, revision, schemaHash, req)
+	it, err := ld.deserializePlanFromRequest(ctx, revision, schemaHash, req)
 	if err != nil {
 		return err
 	}
@@ -663,17 +660,14 @@ func (ld *localDispatcher) DispatchQueryPlan(
 	}
 }
 
-// compileIteratorForDispatchKey loads the schema at the given revision, parses
-// the dispatch key (currently encoded as "definition#relation"), builds the
-// outline standalone for that pair, applies the same optimizers the sender
-// would have used, and compiles to an iterator. The returned iterator's outer
-// node is the *AliasIterator for the requested (definition, relation); callers
-// invoke its Impl method directly so the alias's rewrite + self-edge logic
-// runs without re-triggering the executor's dispatch decision at this level.
-func (ld *localDispatcher) compileIteratorForDispatchKey(ctx context.Context, revision datastore.Revision, schemaHash datalayer.SchemaHash, req *v1.DispatchQueryPlanRequest) (query.Iterator, error) {
-	defName, relName, ok := strings.Cut(req.CanonicalKey, "#")
-	if !ok || defName == "" || relName == "" {
-		return nil, fmt.Errorf("DispatchQueryPlan: invalid dispatch key %q (expected \"definition#relation\")", req.CanonicalKey)
+// deserializePlanFromRequest loads the schema at the requested revision and
+// rehydrates the iterator subtree the sender serialized into req.Plan. The
+// schema is required so DatastoreIterator children can resolve back to live
+// *schema.BaseRelation pointers via DeserializeContext. Optimization and
+// compilation already happened on the sender; this side just decodes and runs.
+func (ld *localDispatcher) deserializePlanFromRequest(ctx context.Context, revision datastore.Revision, schemaHash datalayer.SchemaHash, req *v1.DispatchQueryPlanRequest) (query.Iterator, error) {
+	if len(req.Plan) == 0 {
+		return nil, errors.New("DispatchQueryPlan: missing serialized plan")
 	}
 
 	dl := datalayer.MustFromContext(ctx)
@@ -702,45 +696,9 @@ func (ld *localDispatcher) compileIteratorForDispatchKey(ctx context.Context, re
 		return nil, fmt.Errorf("DispatchQueryPlan: failed to build schema: %w", err)
 	}
 
-	co, err := query.BuildOutlineFromSchema(fullSchema, defName, relName)
+	it, err := query.Deserialize(bytes.NewReader(req.Plan), &query.DeserializeContext{Schema: fullSchema})
 	if err != nil {
-		return nil, fmt.Errorf("DispatchQueryPlan: failed to build outline for %s#%s: %w", defName, relName, err)
-	}
-
-	operation, err := planOperationToQueryOperation(req.Operation)
-	if err != nil {
-		return nil, fmt.Errorf("DispatchQueryPlan: %w", err)
-	}
-
-	params := queryopt.RequestParams{
-		Operation:       operation,
-		SubjectType:     req.Subject.GetNamespace(),
-		SubjectRelation: req.Subject.GetRelation(),
-	}
-	optimized, err := queryopt.ApplyOptimizations(co, queryopt.OptimizersForRequest(params), params)
-	if err != nil {
-		return nil, fmt.Errorf("DispatchQueryPlan: failed to optimize outline for %s#%s: %w", defName, relName, err)
-	}
-
-	// Tag dispatch-eligible aliases by wrapping them in DispatchIterator. This
-	// runs after the standard optimizer set so the wrap sees the post-optimizer
-	// tree shape (e.g. collapsed alias chains).
-	optimized, err = dispatch.ApplyDispatchWrap(optimized, params)
-	if err != nil {
-		return nil, fmt.Errorf("DispatchQueryPlan: failed to apply dispatch wrap for %s#%s: %w", defName, relName, err)
-	}
-
-	// Apply the count-based advisor using the shared QueryPlanMetadata so the
-	// receiver-side compile benefits from stats accumulated by prior runs on
-	// either side of the dispatch boundary.
-	optimized, err = ld.queryPlanMetadata.ApplyAdvisor(optimized)
-	if err != nil {
-		return nil, fmt.Errorf("DispatchQueryPlan: failed to apply advisor for %s#%s: %w", defName, relName, err)
-	}
-
-	it, err := optimized.Compile()
-	if err != nil {
-		return nil, fmt.Errorf("DispatchQueryPlan: failed to compile outline for %s#%s: %w", defName, relName, err)
+		return nil, fmt.Errorf("DispatchQueryPlan: failed to deserialize plan: %w", err)
 	}
 	return it, nil
 }

--- a/internal/dispatch/keys/computed.go
+++ b/internal/dispatch/keys/computed.go
@@ -1,7 +1,10 @@
 package keys
 
 import (
+	"google.golang.org/protobuf/types/known/structpb"
+
 	"github.com/authzed/spicedb/pkg/caveats"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	v1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -115,11 +118,27 @@ func lookupSubjectsRequestToKey(req *v1.DispatchLookupSubjectsRequest) DispatchC
 
 // planCheckRequestToKey converts a plan check request into a cache key
 func planCheckRequestToKey(req *v1.DispatchQueryPlanRequest) DispatchCacheKey {
-	return dispatchCacheKeyHash(planCheckPrefix, req.PlanContext.Revision,
-		hashableString(req.CanonicalKey),
-		hashableOnr{req.Resource},
-		hashableOnr{req.Subject},
-		hashableContext{Struct: req.PlanContext.CaveatContext},
+	return PlanCheckLookupKey(
+		req.PlanContext.Revision,
+		req.CanonicalKey,
+		req.Resource,
+		req.Subject,
+		req.PlanContext.CaveatContext,
+	)
+}
+
+// PlanCheckLookupKey computes the same Plan-Check cache key as
+// planCheckRequestToKey, but takes the inputs directly so callers can probe the
+// cache without first having to construct a DispatchQueryPlanRequest (which
+// forces iterator serialization). The hashed component set must stay identical
+// to planCheckRequestToKey or the cache-hit fast path and the DispatchQueryPlan
+// slow path will end up on different cache entries.
+func PlanCheckLookupKey(revision string, canonicalKey string, resource, subject *core.ObjectAndRelation, caveatContext *structpb.Struct) DispatchCacheKey {
+	return dispatchCacheKeyHash(planCheckPrefix, revision,
+		hashableString(canonicalKey),
+		hashableOnr{resource},
+		hashableOnr{subject},
+		hashableContext{Struct: caveatContext},
 	)
 }
 

--- a/internal/dispatch/keys/computed.go
+++ b/internal/dispatch/keys/computed.go
@@ -120,11 +120,25 @@ func lookupSubjectsRequestToKey(req *v1.DispatchLookupSubjectsRequest) DispatchC
 func planCheckRequestToKey(req *v1.DispatchQueryPlanRequest) DispatchCacheKey {
 	return PlanCheckLookupKey(
 		req.PlanContext.Revision,
-		req.CanonicalKey,
+		currentDispatchKey(req.PlanContext),
 		req.Resource,
 		req.Subject,
 		req.PlanContext.CaveatContext,
 	)
+}
+
+// currentDispatchKey returns the canonical "def#rel" key for the dispatch
+// currently being processed. By contract — see planContextForDispatch in
+// internal/dispatch/executor.go — the sender appends the current dispatch's
+// key to PlanContext.InProgressKeys before sending, so the last entry is
+// always the current dispatch's key. Returns "" if InProgressKeys is empty,
+// which is invalid for a Plan-dispatched request but is tolerated to keep
+// this helper safe to call on partial test fixtures.
+func currentDispatchKey(pc *v1.PlanContext) string {
+	if pc == nil || len(pc.InProgressKeys) == 0 {
+		return ""
+	}
+	return pc.InProgressKeys[len(pc.InProgressKeys)-1]
 }
 
 // PlanCheckLookupKey computes the same Plan-Check cache key as
@@ -145,7 +159,7 @@ func PlanCheckLookupKey(revision string, canonicalKey string, resource, subject 
 // planLookupResourcesRequestToKey converts a plan lookup resources request into a cache key
 func planLookupResourcesRequestToKey(req *v1.DispatchQueryPlanRequest) DispatchCacheKey {
 	return dispatchCacheKeyHash(planLookupResourcesPrefix, req.PlanContext.Revision,
-		hashableString(req.CanonicalKey),
+		hashableString(currentDispatchKey(req.PlanContext)),
 		hashableOnr{req.Subject},
 		hashableContext{Struct: req.PlanContext.CaveatContext},
 	)
@@ -154,7 +168,7 @@ func planLookupResourcesRequestToKey(req *v1.DispatchQueryPlanRequest) DispatchC
 // planLookupSubjectsRequestToKey converts a plan lookup subjects request into a cache key
 func planLookupSubjectsRequestToKey(req *v1.DispatchQueryPlanRequest) DispatchCacheKey {
 	return dispatchCacheKeyHash(planLookupSubjectsPrefix, req.PlanContext.Revision,
-		hashableString(req.CanonicalKey),
+		hashableString(currentDispatchKey(req.PlanContext)),
 		hashableOnr{req.Resource},
 		hashableContext{Struct: req.PlanContext.CaveatContext},
 	)

--- a/internal/dispatch/keys/computed_test.go
+++ b/internal/dispatch/keys/computed_test.go
@@ -554,10 +554,12 @@ var generatorFuncs = map[string]generatorFunc{
 		metadata *v1.ResolverMeta,
 	) (DispatchCacheKey, []string) {
 		return planCheckRequestToKey(&v1.DispatchQueryPlanRequest{
-				CanonicalKey: resourceRelation.Relation,
-				Resource:     ONR(resourceRelation.Namespace, resourceIds[0], resourceRelation.Relation),
-				Subject:      ONR(subjectRelation.Namespace, subjectIds[0], subjectRelation.Relation),
-				PlanContext:  &v1.PlanContext{Revision: metadata.AtRevision},
+				Resource: ONR(resourceRelation.Namespace, resourceIds[0], resourceRelation.Relation),
+				Subject:  ONR(subjectRelation.Namespace, subjectIds[0], subjectRelation.Relation),
+				PlanContext: &v1.PlanContext{
+					Revision:       metadata.AtRevision,
+					InProgressKeys: []string{resourceRelation.Relation},
+				},
 			}), []string{
 				resourceRelation.Relation,
 				resourceRelation.Namespace,
@@ -577,9 +579,11 @@ var generatorFuncs = map[string]generatorFunc{
 		metadata *v1.ResolverMeta,
 	) (DispatchCacheKey, []string) {
 		return planLookupResourcesRequestToKey(&v1.DispatchQueryPlanRequest{
-				CanonicalKey: resourceRelation.Relation,
-				Subject:      ONR(subjectRelation.Namespace, subjectIds[0], subjectRelation.Relation),
-				PlanContext:  &v1.PlanContext{Revision: metadata.AtRevision},
+				Subject: ONR(subjectRelation.Namespace, subjectIds[0], subjectRelation.Relation),
+				PlanContext: &v1.PlanContext{
+					Revision:       metadata.AtRevision,
+					InProgressKeys: []string{resourceRelation.Relation},
+				},
 			}), []string{
 				resourceRelation.Relation,
 				subjectRelation.Namespace,
@@ -597,9 +601,11 @@ var generatorFuncs = map[string]generatorFunc{
 		metadata *v1.ResolverMeta,
 	) (DispatchCacheKey, []string) {
 		return planLookupSubjectsRequestToKey(&v1.DispatchQueryPlanRequest{
-				CanonicalKey: resourceRelation.Relation,
-				Resource:     ONR(resourceRelation.Namespace, resourceIds[0], resourceRelation.Relation),
-				PlanContext:  &v1.PlanContext{Revision: metadata.AtRevision},
+				Resource: ONR(resourceRelation.Namespace, resourceIds[0], resourceRelation.Relation),
+				PlanContext: &v1.PlanContext{
+					Revision:       metadata.AtRevision,
+					InProgressKeys: []string{resourceRelation.Relation},
+				},
 			}), []string{
 				resourceRelation.Relation,
 				resourceRelation.Namespace,

--- a/internal/dispatch/mocks/mock_dispatcher.go
+++ b/internal/dispatch/mocks/mock_dispatcher.go
@@ -143,6 +143,22 @@ func (mr *MockDispatcherMockRecorder) DispatchQueryPlan(req, stream any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchQueryPlan", reflect.TypeOf((*MockDispatcher)(nil).DispatchQueryPlan), req, stream)
 }
 
+// LookupPlanCheck mocks base method.
+func (m *MockDispatcher) LookupPlanCheck(ctx context.Context, lookup dispatch.PlanCheckLookup) (*dispatchv1.ResultPath, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LookupPlanCheck", ctx, lookup)
+	ret0, _ := ret[0].(*dispatchv1.ResultPath)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// LookupPlanCheck indicates an expected call of LookupPlanCheck.
+func (mr *MockDispatcherMockRecorder) LookupPlanCheck(ctx, lookup any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupPlanCheck", reflect.TypeOf((*MockDispatcher)(nil).LookupPlanCheck), ctx, lookup)
+}
+
 // ReadyState mocks base method.
 func (m *MockDispatcher) ReadyState() dispatch.ReadyState {
 	m.ctrl.T.Helper()
@@ -385,6 +401,22 @@ func (m *MockPlan) DispatchQueryPlan(req *dispatchv1.DispatchQueryPlanRequest, s
 func (mr *MockPlanMockRecorder) DispatchQueryPlan(req, stream any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchQueryPlan", reflect.TypeOf((*MockPlan)(nil).DispatchQueryPlan), req, stream)
+}
+
+// LookupPlanCheck mocks base method.
+func (m *MockPlan) LookupPlanCheck(ctx context.Context, lookup dispatch.PlanCheckLookup) (*dispatchv1.ResultPath, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LookupPlanCheck", ctx, lookup)
+	ret0, _ := ret[0].(*dispatchv1.ResultPath)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// LookupPlanCheck indicates an expected call of LookupPlanCheck.
+func (mr *MockPlanMockRecorder) LookupPlanCheck(ctx, lookup any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupPlanCheck", reflect.TypeOf((*MockPlan)(nil).LookupPlanCheck), ctx, lookup)
 }
 
 // MockDispatchableRequest is a mock of DispatchableRequest interface.

--- a/internal/dispatch/remote/cluster.go
+++ b/internal/dispatch/remote/cluster.go
@@ -852,6 +852,15 @@ func (cr *clusterDispatcher) DispatchLookupSubjects(
 		})
 }
 
+// LookupPlanCheck is a no-op on the cluster (remote) dispatcher. Probing a
+// remote cache would require its own RPC, which would defeat the purpose of
+// avoiding the heavy DispatchQueryPlan call; the remote receiver consults its
+// own caching layer when it gets a full request. Future work could expose a
+// cheap "PlanCheckLookup" RPC if remote cache amplification is needed.
+func (cr *clusterDispatcher) LookupPlanCheck(_ context.Context, _ dispatch.PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return nil, false, nil
+}
+
 func (cr *clusterDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
 	var requestKey []byte
 	var err error

--- a/internal/dispatch/singleflight/singleflight.go
+++ b/internal/dispatch/singleflight/singleflight.go
@@ -147,6 +147,13 @@ func (d *Dispatcher) DispatchLookupSubjects(req *v1.DispatchLookupSubjectsReques
 	return d.delegate.DispatchLookupSubjects(req, stream)
 }
 
+// LookupPlanCheck is a passthrough — singleflight provides no cache of its
+// own; it just deduplicates concurrent identical Plan-Check dispatches. The
+// delegate (typically a caching.Dispatcher) is the actual cache holder.
+func (d *Dispatcher) LookupPlanCheck(ctx context.Context, lookup dispatch.PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return d.delegate.LookupPlanCheck(ctx, lookup)
+}
+
 func (d *Dispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
 	// Only PLAN_OPERATION_CHECK is request/response-shaped (single ResultPath
 	// per call) and therefore safe to deduplicate via singleflight. The lookup

--- a/internal/dispatch/singleflight/singleflight_test.go
+++ b/internal/dispatch/singleflight/singleflight_test.go
@@ -361,13 +361,13 @@ func TestDispatchQueryPlanCheckCoalescesConcurrentCalls(t *testing.T) {
 	disp := New(mock, &keys.DirectKeyHandler{})
 
 	req := &v1.DispatchQueryPlanRequest{
-		Operation:    v1.PlanOperation_PLAN_OPERATION_CHECK,
-		CanonicalKey: "document#viewer",
-		Resource:     tuple.ONRStringToCore("document", "doc1", "viewer"),
-		Subject:      tuple.ONRStringToCore("user", "alice", "..."),
+		Operation: v1.PlanOperation_PLAN_OPERATION_CHECK,
+		Resource:  tuple.ONRStringToCore("document", "doc1", "viewer"),
+		Subject:   tuple.ONRStringToCore("user", "alice", "..."),
 		PlanContext: &v1.PlanContext{
-			Revision:   "1234",
-			SchemaHash: []byte(datalayer.NoSchemaHashForTesting),
+			Revision:       "1234",
+			SchemaHash:     []byte(datalayer.NoSchemaHashForTesting),
+			InProgressKeys: []string{"document#viewer"},
 		},
 	}
 

--- a/internal/dispatch/singleflight/singleflight_test.go
+++ b/internal/dispatch/singleflight/singleflight_test.go
@@ -462,6 +462,9 @@ func (m planMockDispatcher) DispatchQueryPlan(_ *v1.DispatchQueryPlanRequest, st
 	})
 }
 
+func (m planMockDispatcher) LookupPlanCheck(_ context.Context, _ dispatch.PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return nil, false, nil
+}
 func (m planMockDispatcher) Close() error                    { return nil }
 func (m planMockDispatcher) ReadyState() dispatch.ReadyState { return dispatch.ReadyState{} }
 
@@ -542,6 +545,10 @@ func (m mockDispatcher) DispatchLookupSubjects(_ *v1.DispatchLookupSubjectsReque
 
 func (m mockDispatcher) DispatchQueryPlan(_ *v1.DispatchQueryPlanRequest, _ dispatch.PlanStream) error {
 	return nil
+}
+
+func (m mockDispatcher) LookupPlanCheck(_ context.Context, _ dispatch.PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return nil, false, nil
 }
 
 func (m mockDispatcher) Close() error {

--- a/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
+++ b/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
@@ -3,6 +3,7 @@
 package integrationtesting_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -221,11 +222,17 @@ func (d *localQueryPlanDispatcher) ReadyState() dispatch.ReadyState {
 func (d *localQueryPlanDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRequest, stream dispatch.PlanStream) error {
 	ctx := stream.Context()
 
-	// Find the iterator for this canonical key by compiling the full plan.
-	// In the real implementation, this would be cached.
-	it, err := d.findIterator(req)
+	// Deserialize the iterator the sender shipped on req.Plan. Mirrors what the
+	// production receiver in dispatch/graph does: the schema is needed so
+	// DatastoreIterator subjects rebind to live *schema.BaseRelation pointers
+	// via DeserializeContext, but no outline build / optimize / compile happens
+	// on this side.
+	if len(req.Plan) == 0 {
+		return fmt.Errorf("DispatchQueryPlan: missing serialized plan")
+	}
+	it, err := query.Deserialize(bytes.NewReader(req.Plan), &query.DeserializeContext{Schema: d.handle.schema})
 	if err != nil {
-		return err
+		return fmt.Errorf("DispatchQueryPlan: deserialize plan: %w", err)
 	}
 
 	// Build execution context with DispatchExecutor so nested aliases in the subtree
@@ -308,64 +315,6 @@ func (d *localQueryPlanDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRe
 	}
 }
 
-// findIterator compiles the full plan from schema and walks the iterator tree
-// to find the subtree matching the requested canonical key.
-func (d *localQueryPlanDispatcher) findIterator(req *v1.DispatchQueryPlanRequest) (query.Iterator, error) {
-	targetKey := query.CanonicalKey(req.CanonicalKey)
-
-	// Map PlanOperation to query.Operation for optimizer selection.
-	var operation query.Operation
-	switch req.Operation {
-	case v1.PlanOperation_PLAN_OPERATION_CHECK:
-		operation = query.OperationCheck
-	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_RESOURCES:
-		operation = query.OperationIterResources
-	case v1.PlanOperation_PLAN_OPERATION_LOOKUP_SUBJECTS:
-		operation = query.OperationIterSubjects
-	}
-
-	queryParams := queryopt.RequestParams{
-		Operation:       operation,
-		SubjectType:     req.Subject.Namespace,
-		SubjectRelation: req.Subject.Relation,
-	}
-
-	for nsName, def := range d.handle.schema.Definitions() {
-		for permName := range def.Permissions() {
-			co, err := query.BuildOutlineFromSchema(d.handle.schema, nsName, permName)
-			if err != nil {
-				continue
-			}
-
-			optimized, err := queryopt.ApplyOptimizations(co, queryopt.OptimizersForRequest(queryParams), queryParams)
-			if err != nil {
-				continue
-			}
-
-			it, err := optimized.Compile()
-			if err != nil {
-				continue
-			}
-			if found := findByCanonicalKey(it, targetKey); found != nil {
-				return found, nil
-			}
-		}
-	}
-	return nil, fmt.Errorf("no iterator found for canonical key %q", req.CanonicalKey)
-}
-
-// findByCanonicalKey recursively searches an iterator tree for a node with the given key.
-func findByCanonicalKey(it query.Iterator, key query.CanonicalKey) query.Iterator {
-	if it.CanonicalKey() == key {
-		return it
-	}
-	for _, sub := range it.Subiterators() {
-		if found := findByCanonicalKey(sub, key); found != nil {
-			return found
-		}
-	}
-	return nil
-}
 
 // --- Benchmarks ---
 

--- a/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
+++ b/internal/services/integrationtesting/benchmark_dispatchqueryplan_test.go
@@ -214,6 +214,11 @@ func (d *localQueryPlanDispatcher) DispatchLookupResources3(_ *v1.DispatchLookup
 func (d *localQueryPlanDispatcher) DispatchLookupSubjects(_ *v1.DispatchLookupSubjectsRequest, _ dispatch.LookupSubjectsStream) error {
 	return fmt.Errorf("not implemented")
 }
+
+func (d *localQueryPlanDispatcher) LookupPlanCheck(_ context.Context, _ dispatch.PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return nil, false, nil
+}
+
 func (d *localQueryPlanDispatcher) Close() error { return nil }
 func (d *localQueryPlanDispatcher) ReadyState() dispatch.ReadyState {
 	return dispatch.ReadyState{IsReady: true}
@@ -314,7 +319,6 @@ func (d *localQueryPlanDispatcher) DispatchQueryPlan(req *v1.DispatchQueryPlanRe
 		return fmt.Errorf("unknown plan operation: %v", req.Operation)
 	}
 }
-
 
 // --- Benchmarks ---
 

--- a/internal/services/integrationtesting/benchmark_executors_test.go
+++ b/internal/services/integrationtesting/benchmark_executors_test.go
@@ -169,6 +169,15 @@ func compileAdvisedCheckIterator(
 	optimized, err := queryopt.ApplyOptimizations(co, queryopt.OptimizersForRequest(params), params)
 	require.NoError(b, err)
 
+	// Match the production pipeline (see graph.DispatchQueryPlan and
+	// permissions_queryplan): every dispatch-eligible alias gets a
+	// DispatchIterator wrap. Without this the queryplan_dispatch variant
+	// would never dispatch — the DispatchExecutor pivots on the wrap, not
+	// on bare aliases — and the benchmark would silently measure the
+	// local path under a dispatch label.
+	optimized, err = dispatch.ApplyDispatchWrap(optimized, params)
+	require.NoError(b, err)
+
 	warmIt, err := optimized.Compile()
 	require.NoError(b, err)
 

--- a/internal/services/integrationtesting/benchmark_executors_test.go
+++ b/internal/services/integrationtesting/benchmark_executors_test.go
@@ -34,6 +34,7 @@ var executorScenarios = []string{
 	"DoubleWideArrow",
 	"DeepArrow",
 	"LookupIntersection",
+	"ShareWith",
 }
 
 // classicDispatchDepthRemaining matches the convention used elsewhere in the

--- a/internal/services/v1/permissions_queryplan.go
+++ b/internal/services/v1/permissions_queryplan.go
@@ -71,6 +71,13 @@ func (ps *permissionServer) checkPermissionWithQueryPlan(ctx context.Context, re
 		return nil, ps.rewriteError(ctx, err)
 	}
 
+	// Tag dispatch-eligible aliases by wrapping them in DispatchIterator, run
+	// after the standard optimizer set so the wrap sees the post-optimizer tree.
+	optimized, err = dispatch.ApplyDispatchWrap(optimized, queryParams)
+	if err != nil {
+		return nil, ps.rewriteError(ctx, err)
+	}
+
 	// Apply count-based advisor if stats have been accumulated from prior requests.
 	optimized, err = ps.queryPlanMetadata.ApplyAdvisor(optimized)
 	if err != nil {
@@ -206,6 +213,13 @@ func (ps *permissionServer) lookupResourcesWithQueryPlan(req *v1.LookupResources
 		return ps.rewriteError(ctx, err)
 	}
 
+	// Tag dispatch-eligible aliases by wrapping them in DispatchIterator, run
+	// after the standard optimizer set so the wrap sees the post-optimizer tree.
+	optimized, err = dispatch.ApplyDispatchWrap(optimized, queryParams)
+	if err != nil {
+		return ps.rewriteError(ctx, err)
+	}
+
 	// Apply count-based advisor if stats have been accumulated from prior requests.
 	optimized, err = ps.queryPlanMetadata.ApplyAdvisor(optimized)
 	if err != nil {
@@ -330,6 +344,13 @@ func (ps *permissionServer) lookupSubjectsWithQueryPlan(req *v1.LookupSubjectsRe
 		SubjectRelation: cmp.Or(req.OptionalSubjectRelation, tuple.Ellipsis),
 	}
 	optimized, err := queryopt.ApplyOptimizations(co, queryopt.OptimizersForRequest(queryParams), queryParams)
+	if err != nil {
+		return ps.rewriteError(ctx, err)
+	}
+
+	// Tag dispatch-eligible aliases by wrapping them in DispatchIterator, run
+	// after the standard optimizer set so the wrap sees the post-optimizer tree.
+	optimized, err = dispatch.ApplyDispatchWrap(optimized, queryParams)
 	if err != nil {
 		return ps.rewriteError(ctx, err)
 	}

--- a/pkg/middleware/dispatcher/dispatcher_test.go
+++ b/pkg/middleware/dispatcher/dispatcher_test.go
@@ -54,6 +54,10 @@ func (m *fakeDispatcher) DispatchQueryPlan(_ *v1.DispatchQueryPlanRequest, _ dis
 	return nil
 }
 
+func (m *fakeDispatcher) LookupPlanCheck(_ context.Context, _ dispatch.PlanCheckLookup) (*v1.ResultPath, bool, error) {
+	return nil, false, nil
+}
+
 func (m *fakeDispatcher) Close() error {
 	return nil
 }

--- a/pkg/proto/dispatch/v1/dispatch.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch.pb.go
@@ -1839,9 +1839,14 @@ func (x *PlanContext) GetTopLevelOperation() PlanOperation {
 }
 
 type DispatchQueryPlanRequest struct {
-	state        protoimpl.MessageState `protogen:"open.v1"`
-	Operation    PlanOperation          `protobuf:"varint,1,opt,name=operation,proto3,enum=dispatch.v1.PlanOperation" json:"operation,omitempty"`
-	CanonicalKey string                 `protobuf:"bytes,2,opt,name=canonical_key,json=canonicalKey,proto3" json:"canonical_key,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Operation PlanOperation          `protobuf:"varint,1,opt,name=operation,proto3,enum=dispatch.v1.PlanOperation" json:"operation,omitempty"`
+	// canonical_key is superseded by `plan`: the iterator subtree now travels
+	// on the wire and the receiver no longer needs to rebuild it from this key.
+	// Retained for in-progress cycle bookkeeping that already keys on it.
+	//
+	// Deprecated: Marked as deprecated in dispatch/v1/dispatch.proto.
+	CanonicalKey string `protobuf:"bytes,2,opt,name=canonical_key,json=canonicalKey,proto3" json:"canonical_key,omitempty"`
 	// For CHECK_MANY_RESOURCES, resource is empty and `many` carries the resources.
 	Resource *v1.ObjectAndRelation `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
 	// For CHECK_MANY_SUBJECTS, subject is empty and `many` carries the subjects.
@@ -1849,7 +1854,12 @@ type DispatchQueryPlanRequest struct {
 	PlanContext *PlanContext          `protobuf:"bytes,5,opt,name=plan_context,json=planContext,proto3" json:"plan_context,omitempty"`
 	// many takes the place of resource or subject (whichever is empty), used by
 	// PLAN_OPERATION_CHECK_MANY_RESOURCES and PLAN_OPERATION_CHECK_MANY_SUBJECTS.
-	Many          []*v1.ObjectAndRelation `protobuf:"bytes,6,rep,name=many,proto3" json:"many,omitempty"`
+	Many []*v1.ObjectAndRelation `protobuf:"bytes,6,rep,name=many,proto3" json:"many,omitempty"`
+	// plan is the iterator subtree to execute, serialized via the pkg/query
+	// wire format. The receiver loads the schema indicated by plan_context and
+	// deserializes the plan in that schema; it executes the deserialized
+	// iterator directly rather than rebuilding from canonical_key.
+	Plan          []byte `protobuf:"bytes,7,opt,name=plan,proto3" json:"plan,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1891,6 +1901,7 @@ func (x *DispatchQueryPlanRequest) GetOperation() PlanOperation {
 	return PlanOperation_PLAN_OPERATION_CHECK
 }
 
+// Deprecated: Marked as deprecated in dispatch/v1/dispatch.proto.
 func (x *DispatchQueryPlanRequest) GetCanonicalKey() string {
 	if x != nil {
 		return x.CanonicalKey
@@ -1922,6 +1933,13 @@ func (x *DispatchQueryPlanRequest) GetPlanContext() *PlanContext {
 func (x *DispatchQueryPlanRequest) GetMany() []*v1.ObjectAndRelation {
 	if x != nil {
 		return x.Many
+	}
+	return nil
+}
+
+func (x *DispatchQueryPlanRequest) GetPlan() []byte {
+	if x != nil {
+		return x.Plan
 	}
 	return nil
 }
@@ -2318,14 +2336,15 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\vschema_hash\x18\x05 \x01(\fR\n" +
 	"schemaHash\x12(\n" +
 	"\x10in_progress_keys\x18\x06 \x03(\tR\x0einProgressKeys\x12J\n" +
-	"\x13top_level_operation\x18\a \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\x11topLevelOperation\"\xd4\x02\n" +
+	"\x13top_level_operation\x18\a \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\x11topLevelOperation\"\xec\x02\n" +
 	"\x18DispatchQueryPlanRequest\x128\n" +
-	"\toperation\x18\x01 \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\toperation\x12#\n" +
-	"\rcanonical_key\x18\x02 \x01(\tR\fcanonicalKey\x126\n" +
+	"\toperation\x18\x01 \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\toperation\x12'\n" +
+	"\rcanonical_key\x18\x02 \x01(\tB\x02\x18\x01R\fcanonicalKey\x126\n" +
 	"\bresource\x18\x03 \x01(\v2\x1a.core.v1.ObjectAndRelationR\bresource\x124\n" +
 	"\asubject\x18\x04 \x01(\v2\x1a.core.v1.ObjectAndRelationR\asubject\x12;\n" +
 	"\fplan_context\x18\x05 \x01(\v2\x18.dispatch.v1.PlanContextR\vplanContext\x12.\n" +
-	"\x04many\x18\x06 \x03(\v2\x1a.core.v1.ObjectAndRelationR\x04many\"\x81\x01\n" +
+	"\x04many\x18\x06 \x03(\v2\x1a.core.v1.ObjectAndRelationR\x04many\x12\x12\n" +
+	"\x04plan\x18\a \x01(\fR\x04plan\"\x81\x01\n" +
 	"\x19DispatchQueryPlanResponse\x125\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x19.dispatch.v1.ResponseMetaR\bmetadata\x12-\n" +
 	"\x05paths\x18\x02 \x03(\v2\x17.dispatch.v1.ResultPathR\x05paths\"\x83\x04\n" +

--- a/pkg/proto/dispatch/v1/dispatch.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch.pb.go
@@ -1841,12 +1841,6 @@ func (x *PlanContext) GetTopLevelOperation() PlanOperation {
 type DispatchQueryPlanRequest struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
 	Operation PlanOperation          `protobuf:"varint,1,opt,name=operation,proto3,enum=dispatch.v1.PlanOperation" json:"operation,omitempty"`
-	// canonical_key is superseded by `plan`: the iterator subtree now travels
-	// on the wire and the receiver no longer needs to rebuild it from this key.
-	// Retained for in-progress cycle bookkeeping that already keys on it.
-	//
-	// Deprecated: Marked as deprecated in dispatch/v1/dispatch.proto.
-	CanonicalKey string `protobuf:"bytes,2,opt,name=canonical_key,json=canonicalKey,proto3" json:"canonical_key,omitempty"`
 	// For CHECK_MANY_RESOURCES, resource is empty and `many` carries the resources.
 	Resource *v1.ObjectAndRelation `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
 	// For CHECK_MANY_SUBJECTS, subject is empty and `many` carries the subjects.
@@ -1858,7 +1852,7 @@ type DispatchQueryPlanRequest struct {
 	// plan is the iterator subtree to execute, serialized via the pkg/query
 	// wire format. The receiver loads the schema indicated by plan_context and
 	// deserializes the plan in that schema; it executes the deserialized
-	// iterator directly rather than rebuilding from canonical_key.
+	// iterator directly.
 	Plan          []byte `protobuf:"bytes,7,opt,name=plan,proto3" json:"plan,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1899,14 +1893,6 @@ func (x *DispatchQueryPlanRequest) GetOperation() PlanOperation {
 		return x.Operation
 	}
 	return PlanOperation_PLAN_OPERATION_CHECK
-}
-
-// Deprecated: Marked as deprecated in dispatch/v1/dispatch.proto.
-func (x *DispatchQueryPlanRequest) GetCanonicalKey() string {
-	if x != nil {
-		return x.CanonicalKey
-	}
-	return ""
 }
 
 func (x *DispatchQueryPlanRequest) GetResource() *v1.ObjectAndRelation {
@@ -2336,15 +2322,14 @@ const file_dispatch_v1_dispatch_proto_rawDesc = "" +
 	"\vschema_hash\x18\x05 \x01(\fR\n" +
 	"schemaHash\x12(\n" +
 	"\x10in_progress_keys\x18\x06 \x03(\tR\x0einProgressKeys\x12J\n" +
-	"\x13top_level_operation\x18\a \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\x11topLevelOperation\"\xec\x02\n" +
+	"\x13top_level_operation\x18\a \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\x11topLevelOperation\"\xd8\x02\n" +
 	"\x18DispatchQueryPlanRequest\x128\n" +
-	"\toperation\x18\x01 \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\toperation\x12'\n" +
-	"\rcanonical_key\x18\x02 \x01(\tB\x02\x18\x01R\fcanonicalKey\x126\n" +
+	"\toperation\x18\x01 \x01(\x0e2\x1a.dispatch.v1.PlanOperationR\toperation\x126\n" +
 	"\bresource\x18\x03 \x01(\v2\x1a.core.v1.ObjectAndRelationR\bresource\x124\n" +
 	"\asubject\x18\x04 \x01(\v2\x1a.core.v1.ObjectAndRelationR\asubject\x12;\n" +
 	"\fplan_context\x18\x05 \x01(\v2\x18.dispatch.v1.PlanContextR\vplanContext\x12.\n" +
 	"\x04many\x18\x06 \x03(\v2\x1a.core.v1.ObjectAndRelationR\x04many\x12\x12\n" +
-	"\x04plan\x18\a \x01(\fR\x04plan\"\x81\x01\n" +
+	"\x04plan\x18\a \x01(\fR\x04planJ\x04\b\x02\x10\x03R\rcanonical_key\"\x81\x01\n" +
 	"\x19DispatchQueryPlanResponse\x125\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x19.dispatch.v1.ResponseMetaR\bmetadata\x12-\n" +
 	"\x05paths\x18\x02 \x03(\v2\x17.dispatch.v1.ResultPathR\x05paths\"\x83\x04\n" +

--- a/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
@@ -681,7 +681,6 @@ func (m *DispatchQueryPlanRequest) CloneVT() *DispatchQueryPlanRequest {
 	}
 	r := new(DispatchQueryPlanRequest)
 	r.Operation = m.Operation
-	r.CanonicalKey = m.CanonicalKey
 	r.PlanContext = m.PlanContext.CloneVT()
 	if rhs := m.Resource; rhs != nil {
 		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *v1.ObjectAndRelation }); ok {
@@ -1740,9 +1739,6 @@ func (this *DispatchQueryPlanRequest) EqualVT(that *DispatchQueryPlanRequest) bo
 		return false
 	}
 	if this.Operation != that.Operation {
-		return false
-	}
-	if this.CanonicalKey != that.CanonicalKey {
 		return false
 	}
 	if equal, ok := interface{}(this.Resource).(interface {
@@ -3786,13 +3782,6 @@ func (m *DispatchQueryPlanRequest) MarshalToSizedBufferVT(dAtA []byte) (int, err
 		i--
 		dAtA[i] = 0x1a
 	}
-	if len(m.CanonicalKey) > 0 {
-		i -= len(m.CanonicalKey)
-		copy(dAtA[i:], m.CanonicalKey)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CanonicalKey)))
-		i--
-		dAtA[i] = 0x12
-	}
 	if m.Operation != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Operation))
 		i--
@@ -4777,10 +4766,6 @@ func (m *DispatchQueryPlanRequest) SizeVT() (n int) {
 	_ = l
 	if m.Operation != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Operation))
-	}
-	l = len(m.CanonicalKey)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if m.Resource != nil {
 		if size, ok := interface{}(m.Resource).(interface {
@@ -9240,38 +9225,6 @@ func (m *DispatchQueryPlanRequest) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field CanonicalKey", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.CanonicalKey = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Resource", wireType)

--- a/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
+++ b/pkg/proto/dispatch/v1/dispatch_vtproto.pb.go
@@ -708,6 +708,11 @@ func (m *DispatchQueryPlanRequest) CloneVT() *DispatchQueryPlanRequest {
 		}
 		r.Many = tmpContainer
 	}
+	if rhs := m.Plan; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.Plan = tmpBytes
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1783,6 +1788,9 @@ func (this *DispatchQueryPlanRequest) EqualVT(that *DispatchQueryPlanRequest) bo
 				return false
 			}
 		}
+	}
+	if string(this.Plan) != string(that.Plan) {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -3693,6 +3701,13 @@ func (m *DispatchQueryPlanRequest) MarshalToSizedBufferVT(dAtA []byte) (int, err
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.Plan) > 0 {
+		i -= len(m.Plan)
+		copy(dAtA[i:], m.Plan)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Plan)))
+		i--
+		dAtA[i] = 0x3a
+	}
 	if len(m.Many) > 0 {
 		for iNdEx := len(m.Many) - 1; iNdEx >= 0; iNdEx-- {
 			if vtmsg, ok := interface{}(m.Many[iNdEx]).(interface {
@@ -4802,6 +4817,10 @@ func (m *DispatchQueryPlanRequest) SizeVT() (n int) {
 			}
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	l = len(m.Plan)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9417,6 +9436,40 @@ func (m *DispatchQueryPlanRequest) UnmarshalVT(dAtA []byte) error {
 				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Many[len(m.Many)-1]); err != nil {
 					return err
 				}
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Plan", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Plan = append(m.Plan[:0], dAtA[iNdEx:postIndex]...)
+			if m.Plan == nil {
+				m.Plan = []byte{}
 			}
 			iNdEx = postIndex
 		default:

--- a/pkg/query/alias.go
+++ b/pkg/query/alias.go
@@ -345,7 +345,7 @@ func (a *AliasIterator) SubjectTypes() ([]ObjectType, error) {
 const aliasFlagHasAliasedAs = 0
 
 func (a *AliasIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, AliasIteratorType, a.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, AliasIteratorType, a.canonicalKey, func(buf io.Writer) error {
 		var flags uint64
 		setFlag(&flags, aliasFlagHasAliasedAs, len(a.aliasedAs) > 0)
 		if err := writeUvarint(buf, flags); err != nil {

--- a/pkg/query/arrow.go
+++ b/pkg/query/arrow.go
@@ -705,7 +705,7 @@ const (
 )
 
 func (a *ArrowIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, ArrowIteratorType, a.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, ArrowIteratorType, a.canonicalKey, func(buf io.Writer) error {
 		var flags uint64
 		setFlag(&flags, arrowFlagSchemaArrow, a.isSchemaArrow)
 		setFlag(&flags, arrowFlagRightToLeft, a.direction == rightToLeft)

--- a/pkg/query/caveat.go
+++ b/pkg/query/caveat.go
@@ -310,7 +310,7 @@ func (c *CaveatIterator) buildExplainInfo() string {
 const caveatFlagHasCaveat = 0
 
 func (c *CaveatIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, CaveatIteratorType, c.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, CaveatIteratorType, c.canonicalKey, func(buf io.Writer) error {
 		var flags uint64
 		setFlag(&flags, caveatFlagHasCaveat, c.caveat != nil)
 		if err := writeUvarint(buf, flags); err != nil {

--- a/pkg/query/datastore.go
+++ b/pkg/query/datastore.go
@@ -488,7 +488,7 @@ const (
 )
 
 func (r *DatastoreIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, DatastoreIteratorType, r.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, DatastoreIteratorType, r.canonicalKey, func(buf io.Writer) error {
 		var flags uint64
 		setFlag(&flags, dsFlagCaveat, r.base.Caveat() != "")
 		setFlag(&flags, dsFlagExpiration, r.base.Expiration())

--- a/pkg/query/exclusion.go
+++ b/pkg/query/exclusion.go
@@ -416,7 +416,7 @@ func (e *ExclusionIterator) SubjectTypes() ([]ObjectType, error) {
 }
 
 func (e *ExclusionIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, ExclusionIteratorType, e.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, ExclusionIteratorType, e.canonicalKey, func(buf io.Writer) error {
 		if err := writeUvarint(buf, 0); err != nil {
 			return err
 		}

--- a/pkg/query/fixed.go
+++ b/pkg/query/fixed.go
@@ -227,11 +227,11 @@ func (f *FixedIterator) Serialize(w io.Writer) error {
 	// Empty FixedIterator decompiles to NullIteratorType; emit Null on the wire
 	// so the receiver reconstructs the same shape.
 	if len(f.paths) == 0 {
-		return serializeWithHeader(w, NullIteratorType, f.canonicalKey, func(buf io.Writer) error {
+		return SerializeWithHeader(w, NullIteratorType, f.canonicalKey, func(buf io.Writer) error {
 			return writeUvarint(buf, 0)
 		})
 	}
-	return serializeWithHeader(w, FixedIteratorType, f.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, FixedIteratorType, f.canonicalKey, func(buf io.Writer) error {
 		var flags uint64
 		setFlag(&flags, fixedFlagHasPaths, len(f.paths) > 0)
 		if err := writeUvarint(buf, flags); err != nil {

--- a/pkg/query/intersection.go
+++ b/pkg/query/intersection.go
@@ -491,7 +491,7 @@ func (i *IntersectionIterator) SubjectTypes() ([]ObjectType, error) {
 }
 
 func (i *IntersectionIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, IntersectionIteratorType, i.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, IntersectionIteratorType, i.canonicalKey, func(buf io.Writer) error {
 		if err := writeUvarint(buf, 0); err != nil {
 			return err
 		}

--- a/pkg/query/intersection_arrow.go
+++ b/pkg/query/intersection_arrow.go
@@ -467,7 +467,7 @@ func (ia *IntersectionArrowIterator) SubjectTypes() ([]ObjectType, error) {
 }
 
 func (ia *IntersectionArrowIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, IntersectionArrowIteratorType, ia.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, IntersectionArrowIteratorType, ia.canonicalKey, func(buf io.Writer) error {
 		if err := writeUvarint(buf, 0); err != nil {
 			return err
 		}

--- a/pkg/query/recursive.go
+++ b/pkg/query/recursive.go
@@ -726,7 +726,7 @@ func (r *RecursiveIterator) recursiveCheckIterResources(ctx *Context, resource O
 const recursiveFlagStrategy = 0 // strategy byte follows if set (default == iter-subjects)
 
 func (r *RecursiveIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, RecursiveIteratorType, r.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, RecursiveIteratorType, r.canonicalKey, func(buf io.Writer) error {
 		var flags uint64
 		nonDefault := r.checkStrategy != recursiveCheckIterSubjects
 		setFlag(&flags, recursiveFlagStrategy, nonDefault)

--- a/pkg/query/recursive_sentinel.go
+++ b/pkg/query/recursive_sentinel.go
@@ -158,7 +158,7 @@ func (r *RecursiveSentinelIterator) SubjectTypes() ([]ObjectType, error) {
 const sentinelFlagWithSubRelations = 0
 
 func (r *RecursiveSentinelIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, RecursiveSentinelIteratorType, r.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, RecursiveSentinelIteratorType, r.canonicalKey, func(buf io.Writer) error {
 		var flags uint64
 		setFlag(&flags, sentinelFlagWithSubRelations, r.withSubRelations)
 		if err := writeUvarint(buf, flags); err != nil {

--- a/pkg/query/self.go
+++ b/pkg/query/self.go
@@ -129,7 +129,7 @@ func (s *SelfIterator) SubjectTypes() ([]ObjectType, error) {
 }
 
 func (s *SelfIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, SelfIteratorType, s.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, SelfIteratorType, s.canonicalKey, func(buf io.Writer) error {
 		if err := writeUvarint(buf, 0); err != nil {
 			return err
 		}

--- a/pkg/query/serde.go
+++ b/pkg/query/serde.go
@@ -90,12 +90,15 @@ func writeHeader(w io.Writer, t IteratorType, key CanonicalKey) error {
 	return writeString(w, string(key))
 }
 
-// serializeWithHeader emits the header and then invokes writeBody to write the
+// SerializeWithHeader emits the header and then invokes writeBody to write the
 // type-specific body straight into w — no intermediate buffer. (An earlier
 // version built the body in a pooled bytes.Buffer so we could length-prefix
 // it; we dropped the length prefix to let the decode side avoid a per-node
 // allocation, which also lets the encode side skip the staging buffer.)
-func serializeWithHeader(w io.Writer, t IteratorType, key CanonicalKey, writeBody func(io.Writer) error) error {
+//
+// Exported for external iterators registered via MustRegisterIterator that
+// need to emit their own bodies with the same framing as the built-ins.
+func SerializeWithHeader(w io.Writer, t IteratorType, key CanonicalKey, writeBody func(io.Writer) error) error {
 	if err := writeHeader(w, t, key); err != nil {
 		return err
 	}

--- a/pkg/query/union.go
+++ b/pkg/query/union.go
@@ -227,7 +227,7 @@ func (u *UnionIterator) SubjectTypes() ([]ObjectType, error) {
 }
 
 func (u *UnionIterator) Serialize(w io.Writer) error {
-	return serializeWithHeader(w, UnionIteratorType, u.canonicalKey, func(buf io.Writer) error {
+	return SerializeWithHeader(w, UnionIteratorType, u.canonicalKey, func(buf io.Writer) error {
 		if err := writeUvarint(buf, 0); err != nil { // flags reserved
 			return err
 		}

--- a/proto/internal/dispatch/v1/dispatch.proto
+++ b/proto/internal/dispatch/v1/dispatch.proto
@@ -258,10 +258,12 @@ message PlanContext {
 
 message DispatchQueryPlanRequest {
   PlanOperation operation = 1;
-  // canonical_key is superseded by `plan`: the iterator subtree now travels
-  // on the wire and the receiver no longer needs to rebuild it from this key.
-  // Retained for in-progress cycle bookkeeping that already keys on it.
-  string canonical_key = 2 [deprecated = true];
+  // Tag 2 was `string canonical_key`, removed once `plan` carried the
+  // iterator subtree on the wire and the sender-side caching/routing layers
+  // were taught to read the current dispatch's "def#rel" key from the last
+  // entry of PlanContext.in_progress_keys instead.
+  reserved 2;
+  reserved "canonical_key";
   // For CHECK_MANY_RESOURCES, resource is empty and `many` carries the resources.
   core.v1.ObjectAndRelation resource = 3;
   // For CHECK_MANY_SUBJECTS, subject is empty and `many` carries the subjects.
@@ -273,7 +275,7 @@ message DispatchQueryPlanRequest {
   // plan is the iterator subtree to execute, serialized via the pkg/query
   // wire format. The receiver loads the schema indicated by plan_context and
   // deserializes the plan in that schema; it executes the deserialized
-  // iterator directly rather than rebuilding from canonical_key.
+  // iterator directly.
   bytes plan = 7;
 }
 

--- a/proto/internal/dispatch/v1/dispatch.proto
+++ b/proto/internal/dispatch/v1/dispatch.proto
@@ -258,7 +258,10 @@ message PlanContext {
 
 message DispatchQueryPlanRequest {
   PlanOperation operation = 1;
-  string canonical_key = 2;
+  // canonical_key is superseded by `plan`: the iterator subtree now travels
+  // on the wire and the receiver no longer needs to rebuild it from this key.
+  // Retained for in-progress cycle bookkeeping that already keys on it.
+  string canonical_key = 2 [deprecated = true];
   // For CHECK_MANY_RESOURCES, resource is empty and `many` carries the resources.
   core.v1.ObjectAndRelation resource = 3;
   // For CHECK_MANY_SUBJECTS, subject is empty and `many` carries the subjects.
@@ -267,6 +270,11 @@ message DispatchQueryPlanRequest {
   // many takes the place of resource or subject (whichever is empty), used by
   // PLAN_OPERATION_CHECK_MANY_RESOURCES and PLAN_OPERATION_CHECK_MANY_SUBJECTS.
   repeated core.v1.ObjectAndRelation many = 6;
+  // plan is the iterator subtree to execute, serialized via the pkg/query
+  // wire format. The receiver loads the schema indicated by plan_context and
+  // deserializes the plan in that schema; it executes the deserialized
+  // iterator directly rather than rebuilding from canonical_key.
+  bytes plan = 7;
 }
 
 message DispatchQueryPlanResponse {


### PR DESCRIPTION
## Description

This PR uses the new hand-written plan serializers to improve query plan dispatch, and make dispatch agnostic to any particular boundary. We maintain the logic of when to dispatch (eg, on Alias boundaries) but this is now factored out as an optimizer, which introduces dispatch boundaries as Dispatch iterators themselves.

Doing this has a performance benefit -- we're not regenerating the plan all the time. This amounts to a mild time benefit against real datastores, but a solid memory improvement. The reason it's better for memory stores in terms of query speed being that we're still over-dispatching (so the benefit is in the noise) because our choice of boundary is non ideal. But; that's why that choice has been factored out for the future changes.

## Testing
### Main

| Engine | Scenario | dispatch ns/op | dispatch B/op | dispatch allocs | qp_dispatch ns/op | qp_dispatch B/op | qp_dispatch allocs |
|---|---|---:|---:|---:|---:|---:|---:|
| memory | WideArrow | 73.37µs | 43.48KiB | 599 | 101.29µs | 49.36KiB | 1.02k |
| memory | DoubleWideArrow | 141.22µs | 92.77KiB | 1.04k | 430.33µs | 127.80KiB | 2.73k |
| memory | DeepArrow | 797.50µs | 715.42KiB | 14.74k | 307.02µs | 518.95KiB | 10.76k |
| memory | LookupIntersection | 61.65µs | 52.62KiB | 1.08k | 112.78µs | 164.13KiB | 3.17k |
| memory | ShareWith | 42.04µs | 94.55KiB | 2.06k | 386.91µs | 836.30KiB | 12.92k |
| postgres | WideArrow | 1.33ms | 127.99KiB | 1.88k | 1.54ms | 147.29KiB | 2.37k |
| postgres | DoubleWideArrow | 2.53ms | 239.28KiB | 3.83k | 5.78ms | 513.85KiB | 8.01k |
| postgres | DeepArrow | 19.84ms | 2.41MiB | 38.63k | 19.59ms | 1.75MiB | 28.30k |
| postgres | LookupIntersection | 1.36ms | 172.15KiB | 2.72k | 2.54ms | 299.52KiB | 5.01k |
| postgres | ShareWith | 1.38ms | 321.05KiB | 5.05k | 2.31ms | 973.37KiB | 14.80k |
| cockroachdb | WideArrow | 1.64ms | 114.38KiB | 1.62k | 1.86ms | 131.44KiB | 2.10k |
| cockroachdb | DoubleWideArrow | 3.90ms | 214.11KiB | 3.43k | 6.28ms | 456.47KiB | 7.17k |
| cockroachdb | DeepArrow | 25.88ms | 2.08MiB | 32.64k | 25.62ms | 1.60MiB | 25.06k |
| cockroachdb | LookupIntersection | 1.78ms | 148.74KiB | 2.31k | 3.34ms | 274.17KiB | 4.53k |
| cockroachdb | ShareWith | 1.77ms | 279.29KiB | 4.38k | 2.84ms | 959.68KiB | 14.52k |

### Branch (`barakmich/serialize_dispatch`)

| Engine | Scenario | dispatch ns/op | dispatch B/op | dispatch allocs | qp_dispatch ns/op | qp_dispatch B/op | qp_dispatch allocs |
|---|---|---:|---:|---:|---:|---:|---:|
| memory | WideArrow | 73.28µs | 43.48KiB | 599 | 90.25µs | 37.55KiB | 832 |
| memory | DoubleWideArrow | 139.95µs | 92.77KiB | 1.04k | 406.28µs | 107.27KiB | 2.34k |
| memory | DeepArrow | 782.44µs | 715.40KiB | 14.74k | 248.12µs | 445.44KiB | 10.09k |
| memory | LookupIntersection | 59.62µs | 52.62KiB | 1.08k | 75.33µs | 120.95KiB | 2.39k |
| memory | ShareWith | 41.60µs | 94.79KiB | 2.07k | 114.87µs | 349.15KiB | 3.90k |
| postgres | WideArrow | 1.33ms | 127.99KiB | 1.88k | 1.54ms | 135.47KiB | 2.18k |
| postgres | DoubleWideArrow | 2.58ms | 239.29KiB | 3.83k | 5.76ms | 493.28KiB | 7.62k |
| postgres | DeepArrow | 19.48ms | 2.41MiB | 38.62k | 19.30ms | 1.68MiB | 27.63k |
| postgres | LookupIntersection | 1.34ms | 172.16KiB | 2.72k | 2.48ms | 256.29KiB | 4.23k |
| postgres | ShareWith | 1.38ms | 321.02KiB | 5.05k | 2.00ms | 486.18KiB | 5.78k |
| cockroachdb | WideArrow | 1.64ms | 114.44KiB | 1.62k | 1.89ms | 119.57KiB | 1.91k |
| cockroachdb | DoubleWideArrow | 3.93ms | 214.06KiB | 3.43k | 6.33ms | 435.90KiB | 6.78k |
| cockroachdb | DeepArrow | 25.77ms | 2.08MiB | 32.64k | 25.83ms | 1.52MiB | 24.39k |
| cockroachdb | LookupIntersection | 1.77ms | 148.72KiB | 2.31k | 3.31ms | 231.01KiB | 3.75k |
| cockroachdb | ShareWith | 1.77ms | 279.25KiB | 4.38k | 2.54ms | 472.56KiB | 5.49k |

### Branch vs main (% change, negative = improvement)

| Engine | Scenario | dispatch ns/op | dispatch B/op | dispatch allocs | qp_dispatch ns/op | qp_dispatch B/op | qp_dispatch allocs |
|---|---|---:|---:|---:|---:|---:|---:|
| memory | WideArrow | -0.1% | +0.0% | +0.0% | -10.9% | -23.9% | -18.4% |
| memory | DoubleWideArrow | -0.9% | +0.0% | +0.0% | -5.6% | -16.1% | -14.2% |
| memory | DeepArrow | -1.9% | -0.0% | -0.0% | -19.2% | -14.2% | -6.2% |
| memory | LookupIntersection | -3.3% | -0.0% | +0.0% | -33.2% | -26.3% | -24.6% |
| memory | ShareWith | -1.0% | +0.3% | +0.2% | -70.3% | -58.3% | -69.8% |
| postgres | WideArrow | +0.5% | -0.0% | +0.0% | +0.1% | -8.0% | -7.9% |
| postgres | DoubleWideArrow | +1.9% | +0.0% | +0.0% | -0.3% | -4.0% | -4.8% |
| postgres | DeepArrow | -1.8% | -0.0% | -0.0% | -1.5% | -4.1% | -2.4% |
| postgres | LookupIntersection | -1.7% | +0.0% | +0.0% | -2.3% | -14.4% | -15.6% |
| postgres | ShareWith | -0.2% | -0.0% | -0.0% | -13.6% | -50.1% | -61.0% |
| cockroachdb | WideArrow | +0.1% | +0.1% | +0.0% | +1.3% | -9.0% | -8.9% |
| cockroachdb | DoubleWideArrow | +0.7% | -0.0% | +0.0% | +0.8% | -4.5% | -5.4% |
| cockroachdb | DeepArrow | -0.4% | -0.0% | -0.0% | +0.8% | -4.5% | -2.7% |
| cockroachdb | LookupIntersection | -0.7% | -0.0% | +0.0% | -1.1% | -15.7% | -17.2% |
| cockroachdb | ShareWith | -0.0% | -0.0% | -0.0% | -10.5% | -50.8% | -62.2% |

