### PR TITLE
fix: three correctness bugs surfaced by GRPC consistency cross-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed regression introduced in 1.53.0 for MySQL migration scripts (https://github.com/authzed/spicedb/pull/3129)
 - Query Planner: `LookupSubjects` no longer returns a subject excluded from a wildcard (e.g. `viewer:* - banned`) when the exclusion feeds an intersection (experimental `--experimental-query-plan ls`) (https://github.com/authzed/spicedb/pull/3136)
 - Tracing: When server is shutting down, flush traces. Also, elide the need for setting `OTEL_EXPORTER_OTLP_ENDPOINT`. (https://github.com/authzed/spicedb/pull/3108)
+- Fixed a LookupSubjects issue in the query planner around the handling of wildcards in compound permissions (https://github.com/authzed/spicedb/pull/3140)
 
 ## [1.53.0] - 2026-05-13
 ### Added

--- a/internal/services/integrationtesting/queryconsistency/query_plan_grpc_test.go
+++ b/internal/services/integrationtesting/queryconsistency/query_plan_grpc_test.go
@@ -168,6 +168,12 @@ func validateQueryPlanLookupResources(
 // pair the query plan handler returns at least the subjects the accessibility
 // set defines as directly accessible. Wildcard exclusion checking is omitted
 // because the query plan handler does not yet populate ExcludedSubjects.
+//
+// It additionally enforces a Check ↔ LookupSubjects consistency invariant:
+// every concrete (non-wildcard) subject returned with HAS_PERMISSION must also
+// pass CheckPermission against the same resource. This catches cases where
+// LookupSubjects re-admits a subject that an upstream wildcard exclusion had
+// removed (e.g. wildcard-main exclusion intersected with a concrete set).
 func validateQueryPlanLookupSubjects(
 	t *testing.T,
 	cad consistencytestutil.ConsistencyClusterAndData,
@@ -191,6 +197,28 @@ func validateQueryPlanLookupSubjects(
 								slices.Collect(maps.Keys(resolvedSubjects)),
 								slices.Collect(maps.Keys(expectedDefinedSubjects)),
 							)
+
+							// Cross-check every concrete (non-wildcard) subject returned with
+							// HAS_PERMISSION against CheckPermission. LookupSubjects must not
+							// claim permission for a subject that Check denies.
+							for subjectID, resp := range resolvedSubjects {
+								if subjectID == tuple.PublicWildcard {
+									continue
+								}
+								if resp.Subject.Permissionship != v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION {
+									continue
+								}
+								subjectONR := tuple.ObjectAndRelation{
+									ObjectType: subjectType.ObjectType,
+									ObjectID:   subjectID,
+									Relation:   subjectType.Relation,
+								}
+								permissionship, err := tester.Check(t.Context(), resource, subjectONR, revision, nil)
+								require.NoError(t, err)
+								require.Equal(t, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, permissionship,
+									"LookupSubjects returned %s as a subject of %s#%s with HAS_PERMISSION, but Check returned %s",
+									subjectID, resource.ObjectType, resource.Relation, permissionship)
+							}
 						})
 				}
 			})

--- a/pkg/query/arrow.go
+++ b/pkg/query/arrow.go
@@ -196,12 +196,14 @@ func (a *ArrowIterator) checkRightToLeft(ctx *Context, resource Object, subject 
 
 		// rightPath.Resource is an intermediate object from the right side.
 		// Check if our input resource connects to this intermediate via the left side.
-		// Use tuple.Ellipsis as the relation since the left side stores subjects with "..."
-		// (the canonical relation for direct membership with no subrelation).
+		// The subject relation must match what the left side stores, which differs
+		// between schema arrows (left stores subjects with Ellipsis) and subrelation
+		// arrows (left stores subjects with a specific subject_relation, e.g. `member`).
+		// Derive it from the left's SubjectTypes for the intermediate's type.
 		intermediateAsSubject := ObjectAndRelation{
 			ObjectType: rightPath.Resource.ObjectType,
 			ObjectID:   rightPath.Resource.ObjectID,
-			Relation:   tuple.Ellipsis,
+			Relation:   a.intermediateSubjectRelation(rightPath.Resource.ObjectType),
 		}
 
 		leftPath, err := ctx.Check(a.left, resource, intermediateAsSubject)
@@ -232,6 +234,32 @@ func (a *ArrowIterator) checkRightToLeft(ctx *Context, resource Object, subject 
 		ctx.TraceStep(a, "arrow (right-to-left) completed: %d right paths, found=%v", rightPathCount, result != nil)
 	}
 	return result, nil
+}
+
+// intermediateSubjectRelation returns the subject_relation that the LEFT side's
+// datastore expects for subjects of the given type. Schema arrows store
+// subjects with Ellipsis (no subject_relation in the schema's allowed type),
+// while subrelation arrows store subjects with a specific relation (e.g.
+// team:foo#member). Passing the wrong relation silently misses datastore rows.
+//
+// Implementation derives the expected relation from a.left.SubjectTypes(),
+// falling back to Ellipsis if the type isn't reflected there (e.g. constructed
+// iterator without metadata).
+func (a *ArrowIterator) intermediateSubjectRelation(intermediateType string) string {
+	subjectTypes, err := a.left.SubjectTypes()
+	if err != nil {
+		return tuple.Ellipsis
+	}
+	for _, st := range subjectTypes {
+		if st.Type != intermediateType {
+			continue
+		}
+		if st.Subrelation == "" {
+			return tuple.Ellipsis
+		}
+		return st.Subrelation
+	}
+	return tuple.Ellipsis
 }
 
 // checkLeftToRightBatch is the batched variant of checkLeftToRight: it drains
@@ -333,7 +361,7 @@ func (a *ArrowIterator) checkRightToLeftBatch(ctx *Context, resource Object, sub
 		intermediates[i] = ObjectAndRelation{
 			ObjectType: rightPath.Resource.ObjectType,
 			ObjectID:   rightPath.Resource.ObjectID,
-			Relation:   tuple.Ellipsis,
+			Relation:   a.intermediateSubjectRelation(rightPath.Resource.ObjectType),
 		}
 	}
 

--- a/pkg/query/intersection_arrow.go
+++ b/pkg/query/intersection_arrow.go
@@ -264,10 +264,15 @@ func (ia *IntersectionArrowIterator) IterSubjectsImpl(ctx *Context, resource Obj
 		return EmptyPathSeq(), nil
 	}
 
-	// For intersection arrow, we need ALL left subjects to satisfy the right side
-	// Track all valid results
-	var validResults []*Path
-	unsatisfied := false
+	// For intersection arrow (e.g. `team.all(member)`), a subject qualifies only
+	// when it appears in the right-hand side for EVERY left subject. Accumulate
+	// the per-left subject sets and intersect by subject key, AND'ing caveats
+	// across the per-left contributions and OR'ing the left-path caveats (since
+	// any matching combination across all lefts is sufficient for that left).
+	var (
+		accumulated      map[string]*Path
+		nonWildcardLefts int
+	)
 
 	for _, leftPath := range leftPaths {
 		// If the left side returned a wildcard, we can't use it as a resource for the
@@ -278,6 +283,7 @@ func (ia *IntersectionArrowIterator) IterSubjectsImpl(ctx *Context, resource Obj
 			}
 			continue
 		}
+		nonWildcardLefts++
 
 		leftSubjectAsResource := GetObject(leftPath.Subject)
 		if ctx.shouldTrace() {
@@ -298,19 +304,16 @@ func (ia *IntersectionArrowIterator) IterSubjectsImpl(ctx *Context, resource Obj
 			if ctx.shouldTrace() {
 				ctx.TraceStep(ia, "left subject %s:%s did NOT satisfy right side", leftSubjectAsResource.ObjectType, leftSubjectAsResource.ObjectID)
 			}
-			unsatisfied = true
-			break
+			return EmptyPathSeq(), nil
 		}
 
 		if ctx.shouldTrace() {
 			ctx.TraceStep(ia, "left subject %s:%s satisfied with %d right subjects", leftSubjectAsResource.ObjectType, leftSubjectAsResource.ObjectID, len(rightPaths))
 		}
 
-		// Collect all valid combinations
+		current := make(map[string]*Path, len(rightPaths))
 		for _, rightPath := range rightPaths {
-			// Combine caveats from left and right with AND logic
 			combinedCaveat := caveats.And(leftPath.Caveat, rightPath.Caveat)
-
 			combinedPath := &Path{
 				Resource:   leftPath.Resource,
 				Relation:   leftPath.Relation,
@@ -320,23 +323,52 @@ func (ia *IntersectionArrowIterator) IterSubjectsImpl(ctx *Context, resource Obj
 				Integrity:  combineIntegrity(leftPath.Integrity, rightPath.Integrity),
 				Metadata:   make(map[string]any),
 			}
-			validResults = append(validResults, combinedPath)
+			key := ObjectAndRelationKey(rightPath.Subject)
+			if existing, ok := current[key]; ok {
+				// Multiple right paths to the same subject from this left:
+				// any of them satisfies "this left has the subject", so OR.
+				if _, err := existing.MergeOr(combinedPath); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			current[key] = combinedPath
+		}
+
+		if accumulated == nil {
+			accumulated = current
+			continue
+		}
+		// Intersect: keep only subjects present in both, AND'ing caveats so all
+		// per-left conditions must hold for the subject to remain.
+		next := make(map[string]*Path, len(current))
+		for key, accPath := range accumulated {
+			currPath, ok := current[key]
+			if !ok {
+				continue
+			}
+			merged := *accPath
+			if _, err := merged.MergeAnd(currPath); err != nil {
+				return nil, err
+			}
+			next[key] = &merged
+		}
+		accumulated = next
+		if len(accumulated) == 0 {
+			return EmptyPathSeq(), nil
 		}
 	}
 
-	if unsatisfied {
-		if ctx.shouldTrace() {
-			ctx.TraceStep(ia, "intersection arrow FAILED - not all left subjects satisfied")
-		}
+	if nonWildcardLefts == 0 || accumulated == nil {
 		return EmptyPathSeq(), nil
 	}
 
 	if ctx.shouldTrace() {
-		ctx.TraceStep(ia, "intersection arrow SUCCESS - returning %d final subjects", len(validResults))
+		ctx.TraceStep(ia, "intersection arrow SUCCESS - returning %d final subjects", len(accumulated))
 	}
 
 	return func(yield func(*Path, error) bool) {
-		for _, path := range validResults {
+		for _, path := range accumulated {
 			if !yield(path, nil) {
 				return
 			}

--- a/pkg/query/recursive.go
+++ b/pkg/query/recursive.go
@@ -649,6 +649,25 @@ func (r *RecursiveIterator) recursiveCheckIterSubjects(ctx *Context, resource Ob
 		ctx.TraceStep(r, "Check via IterSubjects: processing resource %s:%s", resource.ObjectType, resource.ObjectID)
 	}
 
+	// Reflexive identity fast path: if the target subject is the resource itself,
+	// the templateTree's Check (alias self-edge synthesis) resolves it without the
+	// datastore probe that IterSubjects-based BFS would trigger. This matches the
+	// dispatcher's MEMBER-when-resource-equals-subject behavior for relations that
+	// allow themselves as subjects (e.g. `relation member: user | group#member`)
+	// without paying the cost of full BFS enumeration just to look up identity.
+	if resource.ObjectType == subject.ObjectType && resource.ObjectID == subject.ObjectID {
+		path, err := ctx.Check(r.templateTree, resource, subject)
+		if err != nil {
+			return nil, err
+		}
+		if path != nil {
+			if ctx.shouldTrace() {
+				ctx.TraceStep(r, "Check via IterSubjects: matched reflexive identity, skipping BFS")
+			}
+			return path, nil
+		}
+	}
+
 	// Get subject type for filtering (type only, not relation - ellipsis is not a real relation)
 	filterSubjectType := ObjectType{Type: subject.ObjectType}
 


### PR DESCRIPTION
## Description

- recursive: inline the reflexive self-edge in IterSubjects so RecursiveIterator's
  Check-via-IterSubjects path honors `R#rel @ R#rel` identity.
- arrow: stop hard-coding Ellipsis for the intermediate's subject relation
  in checkRightToLeft/checkRightToLeftBatch. Derive it from the left's
  SubjectTypes so subrelation arrows (e.g. `maintainer: user | team#member`)
  pass the stored relation. Bug only manifested after the count advisor
  flipped arrow direction, hiding behind LR→LS sequencing.
- intersection_arrow: IterSubjectsImpl now intersects right-side subjects
  across all left subjects with caveats AND'd, instead of unioning them —
  `team.all(member)` requires the subject in EVERY team's member set.

## Testing

Added to the consistency tests to check the individual members of the set returned by LS