### PR TITLE
fix(schemacache): supervisor recovers from transient watch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cache: switch to [otter](https://maypok86.github.io/otter/) as the primary cache implementation (https://github.com/authzed/spicedb/pull/3112)
 
 ### Fixed
+- The watching schema cache (`--enable-experimental-watchable-schema-cache`) no longer enters permanent fallback on transient watch errors. A new supervisor restarts the watch cycle with bounded exponential backoff and only treats caller-driven cancellation or unsupported-watch as terminal (https://github.com/authzed/spicedb/pull/3134)
 - Watch consumers that request `WatchCheckpoints` now eventually observe every revision returned by `WriteRelationships` as a checkpoint. MemDB regressed this in https://github.com/authzed/spicedb/pull/2578 for no-op writes and MySQL never emitted checkpoints at all prior to now. Both now emit a checkpoint at the new revision. (https://github.com/authzed/spicedb/pull/3114)
 - When Query Planner evaluates a union, short-circuit if one of the branches yields a positive un-caveated result (https://github.com/authzed/spicedb/pull/3120)
 - DispatchQueryPlan previously did not try to use the singleflight middleware for check calls. (https://github.com/authzed/spicedb/pull/3119)

--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/prometheus/client_golang/prometheus"
 
-	pgxcommon "github.com/authzed/spicedb/internal/datastore/postgres/common"
 	"github.com/authzed/spicedb/internal/datastore/revisions"
 	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/cache"
@@ -54,10 +54,80 @@ var definitionsReadTotalCounter = prometheus.NewCounterVec(prometheus.CounterOpt
 	Help:      "total number of definitions read from the watching cache",
 }, []string{"definition_kind"})
 
-const maximumRetryCount = 10
+var cycleRestartsCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	Namespace: "spicedb",
+	Subsystem: "datastore",
+	Name:      "watching_schema_cache_cycle_restarts_total",
+	Help:      "Times the watching schema cache restarted its watch cycle (initial cycle excluded). A high or growing rate indicates a flapping watch.",
+})
+
+var lastEventTimestampGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: "spicedb",
+	Subsystem: "datastore",
+	Name:      "watching_schema_cache_last_event_timestamp_seconds",
+	Help:      "UNIX timestamp (fractional seconds) of the last event consumed from the schema watch. Use `time() - <metric>` for time-since-last-event.",
+})
 
 func init() {
-	prometheus.MustRegister(namespacesFallbackModeGauge, caveatsFallbackModeGauge, schemaCacheRevisionGauge, definitionsReadCachedCounter, definitionsReadTotalCounter)
+	prometheus.MustRegister(
+		namespacesFallbackModeGauge,
+		caveatsFallbackModeGauge,
+		schemaCacheRevisionGauge,
+		definitionsReadCachedCounter,
+		definitionsReadTotalCounter,
+		cycleRestartsCounter,
+		lastEventTimestampGauge,
+	)
+}
+
+// isTerminalWatchError reports whether err represents intentional shutdown
+// (caller cancellation or watch-unsupported); everything else is recoverable.
+func isTerminalWatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var canceled datastore.WatchCanceledError
+	if errors.As(err, &canceled) {
+		return true
+	}
+
+	var disabled datastore.WatchDisabledError
+	if errors.As(err, &disabled) {
+		return true
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	return false
+}
+
+// Do NOT switch to backoff.Retry: its default 15-minute MaxElapsedTime would
+// silently stop the supervisor.
+func newSupervisorBackoff() *backoff.ExponentialBackOff {
+	return &backoff.ExponentialBackOff{
+		InitialInterval:     100 * time.Millisecond,
+		Multiplier:          2.0,
+		RandomizationFactor: 0.5,
+		MaxInterval:         30 * time.Second,
+	}
+}
+
+// sleep returns false if ctx is canceled before d elapses.
+func sleep(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // watchingCachingProxy is a datastore proxy that caches schema (namespaces and caveat definitions)
@@ -152,19 +222,9 @@ func (p *watchingCachingProxy) Start(ctx context.Context) error {
 
 func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 	log.Info().Msg("starting watching cache")
-	headRevWithHash, err := p.HeadRevision(context.Background())
-	if err != nil {
-		p.namespaceCache.setFallbackMode()
-		p.caveatCache.setFallbackMode()
-		log.Warn().Err(err).Msg("received error in schema watch")
-		return err
-	}
-	headRev := headRevWithHash.Revision
 
-	// Start watching for expired entries to be GCed.
-	go (func() {
-		log.Debug().Str("revision", headRev.String()).Msg("starting watching cache GC goroutine")
-
+	go func() {
+		log.Debug().Msg("starting watching cache GC goroutine")
 		for {
 			select {
 			case <-ctx.Done():
@@ -182,178 +242,189 @@ func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 				log.Debug().Msg("schema watch gc operation completed")
 			}
 		}
-	})()
+	}()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	go func() {
+		bo := newSupervisorBackoff()
+		firstCycle := true
 
-	// Start watching for schema changes.
-	go (func() {
-		retryCount := uint8(0)
+		for ctx.Err() == nil {
+			if !firstCycle {
+				cycleRestartsCounter.Inc()
+			}
+			firstCycle = false
 
-	restartWatch:
-		for {
-			p.namespaceCache.reset()
-			p.caveatCache.reset()
-
-			log.Debug().Str("revision", headRev.String()).Msg("starting watching cache watch operation")
-			reader := p.Datastore.SnapshotReader(headRev)
-
-			// Populate the cache with all definitions at the head revision.
-			log.Info().Str("revision", headRev.String()).Msg("prepopulating namespace watching cache")
-			namespaces, err := reader.LegacyListAllNamespaces(ctx)
+			headRevWithHash, err := p.HeadRevision(ctx)
 			if err != nil {
 				p.namespaceCache.setFallbackMode()
 				p.caveatCache.setFallbackMode()
-				log.Warn().Err(err).Msg("received error in schema watch")
-				wg.Done()
-				return
-			}
-
-			for _, namespaceDef := range namespaces {
-				err := p.namespaceCache.updateDefinition(namespaceDef.Definition.Name, namespaceDef.Definition, false, headRev)
-				if err != nil {
-					p.namespaceCache.setFallbackMode()
-					p.caveatCache.setFallbackMode()
-					log.Warn().Err(err).Msg("received error in schema watch")
-					wg.Done()
+				if isTerminalWatchError(err) {
+					log.Warn().Err(err).Msg("schema watch HEAD lookup ended terminally; staying in fallback")
 					return
 				}
+				log.Warn().Err(err).Msg("schema watch HEAD lookup failed; backing off")
+				if !sleep(ctx, bo.NextBackOff()) {
+					return
+				}
+				continue
 			}
-			log.Info().Str("revision", headRev.String()).Int("count", len(namespaces)).Msg("populated namespace watching cache")
 
-			log.Info().Str("revision", headRev.String()).Msg("prepopulating caveat watching cache")
-			caveats, err := reader.LegacyListAllCaveats(ctx)
-			if err != nil {
+			cycleErr, consumedEvent := p.runWatchOnce(ctx, headRevWithHash.Revision)
+			if cycleErr != nil {
 				p.namespaceCache.setFallbackMode()
 				p.caveatCache.setFallbackMode()
-				log.Warn().Err(err).Msg("received error in schema watch")
-				wg.Done()
+			}
+			if isTerminalWatchError(cycleErr) {
+				log.Info().Err(cycleErr).Msg("schema watch ended terminally; staying in fallback")
 				return
 			}
-
-			for _, caveatDef := range caveats {
-				err := p.caveatCache.updateDefinition(caveatDef.Definition.Name, caveatDef.Definition, false, headRev)
-				if err != nil {
-					p.namespaceCache.setFallbackMode()
-					p.caveatCache.setFallbackMode()
-					log.Warn().Err(err).Msg("received error in schema watch")
-					wg.Done()
-					return
-				}
+			if cycleErr != nil {
+				log.Warn().Err(cycleErr).Msg("schema watch cycle ended; backing off")
 			}
-			log.Info().Str("revision", headRev.String()).Int("count", len(caveats)).Msg("populated caveat watching cache")
-
-			log.Debug().Str("revision", headRev.String()).Dur("watch-heartbeat", p.watchHeartbeat).Msg("beginning schema watch")
-			ssc, serrc := p.Watch(ctx, headRev, datastore.WatchOptions{
-				Content:            datastore.WatchSchema | datastore.WatchCheckpoints,
-				CheckpointInterval: p.watchHeartbeat,
-			})
-			spiceerrors.DebugAssertNotNilf(ssc, "ssc is nil")
-			spiceerrors.DebugAssertNotNilf(serrc, "serrc is nil")
-
-			log.Debug().Msg("schema watch started")
-
-			p.namespaceCache.startAtRevision(headRev)
-			p.caveatCache.startAtRevision(headRev)
-
-			wg.Done()
-
-			for {
-				select {
-				case <-ctx.Done():
-					log.Debug().Msg("schema watch closed due to context cancelation")
-					return
-
-				case <-p.closed:
-					log.Debug().Msg("schema watch closed")
-					return
-
-				case ss, ok := <-ssc:
-					if !ok {
-						return
-					}
-					log.Trace().
-						Bool("is-checkpoint", ss.IsCheckpoint).
-						Int("changed-definition-count", len(ss.ChangedDefinitions)).
-						Int("deleted-namespace-count", len(ss.DeletedNamespaces)).
-						Int("deleted-caveat-count", len(ss.DeletedCaveats)).
-						Msg("received update from schema watch")
-
-					if ss.IsCheckpoint {
-						if converted, ok := ss.Revision.(revisions.WithInexactFloat64); ok {
-							schemaCacheRevisionGauge.Set(converted.InexactFloat64())
-						}
-
-						p.namespaceCache.setCheckpointRevision(ss.Revision)
-						p.caveatCache.setCheckpointRevision(ss.Revision)
-						continue
-					}
-
-					// Apply the change to the interval tree entry.
-					for _, changeDef := range ss.ChangedDefinitions {
-						switch t := changeDef.(type) {
-						case *core.NamespaceDefinition:
-							err := p.namespaceCache.updateDefinition(t.Name, t, false, ss.Revision)
-							if err != nil {
-								p.namespaceCache.setFallbackMode()
-								log.Warn().Err(err).Msg("received error in schema watch")
-							}
-
-						case *core.CaveatDefinition:
-							err := p.caveatCache.updateDefinition(t.Name, t, false, ss.Revision)
-							if err != nil {
-								p.caveatCache.setFallbackMode()
-								log.Warn().Err(err).Msg("received error in schema watch")
-							}
-
-						default:
-							p.namespaceCache.setFallbackMode()
-							p.caveatCache.setFallbackMode()
-							log.Error().Msg("unknown change definition type")
-							return
-						}
-					}
-
-					for _, deletedNamespaceName := range ss.DeletedNamespaces {
-						err := p.namespaceCache.updateDefinition(deletedNamespaceName, nil, true, ss.Revision)
-						if err != nil {
-							p.namespaceCache.setFallbackMode()
-							log.Warn().Err(err).Msg("received error in schema watch")
-							break
-						}
-					}
-
-					for _, deletedCaveatName := range ss.DeletedCaveats {
-						err := p.caveatCache.updateDefinition(deletedCaveatName, nil, true, ss.Revision)
-						if err != nil {
-							p.caveatCache.setFallbackMode()
-							log.Warn().Err(err).Msg("received error in schema watch")
-							break
-						}
-					}
-
-				case err := <-serrc:
-					var retryable datastore.WatchRetryableError
-					if errors.As(err, &retryable) && retryCount <= maximumRetryCount {
-						log.Warn().Err(err).Msg("received retryable error in schema watch; sleeping for a bit and restarting watch")
-						retryCount++
-						wg.Add(1)
-						pgxcommon.SleepOnErr(ctx, err, retryCount)
-						continue restartWatch
-					}
-
-					p.namespaceCache.setFallbackMode()
-					p.caveatCache.setFallbackMode()
-					log.Warn().Err(err).Msg("received terminal error in schema watch; setting to permanent fallback mode")
-					return
-				}
+			if consumedEvent {
+				bo.Reset()
+			}
+			if !sleep(ctx, bo.NextBackOff()) {
+				return
 			}
 		}
-	})()
+	}()
 
-	wg.Wait()
 	return nil
+}
+
+// runWatchOnce performs one prepopulate-then-watch cycle. The boolean is true
+// if any event (change or checkpoint) was read from the watch channel — the
+// caller uses it to decide whether the next cycle should reset its backoff.
+func (p *watchingCachingProxy) runWatchOnce(ctx context.Context, headRev datastore.Revision) (error, bool) {
+	p.namespaceCache.reset()
+	p.caveatCache.reset()
+
+	log.Debug().Str("revision", headRev.String()).Msg("starting watching cache watch operation")
+	reader := p.Datastore.SnapshotReader(headRev)
+
+	log.Info().Str("revision", headRev.String()).Msg("prepopulating namespace watching cache")
+	namespaces, err := reader.LegacyListAllNamespaces(ctx)
+	if err != nil {
+		p.namespaceCache.setFallbackMode()
+		p.caveatCache.setFallbackMode()
+		return err, false
+	}
+	for _, namespaceDef := range namespaces {
+		if err := p.namespaceCache.updateDefinition(namespaceDef.Definition.Name, namespaceDef.Definition, false, headRev); err != nil {
+			p.namespaceCache.setFallbackMode()
+			p.caveatCache.setFallbackMode()
+			return err, false
+		}
+	}
+	log.Info().Str("revision", headRev.String()).Int("count", len(namespaces)).Msg("populated namespace watching cache")
+
+	log.Info().Str("revision", headRev.String()).Msg("prepopulating caveat watching cache")
+	caveats, err := reader.LegacyListAllCaveats(ctx)
+	if err != nil {
+		p.namespaceCache.setFallbackMode()
+		p.caveatCache.setFallbackMode()
+		return err, false
+	}
+	for _, caveatDef := range caveats {
+		if err := p.caveatCache.updateDefinition(caveatDef.Definition.Name, caveatDef.Definition, false, headRev); err != nil {
+			p.namespaceCache.setFallbackMode()
+			p.caveatCache.setFallbackMode()
+			return err, false
+		}
+	}
+	log.Info().Str("revision", headRev.String()).Int("count", len(caveats)).Msg("populated caveat watching cache")
+
+	log.Debug().Str("revision", headRev.String()).Dur("watch-heartbeat", p.watchHeartbeat).Msg("beginning schema watch")
+	ssc, serrc := p.Watch(ctx, headRev, datastore.WatchOptions{
+		Content:            datastore.WatchSchema | datastore.WatchCheckpoints,
+		CheckpointInterval: p.watchHeartbeat,
+	})
+	spiceerrors.DebugAssertNotNilf(ssc, "ssc is nil")
+	spiceerrors.DebugAssertNotNilf(serrc, "serrc is nil")
+
+	p.namespaceCache.startAtRevision(headRev)
+	p.caveatCache.startAtRevision(headRev)
+	log.Debug().Msg("schema watch started")
+
+	var consumedEvent bool
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err(), consumedEvent
+
+		case <-p.closed:
+			// Close()'s contract is that ctx is canceled first, but signal
+			// terminal even if it isn't.
+			return datastore.NewWatchCanceledErr(), consumedEvent
+
+		case ss, ok := <-ssc:
+			if !ok {
+				// Channel closed without an error: recoverable, restart.
+				return nil, consumedEvent
+			}
+			consumedEvent = true
+			lastEventTimestampGauge.Set(time.Since(time.Unix(0, 0)).Seconds())
+
+			log.Trace().
+				Bool("is-checkpoint", ss.IsCheckpoint).
+				Int("changed-definition-count", len(ss.ChangedDefinitions)).
+				Int("deleted-namespace-count", len(ss.DeletedNamespaces)).
+				Int("deleted-caveat-count", len(ss.DeletedCaveats)).
+				Msg("received update from schema watch")
+
+			if ss.IsCheckpoint {
+				if converted, ok := ss.Revision.(revisions.WithInexactFloat64); ok {
+					schemaCacheRevisionGauge.Set(converted.InexactFloat64())
+				}
+
+				p.namespaceCache.setCheckpointRevision(ss.Revision)
+				p.caveatCache.setCheckpointRevision(ss.Revision)
+				continue
+			}
+
+			for _, changeDef := range ss.ChangedDefinitions {
+				switch t := changeDef.(type) {
+				case *core.NamespaceDefinition:
+					if err := p.namespaceCache.updateDefinition(t.Name, t, false, ss.Revision); err != nil {
+						p.namespaceCache.setFallbackMode()
+						log.Warn().Err(err).Msg("received error in schema watch")
+					}
+
+				case *core.CaveatDefinition:
+					if err := p.caveatCache.updateDefinition(t.Name, t, false, ss.Revision); err != nil {
+						p.caveatCache.setFallbackMode()
+						log.Warn().Err(err).Msg("received error in schema watch")
+					}
+
+				default:
+					p.namespaceCache.setFallbackMode()
+					p.caveatCache.setFallbackMode()
+					log.Error().Msg("unknown change definition type")
+					return errors.New("unknown change definition type"), consumedEvent
+				}
+			}
+
+			for _, deletedNamespaceName := range ss.DeletedNamespaces {
+				if err := p.namespaceCache.updateDefinition(deletedNamespaceName, nil, true, ss.Revision); err != nil {
+					p.namespaceCache.setFallbackMode()
+					log.Warn().Err(err).Msg("received error in schema watch")
+					break
+				}
+			}
+
+			for _, deletedCaveatName := range ss.DeletedCaveats {
+				if err := p.caveatCache.updateDefinition(deletedCaveatName, nil, true, ss.Revision); err != nil {
+					p.caveatCache.setFallbackMode()
+					log.Warn().Err(err).Msg("received error in schema watch")
+					break
+				}
+			}
+
+		case err := <-serrc:
+			return err, consumedEvent
+		}
+	}
 }
 
 // Close stops all resources.

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -2,6 +2,7 @@ package schemacaching
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/pkg/cache"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
@@ -606,6 +608,94 @@ func TestWatchingCacheFallbackToStandardCache(t *testing.T) {
 	_, _, err = wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "somenamespace")
 	require.ErrorAs(t, err, &datastore.NamespaceNotFoundError{})
 	require.False(t, wcache.namespaceCache.inFallbackMode)
+}
+
+// Common transient Postgres errors observed in production that are NOT
+// matched by common.IsResettableError, so the schema watch routes them as
+// terminal and the watching cache enters permanent fallback.
+var transientPostgresWatchErrors = []struct {
+	name string
+	err  error
+}{
+	// SQLSTATE 57P01 — admin shutdown, failover, replica promotion.
+	{"admin_shutdown", fmt.Errorf("transaction error: %w", errors.New("FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"))},
+	// SQLSTATE 53300 — too many connections on the server.
+	{"too_many_connections", fmt.Errorf("transaction error: %w", errors.New("FATAL: sorry, too many clients already (SQLSTATE 53300)"))},
+	// pgxpool client-side acquisition timeout.
+	{"pool_acquire_timeout", fmt.Errorf("transaction error: %w", errors.New("timeout: failed to send context cancellation request"))},
+	// TCP-level read/write timeout on the watch connection.
+	{"tcp_io_timeout", fmt.Errorf("unable to load new revisions: %w", errors.New("read tcp 10.0.0.1:54321->10.0.0.2:5432: i/o timeout"))},
+	// Server-side close emitted by upstream poolers (PgBouncer, RDS Proxy).
+	{"server_closed_connection_unexpectedly", fmt.Errorf("transaction error: %w", errors.New("server closed the connection unexpectedly"))},
+}
+
+// Transient Postgres errors should be classified as resettable so the schema
+// watch retries instead of dropping into permanent fallback.
+func TestPostgresTransientErrorsAreResettable(t *testing.T) {
+	for _, tc := range transientPostgresWatchErrors {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, common.IsResettableError(tc.err),
+				"%q must be classified as resettable; otherwise the schema watch treats it as terminal and the cache enters permanent fallback: %v",
+				tc.name, tc.err,
+			)
+		})
+	}
+}
+
+// A transient watch error puts the cache into fallback mode and it never
+// recovers: subsequent valid schema changes are not applied because the
+// watch goroutine has returned. Only a process restart restores the cache.
+func TestWatchingCachePermanentlyFallsBackOnTransientError(t *testing.T) {
+	fakeDS := &fakeDatastore{
+		headRevision: rev("0"),
+		namespaces:   map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
+		caveats:      map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]{},
+		schemaChan:   make(chan datastore.RevisionChanges, 16),
+		errChan:      make(chan error, 1),
+	}
+
+	c, err := cache.NewStandardCache[cache.StringKey, *cacheEntry](&cache.Config{
+		NumCounters: 1000,
+		MaxCost:     10000,
+		DefaultTTL:  10000 * time.Second,
+	})
+	require.NoError(t, err)
+
+	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
+	require.NoError(t, wcache.startSync(t.Context()))
+	t.Cleanup(func() { wcache.Close() })
+
+	// Wait for the cache to come out of its initial fallback state after prepopulation.
+	require.Eventually(t, func() bool {
+		wcache.namespaceCache.lock.RLock()
+		defer wcache.namespaceCache.lock.RUnlock()
+		return !wcache.namespaceCache.inFallbackMode
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// Emit a transient error not recognized by common.IsResettableError.
+	fakeDS.errChan <- fmt.Errorf("transaction error: %w",
+		errors.New("FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"))
+
+	// The cache transitions into fallback.
+	require.Eventually(t, func() bool {
+		wcache.namespaceCache.lock.RLock()
+		defer wcache.namespaceCache.lock.RUnlock()
+		return wcache.namespaceCache.inFallbackMode
+	}, 2*time.Second, 5*time.Millisecond, "cache should enter fallback after a transient watch error")
+
+	// Datastore is healthy again — publish a valid schema change. A working
+	// cache would observe it and exit fallback.
+	fakeDS.updateNamespace("ns_after_recovery",
+		&corev1.NamespaceDefinition{Name: "ns_after_recovery"}, rev("1"))
+	time.Sleep(200 * time.Millisecond)
+
+	// Current behavior: the cache stays in fallback forever. Flip this
+	// assertion to require.False once the recovery path is implemented.
+	wcache.namespaceCache.lock.RLock()
+	stillInFallback := wcache.namespaceCache.inFallbackMode
+	wcache.namespaceCache.lock.RUnlock()
+	require.True(t, stillInFallback,
+		"the cache does not recover from a transient watch error without a process restart")
 }
 
 func TestOldWatchingCacheFallbackToStandardCache(t *testing.T) {

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -9,16 +9,26 @@ import (
 	"testing"
 	"time"
 
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/pkg/cache"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/datastore/options"
 	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/testutil"
 )
+
+// assertEventuallyFallback waits for wcache's namespace fallback flag to match want.
+func assertEventuallyFallback(t *testing.T, wcache *watchingCachingProxy, want bool) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		wcache.namespaceCache.lock.RLock()
+		defer wcache.namespaceCache.lock.RUnlock()
+		return wcache.namespaceCache.inFallbackMode == want
+	}, 5*time.Second, 5*time.Millisecond, "cache did not reach inFallbackMode=%v", want)
+}
 
 func TestWatchingCachingProxyUnwrap(t *testing.T) {
 	fakeDS := &fakeDatastore{
@@ -49,6 +59,7 @@ func TestOldWatchingCacheBasicOperation(t *testing.T) {
 
 	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache[cache.StringKey, *cacheEntry](), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
+	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
 		wcache.Close()
 	})
@@ -153,6 +164,7 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 
 	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache[cache.StringKey, *cacheEntry](), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
+	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
 		wcache.Close()
 	})
