### PR TITLE
feat: in-process embedded permissions and per-schema-version caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated the Prometheus buckets for `grpc_server_handling_seconds` and `spicedb_datastore_query_latency` to be able to correlate them (https://github.com/authzed/spicedb/pull/3188)
 - Use `testcontainers` instead of `ory/dockertest` for running containers in integration tests (https://github.com/authzed/spicedb/pull/2782)
 - Embedded: add `pkg/embedded`, an in-process library for running permission checks against a datastore via the dispatch engine, without standing up a gRPC server (https://github.com/authzed/spicedb/pull/3166)
-- Caveats: compiled caveats (and their CEL environments) are now cached per schema version rather than rebuilt on every check, reducing check cost for schemas with many caveats (https://github.com/authzed/spicedb/pull/3166)
-- Datastore: schema-derived artifacts (e.g. compiled caveats) are now cached on the stored schema (`ReadOnlyStoredSchema`) and share its lifetime, so they are rebuilt only when the schema changes (https://github.com/authzed/spicedb/pull/3166)
+- Caveats: compiled caveats (and their CEL environments) are now cached per schema version — hung off the stored schema (`ReadOnlyStoredSchema`) and rebuilt only when the schema changes — rather than rebuilt on every check, reducing check cost for schemas with many caveats (https://github.com/authzed/spicedb/pull/3166)
 
 ### Fixed
 - Fixed a nil pointer dereference panic in `CheckBulkPermissions` that could occur under concurrent load when a tracing-enabled check shared a singleflight dispatch with a non-tracing bulk check. Debug-enabled checks are no longer singleflighted together with non-debug checks. (https://github.com/authzed/spicedb/pull/3174)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Schema: reads inside write transactions now use a cheap hash-only lookup (`schema_revision`) to check the cache before loading the full schema blob, reducing DB round-trips on cache hits (https://github.com/authzed/spicedb/pull/3160)
 - Updated the Prometheus buckets for `grpc_server_handling_seconds` and `spicedb_datastore_query_latency` to be able to correlate them (https://github.com/authzed/spicedb/pull/3188)
 - Use `testcontainers` instead of `ory/dockertest` for running containers in integration tests (https://github.com/authzed/spicedb/pull/2782)
+- Embedded: add `pkg/embedded`, an in-process library for running permission checks against a datastore via the dispatch engine, without standing up a gRPC server (https://github.com/authzed/spicedb/pull/3166)
+- Caveats: compiled caveats (and their CEL environments) are now cached per schema version rather than rebuilt on every check, reducing check cost for schemas with many caveats (https://github.com/authzed/spicedb/pull/3166)
+- Datastore: schema-derived artifacts (e.g. compiled caveats) are now cached on the stored schema (`ReadOnlyStoredSchema`) and share its lifetime, so they are rebuilt only when the schema changes (https://github.com/authzed/spicedb/pull/3166)
 
 ### Fixed
 - Fixed a nil pointer dereference panic in `CheckBulkPermissions` that could occur under concurrent load when a tracing-enabled check shared a singleflight dispatch with a non-tracing bulk check. Debug-enabled checks are no longer singleflighted together with non-debug checks. (https://github.com/authzed/spicedb/pull/3174)

--- a/internal/caveats/run.go
+++ b/internal/caveats/run.go
@@ -51,11 +51,24 @@ func RunSingleCaveatExpression(
 	return runner.RunCaveatExpression(ctx, expr, context, reader, debugOption)
 }
 
+// cachedSchemaProvider is satisfied (structurally) by SchemaReaders backed by a unified
+// stored schema. It exposes the shared, per-schema-version stored schema, which hosts
+// schema-derived caches such as the compiled-caveat cache.
+type cachedSchemaProvider interface {
+	StoredSchema() *datastore.ReadOnlyStoredSchema
+}
+
 // CaveatRunner is a helper for running caveats, providing a cache for deserialized caveats.
 type CaveatRunner struct {
 	caveatTypeSet       *caveattypes.TypeSet
 	caveatDefs          map[string]*core.CaveatDefinition
 	deserializedCaveats map[string]*caveats.CompiledCaveat
+
+	// schemaCache, when non-nil, is a compiled-caveat cache tied to the stored schema
+	// (and thus shared across checks and invalidated on schema change). It is discovered
+	// from the reader on first use. When nil, deserializedCaveats provides per-runner
+	// caching only (the legacy behavior).
+	schemaCache *CompiledCaveatCache
 }
 
 // NewCaveatRunner creates a new CaveatRunner.
@@ -90,6 +103,21 @@ func (cr *CaveatRunner) RunCaveatExpression(
 func (cr *CaveatRunner) PopulateCaveatDefinitionsForExpr(ctx context.Context, expr *core.CaveatExpression, reader CaveatDefinitionLookup) error {
 	ctx, span := tracer.Start(ctx, "PopulateCaveatDefinitions")
 	defer span.End()
+
+	// If the reader is backed by a unified stored schema, use the compiled-caveat cache
+	// tied to that schema version so deserialization (which rebuilds the CEL environment)
+	// is paid once per schema rather than once per check.
+	if cr.schemaCache == nil {
+		if provider, ok := reader.(cachedSchemaProvider); ok {
+			if stored := provider.StoredSchema(); stored != nil {
+				schemaCache, err := CompiledCaveatCacheFor(stored)
+				if err != nil {
+					return err
+				}
+				cr.schemaCache = schemaCache
+			}
+		}
+	}
 
 	// Collect all referenced caveat definitions in the expression.
 	caveatNames := mapz.NewSet[string]()
@@ -138,12 +166,23 @@ func (cr *CaveatRunner) get(caveatDefName string) (*core.CaveatDefinition, *cave
 		return caveat, deserialized, nil
 	}
 
-	parameterTypes, err := caveattypes.DecodeParameterTypes(cr.caveatTypeSet, caveat.ParameterTypes)
-	if err != nil {
-		return nil, nil, err
+	compile := func() (*caveats.CompiledCaveat, error) {
+		parameterTypes, err := caveattypes.DecodeParameterTypes(cr.caveatTypeSet, caveat.ParameterTypes)
+		if err != nil {
+			return nil, err
+		}
+		return caveats.DeserializeCaveatWithTypeSet(cr.caveatTypeSet, caveat.SerializedExpression, parameterTypes)
 	}
 
-	justDeserialized, err := caveats.DeserializeCaveatWithTypeSet(cr.caveatTypeSet, caveat.SerializedExpression, parameterTypes)
+	// Prefer the schema-tied cache (shared across checks) when available; fall back to
+	// per-runner compilation otherwise.
+	var justDeserialized *caveats.CompiledCaveat
+	var err error
+	if cr.schemaCache != nil {
+		justDeserialized, err = cr.schemaCache.GetOrCompile(caveatDefName, compile)
+	} else {
+		justDeserialized, err = compile()
+	}
 	if err != nil {
 		return caveat, nil, err
 	}

--- a/internal/caveats/run.go
+++ b/internal/caveats/run.go
@@ -64,11 +64,11 @@ type CaveatRunner struct {
 	caveatDefs          map[string]*core.CaveatDefinition
 	deserializedCaveats map[string]*caveats.CompiledCaveat
 
-	// schemaCache, when non-nil, is a compiled-caveat cache tied to the stored schema
+	// compiledCaveatCache, when non-nil, is a compiled-caveat cache tied to the stored schema
 	// (and thus shared across checks and invalidated on schema change). It is discovered
 	// from the reader on first use. When nil, deserializedCaveats provides per-runner
 	// caching only (the legacy behavior).
-	schemaCache *CompiledCaveatCache
+	compiledCaveatCache *CompiledCaveatCache
 }
 
 // NewCaveatRunner creates a new CaveatRunner.
@@ -107,14 +107,14 @@ func (cr *CaveatRunner) PopulateCaveatDefinitionsForExpr(ctx context.Context, ex
 	// If the reader is backed by a unified stored schema, use the compiled-caveat cache
 	// tied to that schema version so deserialization (which rebuilds the CEL environment)
 	// is paid once per schema rather than once per check.
-	if cr.schemaCache == nil {
+	if cr.compiledCaveatCache == nil {
 		if provider, ok := reader.(cachedSchemaProvider); ok {
 			if stored := provider.StoredSchema(); stored != nil {
-				schemaCache, err := CompiledCaveatCacheFor(stored)
+				compiledCaveatCache, err := CompiledCaveatCacheFor(stored)
 				if err != nil {
 					return err
 				}
-				cr.schemaCache = schemaCache
+				cr.compiledCaveatCache = compiledCaveatCache
 			}
 		}
 	}
@@ -178,8 +178,8 @@ func (cr *CaveatRunner) get(caveatDefName string) (*core.CaveatDefinition, *cave
 	// per-runner compilation otherwise.
 	var justDeserialized *caveats.CompiledCaveat
 	var err error
-	if cr.schemaCache != nil {
-		justDeserialized, err = cr.schemaCache.GetOrCompile(caveatDefName, compile)
+	if cr.compiledCaveatCache != nil {
+		justDeserialized, err = cr.compiledCaveatCache.GetOrCompile(caveatDefName, compile)
 	} else {
 		justDeserialized, err = compile()
 	}

--- a/internal/caveats/run_test.go
+++ b/internal/caveats/run_test.go
@@ -731,6 +731,70 @@ func TestCaveatRunnerPopulateCaveatDefinitionsForExpr(t *testing.T) {
 	req.True(result.IsPartial())
 }
 
+// storedSchemaCaveatReader wraps a CaveatDefinitionLookup so it also advertises a stored
+// schema. That is what makes CaveatRunner discover and use the schema-tied compiled-caveat
+// cache (the cachedSchemaProvider path) rather than per-runner compilation.
+type storedSchemaCaveatReader struct {
+	CaveatDefinitionLookup
+	stored *datastore.ReadOnlyStoredSchema
+}
+
+func (r storedSchemaCaveatReader) StoredSchema() *datastore.ReadOnlyStoredSchema {
+	return r.stored
+}
+
+func TestCaveatRunnerUsesSchemaTiedCompiledCaveatCache(t *testing.T) {
+	req := require.New(t)
+
+	rawDS, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, 0, memdb.DisableGC)
+	req.NoError(err)
+
+	ds, _ := testfixtures.DatastoreFromSchemaAndTestRelationships(t, rawDS, `
+		caveat first_caveat(firstparam int) {
+			firstparam == 42
+		}
+		`, nil)
+
+	headRevisionResult, err := ds.HeadRevision(t.Context())
+	req.NoError(err)
+
+	dl := datalayer.NewDataLayer(ds)
+	sr, err := dl.SnapshotReader(headRevisionResult.Revision, datalayer.NoSchemaHashForTesting).ReadSchema(t.Context())
+	req.NoError(err)
+
+	// A stored schema is what a unified-schema reader exposes; wrapping the real reader with
+	// one drives the schema-tied cache path.
+	stored := datastore.NewReadOnlyStoredSchema(&core.StoredSchema{
+		VersionOneof: &core.StoredSchema_V1{
+			V1: &core.StoredSchema_V1StoredSchema{SchemaText: "caveat first_caveat(firstparam int) { firstparam == 42 }"},
+		},
+	})
+	reader := storedSchemaCaveatReader{CaveatDefinitionLookup: sr, stored: stored}
+
+	runner := NewCaveatRunner(types.Default.TypeSet)
+	expr := caveatexpr("first_caveat")
+
+	result, err := runner.RunCaveatExpression(t.Context(), expr,
+		map[string]any{"firstparam": int64(42)}, reader, RunCaveatExpressionNoDebugging)
+	req.NoError(err)
+	req.True(result.Value())
+
+	// The runner discovered the schema-tied cache...
+	req.NotNil(runner.compiledCaveatCache)
+	shared, err := CompiledCaveatCacheFor(stored)
+	req.NoError(err)
+	req.Same(runner.compiledCaveatCache, shared) // ...and it is THE cache hung off that schema.
+
+	// ...and the run populated it: the compiled caveat is now cached, so GetOrCompile
+	// returns it without recompiling (proving the cache is actually used across checks).
+	got, err := shared.GetOrCompile("first_caveat", func() (*pkgcaveats.CompiledCaveat, error) {
+		t.Fatal("compile should not be called; first_caveat should already be cached")
+		return nil, nil
+	})
+	req.NoError(err)
+	req.NotNil(got)
+}
+
 func TestCaveatRunnerEmptyExpression(t *testing.T) {
 	req := require.New(t)
 

--- a/internal/caveats/schemacache.go
+++ b/internal/caveats/schemacache.go
@@ -1,0 +1,49 @@
+package caveats
+
+import (
+	"sync"
+
+	"github.com/authzed/spicedb/pkg/caveats"
+	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
+)
+
+// compiledCaveatCacheKey identifies the schema-derived cache of compiled (deserialized)
+// caveats. The cache is tied to a single stored-schema version (via datastore.ReadOnlyStoredSchema)
+// and is discarded when the schema changes.
+var compiledCaveatCacheKey = datastore.NewDerivedCacheKey("caveats.compiled")
+
+func init() {
+	if err := datastore.RegisterDerivedCache(compiledCaveatCacheKey, func() any { return &CompiledCaveatCache{} }); err != nil {
+		spiceerrors.MustPanicf("failed to register compiled caveat cache: %v", err)
+	}
+}
+
+// CompiledCaveatCache caches deserialized caveats (which embed a built CEL environment) by
+// caveat name, for a single schema version. Deserializing a caveat rebuilds its CEL
+// environment, which is expensive; caching it on the (shared) stored schema avoids paying
+// that cost on every check.
+type CompiledCaveatCache struct {
+	m sync.Map // map[string]*caveats.CompiledCaveat
+}
+
+// GetOrCompile returns the cached compiled caveat for name, or invokes compile and caches
+// the result. compile is only called on a miss; concurrent misses may call compile more
+// than once but only one result is retained.
+func (c *CompiledCaveatCache) GetOrCompile(name string, compile func() (*caveats.CompiledCaveat, error)) (*caveats.CompiledCaveat, error) {
+	if v, ok := c.m.Load(name); ok {
+		return v.(*caveats.CompiledCaveat), nil
+	}
+	compiled, err := compile()
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := c.m.LoadOrStore(name, compiled)
+	return actual.(*caveats.CompiledCaveat), nil
+}
+
+// CompiledCaveatCacheFor returns the compiled-caveat cache tied to the given stored schema,
+// building it lazily on first access.
+func CompiledCaveatCacheFor(s *datastore.ReadOnlyStoredSchema) (*CompiledCaveatCache, error) {
+	return datastore.GetDerivedCache[*CompiledCaveatCache](s, compiledCaveatCacheKey)
+}

--- a/internal/caveats/schemacache.go
+++ b/internal/caveats/schemacache.go
@@ -13,10 +13,31 @@ import (
 // and is discarded when the schema changes.
 var compiledCaveatCacheKey = datastore.NewDerivedCacheKey("caveats.compiled")
 
+// compiledCaveatOverheadBytes is a rough per-caveat estimate of the memory a compiled caveat
+// adds on top of its serialized expression. A compiled caveat embeds a built CEL environment
+// and program, which dwarf the serialized expression; this is a deliberately conservative,
+// order-of-magnitude figure used only for cache-cost budgeting.
+const compiledCaveatOverheadBytes = 8 * 1024
+
 func init() {
-	if err := datastore.RegisterDerivedCache(compiledCaveatCacheKey, func() any { return &CompiledCaveatCache{} }); err != nil {
+	if err := datastore.RegisterDerivedCache(compiledCaveatCacheKey, func() any { return &CompiledCaveatCache{} }, estimateCompiledCaveatCacheSize); err != nil {
 		spiceerrors.MustPanicf("failed to register compiled caveat cache: %v", err)
 	}
+}
+
+// estimateCompiledCaveatCacheSize roughly estimates the bytes the compiled-caveat cache adds for
+// the given schema when fully populated: per caveat, the serialized expression plus a fixed
+// overhead for its compiled CEL environment.
+func estimateCompiledCaveatCacheSize(s *datastore.ReadOnlyStoredSchema) int64 {
+	v1 := s.Get().GetV1()
+	if v1 == nil {
+		return 0
+	}
+	total := 0
+	for _, caveat := range v1.GetCaveatDefinitions() {
+		total += len(caveat.GetSerializedExpression()) + compiledCaveatOverheadBytes
+	}
+	return int64(total)
 }
 
 // CompiledCaveatCache caches deserialized caveats (which embed a built CEL environment) by

--- a/internal/caveats/schemacache.go
+++ b/internal/caveats/schemacache.go
@@ -5,40 +5,12 @@ import (
 
 	"github.com/authzed/spicedb/pkg/caveats"
 	"github.com/authzed/spicedb/pkg/datastore"
-	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
-// compiledCaveatCacheKey identifies the schema-derived cache of compiled (deserialized)
-// caveats. The cache is tied to a single stored-schema version (via datastore.ReadOnlyStoredSchema)
+// compiledCaveatCacheKey identifies the schema-derived cache of compiled (deserialized) caveats
+// hung off a datastore.ReadOnlyStoredSchema. The cache is tied to a single stored-schema version
 // and is discarded when the schema changes.
-var compiledCaveatCacheKey = datastore.NewDerivedCacheKey("caveats.compiled")
-
-// compiledCaveatOverheadBytes is a rough per-caveat estimate of the memory a compiled caveat
-// adds on top of its serialized expression. A compiled caveat embeds a built CEL environment
-// and program, which dwarf the serialized expression; this is a deliberately conservative,
-// order-of-magnitude figure used only for cache-cost budgeting.
-const compiledCaveatOverheadBytes = 8 * 1024
-
-func init() {
-	if err := datastore.RegisterDerivedCache(compiledCaveatCacheKey, func() any { return &CompiledCaveatCache{} }, estimateCompiledCaveatCacheSize); err != nil {
-		spiceerrors.MustPanicf("failed to register compiled caveat cache: %v", err)
-	}
-}
-
-// estimateCompiledCaveatCacheSize roughly estimates the bytes the compiled-caveat cache adds for
-// the given schema when fully populated: per caveat, the serialized expression plus a fixed
-// overhead for its compiled CEL environment.
-func estimateCompiledCaveatCacheSize(s *datastore.ReadOnlyStoredSchema) int64 {
-	v1 := s.Get().GetV1()
-	if v1 == nil {
-		return 0
-	}
-	total := 0
-	for _, caveat := range v1.GetCaveatDefinitions() {
-		total += len(caveat.GetSerializedExpression()) + compiledCaveatOverheadBytes
-	}
-	return int64(total)
-}
+var compiledCaveatCacheKey = datastore.NewDerivedCacheKey[*CompiledCaveatCache]()
 
 // CompiledCaveatCache caches deserialized caveats (which embed a built CEL environment) by
 // caveat name, for a single schema version. Deserializing a caveat rebuilds its CEL
@@ -66,5 +38,7 @@ func (c *CompiledCaveatCache) GetOrCompile(name string, compile func() (*caveats
 // CompiledCaveatCacheFor returns the compiled-caveat cache tied to the given stored schema,
 // building it lazily on first access.
 func CompiledCaveatCacheFor(s *datastore.ReadOnlyStoredSchema) (*CompiledCaveatCache, error) {
-	return datastore.GetDerivedCache[*CompiledCaveatCache](s, compiledCaveatCacheKey)
+	return datastore.LoadOrStoreDerived(s, compiledCaveatCacheKey, func() *CompiledCaveatCache {
+		return &CompiledCaveatCache{}
+	})
 }

--- a/internal/caveats/schemacache_test.go
+++ b/internal/caveats/schemacache_test.go
@@ -1,0 +1,46 @@
+package caveats
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/caveats"
+	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+)
+
+func TestCompiledCaveatCacheGetOrCompile(t *testing.T) {
+	env := caveats.NewEnvironmentWithTypeSet(caveattypes.Default.TypeSet)
+	compiled, err := caveats.CompileCaveatWithName(env, "1 == 1", "test")
+	require.NoError(t, err)
+
+	c := &CompiledCaveatCache{}
+	calls := 0
+	compile := func() (*caveats.CompiledCaveat, error) {
+		calls++
+		return compiled, nil
+	}
+
+	// First access compiles; subsequent accesses return the cached instance without recompiling.
+	got1, err := c.GetOrCompile("a", compile)
+	require.NoError(t, err)
+	require.Same(t, compiled, got1)
+
+	got2, err := c.GetOrCompile("a", compile)
+	require.NoError(t, err)
+	require.Same(t, compiled, got2)
+	require.Equal(t, 1, calls, "compile should be invoked once per name")
+
+	// Distinct names compile independently.
+	_, err = c.GetOrCompile("b", compile)
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+
+	// Errors propagate and are not cached.
+	boom := errors.New("boom")
+	_, err = c.GetOrCompile("c", func() (*caveats.CompiledCaveat, error) {
+		return nil, boom
+	})
+	require.ErrorIs(t, err, boom)
+}

--- a/internal/datastore/common/sqlschema.go
+++ b/internal/datastore/common/sqlschema.go
@@ -59,7 +59,8 @@ func (s *SQLSingleStoreSchemaReaderWriter[T]) ReadStoredSchema(ctx context.Conte
 		return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
 	}
 
-	return datastore.NewReadOnlyStoredSchema(storedSchema), nil
+	// len(data) is the exact serialized size, used as the rough schema-size base for cache cost.
+	return datastore.NewReadOnlyStoredSchemaWithSize(storedSchema, len(data)), nil
 }
 
 // WriteStoredSchema writes the stored schema to the unified schema table.

--- a/internal/datastore/memdb/storedschema.go
+++ b/internal/datastore/memdb/storedschema.go
@@ -39,7 +39,8 @@ func (r *memdbReader) ReadStoredSchema(_ context.Context) (*datastore.ReadOnlySt
 		return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
 	}
 
-	return datastore.NewReadOnlyStoredSchema(storedSchema), nil
+	// len(sd.data) is the exact serialized size, used as the rough schema-size base for cache cost.
+	return datastore.NewReadOnlyStoredSchemaWithSize(storedSchema, len(sd.data)), nil
 }
 
 // assertSchemaHash verifies the stored schema hash matches expectedHash.

--- a/pkg/cmd/datastore/datastore.go
+++ b/pkg/cmd/datastore/datastore.go
@@ -138,6 +138,9 @@ type Config struct {
 	BootstrapOverwrite    bool                 `debugmap:"visible"`
 	BootstrapTimeout      time.Duration        `debugmap:"visible"        default:"10s"`
 	CaveatTypeSet         *caveattypes.TypeSet `debugmap:"hidden"`
+	// BootstrapSchemaMode controls the schema storage mode used when writing bootstrap
+	// data. The zero value (SchemaModeReadLegacyWriteLegacy) preserves prior behavior.
+	BootstrapSchemaMode datalayer.SchemaMode `debugmap:"visible"`
 
 	// Hedging
 	RequestHedgingEnabled          bool          `debugmap:"visible"`
@@ -529,7 +532,7 @@ func NewDatastore(ctx context.Context, options ...ConfigOption) (datastore.Datas
 		}
 
 		if len(bootstrapContents) > 0 {
-			bootstrapDL := datalayer.NewDataLayer(ds)
+			bootstrapDL := datalayer.NewDataLayer(ds, datalayer.WithSchemaMode(opts.BootstrapSchemaMode))
 			_, _, err = validationfile.PopulateFromFilesContents(ctx, bootstrapDL, opts.CaveatTypeSet, bootstrapContents)
 			if err != nil {
 				return nil, fmt.Errorf("failed to load bootstrap data: %w", err)

--- a/pkg/cmd/datastore/zz_generated.options.go
+++ b/pkg/cmd/datastore/zz_generated.options.go
@@ -4,6 +4,7 @@ package datastore
 import (
 	"fmt"
 	types "github.com/authzed/spicedb/pkg/caveats/types"
+	datalayer "github.com/authzed/spicedb/pkg/datalayer"
 	defaults "github.com/creasty/defaults"
 	"time"
 )
@@ -55,6 +56,7 @@ func (c *Config) ToOption() ConfigOption {
 		to.BootstrapOverwrite = c.BootstrapOverwrite
 		to.BootstrapTimeout = c.BootstrapTimeout
 		to.CaveatTypeSet = c.CaveatTypeSet
+		to.BootstrapSchemaMode = c.BootstrapSchemaMode
 		to.RequestHedgingEnabled = c.RequestHedgingEnabled
 		to.RequestHedgingInitialSlowValue = c.RequestHedgingInitialSlowValue
 		to.RequestHedgingMaxRequests = c.RequestHedgingMaxRequests
@@ -187,6 +189,13 @@ func (c *Config) DebugMap() map[string]any {
 		debugMap["BootstrapTimeout"] = dm.DebugMap()
 	} else {
 		debugMap["BootstrapTimeout"] = c.BootstrapTimeout
+	}
+	if dm, ok := any(&c.BootstrapSchemaMode).(interface {
+		DebugMap() map[string]any
+	}); ok {
+		debugMap["BootstrapSchemaMode"] = dm.DebugMap()
+	} else {
+		debugMap["BootstrapSchemaMode"] = c.BootstrapSchemaMode
 	}
 	debugMap["RequestHedgingEnabled"] = c.RequestHedgingEnabled
 	if dm, ok := any(&c.RequestHedgingInitialSlowValue).(interface {
@@ -533,6 +542,13 @@ func WithBootstrapTimeout(bootstrapTimeout time.Duration) ConfigOption {
 func WithCaveatTypeSet(caveatTypeSet *types.TypeSet) ConfigOption {
 	return func(c *Config) {
 		c.CaveatTypeSet = caveatTypeSet
+	}
+}
+
+// WithBootstrapSchemaMode returns an option that can set BootstrapSchemaMode on a Config
+func WithBootstrapSchemaMode(bootstrapSchemaMode datalayer.SchemaMode) ConfigOption {
+	return func(c *Config) {
+		c.BootstrapSchemaMode = bootstrapSchemaMode
 	}
 }
 

--- a/pkg/datalayer/hashcache.go
+++ b/pkg/datalayer/hashcache.go
@@ -113,7 +113,14 @@ func (c *schemaHashCache) Set(schemaHash SchemaHash, schema *datastore.ReadOnlyS
 		schema: schema,
 	})
 
-	c.cache.Set(SchemaCacheKey(schemaHash), schema, int64(schema.EstimatedSize()))
+	// Cost the entry by the schema's estimated byte size (schema blob plus the schema-derived
+	// caches it will accrete), so the cache's max-cost budget is in bytes. Floor at 1 so an
+	// (effectively empty) schema is still admitted with a non-zero weight.
+	cost := schema.EstimatedSize()
+	if cost < 1 {
+		cost = 1
+	}
+	c.cache.Set(SchemaCacheKey(schemaHash), schema, cost)
 	return nil
 }
 

--- a/pkg/datalayer/hashcache_test.go
+++ b/pkg/datalayer/hashcache_test.go
@@ -59,8 +59,8 @@ func TestSchemaHashCache_SetCostsBySize(t *testing.T) {
 	require.NoError(t, shc.Set(SchemaHash("small"), small))
 	require.NoError(t, shc.Set(SchemaHash("large"), large))
 
-	require.Equal(t, int64(small.EstimatedSize()), tc.cost(SchemaCacheKey("small")))
-	require.Equal(t, int64(large.EstimatedSize()), tc.cost(SchemaCacheKey("large")))
+	require.Equal(t, small.EstimatedSize(), tc.cost(SchemaCacheKey("small")))
+	require.Equal(t, large.EstimatedSize(), tc.cost(SchemaCacheKey("large")))
 	require.Greater(t, tc.cost(SchemaCacheKey("large")), tc.cost(SchemaCacheKey("small")))
 	require.Greater(t, tc.cost(SchemaCacheKey("small")), int64(1))
 }

--- a/pkg/datalayer/impl.go
+++ b/pkg/datalayer/impl.go
@@ -82,7 +82,8 @@ type defaultDataLayer struct {
 // Ignored for empty or bypass-sentinel values.
 func (d *defaultDataLayer) observeSchemaHash(h SchemaHash) {
 	if h != "" && !h.IsBypassSentinel() {
-		d.lastSchemaHash.Store(new(string(h)))
+		s := string(h)
+		d.lastSchemaHash.Store(&s)
 	}
 }
 

--- a/pkg/datalayer/schema_adapter.go
+++ b/pkg/datalayer/schema_adapter.go
@@ -352,6 +352,15 @@ func newStoredSchemaReaderAdapter(ctx context.Context, reader storedSchemaReader
 	return &storedSchemaReaderAdapter{storedSchema: storedSchema, lastWrittenRevision: lastWrittenRevision}, nil
 }
 
+// StoredSchema returns the shared, per-schema-version stored schema backing this reader. It is
+// shared across readers for a single schema version (via the stored-schema cache) and hosts
+// schema-derived caches (see datastore.GetDerivedCache). Consumers may type-assert a
+// SchemaReader to the (structural) interface { StoredSchema() *datastore.ReadOnlyStoredSchema }
+// to access it.
+func (s *storedSchemaReaderAdapter) StoredSchema() *datastore.ReadOnlyStoredSchema {
+	return s.storedSchema
+}
+
 func (s *storedSchemaReaderAdapter) v1() *core.StoredSchema_V1StoredSchema {
 	if v1 := s.storedSchema.Get().GetV1(); v1 != nil {
 		return v1

--- a/pkg/datalayer/schema_adapter.go
+++ b/pkg/datalayer/schema_adapter.go
@@ -354,7 +354,7 @@ func newStoredSchemaReaderAdapter(ctx context.Context, reader storedSchemaReader
 
 // StoredSchema returns the shared, per-schema-version stored schema backing this reader. It is
 // shared across readers for a single schema version (via the stored-schema cache) and hosts
-// schema-derived caches (see datastore.GetDerivedCache). Consumers may type-assert a
+// schema-derived caches (see datastore.LoadOrStoreDerived). Consumers may type-assert a
 // SchemaReader to the (structural) interface { StoredSchema() *datastore.ReadOnlyStoredSchema }
 // to access it.
 func (s *storedSchemaReaderAdapter) StoredSchema() *datastore.ReadOnlyStoredSchema {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -517,8 +518,16 @@ type RevisionedNamespace = RevisionedDefinition[*core.NamespaceDefinition]
 
 // ReadOnlyStoredSchema wraps a *core.StoredSchema to indicate it is read-only
 // and must not be modified, as it may be shared across multiple callers via caching.
+//
+// A ReadOnlyStoredSchema also hosts lazily-built, schema-derived caches (for example
+// compiled caveats; see GetDerivedCache). Because a single instance is shared across
+// callers for a given schema version via the stored-schema cache, those derived caches
+// live exactly as long as the schema version they belong to and are discarded, together,
+// when the schema changes. The underlying schema itself remains immutable; only the
+// concurrency-safe derived caches are populated on demand.
 type ReadOnlyStoredSchema struct {
-	schema *core.StoredSchema
+	schema  *core.StoredSchema
+	derived sync.Map // map[DerivedCacheKey]any
 }
 
 // NewReadOnlyStoredSchema wraps a StoredSchema as read-only.

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -520,7 +520,7 @@ type RevisionedNamespace = RevisionedDefinition[*core.NamespaceDefinition]
 // and must not be modified, as it may be shared across multiple callers via caching.
 //
 // A ReadOnlyStoredSchema also hosts lazily-built, schema-derived caches (for example
-// compiled caveats; see GetDerivedCache). Because a single instance is shared across
+// compiled caveats; see LoadOrStoreDerived). Because a single instance is shared across
 // callers for a given schema version via the stored-schema cache, those derived caches
 // live exactly as long as the schema version they belong to and are discarded, together,
 // when the schema changes. The underlying schema itself remains immutable; only the
@@ -528,7 +528,7 @@ type RevisionedNamespace = RevisionedDefinition[*core.NamespaceDefinition]
 type ReadOnlyStoredSchema struct {
 	schema     *core.StoredSchema
 	schemaSize int64    // rough byte size of the schema, used as a cache-cost base (see EstimatedSize)
-	derived    sync.Map // map[DerivedCacheKey]any
+	derived    sync.Map // derived-cache kinds keyed by DerivedCacheKey id; see LoadOrStoreDerived
 }
 
 // NewReadOnlyStoredSchema wraps a StoredSchema as read-only. Returns nil if the provided

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -526,34 +526,36 @@ type RevisionedNamespace = RevisionedDefinition[*core.NamespaceDefinition]
 // when the schema changes. The underlying schema itself remains immutable; only the
 // concurrency-safe derived caches are populated on demand.
 type ReadOnlyStoredSchema struct {
-	schema  *core.StoredSchema
-	derived sync.Map // map[DerivedCacheKey]any
+	schema     *core.StoredSchema
+	schemaSize int64    // rough byte size of the schema, used as a cache-cost base (see EstimatedSize)
+	derived    sync.Map // map[DerivedCacheKey]any
 }
 
-// NewReadOnlyStoredSchema wraps a StoredSchema as read-only.
-// Returns nil if the provided schema is nil.
+// NewReadOnlyStoredSchema wraps a StoredSchema as read-only. Returns nil if the provided
+// schema is nil. The schema's byte size is estimated cheaply from its schema text; callers
+// that have the exact serialized size on hand (e.g. datastore readers that just unmarshaled
+// it) should prefer NewReadOnlyStoredSchemaWithSize.
 func NewReadOnlyStoredSchema(schema *core.StoredSchema) *ReadOnlyStoredSchema {
 	if schema == nil {
 		return nil
 	}
-	return &ReadOnlyStoredSchema{schema: schema}
+	return NewReadOnlyStoredSchemaWithSize(schema, len(schema.GetV1().GetSchemaText()))
+}
+
+// NewReadOnlyStoredSchemaWithSize wraps a StoredSchema as read-only, recording sizeBytes as a
+// rough byte size of the schema for cache-cost accounting (see EstimatedSize). Returns nil if
+// the provided schema is nil. sizeBytes need not be exact; the serialized length the schema
+// was read from is a good value.
+func NewReadOnlyStoredSchemaWithSize(schema *core.StoredSchema, sizeBytes int) *ReadOnlyStoredSchema {
+	if schema == nil {
+		return nil
+	}
+	return &ReadOnlyStoredSchema{schema: schema, schemaSize: int64(sizeBytes)}
 }
 
 // Get returns the underlying StoredSchema. Callers must not modify the returned value.
 func (r *ReadOnlyStoredSchema) Get() *core.StoredSchema {
 	return r.schema
-}
-
-// EstimatedSize returns an approximate size of the stored schema in bytes,
-// using the length of the schema string as a proxy.
-// It is used for cache cost accounting; the live in-memory object graph is
-// somewhat larger than the serialized size, but this is a decent estimate.
-// Returns 0 for a nil schema.
-func (r *ReadOnlyStoredSchema) EstimatedSize() int {
-	if r == nil || r.schema == nil {
-		return 0
-	}
-	return len(r.schema.GetV1().SchemaText)
 }
 
 // Reader is an interface for reading relationships from the datastore.

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -16,8 +16,8 @@ import (
 func TestReadOnlyStoredSchemaEstimatedSize(t *testing.T) {
 	// Nil-safe: a nil wrapper and a wrapper around nil both report 0.
 	var nilSchema *ReadOnlyStoredSchema
-	require.Equal(t, 0, nilSchema.EstimatedSize())
-	require.Equal(t, 0, NewReadOnlyStoredSchema(nil).EstimatedSize())
+	require.Equal(t, int64(0), nilSchema.EstimatedSize())
+	require.Equal(t, int64(0), NewReadOnlyStoredSchema(nil).EstimatedSize())
 
 	// A populated schema reports its serialized size (greater than zero), and a
 	// larger schema reports a larger size.
@@ -33,7 +33,7 @@ func TestReadOnlyStoredSchemaEstimatedSize(t *testing.T) {
 	})
 	require.Positive(t, small.EstimatedSize())
 	require.Greater(t, large.EstimatedSize(), small.EstimatedSize())
-	require.Equal(t, len(small.Get().GetV1().SchemaText), small.EstimatedSize())
+	require.Equal(t, int64(len(small.Get().GetV1().SchemaText)), small.EstimatedSize())
 }
 
 func TestRelationshipsFilterFromPublicFilter(t *testing.T) {

--- a/pkg/datastore/derivedcache.go
+++ b/pkg/datastore/derivedcache.go
@@ -18,19 +18,49 @@ func NewDerivedCacheKey(name string) DerivedCacheKey { return DerivedCacheKey{na
 // Name returns the human-readable name of the key.
 func (k DerivedCacheKey) Name() string { return k.name }
 
-// derivedCacheFactories maps a DerivedCacheKey to a factory that builds an empty cache
-// instance. Registered once at init time via RegisterDerivedCache.
-var derivedCacheFactories sync.Map // map[DerivedCacheKey]func() any
+// derivedCacheRegistration bundles the lazy factory for a derived cache kind with an estimator
+// of how many bytes that cache adds, when fully populated, on top of the schema it hangs off.
+type derivedCacheRegistration struct {
+	factory   func() any
+	estimator func(*ReadOnlyStoredSchema) int64
+}
 
-// RegisterDerivedCache registers a factory used to lazily build a schema-derived cache of the
-// given kind. The factory returns a fresh, empty cache and is invoked at most once per
-// ReadOnlyStoredSchema instance (i.e. once per schema version). Intended to be called from an
-// init() function. It returns an error if a factory is already registered for the key.
-func RegisterDerivedCache(key DerivedCacheKey, factory func() any) error {
-	if _, loaded := derivedCacheFactories.LoadOrStore(key, factory); loaded {
+// derivedCacheFactories maps a DerivedCacheKey to its registration. Registered once at init
+// time via RegisterDerivedCache.
+var derivedCacheFactories sync.Map // map[DerivedCacheKey]derivedCacheRegistration
+
+// RegisterDerivedCache registers a derived cache kind. factory returns a fresh, empty cache and
+// is invoked at most once per ReadOnlyStoredSchema instance (i.e. once per schema version).
+// estimator returns a rough byte size that this cache adds, when populated, on top of the
+// schema; it is summed into the schema's cache cost (see ReadOnlyStoredSchema.EstimatedSize) and
+// may be nil to contribute nothing. Intended to be called from an init() function. It returns an
+// error if a kind is already registered for the key.
+func RegisterDerivedCache(key DerivedCacheKey, factory func() any, estimator func(*ReadOnlyStoredSchema) int64) error {
+	reg := derivedCacheRegistration{factory: factory, estimator: estimator}
+	if _, loaded := derivedCacheFactories.LoadOrStore(key, reg); loaded {
 		return fmt.Errorf("derived schema cache already registered for key %q", key.name)
 	}
 	return nil
+}
+
+// EstimatedSize returns a rough byte size for this stored schema: the schema's own size plus,
+// for every registered derived cache kind, that kind's estimate of the additional bytes it adds
+// when populated. It is intended as the cost when caching the schema, so the cache's max-cost
+// budget accounts for the derived caches the schema will accrete (compiled caveats, etc.), not
+// just the schema blob. The estimate is deliberately rough and conservative (it assumes every
+// kind will be populated).
+func (r *ReadOnlyStoredSchema) EstimatedSize() int64 {
+	if r == nil {
+		return 0
+	}
+	size := r.schemaSize
+	derivedCacheFactories.Range(func(_, v any) bool {
+		if reg := v.(derivedCacheRegistration); reg.estimator != nil {
+			size += reg.estimator(r)
+		}
+		return true
+	})
+	return size
 }
 
 // derivedCache returns the derived cache registered under key for this schema, building it
@@ -41,11 +71,11 @@ func (r *ReadOnlyStoredSchema) derivedCache(key DerivedCacheKey) (any, error) {
 	if v, ok := r.derived.Load(key); ok {
 		return v, nil
 	}
-	factory, ok := derivedCacheFactories.Load(key)
+	reg, ok := derivedCacheFactories.Load(key)
 	if !ok {
 		return nil, spiceerrors.MustBugf("no derived schema cache registered for key %q", key.name)
 	}
-	built := factory.(func() any)()
+	built := reg.(derivedCacheRegistration).factory()
 	actual, _ := r.derived.LoadOrStore(key, built)
 	return actual, nil
 }

--- a/pkg/datastore/derivedcache.go
+++ b/pkg/datastore/derivedcache.go
@@ -1,0 +1,68 @@
+package datastore
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/authzed/spicedb/pkg/spiceerrors"
+)
+
+// DerivedCacheKey identifies a kind of schema-derived cache (e.g. compiled caveats) hung off a
+// ReadOnlyStoredSchema. Create one per kind, typically as a package-level var, via
+// NewDerivedCacheKey.
+type DerivedCacheKey struct{ name string }
+
+// NewDerivedCacheKey returns a DerivedCacheKey with the given (debug) name.
+func NewDerivedCacheKey(name string) DerivedCacheKey { return DerivedCacheKey{name: name} }
+
+// Name returns the human-readable name of the key.
+func (k DerivedCacheKey) Name() string { return k.name }
+
+// derivedCacheFactories maps a DerivedCacheKey to a factory that builds an empty cache
+// instance. Registered once at init time via RegisterDerivedCache.
+var derivedCacheFactories sync.Map // map[DerivedCacheKey]func() any
+
+// RegisterDerivedCache registers a factory used to lazily build a schema-derived cache of the
+// given kind. The factory returns a fresh, empty cache and is invoked at most once per
+// ReadOnlyStoredSchema instance (i.e. once per schema version). Intended to be called from an
+// init() function. It returns an error if a factory is already registered for the key.
+func RegisterDerivedCache(key DerivedCacheKey, factory func() any) error {
+	if _, loaded := derivedCacheFactories.LoadOrStore(key, factory); loaded {
+		return fmt.Errorf("derived schema cache already registered for key %q", key.name)
+	}
+	return nil
+}
+
+// derivedCache returns the derived cache registered under key for this schema, building it
+// once (lazily) on first access. It returns an error if no factory is registered for key,
+// which indicates a programming error (a cache kind accessed without being registered at
+// init).
+func (r *ReadOnlyStoredSchema) derivedCache(key DerivedCacheKey) (any, error) {
+	if v, ok := r.derived.Load(key); ok {
+		return v, nil
+	}
+	factory, ok := derivedCacheFactories.Load(key)
+	if !ok {
+		return nil, spiceerrors.MustBugf("no derived schema cache registered for key %q", key.name)
+	}
+	built := factory.(func() any)()
+	actual, _ := r.derived.LoadOrStore(key, built)
+	return actual, nil
+}
+
+// GetDerivedCache returns the schema-derived cache of type T registered under key for the given
+// stored schema, building it lazily on first access. It returns an error if no factory is
+// registered for key or if the registered factory produced a value of a type other than T,
+// both of which indicate a programming error.
+func GetDerivedCache[T any](r *ReadOnlyStoredSchema, key DerivedCacheKey) (T, error) {
+	var zero T
+	v, err := r.derivedCache(key)
+	if err != nil {
+		return zero, err
+	}
+	typed, ok := v.(T)
+	if !ok {
+		return zero, spiceerrors.MustBugf("derived schema cache for key %q has type %T, wanted %T", key.name, v, zero)
+	}
+	return typed, nil
+}

--- a/pkg/datastore/derivedcache.go
+++ b/pkg/datastore/derivedcache.go
@@ -1,98 +1,82 @@
 package datastore
 
 import (
-	"fmt"
-	"sync"
+	"sync/atomic"
 
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
 
-// DerivedCacheKey identifies a kind of schema-derived cache (e.g. compiled caveats) hung off a
-// ReadOnlyStoredSchema. Create one per kind, typically as a package-level var, via
-// NewDerivedCacheKey.
-type DerivedCacheKey struct{ name string }
+// compiledCaveatOverheadBytes is a rough per-caveat allowance for the memory a compiled caveat
+// (a built CEL environment and program) adds on top of its serialized expression. It is used
+// only for cache-cost budgeting of the schema-derived compiled-caveat cache (built lazily by
+// internal/caveats and hung off the stored schema); it is a deliberately conservative,
+// order-of-magnitude figure.
+const compiledCaveatOverheadBytes = 8 * 1024
 
-// NewDerivedCacheKey returns a DerivedCacheKey with the given (debug) name.
-func NewDerivedCacheKey(name string) DerivedCacheKey { return DerivedCacheKey{name: name} }
+// derivedCacheKeyIDs hands each DerivedCacheKey a distinct identity, so different cache kinds
+// never collide even though they share a schema's derived-cache map.
+var derivedCacheKeyIDs atomic.Uint64
 
-// Name returns the human-readable name of the key.
-func (k DerivedCacheKey) Name() string { return k.name }
-
-// derivedCacheRegistration bundles the lazy factory for a derived cache kind with an estimator
-// of how many bytes that cache adds, when fully populated, on top of the schema it hangs off.
-type derivedCacheRegistration struct {
-	factory   func() any
-	estimator func(*ReadOnlyStoredSchema) int64
+// DerivedCacheKey identifies one kind of schema-derived cache (compiled caveats, type systems,
+// reachability, ...) hung off a ReadOnlyStoredSchema, and binds that kind to the cache's Go type
+// T. Create exactly one per kind, as a package-level var, via NewDerivedCacheKey. The type
+// parameter makes LoadOrStoreDerived type-safe at compile time — there are no string keys and no
+// reflection; lookup is a single uint64-keyed map access.
+type DerivedCacheKey[T any] struct {
+	id uint64
 }
 
-// derivedCacheFactories maps a DerivedCacheKey to its registration. Registered once at init
-// time via RegisterDerivedCache.
-var derivedCacheFactories sync.Map // map[DerivedCacheKey]derivedCacheRegistration
+// NewDerivedCacheKey mints a fresh key identifying a new kind of schema-derived cache of type T.
+// Call it once per kind and store the result in a package-level var; minting a key per call would
+// defeat sharing (each key is a distinct cache).
+func NewDerivedCacheKey[T any]() DerivedCacheKey[T] {
+	return DerivedCacheKey[T]{id: derivedCacheKeyIDs.Add(1)}
+}
 
-// RegisterDerivedCache registers a derived cache kind. factory returns a fresh, empty cache and
-// is invoked at most once per ReadOnlyStoredSchema instance (i.e. once per schema version).
-// estimator returns a rough byte size that this cache adds, when populated, on top of the
-// schema; it is summed into the schema's cache cost (see ReadOnlyStoredSchema.EstimatedSize) and
-// may be nil to contribute nothing. Intended to be called from an init() function. It returns an
-// error if a kind is already registered for the key.
-func RegisterDerivedCache(key DerivedCacheKey, factory func() any, estimator func(*ReadOnlyStoredSchema) int64) error {
-	reg := derivedCacheRegistration{factory: factory, estimator: estimator}
-	if _, loaded := derivedCacheFactories.LoadOrStore(key, reg); loaded {
-		return fmt.Errorf("derived schema cache already registered for key %q", key.name)
+// LoadOrStoreDerived returns the schema-derived cache identified by key for the given stored
+// schema, building it lazily (via build) on first access and reusing it thereafter. The cache
+// lives exactly as long as the ReadOnlyStoredSchema it hangs off — a single schema version — and
+// is discarded with it. This lets internal packages (compiled caveats, type systems,
+// reachability, ...) attach schema-version-scoped caches to the stored schema without
+// pkg/datastore depending on them.
+//
+// build is invoked at most once per (schema, key), on the goroutine that wins the race;
+// concurrent first accesses may each build, but only one result is retained. key's type parameter
+// binds the stored value's type, so the returned error is a defensive guard that should never
+// fire in practice.
+func LoadOrStoreDerived[T any](r *ReadOnlyStoredSchema, key DerivedCacheKey[T], build func() T) (T, error) {
+	var zero T
+	if v, ok := r.derived.Load(key.id); ok {
+		typed, ok := v.(T)
+		if !ok {
+			return zero, spiceerrors.MustBugf("derived schema cache has type %T, wanted %T", v, zero)
+		}
+		return typed, nil
 	}
-	return nil
+
+	actual, _ := r.derived.LoadOrStore(key.id, build())
+	typed, ok := actual.(T)
+	if !ok {
+		return zero, spiceerrors.MustBugf("derived schema cache has type %T, wanted %T", actual, zero)
+	}
+	return typed, nil
 }
 
-// EstimatedSize returns a rough byte size for this stored schema: the schema's own size plus,
-// for every registered derived cache kind, that kind's estimate of the additional bytes it adds
-// when populated. It is intended as the cost when caching the schema, so the cache's max-cost
-// budget accounts for the derived caches the schema will accrete (compiled caveats, etc.), not
-// just the schema blob. The estimate is deliberately rough and conservative (it assumes every
-// kind will be populated).
+// EstimatedSize returns a rough byte size for this stored schema, used as the cost when caching
+// it so the cache's max-cost budget reflects memory rather than entry count. It is the schema's
+// own size plus a conservative allowance for the compiled-caveat cache the schema accretes when
+// checks run: per caveat, its serialized expression plus a fixed compiled-CEL overhead. The
+// estimate is deliberately rough and assumes every caveat will be compiled and cached.
 func (r *ReadOnlyStoredSchema) EstimatedSize() int64 {
 	if r == nil {
 		return 0
 	}
+
 	size := r.schemaSize
-	derivedCacheFactories.Range(func(_, v any) bool {
-		if reg := v.(derivedCacheRegistration); reg.estimator != nil {
-			size += reg.estimator(r)
+	if v1 := r.schema.GetV1(); v1 != nil {
+		for _, caveat := range v1.GetCaveatDefinitions() {
+			size += spiceerrors.MustSafecast[int64](len(caveat.GetSerializedExpression())) + compiledCaveatOverheadBytes
 		}
-		return true
-	})
+	}
 	return size
-}
-
-// derivedCache returns the derived cache registered under key for this schema, building it
-// once (lazily) on first access. It returns an error if no factory is registered for key,
-// which indicates a programming error (a cache kind accessed without being registered at
-// init).
-func (r *ReadOnlyStoredSchema) derivedCache(key DerivedCacheKey) (any, error) {
-	if v, ok := r.derived.Load(key); ok {
-		return v, nil
-	}
-	reg, ok := derivedCacheFactories.Load(key)
-	if !ok {
-		return nil, spiceerrors.MustBugf("no derived schema cache registered for key %q", key.name)
-	}
-	built := reg.(derivedCacheRegistration).factory()
-	actual, _ := r.derived.LoadOrStore(key, built)
-	return actual, nil
-}
-
-// GetDerivedCache returns the schema-derived cache of type T registered under key for the given
-// stored schema, building it lazily on first access. It returns an error if no factory is
-// registered for key or if the registered factory produced a value of a type other than T,
-// both of which indicate a programming error.
-func GetDerivedCache[T any](r *ReadOnlyStoredSchema, key DerivedCacheKey) (T, error) {
-	var zero T
-	v, err := r.derivedCache(key)
-	if err != nil {
-		return zero, err
-	}
-	typed, ok := v.(T)
-	if !ok {
-		return zero, spiceerrors.MustBugf("derived schema cache for key %q has type %T, wanted %T", key.name, v, zero)
-	}
-	return typed, nil
 }

--- a/pkg/datastore/derivedcache_test.go
+++ b/pkg/datastore/derivedcache_test.go
@@ -31,7 +31,7 @@ func TestDerivedCacheLazyAndShared(t *testing.T) {
 	require.NoError(t, datastore.RegisterDerivedCache(key, func() any {
 		built++
 		return &testCache{id: built}
-	}))
+	}, nil))
 
 	s := newStoredSchema()
 
@@ -62,6 +62,20 @@ func TestDerivedCacheUnregisteredKeyErrors(t *testing.T) {
 
 func TestDerivedCacheDuplicateRegistrationErrors(t *testing.T) {
 	key := uniqueDerivedCacheKey("dup")
-	require.NoError(t, datastore.RegisterDerivedCache(key, func() any { return &testCache{} }))
-	require.Error(t, datastore.RegisterDerivedCache(key, func() any { return &testCache{} }))
+	require.NoError(t, datastore.RegisterDerivedCache(key, func() any { return &testCache{} }, nil))
+	require.Error(t, datastore.RegisterDerivedCache(key, func() any { return &testCache{} }, nil))
+}
+
+func TestEstimatedSizeIncludesSchemaAndDerivedEstimators(t *testing.T) {
+	// Base size comes from the explicit byte size; registered estimators add on top. The
+	// registry is process-global, so assert against the delta rather than an absolute total.
+	s := datastore.NewReadOnlyStoredSchemaWithSize(&core.StoredSchema{}, 1000)
+	before := s.EstimatedSize()
+	require.GreaterOrEqual(t, before, int64(1000), "estimated size includes the schema byte size")
+
+	key := uniqueDerivedCacheKey("estimator")
+	require.NoError(t, datastore.RegisterDerivedCache(key, func() any { return &testCache{} },
+		func(*datastore.ReadOnlyStoredSchema) int64 { return 250 }))
+
+	require.Equal(t, before+250, s.EstimatedSize(), "a registered estimator adds to estimated size")
 }

--- a/pkg/datastore/derivedcache_test.go
+++ b/pkg/datastore/derivedcache_test.go
@@ -1,0 +1,67 @@
+package datastore_test
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/datastore"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+)
+
+// keyCounter gives each test a fresh registry key so the tests are safe under `go test -count=N`
+// (registration is process-global and panics on duplicate keys by design).
+var keyCounter atomic.Int64
+
+func uniqueDerivedCacheKey(prefix string) datastore.DerivedCacheKey {
+	return datastore.NewDerivedCacheKey(fmt.Sprintf("%s.%d", prefix, keyCounter.Add(1)))
+}
+
+type testCache struct{ id int }
+
+func newStoredSchema() *datastore.ReadOnlyStoredSchema {
+	return datastore.NewReadOnlyStoredSchema(&core.StoredSchema{})
+}
+
+func TestDerivedCacheLazyAndShared(t *testing.T) {
+	key := uniqueDerivedCacheKey("lazy")
+	built := 0
+	require.NoError(t, datastore.RegisterDerivedCache(key, func() any {
+		built++
+		return &testCache{id: built}
+	}))
+
+	s := newStoredSchema()
+
+	// Built lazily on first access, and the same instance is returned thereafter.
+	c1, err := datastore.GetDerivedCache[*testCache](s, key)
+	require.NoError(t, err)
+	c2, err := datastore.GetDerivedCache[*testCache](s, key)
+	require.NoError(t, err)
+	require.Same(t, c1, c2)
+	require.Equal(t, 1, built, "factory should be invoked exactly once per schema instance")
+
+	// A different stored-schema instance gets its own cache (per-schema-version isolation).
+	other := newStoredSchema()
+	c3, err := datastore.GetDerivedCache[*testCache](other, key)
+	require.NoError(t, err)
+	require.NotSame(t, c1, c3)
+	require.Equal(t, 2, built)
+}
+
+func TestDerivedCacheUnregisteredKeyErrors(t *testing.T) {
+	s := newStoredSchema()
+	// An unregistered key is a programming error: MustBugf returns a BUG error in production
+	// but panics under test, so we assert the panic here.
+	require.Panics(t, func() {
+		_, _ = datastore.GetDerivedCache[*testCache](s, uniqueDerivedCacheKey("unregistered"))
+	})
+}
+
+func TestDerivedCacheDuplicateRegistrationErrors(t *testing.T) {
+	key := uniqueDerivedCacheKey("dup")
+	require.NoError(t, datastore.RegisterDerivedCache(key, func() any { return &testCache{} }))
+	require.Error(t, datastore.RegisterDerivedCache(key, func() any { return &testCache{} }))
+}

--- a/pkg/datastore/derivedcache_test.go
+++ b/pkg/datastore/derivedcache_test.go
@@ -1,8 +1,6 @@
 package datastore_test
 
 import (
-	"fmt"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,71 +9,71 @@ import (
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 )
 
-// keyCounter gives each test a fresh registry key so the tests are safe under `go test -count=N`
-// (registration is process-global and panics on duplicate keys by design).
-var keyCounter atomic.Int64
-
-func uniqueDerivedCacheKey(prefix string) datastore.DerivedCacheKey {
-	return datastore.NewDerivedCacheKey(fmt.Sprintf("%s.%d", prefix, keyCounter.Add(1)))
-}
-
 type testCache struct{ id int }
 
 func newStoredSchema() *datastore.ReadOnlyStoredSchema {
 	return datastore.NewReadOnlyStoredSchema(&core.StoredSchema{})
 }
 
-func TestDerivedCacheLazyAndShared(t *testing.T) {
-	key := uniqueDerivedCacheKey("lazy")
+func TestLoadOrStoreDerivedLazyAndShared(t *testing.T) {
+	key := datastore.NewDerivedCacheKey[*testCache]()
 	built := 0
-	require.NoError(t, datastore.RegisterDerivedCache(key, func() any {
+	build := func() *testCache {
 		built++
 		return &testCache{id: built}
-	}, nil))
+	}
 
 	s := newStoredSchema()
 
 	// Built lazily on first access, and the same instance is returned thereafter.
-	c1, err := datastore.GetDerivedCache[*testCache](s, key)
+	c1, err := datastore.LoadOrStoreDerived(s, key, build)
 	require.NoError(t, err)
-	c2, err := datastore.GetDerivedCache[*testCache](s, key)
+	c2, err := datastore.LoadOrStoreDerived(s, key, build)
 	require.NoError(t, err)
 	require.Same(t, c1, c2)
-	require.Equal(t, 1, built, "factory should be invoked exactly once per schema instance")
+	require.Equal(t, 1, built, "build should be invoked exactly once per schema instance")
 
 	// A different stored-schema instance gets its own cache (per-schema-version isolation).
 	other := newStoredSchema()
-	c3, err := datastore.GetDerivedCache[*testCache](other, key)
+	c3, err := datastore.LoadOrStoreDerived(other, key, build)
 	require.NoError(t, err)
 	require.NotSame(t, c1, c3)
 	require.Equal(t, 2, built)
 }
 
-func TestDerivedCacheUnregisteredKeyErrors(t *testing.T) {
+func TestLoadOrStoreDerivedDistinctKeysDoNotCollide(t *testing.T) {
+	// Keys are identified by handle, not by type, so two caches of the same type coexist.
+	keyA := datastore.NewDerivedCacheKey[*testCache]()
+	keyB := datastore.NewDerivedCacheKey[*testCache]()
 	s := newStoredSchema()
-	// An unregistered key is a programming error: MustBugf returns a BUG error in production
-	// but panics under test, so we assert the panic here.
-	require.Panics(t, func() {
-		_, _ = datastore.GetDerivedCache[*testCache](s, uniqueDerivedCacheKey("unregistered"))
-	})
+
+	a, err := datastore.LoadOrStoreDerived(s, keyA, func() *testCache { return &testCache{id: 1} })
+	require.NoError(t, err)
+	b, err := datastore.LoadOrStoreDerived(s, keyB, func() *testCache { return &testCache{id: 2} })
+	require.NoError(t, err)
+	require.NotSame(t, a, b)
+	require.Equal(t, 1, a.id)
+	require.Equal(t, 2, b.id)
 }
 
-func TestDerivedCacheDuplicateRegistrationErrors(t *testing.T) {
-	key := uniqueDerivedCacheKey("dup")
-	require.NoError(t, datastore.RegisterDerivedCache(key, func() any { return &testCache{} }, nil))
-	require.Error(t, datastore.RegisterDerivedCache(key, func() any { return &testCache{} }, nil))
-}
-
-func TestEstimatedSizeIncludesSchemaAndDerivedEstimators(t *testing.T) {
-	// Base size comes from the explicit byte size; registered estimators add on top. The
-	// registry is process-global, so assert against the delta rather than an absolute total.
+func TestEstimatedSizeIncludesSchemaAndCaveatOverhead(t *testing.T) {
+	// With no caveats, the estimated size is just the schema byte size.
 	s := datastore.NewReadOnlyStoredSchemaWithSize(&core.StoredSchema{}, 1000)
-	before := s.EstimatedSize()
-	require.GreaterOrEqual(t, before, int64(1000), "estimated size includes the schema byte size")
+	require.Equal(t, int64(1000), s.EstimatedSize())
 
-	key := uniqueDerivedCacheKey("estimator")
-	require.NoError(t, datastore.RegisterDerivedCache(key, func() any { return &testCache{} },
-		func(*datastore.ReadOnlyStoredSchema) int64 { return 250 }))
+	// Each caveat adds its serialized expression length plus the fixed compiled-CEL overhead.
+	withCaveats := datastore.NewReadOnlyStoredSchemaWithSize(&core.StoredSchema{
+		VersionOneof: &core.StoredSchema_V1{
+			V1: &core.StoredSchema_V1StoredSchema{
+				CaveatDefinitions: map[string]*core.CaveatDefinition{
+					"a": {Name: "a", SerializedExpression: []byte("abc")},
+					"b": {Name: "b", SerializedExpression: []byte("de")},
+				},
+			},
+		},
+	}, 1000)
 
-	require.Equal(t, before+250, s.EstimatedSize(), "a registered estimator adds to estimated size")
+	const compiledCaveatOverheadBytes = 8 * 1024
+	want := int64(1000) + int64(len("abc")+len("de")) + 2*compiledCaveatOverheadBytes
+	require.Equal(t, want, withCaveats.EstimatedSize())
 }

--- a/pkg/embedded/README.md
+++ b/pkg/embedded/README.md
@@ -1,0 +1,177 @@
+# embedded
+
+`embedded` runs SpiceDB's permission engine **in-process, without a gRPC server**. It is
+intended for callers that embed SpiceDB as a library and want to issue permission checks
+directly against a datastore — paying neither network nor gRPC-serialization cost, and
+passing caveat context as native Go values rather than `structpb`.
+
+It is a thin, focused wrapper over SpiceDB's dispatch engine (`computed.ComputeCheck` + a
+local dispatcher), exposing a single operation: `Check`.
+
+## When to use it
+
+- You already have (or can construct) a `datastore.Datastore` in your process and want fast,
+  allocation-light permission checks against it.
+- You want to avoid the overhead of standing up an embedded gRPC server + in-process client
+  (bufconn), the full server middleware chain, and the `structpb`/base64 caveat-context
+  round-trip.
+
+## When **not** to use it
+
+- You need the full SpiceDB v1 API surface (schema writes, relationship writes, bulk
+  operations, watch, lookup, reflection, etc.). This package only does `CheckPermission`.
+- You need remote access or multiple processes sharing one logical SpiceDB. Run a real
+  SpiceDB server instead.
+
+Checks are always **fully consistent** (evaluated at the datastore head revision).
+
+## Quick start
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+	dscfg "github.com/authzed/spicedb/pkg/cmd/datastore"
+	"github.com/authzed/spicedb/pkg/datalayer"
+	"github.com/authzed/spicedb/pkg/embedded"
+)
+
+const bootstrap = `
+schema: |-
+  definition user {}
+
+  caveat is_tuesday(day string) {
+    day == "tuesday"
+  }
+
+  definition document {
+    relation viewer: user
+    relation caveated_viewer: user with is_tuesday
+
+    permission view = viewer
+    permission caveated_view = caveated_viewer
+  }
+relationships: |-
+  document:readme#viewer@user:alice
+
+  document:readme#caveated_viewer@user:bob[is_tuesday]
+`
+
+func main() {
+	ctx := context.Background()
+
+	// Any datastore works. Here we use an in-memory datastore populated from a bootstrap
+	// document and storing schema in the unified ("single store") format.
+	ds, err := dscfg.NewDatastore(ctx,
+		dscfg.DefaultDatastoreConfig().ToOption(),
+		dscfg.SetBootstrapFileContents(map[string][]byte{"bootstrap.yaml": []byte(bootstrap)}),
+		dscfg.WithCaveatTypeSet(caveattypes.Default.TypeSet),
+		dscfg.WithBootstrapSchemaMode(datalayer.SchemaModeReadNewWriteNew),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	perms, err := embedded.NewPermissions(embedded.Config{
+		Datastore: ds,
+		// Read schema from the unified store, and cache it across checks so schema-derived
+		// caches (e.g. compiled caveats) persist and are not rebuilt per check.
+		SchemaMode:              datalayer.SchemaModeReadNewWriteNew,
+		SchemaCacheMaxCostBytes: 16 << 20, // 16 MiB
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer perms.Close()
+
+	// Plain check.
+	res, err := perms.Check(ctx, embedded.CheckRequest{
+		ResourceType: "document", ResourceID: "readme", Permission: "view",
+		SubjectType: "user", SubjectID: "alice",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("alice can view:", res.HasPermission) // true
+
+	// Caveated check — caveat context is passed as native Go values.
+	res, err = perms.Check(ctx, embedded.CheckRequest{
+		ResourceType: "document", ResourceID: "readme", Permission: "caveated_view",
+		SubjectType: "user", SubjectID: "bob",
+		CaveatContext: map[string]any{"day": "tuesday"},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("bob can view on tuesday:", res.HasPermission) // true
+
+	// Without the required context, the result is conditional rather than allowed/denied.
+	res, _ = perms.Check(ctx, embedded.CheckRequest{
+		ResourceType: "document", ResourceID: "readme", Permission: "caveated_view",
+		SubjectType: "user", SubjectID: "bob",
+	})
+	fmt.Println("conditional:", res.IsConditional, "missing:", res.MissingContext)
+	// conditional: true missing: [day]
+}
+```
+
+You are not limited to bootstrap documents — pass any `datastore.Datastore` you have
+populated however you like (the relationships/schema must already be written).
+
+## Configuration
+
+`embedded.Config`:
+
+| Field | Required | Default | Notes |
+|---|---|---|---|
+| `Datastore` | **yes** | — | The datastore to check against. The caller owns its lifecycle (`Close` does not close it). |
+| `CaveatTypeSet` | no | `caveattypes.Default` | Must match the type set the schema/caveats were written with. |
+| `SchemaMode` | no | legacy (per-definition) | Use `datalayer.SchemaModeReadNewWriteNew` (or `*Both`) to read the unified schema. Must match how the datastore's schema was written. |
+| `SchemaCacheMaxCostBytes` | no | `0` (disabled) | When `> 0`, caches the unified stored schema across checks. This is what lets schema-derived caches (compiled caveats, etc.) persist; strongly recommended whenever `SchemaMode` reads from the unified schema. |
+| `DispatchConcurrencyLimit` | no | `10` | Max concurrent sub-dispatches per check. |
+| `DispatchChunkSize` | no | `100` | Datastore query / dispatch chunk size. |
+| `MaxDepth` | no | `50` | Maximum dispatch recursion depth. |
+
+## The `Check` API
+
+```go
+type CheckRequest struct {
+	ResourceType    string
+	ResourceID      string
+	Permission      string
+	SubjectType     string
+	SubjectID       string
+	SubjectRelation string         // optional; defaults to the "..." (ellipsis) relation
+	CaveatContext   map[string]any // native Go values; no structpb / base64
+}
+
+type CheckResult struct {
+	HasPermission  bool     // definitively a member of the permission
+	IsConditional  bool     // membership depends on a caveat that lacked required context
+	MissingContext []string // the caveat context fields that were required but not provided
+}
+```
+
+- `HasPermission == true` → allowed.
+- `HasPermission == false && IsConditional == false` → denied.
+- `IsConditional == true` → a caveat could not be fully evaluated; supply the values named in
+  `MissingContext` and check again.
+
+## Caveat context
+
+Because checks run in-process, caveat context is supplied directly as `map[string]any` and
+consumed by the caveat engine without conversion. For a caveat parameter typed `bytes`, the
+value must still be a base64-encoded string (the caveat type system decodes it); all other
+types accept their natural Go representation.
+
+## Lifecycle
+
+Call `Close` when finished to release the dispatcher. `Close` does **not** close the
+datastore you passed in — you own that.
+
+A `Permissions` value is safe for concurrent use.

--- a/pkg/embedded/permissions.go
+++ b/pkg/embedded/permissions.go
@@ -1,0 +1,187 @@
+// Package embedded runs SpiceDB's permission engine in-process, without standing up a
+// gRPC server. It is intended for callers that embed SpiceDB as a library and want to
+// issue permission checks directly against a datastore, paying neither network nor
+// gRPC-serialization cost, and passing caveat context as native Go values.
+package embedded
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/authzed/spicedb/internal/dispatch"
+	"github.com/authzed/spicedb/internal/dispatch/graph"
+	"github.com/authzed/spicedb/internal/graph/computed"
+	"github.com/authzed/spicedb/pkg/cache"
+	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+	"github.com/authzed/spicedb/pkg/datalayer"
+	"github.com/authzed/spicedb/pkg/datastore"
+	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
+)
+
+const (
+	defaultConcurrencyLimit  = 10
+	defaultDispatchChunkSize = 100
+	defaultMaxDepth          = 50
+)
+
+// Config configures a Permissions checker.
+type Config struct {
+	// Datastore is the datastore to check against. Required. The caller owns its lifecycle.
+	Datastore datastore.Datastore
+
+	// CaveatTypeSet is the caveat type set used to compile and evaluate caveats.
+	// Defaults to caveattypes.Default.
+	CaveatTypeSet *caveattypes.TypeSet
+
+	// SchemaMode controls how schema is read. The zero value reads legacy per-definition
+	// schema. Use datalayer.SchemaModeReadNewWriteNew (or *Both) for the unified schema.
+	SchemaMode datalayer.SchemaMode
+
+	// SchemaCacheMaxCostBytes, when > 0, enables an in-memory stored-schema cache of the
+	// given size in bytes. Caching the stored schema across checks is what allows
+	// schema-derived caches (e.g. compiled caveats) to persist; strongly recommended when
+	// SchemaMode reads from the unified schema.
+	SchemaCacheMaxCostBytes int64
+
+	// DispatchConcurrencyLimit, DispatchChunkSize, and MaxDepth use sane defaults if zero.
+	DispatchConcurrencyLimit uint16
+	DispatchChunkSize        uint16
+	MaxDepth                 uint32
+}
+
+// Permissions issues in-process permission checks against a datastore.
+type Permissions struct {
+	dl         datalayer.DataLayer
+	dispatcher dispatch.Dispatcher
+	cts        *caveattypes.TypeSet
+	chunkSize  uint16
+	maxDepth   uint32
+}
+
+// NewPermissions builds an in-process permissions checker from the given config.
+func NewPermissions(cfg Config) (*Permissions, error) {
+	if cfg.Datastore == nil {
+		return nil, errors.New("embedded: Datastore is required")
+	}
+
+	cts := cfg.CaveatTypeSet
+	if cts == nil {
+		cts = caveattypes.Default.TypeSet
+	}
+	concurrency := cfg.DispatchConcurrencyLimit
+	if concurrency == 0 {
+		concurrency = defaultConcurrencyLimit
+	}
+	chunkSize := cfg.DispatchChunkSize
+	if chunkSize == 0 {
+		chunkSize = defaultDispatchChunkSize
+	}
+	maxDepth := cfg.MaxDepth
+	if maxDepth == 0 {
+		maxDepth = defaultMaxDepth
+	}
+
+	dlOpts := []datalayer.DataLayerOption{datalayer.WithSchemaMode(cfg.SchemaMode)}
+	if cfg.SchemaCacheMaxCostBytes > 0 {
+		schemaCache, err := cache.NewStandardCache[datalayer.SchemaCacheKey, *datastore.ReadOnlyStoredSchema](&cache.Config{
+			MaxCost: cfg.SchemaCacheMaxCostBytes,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("embedded: failed to create stored schema cache: %w", err)
+		}
+		dlOpts = append(dlOpts, datalayer.WithSchemaCache(schemaCache))
+	}
+	dl := datalayer.NewDataLayer(cfg.Datastore, dlOpts...)
+
+	dispatcher, err := graph.NewLocalOnlyDispatcher(graph.DispatcherParameters{
+		ConcurrencyLimits: graph.SharedConcurrencyLimits(concurrency),
+		DispatchChunkSize: chunkSize,
+		TypeSet:           cts,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("embedded: failed to create dispatcher: %w", err)
+	}
+
+	return &Permissions{
+		dl:         dl,
+		dispatcher: dispatcher,
+		cts:        cts,
+		chunkSize:  chunkSize,
+		maxDepth:   maxDepth,
+	}, nil
+}
+
+// CheckRequest is a single, fully-consistent permission check. It intentionally mirrors
+// v1.CheckPermissionRequest but uses native Go values (notably map[string]any for caveat
+// context) to avoid the structpb.Struct round-trip the gRPC path pays. Keep its fields in
+// sync with the proto shape.
+type CheckRequest struct {
+	ResourceType    string
+	ResourceID      string
+	Permission      string
+	SubjectType     string
+	SubjectID       string
+	SubjectRelation string // optional; defaults to the ellipsis ("...") relation
+	CaveatContext   map[string]any
+}
+
+// CheckResult is the outcome of a check.
+type CheckResult struct {
+	// HasPermission is true when the subject is definitively a member of the permission.
+	HasPermission bool
+	// IsConditional is true when membership depends on a caveat that could not be fully
+	// evaluated because required context was missing (see MissingContext).
+	IsConditional bool
+	// MissingContext lists the caveat context fields that were required but not provided.
+	MissingContext []string
+}
+
+// Check runs a single, fully-consistent permission check in-process.
+func (p *Permissions) Check(ctx context.Context, req CheckRequest) (CheckResult, error) {
+	ctx = datalayer.ContextWithDataLayer(ctx, p.dl)
+
+	// The datalayer head revision yields the schema-mode-appropriate schema hash (a real
+	// hash under the unified schema, or a legacy sentinel otherwise).
+	revision, schemaHash, err := p.dl.HeadRevision(ctx)
+	if err != nil {
+		return CheckResult{}, err
+	}
+
+	subjectRel := req.SubjectRelation
+	if subjectRel == "" {
+		subjectRel = tuple.Ellipsis
+	}
+
+	cr, _, err := computed.ComputeCheck(ctx, p.dispatcher, p.cts,
+		computed.CheckParameters{
+			ResourceType:  tuple.RR(req.ResourceType, req.Permission),
+			Subject:       tuple.ONR(req.SubjectType, req.SubjectID, subjectRel),
+			CaveatContext: req.CaveatContext,
+			AtRevision:    revision,
+			MaximumDepth:  p.maxDepth,
+			DebugOption:   computed.NoDebugging,
+			SchemaHash:    schemaHash,
+		},
+		req.ResourceID,
+		p.chunkSize,
+	)
+	if err != nil {
+		return CheckResult{}, err
+	}
+
+	switch cr.Membership {
+	case dispatchv1.ResourceCheckResult_MEMBER:
+		return CheckResult{HasPermission: true}, nil
+	case dispatchv1.ResourceCheckResult_CAVEATED_MEMBER:
+		return CheckResult{IsConditional: true, MissingContext: cr.MissingExprFields}, nil
+	default:
+		return CheckResult{}, nil
+	}
+}
+
+// Close releases resources held by the checker. It does not close the datastore.
+func (p *Permissions) Close() error {
+	return p.dispatcher.Close()
+}

--- a/pkg/embedded/permissions.go
+++ b/pkg/embedded/permissions.go
@@ -35,6 +35,9 @@ type Config struct {
 	// Defaults to caveattypes.Default.
 	CaveatTypeSet *caveattypes.TypeSet
 
+	// TODO(jschorr): once the unified (new) schema mode is the default, default SchemaMode to
+	// it and enable the stored-schema cache by default instead of requiring these opt-ins.
+
 	// SchemaMode controls how schema is read. The zero value reads legacy per-definition
 	// schema. Use datalayer.SchemaModeReadNewWriteNew (or *Both) for the unified schema.
 	SchemaMode datalayer.SchemaMode
@@ -53,11 +56,12 @@ type Config struct {
 
 // Permissions issues in-process permission checks against a datastore.
 type Permissions struct {
-	dl         datalayer.DataLayer
-	dispatcher dispatch.Dispatcher
-	cts        *caveattypes.TypeSet
-	chunkSize  uint16
-	maxDepth   uint32
+	dl          datalayer.DataLayer
+	dispatcher  dispatch.Dispatcher
+	cts         *caveattypes.TypeSet
+	chunkSize   uint16
+	maxDepth    uint32
+	schemaCache cache.Cache[datalayer.SchemaCacheKey, *datastore.ReadOnlyStoredSchema] // nil when caching disabled
 }
 
 // NewPermissions builds an in-process permissions checker from the given config.
@@ -83,14 +87,16 @@ func NewPermissions(cfg Config) (*Permissions, error) {
 		maxDepth = defaultMaxDepth
 	}
 
+	var schemaCache cache.Cache[datalayer.SchemaCacheKey, *datastore.ReadOnlyStoredSchema]
 	dlOpts := []datalayer.DataLayerOption{datalayer.WithSchemaMode(cfg.SchemaMode)}
 	if cfg.SchemaCacheMaxCostBytes > 0 {
-		schemaCache, err := cache.NewStandardCache[datalayer.SchemaCacheKey, *datastore.ReadOnlyStoredSchema](&cache.Config{
+		sc, err := cache.NewStandardCache[datalayer.SchemaCacheKey, *datastore.ReadOnlyStoredSchema](&cache.Config{
 			MaxCost: cfg.SchemaCacheMaxCostBytes,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("embedded: failed to create stored schema cache: %w", err)
 		}
+		schemaCache = sc
 		dlOpts = append(dlOpts, datalayer.WithSchemaCache(schemaCache))
 	}
 	dl := datalayer.NewDataLayer(cfg.Datastore, dlOpts...)
@@ -105,11 +111,12 @@ func NewPermissions(cfg Config) (*Permissions, error) {
 	}
 
 	return &Permissions{
-		dl:         dl,
-		dispatcher: dispatcher,
-		cts:        cts,
-		chunkSize:  chunkSize,
-		maxDepth:   maxDepth,
+		dl:          dl,
+		dispatcher:  dispatcher,
+		cts:         cts,
+		chunkSize:   chunkSize,
+		maxDepth:    maxDepth,
+		schemaCache: schemaCache,
 	}, nil
 }
 
@@ -183,5 +190,9 @@ func (p *Permissions) Check(ctx context.Context, req CheckRequest) (CheckResult,
 
 // Close releases resources held by the checker. It does not close the datastore.
 func (p *Permissions) Close() error {
-	return p.dispatcher.Close()
+	err := p.dispatcher.Close()
+	if p.schemaCache != nil {
+		p.schemaCache.Close()
+	}
+	return err
 }

--- a/pkg/embedded/permissions_test.go
+++ b/pkg/embedded/permissions_test.go
@@ -1,0 +1,155 @@
+package embedded_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
+	dscfg "github.com/authzed/spicedb/pkg/cmd/datastore"
+	"github.com/authzed/spicedb/pkg/datalayer"
+	"github.com/authzed/spicedb/pkg/embedded"
+)
+
+const testBootstrap = `
+schema: |-
+  definition user {}
+
+  caveat is_tuesday(day string) {
+    day == "tuesday"
+  }
+
+  definition document {
+    relation viewer: user
+    relation caveated_viewer: user with is_tuesday
+
+    permission view = viewer
+    permission caveated_view = caveated_viewer
+  }
+relationships: |-
+  document:doc1#viewer@user:alice
+
+  document:doc1#caveated_viewer@user:bob[is_tuesday]
+`
+
+func newTestPermissions(t *testing.T, mode datalayer.SchemaMode) *embedded.Permissions {
+	t.Helper()
+	ctx := t.Context()
+
+	ds, err := dscfg.NewDatastore(ctx,
+		dscfg.DefaultDatastoreConfig().ToOption(),
+		dscfg.SetBootstrapFileContents(map[string][]byte{"test.yaml": []byte(testBootstrap)}),
+		dscfg.WithCaveatTypeSet(caveattypes.Default.TypeSet),
+		dscfg.WithBootstrapSchemaMode(mode),
+	)
+	require.NoError(t, err)
+
+	// A stored-schema cache is only meaningful (and only exercises the schema-tied compiled
+	// caveat cache) when reading from the unified schema.
+	var schemaCacheCost int64
+	if mode.ReadsFromNew() {
+		schemaCacheCost = 1 << 20
+	}
+
+	perms, err := embedded.NewPermissions(embedded.Config{
+		Datastore:               ds,
+		SchemaMode:              mode,
+		SchemaCacheMaxCostBytes: schemaCacheCost,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, perms.Close())
+		require.NoError(t, ds.Close())
+	})
+	return perms
+}
+
+func TestPermissionsCheck(t *testing.T) {
+	modes := []struct {
+		name string
+		mode datalayer.SchemaMode
+	}{
+		{"legacy", datalayer.SchemaModeReadLegacyWriteLegacy},
+		{"single_store", datalayer.SchemaModeReadNewWriteNew},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name, func(t *testing.T) {
+			ctx := t.Context()
+			perms := newTestPermissions(t, m.mode)
+
+			t.Run("member", func(t *testing.T) {
+				res, err := perms.Check(ctx, embedded.CheckRequest{
+					ResourceType: "document", ResourceID: "doc1", Permission: "view",
+					SubjectType: "user", SubjectID: "alice",
+				})
+				require.NoError(t, err)
+				require.True(t, res.HasPermission)
+				require.False(t, res.IsConditional)
+			})
+
+			t.Run("non_member", func(t *testing.T) {
+				res, err := perms.Check(ctx, embedded.CheckRequest{
+					ResourceType: "document", ResourceID: "doc1", Permission: "view",
+					SubjectType: "user", SubjectID: "carol",
+				})
+				require.NoError(t, err)
+				require.False(t, res.HasPermission)
+				require.False(t, res.IsConditional)
+			})
+
+			t.Run("caveated_missing_context", func(t *testing.T) {
+				res, err := perms.Check(ctx, embedded.CheckRequest{
+					ResourceType: "document", ResourceID: "doc1", Permission: "caveated_view",
+					SubjectType: "user", SubjectID: "bob",
+				})
+				require.NoError(t, err)
+				require.False(t, res.HasPermission)
+				require.True(t, res.IsConditional)
+				require.Contains(t, res.MissingContext, "day")
+			})
+
+			t.Run("caveated_satisfied", func(t *testing.T) {
+				res, err := perms.Check(ctx, embedded.CheckRequest{
+					ResourceType: "document", ResourceID: "doc1", Permission: "caveated_view",
+					SubjectType: "user", SubjectID: "bob",
+					CaveatContext: map[string]any{"day": "tuesday"},
+				})
+				require.NoError(t, err)
+				require.True(t, res.HasPermission)
+				require.False(t, res.IsConditional)
+			})
+
+			t.Run("caveated_unsatisfied", func(t *testing.T) {
+				res, err := perms.Check(ctx, embedded.CheckRequest{
+					ResourceType: "document", ResourceID: "doc1", Permission: "caveated_view",
+					SubjectType: "user", SubjectID: "bob",
+					CaveatContext: map[string]any{"day": "monday"},
+				})
+				require.NoError(t, err)
+				require.False(t, res.HasPermission)
+				require.False(t, res.IsConditional)
+			})
+
+			// Repeated checks must return consistent results (exercises the schema-tied
+			// compiled-caveat cache on the unified-schema path).
+			t.Run("repeated_consistent", func(t *testing.T) {
+				for i := 0; i < 3; i++ {
+					res, err := perms.Check(ctx, embedded.CheckRequest{
+						ResourceType: "document", ResourceID: "doc1", Permission: "caveated_view",
+						SubjectType: "user", SubjectID: "bob",
+						CaveatContext: map[string]any{"day": "tuesday"},
+					})
+					require.NoError(t, err)
+					require.True(t, res.HasPermission)
+				}
+			})
+		})
+	}
+}
+
+func TestNewPermissionsRequiresDatastore(t *testing.T) {
+	_, err := embedded.NewPermissions(embedded.Config{})
+	require.Error(t, err)
+}

--- a/pkg/validationfile/loader.go
+++ b/pkg/validationfile/loader.go
@@ -168,7 +168,13 @@ func PopulateFromFilesContents(ctx context.Context, dl datalayer.DataLayer, cave
 	revision, err := dl.ReadWriteTx(ctx, func(ctx context.Context, rwt datalayer.ReadWriteTransaction) error {
 		resolver, err := schema.ResolverForSchemaReader(ctx, rwt)
 		if err != nil {
-			return err
+			if !errors.Is(err, datastore.ErrSchemaNotFound) {
+				return err
+			}
+			// No existing schema yet (the first write under the unified schema): resolve
+			// only against the definitions being written, which are supplied as predefined
+			// elements below. A nil-backed resolver returns not-found for everything else.
+			resolver = schema.ResolverFor(nil)
 		}
 		ts := schema.NewTypeSystem(resolver.WithPredefinedElements(schema.PredefinedElements{
 			Definitions: objectDefs,


### PR DESCRIPTION
## Summary

Adds `pkg/embedded`, an in-process (no gRPC) permissions library, and makes checks cheaper by caching schema-derived artifacts once per schema version.

### Changes

- **`datastore`: schema-derived caches on the stored schema.** `ReadOnlyStoredSchema` now hosts lazily-built derived caches that live exactly as long as their schema version and are discarded with it. Cache kinds self-register at init via `RegisterDerivedCache` (avoiding an import cycle back into the owning packages) and are fetched with `GetDerivedCache`. Compiled caveats today; type systems/reachability planned.
- **`caveats`: compiled caveats cached per schema version.** Deserializing a caveat rebuilds its CEL environment, previously paid on every check because each check constructs a fresh `CaveatRunner`. Now cached on the shared stored schema, keyed by caveat name; falls back to per-runner caching when the reader isn't backed by a unified stored schema.
- **`datastore`: stored-schema cache costed by bytes.** Entries were admitted at cost 1, so the byte-denominated `MaxCost` (server default 32MiB; `SchemaCacheMaxCostBytes` in embedded) bounded entry *count*, not memory. Entries are now costed by `EstimatedSize()`: schema bytes (exact serialized size when the reader has it) plus each registered derived-cache kind's estimate once populated.
- **`datastore`: bootstrap honors schema mode.** Bootstrap always wrote legacy per-definition schema, so unified-schema servers found none. New `BootstrapSchemaMode` option; zero value preserves prior behavior.
- **`embedded`: new `pkg/embedded`.** Permission checks in-process against a datastore via the dispatch engine; caveat context passed as native Go values. Includes README and tests.

### Testing

`mage lint:all` and the unit suite pass. New tests: derived-cache registry and cost estimation (`pkg/datastore`), compiled-caveat cache (`internal/caveats`), embedded checks across both schema modes (`pkg/embedded`).
