### PR TITLE
chore: use StopAllGoroutines for otter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/mattn/go-isatty v0.0.22
-	github.com/maypok86/otter/v2 v2.2.1
+	github.com/maypok86/otter/v2 v2.3.0
 	github.com/mostynb/go-grpc-compression v1.2.3
 	github.com/muesli/mango-cobra v1.3.0
 	github.com/muesli/roff v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,8 @@ github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3Ry
 github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/maypok86/otter/v2 v2.2.1 h1:hnGssisMFkdisYcvQ8L019zpYQcdtPse+g0ps2i7cfI=
 github.com/maypok86/otter/v2 v2.2.1/go.mod h1:1NKY9bY+kB5jwCXBJfE59u+zAwOt6C7ni1FTlFFMqVs=
+github.com/maypok86/otter/v2 v2.3.0 h1:8H8AVVFUSzJwIegKwv1uF5aGitTY+AIrtktg7OcLs8w=
+github.com/maypok86/otter/v2 v2.3.0/go.mod h1:XgIdlpmL6jYz882/CAx1E4C1ukfgDKSaw4mWq59+7l8=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=

--- a/pkg/cache/cache_otter.go
+++ b/pkg/cache/cache_otter.go
@@ -99,10 +99,8 @@ func (wtc *otterCache[K, V]) Set(key K, value V, cost int64) bool {
 
 func (wtc *otterCache[K, V]) Wait() {}
 func (wtc *otterCache[K, V]) Close() {
-	// NOTE: CleanUp is *not* the same as Close - otter/v2 doesn't expose a Close
-	// method. It should help reduce resource usage e.g. in tests, but there will
-	// still be a periodicCleanup goroutine hanging around.
-	wtc.cache.CleanUp()
+	// Stops the pending goroutine that Otter spins off
+	wtc.cache.StopAllGoroutines()
 	unregisterCache(wtc.name)
 }
 

--- a/pkg/cache/standard.go
+++ b/pkg/cache/standard.go
@@ -11,7 +11,6 @@ package cache
 
 // NewStandardCache creates a new cache with the given configuration.
 func NewStandardCache[K KeyString, V any](config *Config) (Cache[K, V], error) {
-	// TODO: check name here
 	return NewOtterCache[K, V]("", config)
 }
 

--- a/pkg/testutil/leakdetection.go
+++ b/pkg/testutil/leakdetection.go
@@ -9,8 +9,5 @@ func GoLeakIgnores() []goleak.Option {
 		// TODO: https://github.com/googleapis/google-cloud-go/issues/14228
 		// when that is complete, remove this line
 		goleak.IgnoreAnyFunction("go.opencensus.io/stats/view.(*worker).start"),
-		// Otter doesn't expose a `close` function, so we can't close down its periodicCleanup
-		// function. See https://github.com/maypok86/otter/issues/181
-		goleak.IgnoreAnyFunction("github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp"),
 	}
 }


### PR DESCRIPTION
## Description
I found [this](https://github.com/maypok86/otter/blob/8c526307556486ea0337280a4211135720bc29cc/cache.go#L468-L479) while looking around in issues and PRs for otter. This is a better solution than ignoring the goroutines.

## Changes
* Use StopAllGoroutines
* Get rid of ignores
## Testing
Review. See that tests pass.