@@ -257,6 +269,7 @@ func TestOldWatchingCacheParallelOperations(t *testing.T) {
 
 	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache[cache.StringKey, *cacheEntry](), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
+	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
 		wcache.Close()
 	})
@@ -350,6 +363,7 @@ func TestWatchingCacheParallelOperations(t *testing.T) {
 
 	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache[cache.StringKey, *cacheEntry](), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
+	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
 		wcache.Close()
 	})
@@ -443,6 +457,7 @@ func TestWatchingCacheParallelReaderWriter(t *testing.T) {
 
 	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache[cache.StringKey, *cacheEntry](), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
+	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
 		wcache.Close()
 	})
@@ -512,6 +527,7 @@ func TestOldWatchingCacheParallelReaderWriter(t *testing.T) {
 
 	wcache := createWatchingCacheProxy(fakeDS, cache.NoopCache[cache.StringKey, *cacheEntry](), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
+	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
 		wcache.Close()
 	})
@@ -587,6 +603,7 @@ func TestWatchingCacheFallbackToStandardCache(t *testing.T) {
 
 	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
+	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
 		wcache.Close()
 	})
@@ -610,42 +627,7 @@ func TestWatchingCacheFallbackToStandardCache(t *testing.T) {
 	require.False(t, wcache.namespaceCache.inFallbackMode)
 }
 
