### PR TITLE
test: address flake in HeadRevisionDoesNotConsumeXID

### DIFF
--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -1162,7 +1162,11 @@ func HeadRevisionDoesNotConsumeXIDTest(t *testing.T, ds datastore.Datastore) {
 	}
 	after := nextXID()
 
-	require.Equal(t, before, after, "HeadRevision burned %d xid(s) over %d calls; expected 0", after-before, iterations)
+	// NOTE: we're expecting <= 1 here because there's a heartbeat goroutine that increments
+	// the xid over time. this may or may not fire once during the test.
+	// We still want to assert that it doesn't happen 10 times, because that was the regression
+	// that this test was intended to catch.
+	require.LessOrEqual(t, after-before, uint64(0), "HeadRevision burned %d xid(s) over %d calls; expected <=1", after-before, iterations)
 }
 
 // ConcurrentRevisionWatchTest uses goroutines and channels to intentionally set up a pair of

--- a/internal/datastore/postgres/postgres_shared_test.go
+++ b/internal/datastore/postgres/postgres_shared_test.go
@@ -1162,11 +1162,7 @@ func HeadRevisionDoesNotConsumeXIDTest(t *testing.T, ds datastore.Datastore) {
 	}
 	after := nextXID()
 
-	// NOTE: we're expecting <= 1 here because there's a heartbeat goroutine that increments
-	// the xid over time. this may or may not fire once during the test.
-	// We still want to assert that it doesn't happen 10 times, because that was the regression
-	// that this test was intended to catch.
-	require.LessOrEqual(t, after-before, uint64(0), "HeadRevision burned %d xid(s) over %d calls; expected <=1", after-before, iterations)
+	require.Equal(t, before, after, "HeadRevision burned %d xid(s) over %d calls; expected 0", after-before, iterations)
 }
 
 // ConcurrentRevisionWatchTest uses goroutines and channels to intentionally set up a pair of

--- a/internal/testserver/datastore/postgres.go
+++ b/internal/testserver/datastore/postgres.go
@@ -64,6 +64,11 @@ func RunPostgresForTestingWithCommitTimestamps(t testing.TB, bridgeNetworkName s
 		cmd = append(cmd, "-c", "track_commit_timestamp=1")
 	}
 
+	// Turn off autovacuum. This shouldn't meaningfully change the behavior of postgres
+	// on the timescale of our tests and should allow the XID consumption test to run without
+	// failing.
+	cmd = append(cmd, "-c", "autovacuum=off")
+
 	postgres, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Name:       postgresContainerHostname,
 		Repository: "postgres",


### PR DESCRIPTION
## Description
This test has been flaking: https://github.com/authzed/spicedb/actions/runs/27164166509/job/80187393099?pr=3154

Relaxing the assertion slightly should help.

## Changes
* Use a leq assertion instead of an equality assertion
## Testing
Review.