### PR TITLE
fix: set library-friendly defaults on server Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tracing: When server is shutting down, flush traces. Also, elide the need for setting `OTEL_EXPORTER_OTLP_ENDPOINT`. (https://github.com/authzed/spicedb/pull/3108)
 - Fixed a LookupSubjects issue in the query planner around the handling of wildcards in compound permissions (https://github.com/authzed/spicedb/pull/3140)
 - MySQL: identifiers (object/subject IDs and relationship counter names) are now stored with a case-sensitive (binary) collation, matching the Postgres, CockroachDB, and Spanner datastores. Previously, identifiers differing only in letter case (e.g. `Foo` and `foo`) incorrectly collided in unique indexes and lookups. ⚠️ The migration rebuilds the `relation_tuple` table in place via `ALTER TABLE`, which can hold a metadata/table lock for a long time on large datasets — run the upgrade in a low-traffic window, or apply it with an online schema-change tool (e.g. gh-ost). (https://github.com/authzed/spicedb/pull/3161)
+- `server.NewConfigWithOptionsAndDefaults` now populates `Config` and its embedded structs with the same defaults as the CLI flags, fixing zero-value behavior when embedding SpiceDB as a library. (https://github.com/authzed/spicedb/pull/3156)
 
 ## [1.53.0] - 2026-05-13
 ### Added

--- a/internal/services/integrationtesting/certtest/cert_test.go
+++ b/internal/services/integrationtesting/certtest/cert_test.go
@@ -184,12 +184,7 @@ func TestCertRotation(t *testing.T) {
 			},
 		}),
 	)
-	// Disable all caching and metrics so this test server retains its
-	// pre-PR behavior. The new library defaults enable real caches
-	// (matching CLI), which (a) break parallel subtests by registering
-	// duplicate metrics with prometheus.DefaultRegisterer and (b) can
-	// affect test semantics by introducing caching where there was
-	// previously a NoopCache.
+	// Disable caches and their metrics to avoid "duplicate metrics" errors
 	cfg.DispatchClusterMetricsEnabled = false
 	cfg.DispatchClientMetricsEnabled = false
 	cfg.DatastoreConfig.EnableDatastoreMetrics = false

--- a/internal/services/integrationtesting/certtest/cert_test.go
+++ b/internal/services/integrationtesting/certtest/cert_test.go
@@ -126,7 +126,7 @@ func TestCertRotation(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
-	srv, err := server.NewConfigWithOptionsAndDefaults(
+	cfg := server.NewConfigWithOptionsAndDefaults(
 		server.WithDatastore(ds),
 		server.WithDispatcher(dispatcher),
 		server.WithDispatchMaxDepth(50),
@@ -183,7 +183,22 @@ func TestCertRotation(t *testing.T) {
 				},
 			},
 		}),
-	).Complete(ctx)
+	)
+	// Disable all caching and metrics so this test server retains its
+	// pre-PR behavior. The new library defaults enable real caches
+	// (matching CLI), which (a) break parallel subtests by registering
+	// duplicate metrics with prometheus.DefaultRegisterer and (b) can
+	// affect test semantics by introducing caching where there was
+	// previously a NoopCache.
+	cfg.DispatchClusterMetricsEnabled = false
+	cfg.DispatchClientMetricsEnabled = false
+	cfg.DatastoreConfig.EnableDatastoreMetrics = false
+	cfg.NamespaceCacheConfig = server.CacheConfig{}
+	cfg.DispatchCacheConfig = server.CacheConfig{}
+	cfg.ClusterDispatchCacheConfig = server.CacheConfig{}
+	cfg.LR3ResourceChunkCacheConfig = server.CacheConfig{}
+	cfg.StoredSchemaCacheConfig = server.CacheConfig{}
+	srv, err := cfg.Complete(ctx)
 	require.NoError(t, err)
 
 	wait := make(chan error, 1)