-// Common transient Postgres errors observed in production that are NOT
-// matched by common.IsResettableError, so the schema watch routes them as
-// terminal and the watching cache enters permanent fallback.
-var transientPostgresWatchErrors = []struct {
-	name string
-	err  error
-}{
-	// SQLSTATE 57P01 — admin shutdown, failover, replica promotion.
-	{"admin_shutdown", fmt.Errorf("transaction error: %w", errors.New("FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"))},
-	// SQLSTATE 53300 — too many connections on the server.
-	{"too_many_connections", fmt.Errorf("transaction error: %w", errors.New("FATAL: sorry, too many clients already (SQLSTATE 53300)"))},
-	// pgxpool client-side acquisition timeout.
-	{"pool_acquire_timeout", fmt.Errorf("transaction error: %w", errors.New("timeout: failed to send context cancellation request"))},
-	// TCP-level read/write timeout on the watch connection.
-	{"tcp_io_timeout", fmt.Errorf("unable to load new revisions: %w", errors.New("read tcp 10.0.0.1:54321->10.0.0.2:5432: i/o timeout"))},
-	// Server-side close emitted by upstream poolers (PgBouncer, RDS Proxy).
-	{"server_closed_connection_unexpectedly", fmt.Errorf("transaction error: %w", errors.New("server closed the connection unexpectedly"))},
-}
-
-// Transient Postgres errors should be classified as resettable so the schema
-// watch retries instead of dropping into permanent fallback.
-func TestPostgresTransientErrorsAreResettable(t *testing.T) {
-	for _, tc := range transientPostgresWatchErrors {
-		t.Run(tc.name, func(t *testing.T) {
-			require.True(t, common.IsResettableError(tc.err),
-				"%q must be classified as resettable; otherwise the schema watch treats it as terminal and the cache enters permanent fallback: %v",
-				tc.name, tc.err,
-			)
-		})
-	}
-}
-
-// A transient watch error puts the cache into fallback mode and it never
-// recovers: subsequent valid schema changes are not applied because the
-// watch goroutine has returned. Only a process restart restores the cache.
-func TestWatchingCachePermanentlyFallsBackOnTransientError(t *testing.T) {
+func TestWatchingCacheRecoversFromTransientError(t *testing.T) {
 	fakeDS := &fakeDatastore{
 		headRevision: rev("0"),
 		namespaces:   map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
@@ -665,37 +647,17 @@ func TestWatchingCachePermanentlyFallsBackOnTransientError(t *testing.T) {
 	require.NoError(t, wcache.startSync(t.Context()))
 	t.Cleanup(func() { wcache.Close() })
 
-	// Wait for the cache to come out of its initial fallback state after prepopulation.
-	require.Eventually(t, func() bool {
-		wcache.namespaceCache.lock.RLock()
-		defer wcache.namespaceCache.lock.RUnlock()
-		return !wcache.namespaceCache.inFallbackMode
-	}, 2*time.Second, 5*time.Millisecond)
+	assertEventuallyFallback(t, wcache, false)
 
-	// Emit a transient error not recognized by common.IsResettableError.
 	fakeDS.errChan <- fmt.Errorf("transaction error: %w",
 		errors.New("FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"))
 
-	// The cache transitions into fallback.
-	require.Eventually(t, func() bool {
-		wcache.namespaceCache.lock.RLock()
-		defer wcache.namespaceCache.lock.RUnlock()
-		return wcache.namespaceCache.inFallbackMode
-	}, 2*time.Second, 5*time.Millisecond, "cache should enter fallback after a transient watch error")
+	assertEventuallyFallback(t, wcache, true)
 
-	// Datastore is healthy again — publish a valid schema change. A working
-	// cache would observe it and exit fallback.
 	fakeDS.updateNamespace("ns_after_recovery",
 		&corev1.NamespaceDefinition{Name: "ns_after_recovery"}, rev("1"))
-	time.Sleep(200 * time.Millisecond)
 
-	// Current behavior: the cache stays in fallback forever. Flip this
-	// assertion to require.False once the recovery path is implemented.
-	wcache.namespaceCache.lock.RLock()
-	stillInFallback := wcache.namespaceCache.inFallbackMode
-	wcache.namespaceCache.lock.RUnlock()
-	require.True(t, stillInFallback,
-		"the cache does not recover from a transient watch error without a process restart")
+	assertEventuallyFallback(t, wcache, false)
 }
 
 func TestOldWatchingCacheFallbackToStandardCache(t *testing.T) {
@@ -719,6 +681,7 @@ func TestOldWatchingCacheFallbackToStandardCache(t *testing.T) {
 
 	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
+	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
 		wcache.Close()
 	})
@@ -777,6 +740,7 @@ func TestOldWatchingCachePrepopulated(t *testing.T) {
 
 	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
+	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
 		wcache.Close()
 	})
@@ -822,6 +786,7 @@ func TestWatchingCachePrepopulated(t *testing.T) {
 
 	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
+	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
 		wcache.Close()
 	})
@@ -1122,4 +1087,235 @@ func (*fakeSnapshotReader) ReverseQueryRelationships(context.Context, datastore.
 
 func (*fakeSnapshotReader) ReadStoredSchema(_ context.Context) (*datastore.ReadOnlyStoredSchema, error) {
 	return nil, nil
+}
+
+func TestWatchingCacheTerminatesOnWatchDisabled(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
+
+	fakeDS := &fakeDatastore{
+		headRevision: rev("0"),
+		namespaces:   map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
+		caveats:      map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]{},
+		schemaChan:   make(chan datastore.RevisionChanges, 16),
+		errChan:      make(chan error, 1),
+	}
+
+	c, err := cache.NewStandardCache[cache.StringKey, *cacheEntry](&cache.Config{
+		NumCounters: 1000, MaxCost: 10000, DefaultTTL: 10000 * time.Second,
+	})
+	require.NoError(t, err)
+
+	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
+	require.NoError(t, wcache.startSync(t.Context()))
+	t.Cleanup(func() { wcache.Close() })
+
+	stable := promtestutil.ToFloat64(cycleRestartsCounter)
+	fakeDS.errChan <- datastore.NewWatchDisabledErr("test-disabled")
+
+	assertEventuallyFallback(t, wcache, true)
+
+	require.Never(t, func() bool {
+		return promtestutil.ToFloat64(cycleRestartsCounter) > stable
+	}, 300*time.Millisecond, 10*time.Millisecond,
+		"cycleRestartsCounter must not advance after a terminal WatchDisabledError")
+}
+
+func TestWatchingCacheTerminatesOnContextCancellation(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
+
+	fakeDS := &fakeDatastore{
+		headRevision: rev("0"),
+		namespaces:   map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
+		caveats:      map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]{},
+		schemaChan:   make(chan datastore.RevisionChanges, 16),
+		errChan:      make(chan error, 1),
+	}
+
+	c, err := cache.NewStandardCache[cache.StringKey, *cacheEntry](&cache.Config{
+		NumCounters: 1000, MaxCost: 10000, DefaultTTL: 10000 * time.Second,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
+	require.NoError(t, wcache.startSync(ctx))
+
+	assertEventuallyFallback(t, wcache, false)
+
+	cancel()
+	// Witness that the supervisor processed the cancellation via its terminal
+	// path (which sets fallback) before Close() runs and would set it anyway.
+	assertEventuallyFallback(t, wcache, true)
+	require.NoError(t, wcache.Close())
+}
+
+func TestWatchingCacheRecoversAcrossMultipleErrors(t *testing.T) {
+	fakeDS := &fakeDatastore{
+		headRevision: rev("0"),
+		namespaces:   map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
+		caveats:      map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]{},
+		schemaChan:   make(chan datastore.RevisionChanges, 16),
+		errChan:      make(chan error, 1),
+	}
+
+	c, err := cache.NewStandardCache[cache.StringKey, *cacheEntry](&cache.Config{
+		NumCounters: 1000, MaxCost: 10000, DefaultTTL: 10000 * time.Second,
+	})
+	require.NoError(t, err)
+
+	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
+	require.NoError(t, wcache.startSync(t.Context()))
+	t.Cleanup(func() { wcache.Close() })
+
+	// With backoff Reset() working each restart starts at InitialInterval
+	// (~100 ms) so 5 iterations finish under 2 s; without it the 5th
+	// iteration's backoff alone is ~1.6 s and the total exceeds 3 s.
+	const iterations = 5
+	startCount := promtestutil.ToFloat64(cycleRestartsCounter)
+	startTime := time.Now()
+
+	for i := 0; i < iterations; i++ {
+		before := promtestutil.ToFloat64(cycleRestartsCounter)
+		fakeDS.updateNamespace(fmt.Sprintf("ns_%d", i),
+			&corev1.NamespaceDefinition{Name: fmt.Sprintf("ns_%d", i)}, rev(fmt.Sprintf("%d", i+1)))
+		fakeDS.errChan <- fmt.Errorf("transient %d", i)
+
+		require.Eventually(t, func() bool {
+			return promtestutil.ToFloat64(cycleRestartsCounter) > before
+		}, 5*time.Second, 5*time.Millisecond, "supervisor should restart after error %d", i)
+	}
+
+	elapsed := time.Since(startTime)
+	require.GreaterOrEqual(t,
+		promtestutil.ToFloat64(cycleRestartsCounter)-startCount, float64(iterations),
+		"expected at least %d cycle restarts", iterations)
+	require.Less(t, elapsed, 2*time.Second,
+		"5 restarts took %s; backoff is not being reset on successful events", elapsed)
+}
+
+func TestWatchingCacheUpdatesLastEventTimestamp(t *testing.T) {
+	fakeDS := &fakeDatastore{
+		headRevision: rev("0"),
+		namespaces:   map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
+		caveats:      map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]{},
+		schemaChan:   make(chan datastore.RevisionChanges, 16),
+		errChan:      make(chan error, 1),
+	}
+
+	c, err := cache.NewStandardCache[cache.StringKey, *cacheEntry](&cache.Config{
+		NumCounters: 1000, MaxCost: 10000, DefaultTTL: 10000 * time.Second,
+	})
+	require.NoError(t, err)
+
+	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
+	require.NoError(t, wcache.startSync(t.Context()))
+	t.Cleanup(func() { wcache.Close() })
+
+	assertEventuallyFallback(t, wcache, false)
+
+	before := promtestutil.ToFloat64(lastEventTimestampGauge)
+	fakeDS.updateNamespace("ns", &corev1.NamespaceDefinition{Name: "ns"}, rev("1"))
+
+	require.Eventually(t, func() bool {
+		return promtestutil.ToFloat64(lastEventTimestampGauge) > before
+	}, 5*time.Second, 10*time.Millisecond, "lastEventTimestampGauge should advance after a schema event")
+}
+
+func TestWatchingCacheIncrementsCycleRestartsOnRecovery(t *testing.T) {
+	fakeDS := &fakeDatastore{
+		headRevision: rev("0"),
+		namespaces:   map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
+		caveats:      map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]{},
+		schemaChan:   make(chan datastore.RevisionChanges, 16),
+		errChan:      make(chan error, 1),
+	}
+
+	c, err := cache.NewStandardCache[cache.StringKey, *cacheEntry](&cache.Config{
+		NumCounters: 1000, MaxCost: 10000, DefaultTTL: 10000 * time.Second,
+	})
+	require.NoError(t, err)
+
+	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
+	require.NoError(t, wcache.startSync(t.Context()))
+	t.Cleanup(func() { wcache.Close() })
+
+	before := promtestutil.ToFloat64(cycleRestartsCounter)
+	fakeDS.errChan <- errors.New("transient")
+
+	require.Eventually(t, func() bool {
+		return promtestutil.ToFloat64(cycleRestartsCounter) > before
+	}, 5*time.Second, 10*time.Millisecond, "cycleRestartsCounter should increment after a transient error")
+}
+
+func TestNewSupervisorBackoff(t *testing.T) {
+	bo := newSupervisorBackoff()
+	require.Equal(t, 100*time.Millisecond, bo.InitialInterval)
+	require.InEpsilon(t, 2.0, bo.Multiplier, 1e-9)
+	require.InEpsilon(t, 0.5, bo.RandomizationFactor, 1e-9)
+	require.Equal(t, 30*time.Second, bo.MaxInterval)
+
+	bo.NextBackOff()
+	bo.NextBackOff()
+	bo.Reset()
+	d := bo.NextBackOff()
+	require.LessOrEqual(t, d, 150*time.Millisecond) // 100ms +50% jitter
+	require.GreaterOrEqual(t, d, 50*time.Millisecond)
+}
+
+func TestSleepHelper(t *testing.T) {
+	t.Run("returns true after duration", func(t *testing.T) {
+		ok := sleep(t.Context(), 10*time.Millisecond)
+		require.True(t, ok)
+	})
+
+	t.Run("returns false when context already canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		ok := sleep(ctx, time.Second)
+		require.False(t, ok)
+	})
+
+	t.Run("returns false when canceled while sleeping", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		go func() {
+			time.Sleep(5 * time.Millisecond)
+			cancel()
+		}()
+		ok := sleep(ctx, time.Second)
+		require.False(t, ok)
+	})
+
+	t.Run("non-positive duration short-circuits", func(t *testing.T) {
+		start := time.Now()
+		ok := sleep(t.Context(), 0)
+		require.True(t, ok)
+		require.Less(t, time.Since(start), 5*time.Millisecond)
+	})
+}
+
+func TestIsTerminalWatchError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		terminal bool
+	}{
+		{"nil", nil, false},
+		{"watch_canceled", datastore.NewWatchCanceledErr(), true},
+		{"watch_disabled", datastore.NewWatchDisabledErr("test"), true},
+		{"context_canceled", context.Canceled, true},
+		{"context_deadline_exceeded", context.DeadlineExceeded, true},
+		{"wrapped_context_canceled", fmt.Errorf("transaction: %w", context.Canceled), true},
+		{"watch_retryable", datastore.NewWatchTemporaryErr(errors.New("transient")), false},
+		{"watch_disconnected", datastore.NewWatchDisconnectedErr(), false},
+		{"bare_error", errors.New("FATAL: terminating connection"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.terminal, isTerminalWatchError(tc.err))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Replaces the one-shot watch goroutine in the watching schema cache (`--enable-experimental-watchable-schema-cache`) with a supervisor that classifies errors via a deny-list and applies bounded exponential backoff. The cache now recovers from transient watch errors without a process restart.

The previous permanent-fallback path was datastore-agnostic — reachable from every backend — so the fix lives entirely on the cache side.

## Root cause

`internal/datastore/proxy/schemacaching/watchingcache.go` only retried `datastore.WatchRetryableError`. Any other error type — `WatchDisconnectedError`, bare unwrapped errors from datastore `default:` branches, unknown types — called `setFallbackMode()` and `return`ed. The retry counter was a lifetime cap (`maximumRetryCount = 10`), never reset on success, so a long-running pod that accumulated 11 transient blips would also fall back permanently.

## Fix

- **Deny-list classification (`isTerminalWatchError`).** Only `WatchCanceledError`, `WatchDisabledError`, and direct context cancellation are terminal. Watch is a read-only API, so retrying everything else is safe.
- **`setFallbackMode` on every cycle error**, terminal or not. Reads during the backoff window route through the standard caching proxy → datastore rather than being served from potentially-stale entries left over from the previous cycle.
- **Exponential backoff** via `github.com/cenkalti/backoff/v5` (`InitialInterval=100ms`, `Multiplier=2.0`, `RandomizationFactor=0.5`, `MaxInterval=30s`). `ExponentialBackOff` used directly — never `backoff.Retry()`, whose default 15-minute `MaxElapsedTime` would silently stop the supervisor.
- **Reset on success.** `bo.Reset()` fires when a cycle consumes any event so transient blips don't accumulate.
- **Cycle extraction.** Restart-loop body moved into `runWatchOnce` returning `(error, consumedEvent bool)`. Supervisor calls it in a loop, refreshing `HEAD` per cycle so long outages don't expire the revision.
- **`startSync` is now async.** The `wg.Wait()` barrier is gone — only the test suite observed it.

## New metrics

- `spicedb_datastore_watching_schema_cache_cycle_restarts_total` — counter, incremented at the start of every cycle after the first. A growing rate flags a flapping watch.
- `spicedb_datastore_watching_schema_cache_last_event_timestamp_seconds` — gauge, set to the wall-clock timestamp every time an event is consumed. Dashboards build "time since last event" as `time() - <metric>`.

## Tests

In `internal/datastore/proxy/schemacaching/watchingcache_test.go`:

- `TestIsTerminalWatchError`, `TestSleepHelper`, `TestNewSupervisorBackoff` — unit coverage for the new helpers.
- `TestWatchingCacheRecoversFromTransientError` — repro flipped, now asserts the full round-trip: `not-in-fallback` → error pushed → `in-fallback` → recovery event pushed → `not-in-fallback`. The intermediate assertion proves the error actually broke the cache.
- `TestWatchingCacheRecoversAcrossMultipleErrors` — 5 error→event cycles finish under 2 s, proving `bo.Reset()` works (without it the 5th iteration's backoff alone is ~1.6 s).
- `TestWatchingCacheTerminatesOnContextCancellation` — asserts fallback after `cancel()` but before `Close()` to isolate the cancellation path (`Close()` would otherwise mask a broken cancellation).
- `TestWatchingCacheTerminatesOnWatchDisabled` — `require.Never` (not `time.Sleep + check`) asserts the cycle counter doesn't advance after a terminal error.
- `TestWatchingCacheIncrementsCycleRestartsOnRecovery`, `TestWatchingCacheUpdatesLastEventTimestamp` — metric coverage.

10+ existing fallback-mode `require.Eventually` blocks were consolidated into an `assertEventuallyFallback(t, wcache, want bool)` helper.

`TestPostgresTransientErrorsAreResettable` was removed — supervisor correctness no longer depends on per-datastore classification.

## Behavior summary

| Error class | Before | After |
|---|---|---|
| Bare unwrapped datastore error | Permanent fallback | Brief fallback, supervisor restarts; cache recovers |
| `WatchRetryableError` | Retry up to 10 lifetime, then permanent fallback | Brief fallback, supervisor restarts; cache recovers |
| `WatchDisconnectedError` | Permanent fallback | Brief fallback, supervisor restarts; cache recovers |
| `WatchCanceledError` | Permanent fallback | Permanent fallback (shutdown — intended) |
| `WatchDisabledError` | Permanent fallback | Permanent fallback (datastore unsupported — intended) |