### PR TITLE
chore: add buffnet authority to connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Cache: switch to [otter](https://maypok86.github.io/otter/) as the primary cache implementation (https://github.com/authzed/spicedb/pull/3112)
+- Server handles: `GRPCDialContext` as a handle on the server used deprecated gRPC methods. We modernized it and renamed it to `NewClient` (https://github.com/authzed/spicedb/pull/3147)
 
 ### Fixed
 - The watching schema cache (`--enable-experimental-watchable-schema-cache`) no longer enters permanent fallback on transient watch errors. A new supervisor restarts the watch cycle with bounded exponential backoff and only treats caller-driven cancellation or unsupported-watch as terminal (https://github.com/authzed/spicedb/pull/3134)

--- a/internal/grpchelpers/grpchelpers.go
+++ b/internal/grpchelpers/grpchelpers.go
@@ -23,6 +23,8 @@ func NewBufferedClient(listener *bufconn.Listener, opts ...grpc.DialOption) (*gr
 			return listener.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		// This identifies the client to the server as being over the buffered network
+		grpc.WithAuthority("buffnet"),
 	}, opts...)
 	return grpc.NewClient("passthrough:///localhost", opts...)
 }


### PR DESCRIPTION
## Description
This is a behavior I missed in #3147. The `GRPCDialContext` for buffered connections was setting this authority flag.

## Changes
* Reinstate the flag
## Testing
Review.