### PR TITLE
refactor(schemacache): post-#3134 cleanup and race fix

### DIFF
--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -150,6 +150,14 @@ func (p *watchingCachingProxy) Unwrap() datastore.Datastore {
 	return p.Datastore
 }
 
+// enterFallback puts both schema caches (namespaces and caveats) into fallback
+// mode so reads route through the standard definition-caching proxy until the
+// next successful watch cycle.
+func (p *watchingCachingProxy) enterFallback() {
+	p.namespaceCache.setFallbackMode()
+	p.caveatCache.setFallbackMode()
+}
+
 // createWatchingCacheProxy creates and returns a watching cache proxy.
 func createWatchingCacheProxy(delegate datastore.Datastore, c cache.Cache[cache.StringKey, *cacheEntry], gcWindow time.Duration, watchHeartbeat time.Duration) *watchingCachingProxy {
 	fallbackCache := &definitionCachingProxy{
@@ -256,8 +264,7 @@ func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 
 			headRevWithHash, err := p.HeadRevision(ctx)
 			if err != nil {
-				p.namespaceCache.setFallbackMode()
-				p.caveatCache.setFallbackMode()
+				p.enterFallback()
 				if isTerminalWatchError(err) {
 					log.Warn().Err(err).Msg("schema watch HEAD lookup ended terminally; staying in fallback")
 					return
@@ -271,8 +278,7 @@ func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 
 			cycleErr, consumedEvent := p.runWatchOnce(ctx, headRevWithHash.Revision)
 			if cycleErr != nil {
-				p.namespaceCache.setFallbackMode()
-				p.caveatCache.setFallbackMode()
+				p.enterFallback()
 				if isTerminalWatchError(cycleErr) {
 					log.Info().Err(cycleErr).Msg("schema watch ended terminally; staying in fallback")
 					return
@@ -304,14 +310,12 @@ func (p *watchingCachingProxy) runWatchOnce(ctx context.Context, headRev datasto
 	log.Info().Str("revision", headRev.String()).Msg("prepopulating namespace watching cache")
 	namespaces, err := reader.LegacyListAllNamespaces(ctx)
 	if err != nil {
-		p.namespaceCache.setFallbackMode()
-		p.caveatCache.setFallbackMode()
+		p.enterFallback()
 		return err, false
 	}
 	for _, namespaceDef := range namespaces {
 		if err := p.namespaceCache.updateDefinition(namespaceDef.Definition.Name, namespaceDef.Definition, false, headRev); err != nil {
-			p.namespaceCache.setFallbackMode()
-			p.caveatCache.setFallbackMode()
+			p.enterFallback()
 			return err, false
 		}
 	}
@@ -320,14 +324,12 @@ func (p *watchingCachingProxy) runWatchOnce(ctx context.Context, headRev datasto
 	log.Info().Str("revision", headRev.String()).Msg("prepopulating caveat watching cache")
 	caveats, err := reader.LegacyListAllCaveats(ctx)
 	if err != nil {
-		p.namespaceCache.setFallbackMode()
-		p.caveatCache.setFallbackMode()
+		p.enterFallback()
 		return err, false
 	}
 	for _, caveatDef := range caveats {
 		if err := p.caveatCache.updateDefinition(caveatDef.Definition.Name, caveatDef.Definition, false, headRev); err != nil {
-			p.namespaceCache.setFallbackMode()
-			p.caveatCache.setFallbackMode()
+			p.enterFallback()
 			return err, false
 		}
 	}
@@ -396,8 +398,7 @@ func (p *watchingCachingProxy) runWatchOnce(ctx context.Context, headRev datasto
 					}
 
 				default:
-					p.namespaceCache.setFallbackMode()
-					p.caveatCache.setFallbackMode()
+					p.enterFallback()
 					log.Error().Msg("unknown change definition type")
 					return errors.New("unknown change definition type"), consumedEvent
 				}
@@ -428,8 +429,7 @@ func (p *watchingCachingProxy) runWatchOnce(ctx context.Context, headRev datasto
 // Close stops all resources.
 // The caller must have canceled the context passed to Start.
 func (p *watchingCachingProxy) Close() error {
-	p.caveatCache.setFallbackMode()
-	p.namespaceCache.setFallbackMode()
+	p.enterFallback()
 
 	// Close both goroutines
 	p.closed <- true

--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -559,12 +559,16 @@ func (swc *schemaWatchCache[T]) isInFallback() bool {
 	return swc.inFallbackMode
 }
 
+// reset clears the cache state in preparation for a new watch cycle.
+// inFallbackMode stays true until startAtRevision flips it off after
+// prepopulate completes — readers must not be told the cache is ready
+// while entries are still empty and the checkpoint revision is nil.
 func (swc *schemaWatchCache[T]) reset() {
 	swc.lock.Lock()
 	defer swc.lock.Unlock()
 
-	swc.inFallbackMode = false
-	swc.fallbackGauge.Set(0)
+	swc.inFallbackMode = true
+	swc.fallbackGauge.Set(1)
 	swc.entries = map[string]*intervalTracker[revisionedEntry[T]]{}
 	swc.checkpointRevision = nil
 }

--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -23,14 +23,14 @@ var namespacesFallbackModeGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: "spicedb",
 	Subsystem: "datastore",
 	Name:      "watching_schema_cache_namespaces_fallback_mode",
-	Help:      "Whether the watching schema cache for namespace definitions is in fallback mode (1) or normal mode (0). Fallback is triggered when the CockroachDB changefeed used to track schema updates becomes unavailable; in this state every schema lookup hits the datastore directly.",
+	Help:      "Whether the watching schema cache for namespace definitions is in fallback mode (1) or normal mode (0). Fallback is triggered when the underlying datastore's schema watch becomes unavailable; in this state lookups bypass the watch-backed cache and are served from a standard caching proxy that reads from the datastore on miss.",
 })
 
 var caveatsFallbackModeGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: "spicedb",
 	Subsystem: "datastore",
 	Name:      "watching_schema_cache_caveats_fallback_mode",
-	Help:      "Whether the watching schema cache for caveat definitions is in fallback mode (1) or normal mode (0). Fallback is triggered when the CockroachDB changefeed used to track schema updates becomes unavailable; in this state every schema lookup hits the datastore directly.",
+	Help:      "Whether the watching schema cache for caveat definitions is in fallback mode (1) or normal mode (0). Fallback is triggered when the underlying datastore's schema watch becomes unavailable; in this state lookups bypass the watch-backed cache and are served from a standard caching proxy that reads from the datastore on miss.",
 })
 
 var schemaCacheRevisionGauge = prometheus.NewGauge(prometheus.GaugeOpts{

--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -548,6 +548,17 @@ func (swc *schemaWatchCache[T]) setFallbackMode() {
 	swc.fallbackGauge.Set(1)
 }
 
+// isInFallback returns the current fallback flag under the read lock.
+// Callers outside this type MUST use this rather than reading
+// inFallbackMode directly; the supervisor goroutine writes it under
+// swc.lock and the race detector will flag any unsynchronized read.
+func (swc *schemaWatchCache[T]) isInFallback() bool {
+	swc.lock.RLock()
+	defer swc.lock.RUnlock()
+
+	return swc.inFallbackMode
+}
+
 func (swc *schemaWatchCache[T]) reset() {
 	swc.lock.Lock()
 	defer swc.lock.Unlock()

--- a/internal/datastore/proxy/schemacaching/watchingcache.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache.go
@@ -273,12 +273,10 @@ func (p *watchingCachingProxy) startSync(ctx context.Context) error {
 			if cycleErr != nil {
 				p.namespaceCache.setFallbackMode()
 				p.caveatCache.setFallbackMode()
-			}
-			if isTerminalWatchError(cycleErr) {
-				log.Info().Err(cycleErr).Msg("schema watch ended terminally; staying in fallback")
-				return
-			}
-			if cycleErr != nil {
+				if isTerminalWatchError(cycleErr) {
+					log.Info().Err(cycleErr).Msg("schema watch ended terminally; staying in fallback")
+					return
+				}
 				log.Warn().Err(cycleErr).Msg("schema watch cycle ended; backing off")
 			}
 			if consumedEvent {

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -24,9 +24,7 @@ import (
 func assertEventuallyFallback(t *testing.T, wcache *watchingCachingProxy, want bool) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		wcache.namespaceCache.lock.RLock()
-		defer wcache.namespaceCache.lock.RUnlock()
-		return wcache.namespaceCache.inFallbackMode == want
+		return wcache.namespaceCache.isInFallback() == want
 	}, 5*time.Second, 5*time.Millisecond, "cache did not reach inFallbackMode=%v", want)
 }
 
@@ -67,7 +65,7 @@ func TestOldWatchingCacheBasicOperation(t *testing.T) {
 	// Ensure no namespaces are found.
 	_, _, err := wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "somenamespace")
 	require.ErrorAs(t, err, &datastore.NamespaceNotFoundError{})
-	require.False(t, wcache.namespaceCache.inFallbackMode)
+	require.False(t, wcache.namespaceCache.isInFallback())
 
 	// Ensure a re-read also returns not found, even before a checkpoint is received.
 	_, _, err = wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "somenamespace")
@@ -103,7 +101,7 @@ func TestOldWatchingCacheBasicOperation(t *testing.T) {
 
 	// Checkpoint to rev 4.
 	fakeDS.sendCheckpoint(rev("4"))
-	require.False(t, wcache.namespaceCache.inFallbackMode)
+	require.False(t, wcache.namespaceCache.isInFallback())
 
 	// Disable reads.
 	fakeDS.disableReads()
@@ -172,7 +170,7 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 	// Ensure no namespaces are found.
 	_, _, err := wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "somenamespace")
 	require.ErrorAs(t, err, &datastore.NamespaceNotFoundError{})
-	require.False(t, wcache.namespaceCache.inFallbackMode)
+	require.False(t, wcache.namespaceCache.isInFallback())
 
 	// Ensure a re-read also returns not found, even before a checkpoint is received.
 	_, _, err = wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "somenamespace")
@@ -208,7 +206,7 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 
 	// Checkpoint to rev 4.
 	fakeDS.sendCheckpoint(rev("4"))
-	require.False(t, wcache.namespaceCache.inFallbackMode)
+	require.False(t, wcache.namespaceCache.isInFallback())
 
 	// Disable reads.
 	fakeDS.disableReads()
@@ -291,7 +289,7 @@ func TestOldWatchingCacheParallelOperations(t *testing.T) {
 		// Read somenamespace (which should not be found)
 		_, _, err := wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "somenamespace")
 		firstErrs <- err
-		firstFallbackModes <- wcache.namespaceCache.inFallbackMode
+		firstFallbackModes <- wcache.namespaceCache.isInFallback()
 
 		// Write somenamespace.
 		fakeDS.updateNamespace("somenamespace", &corev1.NamespaceDefinition{Name: "somenamespace"}, rev("2"))
@@ -308,12 +306,12 @@ func TestOldWatchingCacheParallelOperations(t *testing.T) {
 		// Read anothernamespace (which should not be found)
 		_, _, err := wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "anothernamespace")
 		secondErrs <- err
-		secondFallbackModes <- wcache.namespaceCache.inFallbackMode
+		secondFallbackModes <- wcache.namespaceCache.isInFallback()
 
 		// Read again (which should still not be found)
 		_, _, err = wcache.SnapshotReader(rev("3")).LegacyReadNamespaceByName(t.Context(), "anothernamespace")
 		secondErrs <- err
-		secondFallbackModes <- wcache.namespaceCache.inFallbackMode
+		secondFallbackModes <- wcache.namespaceCache.isInFallback()
 	})()
 
 	wg.Wait()
@@ -385,7 +383,7 @@ func TestWatchingCacheParallelOperations(t *testing.T) {
 		// Read somenamespace (which should not be found)
 		_, _, err := wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "somenamespace")
 		firstErrs <- err
-		firstFallbackModes <- wcache.namespaceCache.inFallbackMode
+		firstFallbackModes <- wcache.namespaceCache.isInFallback()
 
 		// Write somenamespace.
 		fakeDS.updateNamespace("somenamespace", &corev1.NamespaceDefinition{Name: "somenamespace"}, rev("2"))
@@ -402,12 +400,12 @@ func TestWatchingCacheParallelOperations(t *testing.T) {
 		// Read anothernamespace (which should not be found)
 		_, _, err := wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "anothernamespace")
 		secondErrs <- err
-		secondFallbackModes <- wcache.namespaceCache.inFallbackMode
+		secondFallbackModes <- wcache.namespaceCache.isInFallback()
 
 		// Read again (which should still not be found)
 		_, _, err = wcache.SnapshotReader(rev("3")).LegacyReadNamespaceByName(t.Context(), "anothernamespace")
 		secondErrs <- err
-		secondFallbackModes <- wcache.namespaceCache.inFallbackMode
+		secondFallbackModes <- wcache.namespaceCache.isInFallback()
 	})()
 
 	wg.Wait()
@@ -612,7 +610,7 @@ func TestWatchingCacheFallbackToStandardCache(t *testing.T) {
 	r := rev("1")
 	_, _, err = wcache.SnapshotReader(r).LegacyReadNamespaceByName(t.Context(), "somenamespace")
 	require.ErrorAs(t, err, &datastore.NamespaceNotFoundError{})
-	require.False(t, wcache.namespaceCache.inFallbackMode)
+	require.False(t, wcache.namespaceCache.isInFallback())
 
 	expectedKey := cache.StringKey("n:somenamespace@" + r.String())
 	entry, ok := c.Get(expectedKey)
@@ -624,7 +622,7 @@ func TestWatchingCacheFallbackToStandardCache(t *testing.T) {
 
 	_, _, err = wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "somenamespace")
 	require.ErrorAs(t, err, &datastore.NamespaceNotFoundError{})
-	require.False(t, wcache.namespaceCache.inFallbackMode)
+	require.False(t, wcache.namespaceCache.isInFallback())
 }
 
 func TestWatchingCacheRecoversFromTransientError(t *testing.T) {
@@ -690,7 +688,7 @@ func TestOldWatchingCacheFallbackToStandardCache(t *testing.T) {
 	r := rev("1")
 	_, _, err = wcache.SnapshotReader(r).LegacyReadNamespaceByName(t.Context(), "somenamespace")
 	require.ErrorAs(t, err, &datastore.NamespaceNotFoundError{})
-	require.False(t, wcache.namespaceCache.inFallbackMode)
+	require.False(t, wcache.namespaceCache.isInFallback())
 
 	expectedKey := cache.StringKey("n:somenamespace@" + r.String())
 	entry, ok := c.Get(expectedKey)
@@ -702,7 +700,7 @@ func TestOldWatchingCacheFallbackToStandardCache(t *testing.T) {
 
 	_, _, err = wcache.SnapshotReader(rev("1")).LegacyReadNamespaceByName(t.Context(), "somenamespace")
 	require.ErrorAs(t, err, &datastore.NamespaceNotFoundError{})
-	require.False(t, wcache.namespaceCache.inFallbackMode)
+	require.False(t, wcache.namespaceCache.isInFallback())
 }
 
 func TestOldWatchingCachePrepopulated(t *testing.T) {

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -625,6 +625,65 @@ func TestWatchingCacheFallbackToStandardCache(t *testing.T) {
 	require.False(t, wcache.namespaceCache.isInFallback())
 }
 
+// While a watch cycle is in flight — entries are reset and prepopulate has
+// not finished — the cache must report as in fallback, because reads from
+// the watch-backed cache would otherwise see an empty tracker and return
+// spurious not-found errors for definitions that exist in the datastore.
+// Gating LegacyListAllNamespaces holds the supervisor inside runWatchOnce
+// past reset() but before startAtRevision, making this assertion deterministic.
+func TestWatchingCacheStaysInFallbackDuringPrepopulate(t *testing.T) {
+	listGate := make(chan struct{})
+	fakeDS := &fakeDatastore{
+		headRevision:       rev("4"),
+		namespaces:         map[string][]fakeEntry[datastore.RevisionedNamespace, *corev1.NamespaceDefinition]{},
+		caveats:            map[string][]fakeEntry[datastore.RevisionedCaveat, *corev1.CaveatDefinition]{},
+		schemaChan:         make(chan datastore.RevisionChanges, 1),
+		errChan:            make(chan error, 1),
+		listNamespacesGate: listGate,
+		existingNamespaces: []datastore.RevisionedNamespace{
+			datastore.RevisionedDefinition[*corev1.NamespaceDefinition]{
+				Definition:          &corev1.NamespaceDefinition{Name: "somenamespace"},
+				LastWrittenRevision: rev("1"),
+			},
+		},
+	}
+
+	c, err := cache.NewStandardCache[cache.StringKey, *cacheEntry](&cache.Config{
+		NumCounters: 1000, MaxCost: 10000, DefaultTTL: 10000 * time.Second,
+	})
+	require.NoError(t, err)
+
+	wcache := createWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
+	require.NoError(t, wcache.startSync(t.Context()))
+
+	// Ensure cleanup completes even if the assertion fails — close the gate
+	// so the supervisor can exit through Close().
+	gateClosed := false
+	releaseGate := func() {
+		if !gateClosed {
+			close(listGate)
+			gateClosed = true
+		}
+	}
+	t.Cleanup(func() {
+		releaseGate()
+		wcache.Close()
+	})
+
+	// The supervisor is now blocked inside LegacyListAllNamespaces. While
+	// prepopulate is in flight, isInFallback() must report true for the
+	// entire 200ms observation window.
+	require.Never(t, func() bool {
+		return !wcache.namespaceCache.isInFallback()
+	}, 200*time.Millisecond, 10*time.Millisecond,
+		"cache must stay in fallback while prepopulate is in flight")
+
+	// Release prepopulate and confirm the cache exits fallback after
+	// startAtRevision runs.
+	releaseGate()
+	assertEventuallyFallback(t, wcache, false)
+}
+
 func TestWatchingCacheRecoversFromTransientError(t *testing.T) {
 	fakeDS := &fakeDatastore{
 		headRevision: rev("0"),
@@ -807,6 +866,12 @@ type fakeDatastore struct {
 	errChan    chan error
 
 	existingNamespaces []datastore.RevisionedNamespace
+
+	// listNamespacesGate, if non-nil, makes LegacyListAllNamespaces block
+	// until the channel is closed (or receives a value). Tests use it to
+	// hold the supervisor inside prepopulate so they can observe in-flight
+	// cache state deterministically.
+	listNamespacesGate chan struct{}
 }
 
 func (fds *fakeDatastore) MetricsID() (string, error) {
@@ -1067,7 +1132,15 @@ func (*fakeSnapshotReader) LegacyListAllCaveats(context.Context) ([]datastore.Re
 	return []datastore.RevisionedDefinition[*corev1.CaveatDefinition]{}, nil
 }
 
-func (fsr *fakeSnapshotReader) LegacyListAllNamespaces(context.Context) ([]datastore.RevisionedDefinition[*corev1.NamespaceDefinition], error) {
+func (fsr *fakeSnapshotReader) LegacyListAllNamespaces(ctx context.Context) ([]datastore.RevisionedDefinition[*corev1.NamespaceDefinition], error) {
+	if gate := fsr.fds.listNamespacesGate; gate != nil {
+		select {
+		case <-gate:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
 	if fsr.fds.existingNamespaces != nil {
 		return fsr.fds.existingNamespaces, nil
 	}


### PR DESCRIPTION
## What

Follow-up to #3134 covering review feedback from Maria and two bug fixes uncovered during the round-trip:

- Correct the fallback-mode gauge help text — drop the CRDB-specific wording and the inaccurate "every lookup hits the datastore directly" claim.
- Nest cycle-error handling inside the `cycleErr != nil` block so it mirrors the HEAD-fetch path, eliminating a duplicate `if cycleErr != nil` guard.
- Extract `enterFallback()` for the eight sites that called `p.namespaceCache.setFallbackMode(); p.caveatCache.setFallbackMode()` in sequence. The four single-cache sites stay as-is.
- Add `isInFallback()` accessor that takes `lock.RLock()`; route all test reads (and `assertEventuallyFallback`) through it.
- Have `reset()` set `inFallbackMode = true` (previously `false`). Add `TestWatchingCacheStaysInFallbackDuringPrepopulate` as a deterministic repro.

## Why

- The gauge help missed cache is datastore-agnostic and overstated the fallback behavior (reads still go through the standard definition-caching proxy on miss, not the datastore directly).
- The cycle-error and HEAD-fetch error branches do the same thing on different shapes; consolidating the structure makes the policy easier to spot and removes a duplicate guard.
- `enterFallback()` is a single touchpoint for "the cache is no longer up to date" — useful if we ever want to attach metrics or logging to that state transition.
- The race detector caught unsynchronized test reads of `inFallbackMode`. The supervisor writes that field under `swc.lock`; tests were reading it directly, which had been masked by the synchronous `wg.Wait()` barrier in `startSync` before #3134 made `startSync` async.
- `reset()` was setting `inFallbackMode = false` *before* prepopulate ran, so `isInFallback()` could report ready while `entries` was still empty. Concurrent reads in that window missed the empty tracker, fell through to `readDefinition`, and produced spurious `NotFound` errors. The cache genuinely isn't ready between cycles — only `startAtRevision` should mark it ready. Side benefit: the fallback gauge no longer flickers `1 → 0 → 1` during recovery cycles, which is what operators looking at the metric actually want.

Both bug fixes verified with `go test ./internal/datastore/proxy/schemacaching/ -count=30 -race`.

## References

- Original PR: #3134