### PR TITLE
fix(lsp): resolve hover on the right side of arrow expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - When SpiceDB loses a connection to a CockroachDB node, every read happening in the server blocks for a short period of time (https://github.com/authzed/spicedb/pull/3181)
+- LSP: hover and go-to-definition now resolve identifiers on the right-hand side of arrow expressions (`->`, `.any(...)`, `.all(...)`) (https://github.com/authzed/spicedb/pull/3157)
 
 ## [1.54.0] - 2026-06-18
 ### Added
@@ -210,10 +211,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - expose x-request-id header in HTTP Gateway responses by @Verolop in https://github.com/authzed/spicedb/pull/2712
 - error message when cannot run 'datastore gc' or 'datastore repair' by @miparnisari in https://github.com/authzed/spicedb/pull/2609
 - Postgres:
-    * wire up missing revision timestamp on PG ReadWriteTx by [@vroldanbet](https://authzed.slack.com/team/U03HU4QUZU3) in https://github.com/authzed/spicedb/pull/2725
+  * wire up missing revision timestamp on PG ReadWriteTx by [@vroldanbet](https://authzed.slack.com/team/U03HU4QUZU3) in https://github.com/authzed/spicedb/pull/2725
 - Spanner:
-    * Watch API by @miparnisari in https://github.com/authzed/spicedb/pull/2560
-    * statistics by @miparnisari in https://github.com/authzed/spicedb/pull/2745
+  * Watch API by @miparnisari in https://github.com/authzed/spicedb/pull/2560
+  * statistics by @miparnisari in https://github.com/authzed/spicedb/pull/2745
 
 ## [1.47.1] - 2025-11-20
 ### Changed
@@ -236,7 +237,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - add man page generation support by @ivanauth in https://github.com/authzed/spicedb/pull/2595
 - add fgprof wall-clock profiler by @vroldanbet in https://github.com/authzed/spicedb/pull/2618
 - CRDB: add write backpressure when write pool is overloaded  by @ecordell in https://github.com/authzed/spicedb/pull/2642
-    * ⚠️ With this change, Write APIs now return ResourceExhausted errors if there are no available connections in the pool
+  * ⚠️ With this change, Write APIs now return ResourceExhausted errors if there are no available connections in the pool
 
 ### Changed
 - perf: significant improvements around LR3 dispatching by @josephschorr in https://github.com/authzed/spicedb/pull/2587
@@ -256,7 +257,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - LR3 Fixes and Improvements by @josephschorr in https://github.com/authzed/spicedb/pull/2570 and https://github.com/authzed/spicedb/pull/2574
 - propagate cancellation errors in consistency middleware by @tstirrat15 in https://github.com/authzed/spicedb/pull/2581
 - breakage of gRPC retries by @vroldanbet in https://github.com/authzed/spicedb/pull/2577
-    *  ⚠️ With this change, if you use the `zed` CLI, you must update to the latest version ([v0.33.0](https://github.com/authzed/zed/releases/tag/v0.33.0))
+  *  ⚠️ With this change, if you use the `zed` CLI, you must update to the latest version ([v0.33.0](https://github.com/authzed/zed/releases/tag/v0.33.0))
 - fix: add flags to configure how to handle zedtokens meant for a different datastore by @josephschorr in https://github.com/authzed/spicedb/pull/1723
 
 ## [1.45.4] - 2025-09-12

--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -712,6 +712,49 @@ func TestHoverNoReferenceFound(t *testing.T) {
 	require.Nil(t, resp)
 }
 
+func TestHoverArrowRHSMultiTargetLHS(t *testing.T) {
+	tester := newLSPTester(t)
+	tester.initialize()
+
+	sendAndReceive[any](tester, "textDocument/didOpen", lsp.DidOpenTextDocumentParams{
+		TextDocument: lsp.TextDocumentItem{
+			URI:        lsp.DocumentURI("file:///test"),
+			LanguageID: "test",
+			Version:    1,
+			Text: `definition user {}
+definition somethingelse {}
+
+definition org {
+	relation member: user
+}
+
+definition team {
+	relation member: somethingelse
+}
+
+definition document {
+	relation parent: org | team
+	permission viewable = parent->member
+}
+`,
+		},
+	})
+
+	// Hover on "member" in `parent->member`. The LHS `parent` allows both org
+	// and team and the RHS name resolves on each with a different signature.
+	// Hover content should surface both definitions so the reader sees every
+	// namespace the arrow can resolve to, not just the first match.
+	resp, _ := sendAndReceive[Hover](tester, "textDocument/hover", lsp.TextDocumentPositionParams{
+		TextDocument: lsp.TextDocumentIdentifier{
+			URI: lsp.DocumentURI("file:///test"),
+		},
+		Position: lsp.Position{Line: 13, Character: 33},
+	})
+
+	require.Equal(t, "spicedb", resp.Contents.Language)
+	require.Equal(t, "// from org\nrelation member: user\n\n// from team\nrelation member: somethingelse\n", resp.Contents.Value)
+}
+
 func TestHoverDuplicateDefinitionAcrossFiles(t *testing.T) {
 	tester := newLSPTester(t)
 	tester.initialize()

--- a/pkg/development/schema_position_mapper.go
+++ b/pkg/development/schema_position_mapper.go
@@ -122,63 +122,10 @@ func (r *SchemaPositionMapper) ReferenceAtPosition(source input.Source, position
 		}, nil
 	}
 
-	relationReference := func(relation *core.Relation, def *schema.Definition) (*SchemaReference, error) {
-		// NOTE: zeroes are fine here to mean "unknown"
-		lineNumber, err := safecast.Convert[int](relation.SourcePosition.ZeroIndexedLineNumber)
-		if err != nil {
-			log.Err(err).Msg("could not cast lineNumber to uint32")
-		}
-		columnPosition, err := safecast.Convert[int](relation.SourcePosition.ZeroIndexedColumnPosition)
-		if err != nil {
-			log.Err(err).Msg("could not cast columnPosition to uint32")
-		}
-		relationPosition := input.Position{
-			LineNumber:     lineNumber,
-			ColumnPosition: columnPosition,
-		}
-
-		targetSourceCode, err := generator.GenerateRelationSource(relation, caveattypes.Default.TypeSet)
-		if err != nil {
-			return nil, err
-		}
-
-		targetSource := r.resolveTargetSource(relation.Name, source)
-
-		if def.IsPermission(relation.Name) {
-			return &SchemaReference{
-				Source:   source,
-				Position: position,
-				Text:     relation.Name,
-
-				ReferenceType:     ReferenceTypePermission,
-				ReferenceMarkdown: "permission " + relation.Name,
-
-				TargetSource:             &targetSource,
-				TargetPosition:           &relationPosition,
-				TargetSourceCode:         targetSourceCode,
-				TargetNamePositionOffset: len("permission "),
-			}, nil
-		}
-
-		return &SchemaReference{
-			Source:   source,
-			Position: position,
-			Text:     relation.Name,
-
-			ReferenceType:     ReferenceTypeRelation,
-			ReferenceMarkdown: "relation " + relation.Name,
-
-			TargetSource:             &targetSource,
-			TargetPosition:           &relationPosition,
-			TargetSourceCode:         targetSourceCode,
-			TargetNamePositionOffset: len("relation "),
-		}, nil
-	}
-
 	// Type reference.
 	if ts, relation, ok := r.typeReferenceChain(nodeChain); ok {
 		if relation != nil {
-			return relationReference(relation, ts)
+			return r.buildRelationReference(source, position, relation, ts)
 		}
 
 		def := ts.Namespace()
@@ -271,9 +218,16 @@ func (r *SchemaPositionMapper) ReferenceAtPosition(source input.Source, position
 		}, nil
 	}
 
+	// Arrow RHS reference. Must run before the generic relation path so the
+	// RHS identifier is resolved against the LHS target namespace(s), not the
+	// parent definition.
+	if ref, ok, err := r.arrowRHSReferenceChain(nodeChain, source, position); ok {
+		return ref, err
+	}
+
 	// Relation reference.
 	if relation, ts, ok := r.relationReferenceChain(nodeChain); ok {
-		return relationReference(relation, ts)
+		return r.buildRelationReference(source, position, relation, ts)
 	}
 
 	// Caveat parameter used in expression.
@@ -462,18 +416,6 @@ func (r *SchemaPositionMapper) relationReferenceChain(nodeChain *compiler.NodeCh
 		return nil, nil, false
 	}
 
-	if arrowExpr := nodeChain.FindNodeOfType(dslshape.NodeTypeArrowExpression); arrowExpr != nil {
-		// Ensure this on the left side of the arrow.
-		rightExpr, err := arrowExpr.Lookup(dslshape.NodeExpressionPredicateRightExpr)
-		if err != nil {
-			return nil, nil, false
-		}
-
-		if rightExpr == nodeChain.Head() {
-			return nil, nil, false
-		}
-	}
-
 	relationName, err := nodeChain.Head().GetString(dslshape.NodeIdentiferPredicateValue)
 	if err != nil {
 		return nil, nil, false
@@ -490,6 +432,204 @@ func (r *SchemaPositionMapper) relationReferenceChain(nodeChain *compiler.NodeCh
 	}
 
 	return r.lookupRelation(defName, relationName)
+}
+
+// arrowRHSReferenceChain resolves a reference when the cursor sits on the RHS of
+// an arrow expression (e.g. `parent->member`, `parent.any(member)`).
+//
+// The RHS names a relation or permission on the target namespace(s) pointed to
+// by the LHS, not on the parent definition. The LHS may allow multiple subject
+// types, and each may define the RHS name with a different signature. When more
+// than one match exists, all of them are surfaced in the hover content so the
+// reader can see every namespace the arrow can resolve to.
+//
+// When matches span both relations and permissions across namespaces, the
+// top-level ReferenceType, ReferenceMarkdown, and TargetPosition fields
+// reflect the first match. The combined TargetSourceCode still shows every
+// signature, so the hover content remains complete; only go-to-definition
+// collapses to the first target.
+//
+// The bool return distinguishes "not an arrow RHS, try other paths" (false)
+// from "is an arrow RHS, stop here" (true, possibly with a nil reference if
+// no allowed type defines the RHS name). The error return is reserved for
+// failures from the relation-reference builder and source-code generator;
+// AST-traversal and type-system lookup failures are swallowed silently and
+// terminate the chain with a nil reference, matching the behavior of the
+// surrounding chain methods.
+func (r *SchemaPositionMapper) arrowRHSReferenceChain(nodeChain *compiler.NodeChain, source input.Source, position input.Position) (*SchemaReference, bool, error) {
+	if !nodeChain.HasHeadType(dslshape.NodeTypeIdentifier) {
+		return nil, false, nil
+	}
+
+	arrowExpr := nodeChain.FindNodeOfType(dslshape.NodeTypeArrowExpression)
+	if arrowExpr == nil {
+		return nil, false, nil
+	}
+
+	rightExpr, err := arrowExpr.Lookup(dslshape.NodeExpressionPredicateRightExpr)
+	if err != nil {
+		return nil, false, nil
+	}
+	if rightExpr != nodeChain.Head() {
+		return nil, false, nil
+	}
+
+	relationName, err := nodeChain.Head().GetString(dslshape.NodeIdentiferPredicateValue)
+	if err != nil {
+		return nil, true, nil
+	}
+
+	parentDefNode := nodeChain.FindNodeOfType(dslshape.NodeTypeDefinition)
+	if parentDefNode == nil {
+		return nil, true, nil
+	}
+
+	defName, err := parentDefNode.GetString(dslshape.NodeDefinitionPredicateName)
+	if err != nil {
+		return nil, true, nil
+	}
+
+	leftExpr, err := arrowExpr.Lookup(dslshape.NodeExpressionPredicateLeftExpr)
+	if err != nil {
+		return nil, true, nil
+	}
+
+	lhsRelationName, err := leftExpr.GetString(dslshape.NodeIdentiferPredicateValue)
+	if err != nil {
+		return nil, true, nil
+	}
+
+	parentDef, err := r.typeSystem.GetDefinition(context.Background(), defName)
+	if err != nil {
+		return nil, true, nil
+	}
+
+	allowedSubjects, err := parentDef.AllowedSubjectRelations(lhsRelationName)
+	if err != nil {
+		return nil, true, nil
+	}
+
+	type rhsMatch struct {
+		rel *core.Relation
+		def *schema.Definition
+	}
+	// Dedup by target namespace: `AllowedSubjectRelations` returns one entry
+	// per allowed direct subject (so `parent: org | org#admin` yields two
+	// entries on `org`) but we resolve the RHS name on the namespace alone, so
+	// without dedup the same block would appear multiple times in the hover.
+	seen := make(map[string]struct{}, len(allowedSubjects))
+	var matches []rhsMatch
+	for _, subject := range allowedSubjects {
+		if _, dup := seen[subject.Namespace]; dup {
+			continue
+		}
+		seen[subject.Namespace] = struct{}{}
+		if rel, ts, ok := r.lookupRelation(subject.Namespace, relationName); ok {
+			matches = append(matches, rhsMatch{rel: rel, def: ts})
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil, true, nil
+	}
+
+	if len(matches) == 1 {
+		ref, err := r.buildRelationReference(source, position, matches[0].rel, matches[0].def)
+		if err != nil {
+			return nil, true, err
+		}
+		return ref, true, nil
+	}
+
+	sourceBlocks := make([]string, 0, len(matches))
+	for _, m := range matches {
+		relSource, err := generator.GenerateRelationSource(m.rel, caveattypes.Default.TypeSet)
+		if err != nil {
+			return nil, true, err
+		}
+		sourceBlocks = append(sourceBlocks, fmt.Sprintf("// from %s\n%s", m.def.Namespace().Name, relSource))
+	}
+	combinedSource := strings.Join(sourceBlocks, "\n")
+
+	first := matches[0]
+	lineNumber, err := safecast.Convert[int](first.rel.SourcePosition.ZeroIndexedLineNumber)
+	if err != nil {
+		log.Err(err).Msg("could not cast lineNumber to uint32")
+	}
+	columnPosition, err := safecast.Convert[int](first.rel.SourcePosition.ZeroIndexedColumnPosition)
+	if err != nil {
+		log.Err(err).Msg("could not cast columnPosition to uint32")
+	}
+	targetSource := r.resolveTargetSource(first.rel.Name, source)
+
+	refType := ReferenceTypeRelation
+	refMarkdown := "relation " + first.rel.Name
+	namePosOffset := len("relation ")
+	if first.def.IsPermission(first.rel.Name) {
+		refType = ReferenceTypePermission
+		refMarkdown = "permission " + first.rel.Name
+		namePosOffset = len("permission ")
+	}
+
+	return &SchemaReference{
+		Source:                   source,
+		Position:                 position,
+		Text:                     first.rel.Name,
+		ReferenceType:            refType,
+		ReferenceMarkdown:        refMarkdown,
+		TargetSource:             &targetSource,
+		TargetPosition:           &input.Position{LineNumber: lineNumber, ColumnPosition: columnPosition},
+		TargetSourceCode:         combinedSource,
+		TargetNamePositionOffset: namePosOffset,
+	}, true, nil
+}
+
+// buildRelationReference renders a SchemaReference for a single relation or
+// permission. It is the shared builder used by the type-reference and relation-
+// reference paths, as well as the single-match branch of arrow RHS resolution.
+func (r *SchemaPositionMapper) buildRelationReference(source input.Source, position input.Position, relation *core.Relation, def *schema.Definition) (*SchemaReference, error) {
+	lineNumber, err := safecast.Convert[int](relation.SourcePosition.ZeroIndexedLineNumber)
+	if err != nil {
+		log.Err(err).Msg("could not cast lineNumber to uint32")
+	}
+	columnPosition, err := safecast.Convert[int](relation.SourcePosition.ZeroIndexedColumnPosition)
+	if err != nil {
+		log.Err(err).Msg("could not cast columnPosition to uint32")
+	}
+	relationPosition := input.Position{LineNumber: lineNumber, ColumnPosition: columnPosition}
+
+	targetSourceCode, err := generator.GenerateRelationSource(relation, caveattypes.Default.TypeSet)
+	if err != nil {
+		return nil, err
+	}
+
+	targetSource := r.resolveTargetSource(relation.Name, source)
+
+	if def.IsPermission(relation.Name) {
+		return &SchemaReference{
+			Source:                   source,
+			Position:                 position,
+			Text:                     relation.Name,
+			ReferenceType:            ReferenceTypePermission,
+			ReferenceMarkdown:        "permission " + relation.Name,
+			TargetSource:             &targetSource,
+			TargetPosition:           &relationPosition,
+			TargetSourceCode:         targetSourceCode,
+			TargetNamePositionOffset: len("permission "),
+		}, nil
+	}
+
+	return &SchemaReference{
+		Source:                   source,
+		Position:                 position,
+		Text:                     relation.Name,
+		ReferenceType:            ReferenceTypeRelation,
+		ReferenceMarkdown:        "relation " + relation.Name,
+		TargetSource:             &targetSource,
+		TargetPosition:           &relationPosition,
+		TargetSourceCode:         targetSourceCode,
+		TargetNamePositionOffset: len("relation "),
+	}, nil
 }
 
 func (r *SchemaPositionMapper) importReferenceChain(nodeChain *compiler.NodeChain) (string, bool) {

--- a/pkg/development/schema_position_mapper_test.go
+++ b/pkg/development/schema_position_mapper_test.go
@@ -232,6 +232,254 @@ func TestSchemaPositionMapper(t *testing.T) {
 			expectedReference: nil,
 		},
 		{
+			name: "arrow rhs resolves relation on target type",
+			schema: `definition user {}
+
+			definition org {
+				relation member: user
+			}
+
+			definition document {
+				relation parent: org
+				permission viewable = parent->member
+			}
+			`,
+			line:   8,
+			column: 36,
+			expectedReference: &SchemaReference{
+				Source:                   input.Source("test"),
+				Position:                 input.Position{LineNumber: 8, ColumnPosition: 36},
+				Text:                     "member",
+				ReferenceType:            ReferenceTypeRelation,
+				ReferenceMarkdown:        "relation member",
+				TargetSource:             &testSource,
+				TargetPosition:           &input.Position{LineNumber: 3, ColumnPosition: 4},
+				TargetSourceCode:         "relation member: user\n",
+				TargetNamePositionOffset: 9,
+			},
+		},
+		{
+			name: "arrow rhs (.any) resolves relation on target type",
+			schema: `definition user {}
+
+			definition org {
+				relation member: user
+			}
+
+			definition document {
+				relation parent: org
+				permission viewable = parent.any(member)
+			}
+			`,
+			line:   8,
+			column: 37,
+			expectedReference: &SchemaReference{
+				Source:                   input.Source("test"),
+				Position:                 input.Position{LineNumber: 8, ColumnPosition: 37},
+				Text:                     "member",
+				ReferenceType:            ReferenceTypeRelation,
+				ReferenceMarkdown:        "relation member",
+				TargetSource:             &testSource,
+				TargetPosition:           &input.Position{LineNumber: 3, ColumnPosition: 4},
+				TargetSourceCode:         "relation member: user\n",
+				TargetNamePositionOffset: 9,
+			},
+		},
+		{
+			name: "arrow rhs (.all) resolves relation on target type",
+			schema: `definition user {}
+
+			definition org {
+				relation member: user
+			}
+
+			definition document {
+				relation parent: org
+				permission viewable = parent.all(member)
+			}
+			`,
+			line:   8,
+			column: 37,
+			expectedReference: &SchemaReference{
+				Source:                   input.Source("test"),
+				Position:                 input.Position{LineNumber: 8, ColumnPosition: 37},
+				Text:                     "member",
+				ReferenceType:            ReferenceTypeRelation,
+				ReferenceMarkdown:        "relation member",
+				TargetSource:             &testSource,
+				TargetPosition:           &input.Position{LineNumber: 3, ColumnPosition: 4},
+				TargetSourceCode:         "relation member: user\n",
+				TargetNamePositionOffset: 9,
+			},
+		},
+		{
+			name: "arrow rhs resolves permission on target type",
+			schema: `definition user {}
+
+			definition org {
+				relation member: user
+				permission view = member
+			}
+
+			definition document {
+				relation parent: org
+				permission viewable = parent->view
+			}
+			`,
+			line:   9,
+			column: 35,
+			expectedReference: &SchemaReference{
+				Source:                   input.Source("test"),
+				Position:                 input.Position{LineNumber: 9, ColumnPosition: 35},
+				Text:                     "view",
+				ReferenceType:            ReferenceTypePermission,
+				ReferenceMarkdown:        "permission view",
+				TargetSource:             &testSource,
+				TargetPosition:           &input.Position{LineNumber: 4, ColumnPosition: 4},
+				TargetSourceCode:         "permission view = member\n",
+				TargetNamePositionOffset: 11,
+			},
+		},
+		{
+			name: "arrow rhs subject-subrelation LHS resolves on target namespace",
+			schema: `definition user {}
+
+			definition group {
+				relation member: user
+			}
+
+			definition document {
+				relation owner_group: group#member
+				permission viewable = owner_group->member
+			}
+			`,
+			line:   8,
+			column: 41,
+			expectedReference: &SchemaReference{
+				Source:                   input.Source("test"),
+				Position:                 input.Position{LineNumber: 8, ColumnPosition: 41},
+				Text:                     "member",
+				ReferenceType:            ReferenceTypeRelation,
+				ReferenceMarkdown:        "relation member",
+				TargetSource:             &testSource,
+				TargetPosition:           &input.Position{LineNumber: 3, ColumnPosition: 4},
+				TargetSourceCode:         "relation member: user\n",
+				TargetNamePositionOffset: 9,
+			},
+		},
+		{
+			name: "arrow rhs with multi-target LHS combines identical matches",
+			schema: `definition user {}
+
+			definition org {
+				relation member: user
+			}
+
+			definition team {
+				relation member: user
+			}
+
+			definition document {
+				relation parent: org | team
+				permission viewable = parent->member
+			}
+			`,
+			line:   12,
+			column: 36,
+			expectedReference: &SchemaReference{
+				Source:                   input.Source("test"),
+				Position:                 input.Position{LineNumber: 12, ColumnPosition: 36},
+				Text:                     "member",
+				ReferenceType:            ReferenceTypeRelation,
+				ReferenceMarkdown:        "relation member",
+				TargetSource:             &testSource,
+				TargetPosition:           &input.Position{LineNumber: 3, ColumnPosition: 4},
+				TargetSourceCode:         "// from org\nrelation member: user\n\n// from team\nrelation member: user\n",
+				TargetNamePositionOffset: 9,
+			},
+		},
+		{
+			name: "arrow rhs with multi-target LHS shows all matches",
+			schema: `definition user {}
+definition somethingelse {}
+
+			definition org {
+				relation member: user
+			}
+
+			definition team {
+				relation member: somethingelse
+			}
+
+			definition document {
+				relation parent: org | team
+				permission viewable = parent->member
+			}
+			`,
+			line:   13,
+			column: 36,
+			expectedReference: &SchemaReference{
+				Source:                   input.Source("test"),
+				Position:                 input.Position{LineNumber: 13, ColumnPosition: 36},
+				Text:                     "member",
+				ReferenceType:            ReferenceTypeRelation,
+				ReferenceMarkdown:        "relation member",
+				TargetSource:             &testSource,
+				TargetPosition:           &input.Position{LineNumber: 4, ColumnPosition: 4},
+				TargetSourceCode:         "// from org\nrelation member: user\n\n// from team\nrelation member: somethingelse\n",
+				TargetNamePositionOffset: 9,
+			},
+		},
+		{
+			name: "arrow rhs with duplicate-namespace LHS dedupes",
+			schema: `definition user {}
+
+			definition org {
+				relation admin: user
+				relation member: user
+			}
+
+			definition document {
+				relation parent: org | org#admin
+				permission viewable = parent->member
+			}
+			`,
+			line:   9,
+			column: 36,
+			// `AllowedSubjectRelations` returns one entry per allowed direct
+			// subject type, so `parent: org | org#admin` produces two entries
+			// that both resolve `member` on `org`. Dedup by namespace so we
+			// don't repeat the same block in the hover output.
+			expectedReference: &SchemaReference{
+				Source:                   input.Source("test"),
+				Position:                 input.Position{LineNumber: 9, ColumnPosition: 36},
+				Text:                     "member",
+				ReferenceType:            ReferenceTypeRelation,
+				ReferenceMarkdown:        "relation member",
+				TargetSource:             &testSource,
+				TargetPosition:           &input.Position{LineNumber: 4, ColumnPosition: 4},
+				TargetSourceCode:         "relation member: user\n",
+				TargetNamePositionOffset: 9,
+			},
+		},
+		{
+			name: "arrow rhs with no match returns nil",
+			schema: `definition user {}
+
+			definition org {
+				relation member: user
+			}
+
+			definition document {
+				relation parent: org
+				permission viewable = parent->nonexistent
+			}
+			`,
+			line:              8,
+			column:            36,
+			expectedReference: nil,
+		},
+		{
 			name: "caveat parameter reference",
 			schema: `definition user {}
 
@@ -601,4 +849,46 @@ definition resource {
 		require.Equal(t, input.Position{LineNumber: 9, ColumnPosition: 5}, ref.Position)
 		require.Equal(t, &input.Position{LineNumber: 1, ColumnPosition: 0}, ref.TargetPosition)
 	})
+}
+
+// TestSchemaPositionMapperArrowRHSImportedTarget exercises arrow RHS hover when
+// the target namespace lives in an imported file. The arrow resolution itself
+// finds the right relation; the TargetSource may currently point at the wrong
+// file because resolveTargetSource keys off the relation name rather than the
+// owning definition name. This test pins the current behavior so regressions
+// are caught and the unrelated TargetSource fix can be tracked separately.
+func TestSchemaPositionMapperArrowRHSImportedTarget(t *testing.T) {
+	rootSchema := `use import
+import "path/groups.zed"
+
+definition document {
+	relation parent: group
+	permission viewable = parent->member
+}
+`
+	sourceFS := fstest.MapFS{
+		"path/groups.zed": &fstest.MapFile{Data: []byte("definition user {}\ndefinition group {\nrelation member: user\n}\n")},
+	}
+
+	rootSource := input.Source("path/root.zed")
+	compiled, err := compiler.Compile(compiler.InputSchema{
+		Source:       rootSource,
+		SchemaString: rootSchema,
+	}, compiler.AllowUnprefixedObjectType(), compiler.SourceFS(sourceFS))
+	require.NoError(t, err)
+
+	mapper, err := NewSchemaPositionMapper(compiled)
+	require.NoError(t, err)
+
+	// Cursor on "member" in `parent->member`.
+	ref, err := mapper.ReferenceAtPosition(rootSource, input.Position{
+		LineNumber:     5,
+		ColumnPosition: 32,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ref, "arrow RHS should now resolve")
+	require.Equal(t, "member", ref.Text)
+	require.Equal(t, ReferenceTypeRelation, ref.ReferenceType)
+	require.Equal(t, "relation member", ref.ReferenceMarkdown)
+	require.Equal(t, &input.Position{LineNumber: 2, ColumnPosition: 0}, ref.TargetPosition)
 }


### PR DESCRIPTION
## Changes

* Replace the arrow RHS short-circuit in `SchemaPositionMapper.relationReferenceChain` with proper resolution via `Definition.AllowedSubjectRelations`, so hover and go-to-definition work on the right side of `.any`, `.all`, and `->`.

<img width="832" height="532" alt="Screenshot 2026-06-05 at 6 04 43 PM" src="https://github.com/user-attachments/assets/41e50b9a-ee64-4827-904d-e6b60e4752ad" />
<img width="832" height="532" alt="Screenshot 2026-06-05 at 6 35 19 PM" src="https://github.com/user-attachments/assets/6cde50ac-65a4-46e2-bacf-e70af18cf432" />


Closes #2990