--- a/internal/services/v1/experimental_test.go
+++ b/internal/services/v1/experimental_test.go
@@ -157,7 +157,7 @@ func TestBulkExportRelationshipsBeyondAllowedLimit(t *testing.T) {
 
 	_, err = resp.Recv()
 	require.Error(err)
-	require.Contains(err.Error(), "provided limit 10000005 is greater than maximum allowed of 100000")
+	require.Contains(err.Error(), "provided limit 10000005 is greater than maximum allowed of 10000")
 }
 
 func TestBulkExportRelationships(t *testing.T) {

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -736,6 +736,9 @@ func TestCheckPermissionWithDebugInfoInError(t *testing.T) {
 }
 
 func TestLookupResources(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	testCases := []struct {
 		objectType           string
 		permission           string
@@ -920,9 +923,9 @@ func TestLookupResources(t *testing.T) {
 								tf.StandardDatastoreWithData,
 							)
 							client := v1.NewPermissionsServiceClient(conn)
-							defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-							defer cleanup()
-
+							t.Cleanup(func() {
+								cleanup()
+							})
 							var trailer metadata.MD
 							lookupClient, err := client.LookupResources(t.Context(), &v1.LookupResourcesRequest{
 								ResourceObjectType: tc.objectType,

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -2469,7 +2469,7 @@ func TestExportBulkRelationshipsBeyondAllowedLimit(t *testing.T) {
 
 	_, err = resp.Recv()
 	require.Error(err)
-	require.Contains(err.Error(), "provided limit 10000005 is greater than maximum allowed of 100000")
+	require.Contains(err.Error(), "provided limit 10000005 is greater than maximum allowed of 10000")
 }
 
 func TestExportBulkRelationships(t *testing.T) {

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -158,7 +158,7 @@ func NewPermissionsServer(
 		MaxReadRelationshipsLimit:          defaultIfZero(config.MaxReadRelationshipsLimit, 1_000),
 		MaxDeleteRelationshipsLimit:        defaultIfZero(config.MaxDeleteRelationshipsLimit, 1_000),
 		MaxLookupResourcesLimit:            defaultIfZero(config.MaxLookupResourcesLimit, 1_000),
-		MaxBulkExportRelationshipsLimit:    defaultIfZero(config.MaxBulkExportRelationshipsLimit, 100_000),
+		MaxBulkExportRelationshipsLimit:    defaultIfZero(config.MaxBulkExportRelationshipsLimit, 10_000),
 		DispatchChunkSize:                  defaultIfZero(config.DispatchChunkSize, 100),
 		MaxCheckBulkConcurrency:            defaultIfZero(config.MaxCheckBulkConcurrency, 50),
 		CaveatTypeSet:                      caveattypes.TypeSetOrDefault(config.CaveatTypeSet),

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -229,6 +229,20 @@ func TestClusterWithDispatch(t testing.TB, size uint, ds datastore.Datastore, ad
 
 		ctx, cancel := context.WithCancel(t.Context())
 		cfg := server.NewConfigWithOptionsAndDefaults(serverOptions...)
+		// Disable all caching and metrics so test clusters retain their
+		// pre-PR behavior. The new library defaults enable real caches
+		// (matching CLI), which (a) breaks parallel subtests by registering
+		// duplicate metrics with prometheus.DefaultRegisterer and (b) can
+		// affect test semantics by introducing caching where there was
+		// previously a NoopCache.
+		cfg.DispatchClusterMetricsEnabled = false
+		cfg.DispatchClientMetricsEnabled = false
+		cfg.DatastoreConfig.EnableDatastoreMetrics = false
+		cfg.NamespaceCacheConfig = server.CacheConfig{}
+		cfg.DispatchCacheConfig = server.CacheConfig{}
+		cfg.ClusterDispatchCacheConfig = server.CacheConfig{}
+		cfg.LR3ResourceChunkCacheConfig = server.CacheConfig{}
+		cfg.StoredSchemaCacheConfig = server.CacheConfig{}
 		srv, listeners, err := cfg.CompleteForTesting(ctx)
 		require.NoError(t, err)
 

--- a/internal/testserver/cluster.go
+++ b/internal/testserver/cluster.go
@@ -229,12 +229,7 @@ func TestClusterWithDispatch(t testing.TB, size uint, ds datastore.Datastore, ad
 
 		ctx, cancel := context.WithCancel(t.Context())
 		cfg := server.NewConfigWithOptionsAndDefaults(serverOptions...)
-		// Disable all caching and metrics so test clusters retain their
-		// pre-PR behavior. The new library defaults enable real caches
-		// (matching CLI), which (a) breaks parallel subtests by registering
-		// duplicate metrics with prometheus.DefaultRegisterer and (b) can
-		// affect test semantics by introducing caching where there was
-		// previously a NoopCache.
+		// Disable caches and their metrics to avoid "duplicate metrics" errors
 		cfg.DispatchClusterMetricsEnabled = false
 		cfg.DispatchClientMetricsEnabled = false
 		cfg.DatastoreConfig.EnableDatastoreMetrics = false

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -95,7 +95,7 @@ func NewTestServerWithConfigAndDatastore(t testing.TB,
 	dispatcher, err := graph.NewLocalOnlyDispatcher(params)
 	require.NoError(t, err)
 
-	srv, err := server.NewConfigWithOptionsAndDefaults(
+	cfg := server.NewConfigWithOptionsAndDefaults(
 		server.WithDatastore(ds),
 		server.WithDispatcher(dispatcher),
 		server.WithQueryPlanMetadata(queryPlanMetadata),
@@ -163,7 +163,21 @@ func NewTestServerWithConfigAndDatastore(t testing.TB,
 				},
 			},
 		}),
-	).Complete(ctx)
+	)
+	// Disable all caching and metrics so test servers retain their pre-PR
+	// behavior. The new library defaults enable real caches (matching CLI),
+	// which (a) break parallel subtests by registering duplicate metrics
+	// with prometheus.DefaultRegisterer and (b) can affect test semantics
+	// by introducing caching where there was previously a NoopCache.
+	cfg.DispatchClusterMetricsEnabled = false
+	cfg.DispatchClientMetricsEnabled = false
+	cfg.DatastoreConfig.EnableDatastoreMetrics = false
+	cfg.NamespaceCacheConfig = server.CacheConfig{}
+	cfg.DispatchCacheConfig = server.CacheConfig{}
+	cfg.ClusterDispatchCacheConfig = server.CacheConfig{}
+	cfg.LR3ResourceChunkCacheConfig = server.CacheConfig{}
+	cfg.StoredSchemaCacheConfig = server.CacheConfig{}
+	srv, err := cfg.Complete(ctx)
 	require.NoError(t, err)
 
 	go func() {

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -52,12 +52,12 @@ var BuilderForEngine = map[string]engineBuilderFunc{
 
 //go:generate go run github.com/ecordell/optgen -output zz_generated.connpool.options.go . ConnPoolConfig
 type ConnPoolConfig struct {
-	MaxIdleTime         time.Duration `debugmap:"visible"`
-	MaxLifetime         time.Duration `debugmap:"visible"`
+	MaxIdleTime         time.Duration `debugmap:"visible" default:"30m"`
+	MaxLifetime         time.Duration `debugmap:"visible" default:"30m"`
 	MaxLifetimeJitter   time.Duration `debugmap:"visible"`
 	MaxOpenConns        int           `debugmap:"visible"`
 	MinOpenConns        int           `debugmap:"visible"`
-	HealthCheckInterval time.Duration `debugmap:"visible"`
+	HealthCheckInterval time.Duration `debugmap:"visible" default:"30s"`
 }
 
 func DefaultReadConnPool() *ConnPoolConfig {
@@ -104,12 +104,12 @@ func deprecateUnifiedConnFlags(flagSet *pflag.FlagSet) {
 
 //go:generate go run github.com/ecordell/optgen -sensitive-field-name-matches uri,secure -output zz_generated.options.go . Config
 type Config struct {
-	Engine                      string        `debugmap:"visible"`
+	Engine                      string        `debugmap:"visible"   default:"memory"`
 	URI                         string        `debugmap:"sensitive"`
-	GCWindow                    time.Duration `debugmap:"visible"`
-	LegacyFuzzing               time.Duration `debugmap:"visible"`
-	RevisionQuantization        time.Duration `debugmap:"visible"`
-	MaxRevisionStalenessPercent float64       `debugmap:"visible"`
+	GCWindow                    time.Duration `debugmap:"visible"   default:"24h"`
+	LegacyFuzzing               time.Duration `debugmap:"visible"   default:"-1ns"`
+	RevisionQuantization        time.Duration `debugmap:"visible"   default:"5s"`
+	MaxRevisionStalenessPercent float64       `debugmap:"visible"   default:"0.1"`
 	CredentialsProviderName     string        `debugmap:"visible"`
 	FilterMaximumIDCount        uint16        `debugmap:"hidden"    default:"100"`
 
@@ -117,7 +117,7 @@ type Config struct {
 	ReadConnPool                   ConnPoolConfig `debugmap:"visible"`
 	WriteConnPool                  ConnPoolConfig `debugmap:"visible"`
 	ReadOnly                       bool           `debugmap:"visible"`
-	EnableDatastoreMetrics         bool           `debugmap:"visible"`
+	EnableDatastoreMetrics         bool           `debugmap:"visible" default:"true"`
 	DisableStats                   bool           `debugmap:"visible"`
 	IncludeQueryParametersInTraces bool           `debugmap:"visible"`
 
@@ -132,7 +132,7 @@ type Config struct {
 	BootstrapFiles        []string             `debugmap:"visible-format"`
 	BootstrapFileContents map[string][]byte    `debugmap:"visible"`
 	BootstrapOverwrite    bool                 `debugmap:"visible"`
-	BootstrapTimeout      time.Duration        `debugmap:"visible"`
+	BootstrapTimeout      time.Duration        `debugmap:"visible"        default:"10s"`
 	CaveatTypeSet         *caveattypes.TypeSet `debugmap:"hidden"`
 
 	// Hedging
@@ -142,17 +142,17 @@ type Config struct {
 	RequestHedgingQuantile         float64       `debugmap:"visible"`
 
 	// CRDB
-	FollowerReadDelay         time.Duration `debugmap:"visible"`
-	MaxRetries                int           `debugmap:"visible"`
-	OverlapKey                string        `debugmap:"visible"`
-	OverlapStrategy           string        `debugmap:"visible"`
-	EnableConnectionBalancing bool          `debugmap:"visible"`
-	ConnectRate               time.Duration `debugmap:"visible"`
-	WriteAcquisitionTimeout   time.Duration `debugmap:"visible"`
+	FollowerReadDelay         time.Duration `debugmap:"visible" default:"4800ms"`
+	MaxRetries                int           `debugmap:"visible" default:"10"`
+	OverlapKey                string        `debugmap:"visible" default:"key"`
+	OverlapStrategy           string        `debugmap:"visible" default:"static"`
+	EnableConnectionBalancing bool          `debugmap:"visible" default:"true"`
+	ConnectRate               time.Duration `debugmap:"visible" default:"100ms"`
+	WriteAcquisitionTimeout   time.Duration `debugmap:"visible" default:"30ms"`
 
 	// Postgres
-	GCInterval            time.Duration `debugmap:"visible"`
-	GCMaxOperationTime    time.Duration `debugmap:"visible"`
+	GCInterval            time.Duration `debugmap:"visible" default:"3m"`
+	GCMaxOperationTime    time.Duration `debugmap:"visible" default:"1m"`
 	RelaxedIsolationLevel bool          `debugmap:"visible"`
 
 	// Spanner
@@ -168,9 +168,9 @@ type Config struct {
 	// https://docs.cloud.google.com/docs/authentication/client-libraries#adc
 	SpannerCredentialsJSON        []byte `debugmap:"sensitive"`
 	SpannerEmulatorHost           string `debugmap:"visible"`
-	SpannerMinSessions            uint64 `debugmap:"visible"`
-	SpannerMaxSessions            uint64 `debugmap:"visible"`
-	SpannerDatastoreMetricsOption string `debugmap:"visible"`
+	SpannerMinSessions            uint64 `debugmap:"visible"   default:"100"`
+	SpannerMaxSessions            uint64 `debugmap:"visible"   default:"400"`
+	SpannerDatastoreMetricsOption string `debugmap:"visible"   default:"otel"`
 
 	// MySQL
 	TablePrefix string `debugmap:"visible"`
@@ -181,10 +181,10 @@ type Config struct {
 	RelationshipIntegrityExpiredKeys []string        `debugmap:"visible"`
 
 	// Internal
-	WatchBufferLength            uint16        `debugmap:"visible"`
-	WatchChangeBufferMaximumSize string        `debugmap:"visible"`
-	WatchBufferWriteTimeout      time.Duration `debugmap:"visible"`
-	WatchConnectTimeout          time.Duration `debugmap:"visible"`
+	WatchBufferLength            uint16        `debugmap:"visible" default:"1024"`
+	WatchChangeBufferMaximumSize string        `debugmap:"visible" default:"15%"`
+	WatchBufferWriteTimeout      time.Duration `debugmap:"visible" default:"1s"`
+	WatchConnectTimeout          time.Duration `debugmap:"visible" default:"1s"`
 	DisableWatchSupport          bool          `debugmap:"hidden"`
 
 	// Migrations
@@ -192,8 +192,43 @@ type Config struct {
 	AllowedMigrations []string `debugmap:"visible"`
 
 	// Experimental
-	ExperimentalColumnOptimization bool `debugmap:"visible"`
+	ExperimentalColumnOptimization bool `debugmap:"visible" default:"true"`
 	EnableRevisionHeartbeat        bool `debugmap:"visible"`
+}
+
+// SetDefaults is invoked by github.com/creasty/defaults after struct-tag
+// defaults are applied. It fills the four ConnPoolConfig slots from the
+// canonical DefaultReadConnPool / DefaultWriteConnPool constructors because
+// each slot receives a different default set from RegisterConnPoolFlagsWithPrefix
+// in RegisterDatastoreFlagsWithPrefix (Read pools = 20/20 conns, Write = 10/10).
+// It also pre-allocates slice fields to empty (non-nil) values so the
+// resulting Config matches what RegisterDatastoreFlags writes via
+// StringSliceVar/StringArrayVar.
+func (c *Config) SetDefaults() {
+	c.ReadConnPool = *DefaultReadConnPool()
+	c.WriteConnPool = *DefaultWriteConnPool()
+	c.ReadReplicaConnPool = *DefaultReadConnPool()
+	c.OldReadReplicaConnPool = *DefaultReadConnPool()
+
+	// CaveatTypeSet is hidden from DebugMap but RegisterDatastoreFlags
+	// initializes it from DefaultDatastoreConfig at line 223. Mirror that
+	// here so library users get the same value as CLI users.
+	if c.CaveatTypeSet == nil {
+		c.CaveatTypeSet = caveattypes.Default.TypeSet
+	}
+
+	if c.BootstrapFiles == nil {
+		c.BootstrapFiles = []string{}
+	}
+	if c.ReadReplicaURIs == nil {
+		c.ReadReplicaURIs = []string{}
+	}
+	if c.AllowedMigrations == nil {
+		c.AllowedMigrations = []string{}
+	}
+	if c.RelationshipIntegrityExpiredKeys == nil {
+		c.RelationshipIntegrityExpiredKeys = []string{}
+	}
 }
 
 //go:generate go run github.com/ecordell/optgen -sensitive-field-name-matches uri,secure -output zz_generated.relintegritykey.options.go . RelIntegrityKey

--- a/pkg/cmd/serve_test.go
+++ b/pkg/cmd/serve_test.go
@@ -74,6 +74,23 @@ func restoreEnv(prevEnv []string) {
 	}
 }
 
+// TestConfigDefaultsMatchCLIFlags asserts that NewConfigWithOptionsAndDefaults
+// (the library entry point) produces the same Config as RegisterServeFlags
+// (the CLI entry point). Any drift is a bug: a new flag or a new struct field
+// added without a matching default tag/SetDefaults hook will be caught here.
+//
+// pflag writes each flag's default into the bound destination at registration
+// time, so RegisterServeFlags alone (no ParseFlags call) is enough to fully
+// populate cliCfg with the CLI defaults.
+func TestConfigDefaultsMatchCLIFlags(t *testing.T) {
+	cliCfg := &server.Config{}
+	require.NoError(t, RegisterServeFlags(&cobra.Command{}, cliCfg))
+
+	libCfg := server.NewConfigWithOptionsAndDefaults()
+
+	require.Equal(t, cliCfg.DebugMap(), libCfg.DebugMap())
+}
+
 func TestDefaultConfig(t *testing.T) {
 	flags := []string{
 		"--grpc-preshared-key", "some_key",

--- a/pkg/cmd/server/otel.go
+++ b/pkg/cmd/server/otel.go
@@ -30,12 +30,12 @@ type otelShutdowner interface {
 }
 
 type OTelConfig struct {
-	Provider        string  `debugmap:"visible"`
+	Provider        string  `debugmap:"visible" default:"none"`
 	Endpoint        string  `debugmap:"visible"`
-	ServiceName     string  `debugmap:"visible"`
-	TracePropagator string  `debugmap:"visible"`
+	ServiceName     string  `debugmap:"visible" default:"spicedb"`
+	TracePropagator string  `debugmap:"visible" default:"w3c"`
 	UsePlaintext    bool    `debugmap:"visible"`
-	SampleRatio     float64 `debugmap:"visible"`
+	SampleRatio     float64 `debugmap:"visible" default:"0.01"`
 }
 
 // RegisterOTelFlags registers all OpenTelemetry flags on cmd, binding them directly into cfg.

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -63,8 +63,8 @@ type Config struct {
 	// API config
 	GRPCServer             util.GRPCServerConfig `debugmap:"visible"`
 	GRPCAuthFunc           grpc_auth.AuthFunc    `debugmap:"visible"`
-	PresharedSecureKey     []string              `debugmap:"sensitive"`
-	ShutdownGracePeriod    time.Duration         `debugmap:"visible"`
+	PresharedSecureKey     []string              `debugmap:"sensitive" default:"[]"`
+	ShutdownGracePeriod    time.Duration         `debugmap:"visible"   default:"5s"`
 	DisableVersionResponse bool                  `debugmap:"visible"`
 	ServerName             string                `debugmap:"visible"`
 
@@ -85,7 +85,7 @@ type Config struct {
 
 	// Namespace cache
 	EnableExperimentalWatchableSchemaCache bool          `debugmap:"visible"`
-	SchemaWatchHeartbeat                   time.Duration `debugmap:"visible"`
+	SchemaWatchHeartbeat                   time.Duration `debugmap:"visible" default:"1s"`
 	NamespaceCacheConfig                   CacheConfig   `debugmap:"visible"`
 
 	// Stored schema hash cache
@@ -93,24 +93,24 @@ type Config struct {
 
 	// Schema options
 	SchemaPrefixesRequired bool   `debugmap:"visible"`
-	ExperimentalSchemaMode string `debugmap:"visible"`
+	ExperimentalSchemaMode string `debugmap:"visible" default:"read-legacy-write-legacy"`
 
 	// Dispatch options
 	DispatchServer                    util.GRPCServerConfig    `debugmap:"visible"`
-	DispatchMaxDepth                  uint32                   `debugmap:"visible"`
-	GlobalDispatchConcurrencyLimit    uint16                   `debugmap:"visible"`
+	DispatchMaxDepth                  uint32                   `debugmap:"visible" default:"50"`
+	GlobalDispatchConcurrencyLimit    uint16                   `debugmap:"visible" default:"50"`
 	DispatchConcurrencyLimits         graph.ConcurrencyLimits  `debugmap:"visible"`
 	DispatchUpstreamAddr              string                   `debugmap:"visible"`
 	DispatchUpstreamCAPath            string                   `debugmap:"visible"`
-	DispatchUpstreamTimeout           time.Duration            `debugmap:"visible"`
+	DispatchUpstreamTimeout           time.Duration            `debugmap:"visible" default:"60s"`
 	DispatchClientMetricsEnabled      bool                     `debugmap:"visible"`
 	DispatchClientMetricsPrefix       string                   `debugmap:"visible"`
 	DispatchClusterMetricsEnabled     bool                     `debugmap:"visible"`
 	DispatchClusterMetricsPrefix      string                   `debugmap:"visible"`
 	Dispatcher                        dispatch.Dispatcher      `debugmap:"visible"`
 	QueryPlanMetadata                 *query.QueryPlanMetadata `debugmap:"hidden"`
-	DispatchHashringReplicationFactor uint16                   `debugmap:"visible"`
-	DispatchHashringSpread            uint8                    `debugmap:"visible"`
+	DispatchHashringReplicationFactor uint16                   `debugmap:"visible" default:"100"`
+	DispatchHashringSpread            uint8                    `debugmap:"visible" default:"1"`
 	DispatchChunkSize                 uint16                   `debugmap:"visible" default:"100"`
 
 	DispatchSecondaryUpstreamAddrs               map[string]string `debugmap:"visible"`
@@ -125,22 +125,22 @@ type Config struct {
 	// API Behavior
 	DisableV1SchemaAPI                 bool          `debugmap:"visible"`
 	V1SchemaAdditiveOnly               bool          `debugmap:"visible"`
-	MaximumUpdatesPerWrite             uint16        `debugmap:"visible"`
-	MaximumPreconditionCount           uint16        `debugmap:"visible"`
-	MaxDatastoreReadPageSize           uint64        `debugmap:"visible"`
-	StreamingAPITimeout                time.Duration `debugmap:"visible"`
-	WatchHeartbeat                     time.Duration `debugmap:"visible"`
-	MaxReadRelationshipsLimit          uint32        `debugmap:"visible"`
-	MaxDeleteRelationshipsLimit        uint32        `debugmap:"visible"`
-	MaxLookupResourcesLimit            uint32        `debugmap:"visible"`
-	MaxBulkExportRelationshipsLimit    uint32        `debugmap:"visible"`
+	MaximumUpdatesPerWrite             uint16        `debugmap:"visible" default:"1000"`
+	MaximumPreconditionCount           uint16        `debugmap:"visible" default:"1000"`
+	MaxDatastoreReadPageSize           uint64        `debugmap:"visible" default:"1000"`
+	StreamingAPITimeout                time.Duration `debugmap:"visible" default:"30s"`
+	WatchHeartbeat                     time.Duration `debugmap:"visible" default:"1s"`
+	MaxReadRelationshipsLimit          uint32        `debugmap:"visible" default:"1000"`
+	MaxDeleteRelationshipsLimit        uint32        `debugmap:"visible" default:"1000"`
+	MaxLookupResourcesLimit            uint32        `debugmap:"visible" default:"1000"`
+	MaxBulkExportRelationshipsLimit    uint32        `debugmap:"visible" default:"10000"`
 	EnableExperimentalLookupResources  bool          `debugmap:"visible"`
 	ExperimentalLookupResourcesVersion string        `debugmap:"visible"`
 	ExperimentalQueryPlan              []string      `debugmap:"visible"`
 	EnableRelationshipExpiration       bool          `debugmap:"visible" default:"true"`
-	EnableRevisionHeartbeat            bool          `debugmap:"visible"`
+	EnableRevisionHeartbeat            bool          `debugmap:"visible" default:"true"`
 	EnablePerformanceInsightMetrics    bool          `debugmap:"visible"`
-	MismatchZedTokenBehavior           string        `debugmap:"visible"`
+	MismatchZedTokenBehavior           string        `debugmap:"visible" default:"full-consistency"`
 
 	// Additional Services
 	MetricsAPI util.HTTPServerConfig `debugmap:"visible"`
@@ -159,8 +159,8 @@ type Config struct {
 	// Telemetry
 	SilentlyDisableTelemetry bool          `debugmap:"visible"`
 	TelemetryCAOverridePath  string        `debugmap:"visible"`
-	TelemetryEndpoint        string        `debugmap:"visible"`
-	TelemetryInterval        time.Duration `debugmap:"visible"`
+	TelemetryEndpoint        string        `debugmap:"visible" default:"https://telemetry.authzed.com"`
+	TelemetryInterval        time.Duration `debugmap:"visible" default:"1h"`
 
 	// OpenTelemetry tracing
 	OTel OTelConfig `debugmap:"visible"`
@@ -171,6 +171,41 @@ type Config struct {
 
 	// Metrics
 	DisableGRPCLatencyHistogram bool `debugmap:"visible"`
+}
+
+// SetDefaults is invoked by github.com/creasty/defaults after struct-tag
+// defaults are applied. It populates the per-instance defaults that struct
+// tags cannot express because the same struct type is embedded in Config in
+// multiple places with different defaults (GRPCServer vs. DispatchServer,
+// HTTPGateway vs. MetricsAPI, the five CacheConfig sites). It also matches
+// the empty (non-nil) slice defaults that RegisterServeFlags writes via
+// StringSliceVar so the library and CLI configurations stay identical.
+//
+// These values must stay in sync with cmd.RegisterServeFlags;
+// TestConfigDefaultsMatchCLIFlags in pkg/cmd enforces that parity.
+func (c *Config) SetDefaults() {
+	c.GRPCServer.Address = ":50051"
+	c.GRPCServer.Enabled = true
+	c.DispatchServer.Address = ":50053"
+
+	c.HTTPGateway.HTTPAddress = ":8443"
+	c.MetricsAPI.HTTPAddress = ":9090"
+	c.MetricsAPI.HTTPEnabled = true
+
+	c.DispatchClusterMetricsEnabled = true
+	c.DispatchClientMetricsEnabled = true
+
+	// NOTE: NumCounters stays 0 here to match RegisterCacheFlags, which
+	// hardcodes the flag default to 0 (the flag is deprecated and unused).
+	c.NamespaceCacheConfig = CacheConfig{Name: "namespace", Enabled: true, Metrics: true, MaxCost: "32MiB"}
+	c.DispatchCacheConfig = CacheConfig{Name: "dispatch", Enabled: true, Metrics: true, MaxCost: "30%"}
+	c.ClusterDispatchCacheConfig = CacheConfig{Name: "cluster_dispatch", Enabled: true, Metrics: true, MaxCost: "70%"}
+	c.LR3ResourceChunkCacheConfig = CacheConfig{Name: "lr3_chunk", Enabled: true, MaxCost: "50MiB"}
+	c.StoredSchemaCacheConfig = CacheConfig{Name: "stored_schema", Enabled: true, Metrics: true, MaxCost: "32MiB"}
+
+	if c.HTTPGatewayCorsAllowedOrigins == nil {
+		c.HTTPGatewayCorsAllowedOrigins = []string{"*"}
+	}
 }
 
 // Complete validates the config and fills out defaults.

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -81,7 +81,112 @@ func TestServerGracefulTermination(t *testing.T) {
 func TestServerDefaultOptions(t *testing.T) {
 	cfg := NewConfigWithOptionsAndDefaults()
 
+	require.Equal(t, 5*time.Second, cfg.ShutdownGracePeriod)
+	require.Equal(t, 4096, cfg.MaxCaveatContextSize)
+	require.Equal(t, 25_000, cfg.MaxRelationshipContextSize)
+	require.Equal(t, time.Second, cfg.SchemaWatchHeartbeat)
+	require.Equal(t, "read-legacy-write-legacy", cfg.ExperimentalSchemaMode)
+
+	require.Equal(t, uint32(50), cfg.DispatchMaxDepth)
+	require.Equal(t, uint16(50), cfg.GlobalDispatchConcurrencyLimit)
+	require.Equal(t, 60*time.Second, cfg.DispatchUpstreamTimeout)
+	require.Equal(t, uint16(100), cfg.DispatchHashringReplicationFactor)
+	require.Equal(t, uint8(1), cfg.DispatchHashringSpread)
+	require.Equal(t, uint16(100), cfg.DispatchChunkSize)
+
+	require.Equal(t, uint16(1000), cfg.MaximumUpdatesPerWrite)
+	require.Equal(t, uint16(1000), cfg.MaximumPreconditionCount)
+	require.Equal(t, uint64(1000), cfg.MaxDatastoreReadPageSize)
+	require.Equal(t, 30*time.Second, cfg.StreamingAPITimeout)
+	require.Equal(t, time.Second, cfg.WatchHeartbeat)
+	require.Equal(t, uint32(1000), cfg.MaxReadRelationshipsLimit)
+	require.Equal(t, uint32(1000), cfg.MaxDeleteRelationshipsLimit)
+	require.Equal(t, uint32(1000), cfg.MaxLookupResourcesLimit)
+	require.Equal(t, uint32(10_000), cfg.MaxBulkExportRelationshipsLimit)
 	require.True(t, cfg.EnableRelationshipExpiration)
+	require.True(t, cfg.EnableRevisionHeartbeat)
+	require.Equal(t, "full-consistency", cfg.MismatchZedTokenBehavior)
+	require.True(t, cfg.EnableMemoryProtectionMiddleware)
+
+	require.Equal(t, "https://telemetry.authzed.com", cfg.TelemetryEndpoint)
+	require.Equal(t, time.Hour, cfg.TelemetryInterval)
+
+	// Embedded gRPC servers: per-instance defaults from (*Config).SetDefaults
+	// plus shared field defaults from struct tags on util.GRPCServerConfig.
+	require.Equal(t, ":50051", cfg.GRPCServer.Address)
+	require.True(t, cfg.GRPCServer.Enabled)
+	require.Equal(t, "tcp", cfg.GRPCServer.Network)
+	require.Equal(t, 30*time.Second, cfg.GRPCServer.MaxConnAge)
+	require.Equal(t, ":50053", cfg.DispatchServer.Address)
+	require.False(t, cfg.DispatchServer.Enabled)
+	require.Equal(t, "tcp", cfg.DispatchServer.Network)
+
+	// Embedded HTTP servers.
+	require.Equal(t, ":8443", cfg.HTTPGateway.HTTPAddress)
+	require.False(t, cfg.HTTPGateway.HTTPEnabled)
+	require.Equal(t, []string{"*"}, cfg.HTTPGatewayCorsAllowedOrigins)
+	require.Equal(t, ":9090", cfg.MetricsAPI.HTTPAddress)
+	require.True(t, cfg.MetricsAPI.HTTPEnabled)
+
+	// CacheConfig: five sites with different names and sizes. NumCounters
+	// stays 0 in every site to match RegisterCacheFlags, which hardcodes the
+	// (deprecated) flag default to 0.
+	require.Equal(t, CacheConfig{Name: "namespace", Enabled: true, Metrics: true, MaxCost: "32MiB"}, cfg.NamespaceCacheConfig)
+	require.Equal(t, CacheConfig{Name: "dispatch", Enabled: true, Metrics: true, MaxCost: "30%"}, cfg.DispatchCacheConfig)
+	require.Equal(t, CacheConfig{Name: "cluster_dispatch", Enabled: true, Metrics: true, MaxCost: "70%"}, cfg.ClusterDispatchCacheConfig)
+	require.Equal(t, CacheConfig{Name: "lr3_chunk", Enabled: true, MaxCost: "50MiB"}, cfg.LR3ResourceChunkCacheConfig)
+	require.Equal(t, CacheConfig{Name: "stored_schema", Enabled: true, Metrics: true, MaxCost: "32MiB"}, cfg.StoredSchemaCacheConfig)
+	require.True(t, cfg.DispatchClusterMetricsEnabled)
+	require.True(t, cfg.DispatchClientMetricsEnabled)
+
+	// OTel.
+	require.Equal(t, "none", cfg.OTel.Provider)
+	require.Equal(t, "spicedb", cfg.OTel.ServiceName)
+	require.Equal(t, "w3c", cfg.OTel.TracePropagator)
+	require.InEpsilon(t, 0.01, cfg.OTel.SampleRatio, 1e-9)
+
+	// Datastore: every non-zero field from DefaultDatastoreConfig is now
+	// reachable via struct tags so library users get the same defaults as
+	// CLI users.
+	require.Equal(t, "memory", cfg.DatastoreConfig.Engine)
+	require.Equal(t, 24*time.Hour, cfg.DatastoreConfig.GCWindow)
+	require.Equal(t, 5*time.Second, cfg.DatastoreConfig.RevisionQuantization)
+	require.InEpsilon(t, 0.1, cfg.DatastoreConfig.MaxRevisionStalenessPercent, 1e-9)
+	require.Equal(t, uint16(100), cfg.DatastoreConfig.FilterMaximumIDCount)
+	require.True(t, cfg.DatastoreConfig.EnableDatastoreMetrics)
+	require.Equal(t, 10*time.Second, cfg.DatastoreConfig.BootstrapTimeout)
+	require.Equal(t, 4800*time.Millisecond, cfg.DatastoreConfig.FollowerReadDelay)
+	require.Equal(t, 10, cfg.DatastoreConfig.MaxRetries)
+	require.Equal(t, "key", cfg.DatastoreConfig.OverlapKey)
+	require.Equal(t, "static", cfg.DatastoreConfig.OverlapStrategy)
+	require.True(t, cfg.DatastoreConfig.EnableConnectionBalancing)
+	require.Equal(t, 100*time.Millisecond, cfg.DatastoreConfig.ConnectRate)
+	require.Equal(t, 30*time.Millisecond, cfg.DatastoreConfig.WriteAcquisitionTimeout)
+	require.Equal(t, 3*time.Minute, cfg.DatastoreConfig.GCInterval)
+	require.Equal(t, time.Minute, cfg.DatastoreConfig.GCMaxOperationTime)
+	require.Equal(t, uint16(1024), cfg.DatastoreConfig.WatchBufferLength)
+	require.Equal(t, "15%", cfg.DatastoreConfig.WatchChangeBufferMaximumSize)
+	require.Equal(t, time.Second, cfg.DatastoreConfig.WatchBufferWriteTimeout)
+	require.Equal(t, time.Second, cfg.DatastoreConfig.WatchConnectTimeout)
+	require.Equal(t, uint64(100), cfg.DatastoreConfig.SpannerMinSessions)
+	require.Equal(t, uint64(400), cfg.DatastoreConfig.SpannerMaxSessions)
+	require.Equal(t, "otel", cfg.DatastoreConfig.SpannerDatastoreMetricsOption)
+	require.True(t, cfg.DatastoreConfig.ExperimentalColumnOptimization)
+
+	// Connection pools: Read default 20/20, Write default 10/10, both with
+	// 30m lifetime/idle and 30s healthcheck. Slice fields default to empty
+	// (non-nil) to match the CLI's StringSliceVar/StringArrayVar defaults.
+	require.Equal(t, 20, cfg.DatastoreConfig.ReadConnPool.MaxOpenConns)
+	require.Equal(t, 20, cfg.DatastoreConfig.ReadConnPool.MinOpenConns)
+	require.Equal(t, 30*time.Minute, cfg.DatastoreConfig.ReadConnPool.MaxLifetime)
+	require.Equal(t, 30*time.Minute, cfg.DatastoreConfig.ReadConnPool.MaxIdleTime)
+	require.Equal(t, 30*time.Second, cfg.DatastoreConfig.ReadConnPool.HealthCheckInterval)
+	require.Equal(t, 10, cfg.DatastoreConfig.WriteConnPool.MaxOpenConns)
+	require.Equal(t, 10, cfg.DatastoreConfig.WriteConnPool.MinOpenConns)
+	require.Equal(t, []string{}, cfg.DatastoreConfig.BootstrapFiles)
+	require.Equal(t, []string{}, cfg.DatastoreConfig.ReadReplicaURIs)
+	require.Equal(t, []string{}, cfg.DatastoreConfig.AllowedMigrations)
+	require.Equal(t, []string{}, cfg.DatastoreConfig.RelationshipIntegrityExpiredKeys)
 }
 
 func TestExperimentalQueryPlanStringSliceMapping(t *testing.T) {

--- a/pkg/cmd/util/util.go
+++ b/pkg/cmd/util/util.go
@@ -33,10 +33,10 @@ const BufferedNetwork string = "buffnet"
 
 type GRPCServerConfig struct {
 	Address      string        `debugmap:"visible"`
-	Network      string        `debugmap:"visible"`
+	Network      string        `debugmap:"visible" default:"tcp"`
 	TLSCertPath  string        `debugmap:"visible"`
 	TLSKeyPath   string        `debugmap:"visible"`
-	MaxConnAge   time.Duration `debugmap:"visible"`
+	MaxConnAge   time.Duration `debugmap:"visible" default:"30s"`
 	Enabled      bool          `debugmap:"visible"`
 	BufferSize   int           `debugmap:"visible"`
 	ClientCAPath string        `debugmap:"visible"`


### PR DESCRIPTION
## Changes

* Add `default:"..."` tags for scalar `Config` fields whose CLI flag
  default in `pkg/cmd/serve.go` is non-zero.

Closes #2502