### PR TITLE
test: add more goleak checks

### DIFF
--- a/internal/fdw/pgserver_e2e_test.go
+++ b/internal/fdw/pgserver_e2e_test.go
@@ -964,9 +964,8 @@ func runPGServer(t *testing.T, client *authzed.Client) int {
 	port, err := GetFreePort()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx := t.Context()
 	t.Cleanup(func() {
-		cancel()
 		require.NoError(t, pgserver.Close())
 	})
 
@@ -1024,10 +1023,6 @@ func runSpiceDB(t *testing.T) *authzed.Client {
 	}
 
 	ctx := t.Context()
-	ctx, cancel := context.WithCancel(ctx)
-	t.Cleanup(func() {
-		cancel()
-	})
 
 	runnableServer, err := config.Complete(ctx)
 	require.NoError(t, err)

--- a/internal/services/v1/debug_test.go
+++ b/internal/services/v1/debug_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -29,6 +30,7 @@ import (
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	dispatch "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
+	"github.com/authzed/spicedb/pkg/testutil"
 	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
@@ -589,6 +591,9 @@ func expectFrames(req *require.Assertions, frames []frameInfo, check *v1.CheckDe
 }
 
 func TestBulkCheckPermissionWithDebug(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	tcs := []struct {
 		name          string
 		schema        string
@@ -929,6 +934,10 @@ func TestBulkCheckPermissionWithDebug(t *testing.T) {
 }
 
 func TestLookupResourcesDebugTrace_LR3(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
+
 	req := require.New(t)
 
 	schema := `
@@ -1015,6 +1024,9 @@ func TestLookupResourcesDebugTrace_LR3(t *testing.T) {
 }
 
 func TestLookupResourcesDebugTrace_LR2(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	req := require.New(t)
 
 	schema := `

--- a/internal/services/v1/expreflection_test.go
+++ b/internal/services/v1/expreflection_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ettle/strcase"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
@@ -23,6 +24,9 @@ import (
 )
 
 func TestExpConvertDiff(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	tcs := []struct {
 		name             string
 		existingSchema   string
@@ -592,6 +596,9 @@ func TestExpConvertDiff(t *testing.T) {
 type expFilterCheck func(sf *expSchemaFilters) bool
 
 func TestExpSchemaFiltering(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	tcs := []struct {
 		name     string
 		filters  []*v1.ExpSchemaFilter
@@ -790,6 +797,9 @@ func TestExpSchemaFiltering(t *testing.T) {
 }
 
 func TestExpNewexpSchemaFilters(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	tcs := []struct {
 		name    string
 		filters []*v1.ExpSchemaFilter

--- a/internal/services/v1/metadata_test.go
+++ b/internal/services/v1/metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
@@ -17,11 +18,15 @@ import (
 	tf "github.com/authzed/spicedb/internal/testfixtures"
 	"github.com/authzed/spicedb/internal/testserver"
 	"github.com/authzed/spicedb/pkg/datalayer"
+	"github.com/authzed/spicedb/pkg/testutil"
 	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
 
 func TestAllMethodsReturnMetadata(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, revision := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.StandardDatastoreWithData)

--- a/internal/services/v1/permissions_test.go
+++ b/internal/services/v1/permissions_test.go
@@ -1911,6 +1911,10 @@ func randString(length int) string {
 }
 
 func TestGetCaveatContext(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
+
 	strct, err := structpb.NewStruct(map[string]any{"foo": "bar"})
 	require.NoError(t, err)
 

--- a/internal/services/v1/preconditions_test.go
+++ b/internal/services/v1/preconditions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/authzed/spicedb/internal/datastore/memdb"
 	"github.com/authzed/spicedb/internal/testfixtures"
 	"github.com/authzed/spicedb/pkg/datalayer"
+	"github.com/authzed/spicedb/pkg/testutil"
 )
 
 var companyPlanFolder = &v1.RelationshipFilter{
@@ -33,6 +35,10 @@ var prefixNoMatch = &v1.RelationshipFilter{
 }
 
 func TestPreconditions(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
+
 	require := require.New(t)
 	uninitialized, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, 0, memdb.DisableGC)
 	require.NoError(err)

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ccoveille/go-safecast/v2"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -30,11 +31,15 @@ import (
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
+	"github.com/authzed/spicedb/pkg/testutil"
 	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
 
 func TestReadRelationships(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	testCases := []struct {
 		name         string
 		filter       *v1.RelationshipFilter
@@ -364,6 +369,9 @@ func TestReadRelationships(t *testing.T) {
 }
 
 func TestWriteRelationships(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
@@ -466,6 +474,9 @@ func TestWriteRelationships(t *testing.T) {
 }
 
 func TestDeleteRelationshipViaWriteNoop(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
@@ -486,6 +497,9 @@ func TestDeleteRelationshipViaWriteNoop(t *testing.T) {
 }
 
 func TestWriteExpiringRelationships(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	req := require.New(t)
 
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
@@ -511,6 +525,9 @@ func TestWriteExpiringRelationships(t *testing.T) {
 }
 
 func TestWriteCaveatedRelationships(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	for _, deleteWithCaveat := range []bool{true, false} {
 		t.Run(fmt.Sprintf("with-caveat-%v", deleteWithCaveat), func(t *testing.T) {
 			req := require.New(t)
@@ -745,6 +762,9 @@ func relationshipForBulkTesting(nsAndRel struct {
 }
 
 func TestInvalidWriteRelationship(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	testCases := []struct {
 		name          string
 		preconditions []*v1.RelationshipFilter
@@ -921,6 +941,9 @@ func TestInvalidWriteRelationship(t *testing.T) {
 }
 
 func TestDeleteRelationships(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	testCases := []struct {
 		name          string
 		req           *v1.DeleteRelationshipsRequest
@@ -1281,6 +1304,9 @@ func TestDeleteRelationships(t *testing.T) {
 }
 
 func TestDeleteRelationshipsBeyondLimit(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
@@ -1300,6 +1326,9 @@ func TestDeleteRelationshipsBeyondLimit(t *testing.T) {
 }
 
 func TestDeleteRelationshipsBeyondAllowedLimit(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
@@ -1319,6 +1348,9 @@ func TestDeleteRelationshipsBeyondAllowedLimit(t *testing.T) {
 }
 
 func TestReadRelationshipsBeyondAllowedLimit(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
@@ -1340,6 +1372,9 @@ func TestReadRelationshipsBeyondAllowedLimit(t *testing.T) {
 }
 
 func TestDeleteRelationshipsBeyondLimitPartial(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	expected := map[string]struct{}{
 		"document:ownerplan#viewer@user:owner":                       {},
 		"document:companyplan#parent@folder:company":                 {},
@@ -1417,6 +1452,9 @@ func TestDeleteRelationshipsBeyondLimitPartial(t *testing.T) {
 }
 
 func TestDeleteRelationshipsPreconditionsOverLimit(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 	conn, _, _ := testserver.NewTestServerWithConfig(
 		t,
@@ -1474,6 +1512,9 @@ func TestDeleteRelationshipsPreconditionsOverLimit(t *testing.T) {
 }
 
 func TestWriteRelationshipsWithMetadata(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 	conn, _, beforeWriteRev := testserver.NewTestServerWithConfig(
 		t,
@@ -1521,6 +1562,9 @@ func TestWriteRelationshipsWithMetadata(t *testing.T) {
 }
 
 func TestWriteRelationshipsMetadataOverLimit(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 	conn, _, _ := testserver.NewTestServerWithConfig(
 		t,
@@ -1549,6 +1593,9 @@ func TestWriteRelationshipsMetadataOverLimit(t *testing.T) {
 }
 
 func TestDeleteRelationshipsMetadataOverLimit(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 	conn, _, _ := testserver.NewTestServerWithConfig(
 		t,
@@ -1578,6 +1625,9 @@ func TestDeleteRelationshipsMetadataOverLimit(t *testing.T) {
 }
 
 func TestWriteRelationshipsPreconditionsOverLimit(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 	conn, _, _ := testserver.NewTestServerWithConfig(
 		t,
@@ -1626,6 +1676,9 @@ func TestWriteRelationshipsPreconditionsOverLimit(t *testing.T) {
 }
 
 func TestWriteRelationshipsUpdatesOverLimit(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 	conn, _, _ := testserver.NewTestServerWithConfig(
 		t,
@@ -1658,6 +1711,9 @@ func TestWriteRelationshipsUpdatesOverLimit(t *testing.T) {
 }
 
 func TestWriteRelationshipsCaveatExceedsMaxSize(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 	conn, _, _ := testserver.NewTestServerWithConfig(
 		t,
@@ -1691,6 +1747,9 @@ func TestWriteRelationshipsCaveatExceedsMaxSize(t *testing.T) {
 }
 
 func TestReadRelationshipsWithTimeout(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 
 	conn, _, _ := testserver.NewTestServerWithConfig(
@@ -1750,6 +1809,9 @@ func TestReadRelationshipsWithTimeout(t *testing.T) {
 }
 
 func TestReadRelationshipsInvalidCursor(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 
 	conn, _, revision := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
@@ -1832,6 +1894,9 @@ func standardTuplesWithout(without map[string]struct{}) map[string]struct{} {
 }
 
 func TestManyConcurrentWriteRelationshipsReturnsSerializationErrorOnMemdb(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
@@ -1867,6 +1932,9 @@ func TestManyConcurrentWriteRelationshipsReturnsSerializationErrorOnMemdb(t *tes
 }
 
 func TestReadRelationshipsWithTraitsAndFilters(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	// Test cases covering various combinations of expiration, caveats, and filters
 	testCases := []struct {
 		name                  string

--- a/internal/services/v1/schema_test.go
+++ b/internal/services/v1/schema_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -22,6 +23,9 @@ import (
 )
 
 func TestSchemaWriteNoPrefix(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -35,6 +39,9 @@ func TestSchemaWriteNoPrefix(t *testing.T) {
 }
 
 func TestSchemaWriteInvalidSchema(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -50,6 +57,9 @@ func TestSchemaWriteInvalidSchema(t *testing.T) {
 }
 
 func TestSchemaWriteInvalidNamespace(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -69,6 +79,9 @@ func TestSchemaWriteInvalidNamespace(t *testing.T) {
 // NOTE: imports must be handled by precompilation;
 // a write of a schema with an import statement is an error.
 func TestSchemaWriteImportsDisallowed(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -89,6 +102,9 @@ func TestSchemaWriteImportsDisallowed(t *testing.T) {
 }
 
 func TestSchemaWriteAndReadBack(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -114,6 +130,9 @@ func TestSchemaWriteAndReadBack(t *testing.T) {
 }
 
 func TestSchemaWriteReturnsSchemaHashInZedToken(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	config := testserver.DefaultTestServerConfig
 	config.DataLayerOpts = []datalayer.DataLayerOption{
 		datalayer.WithSchemaMode(datalayer.SchemaModeReadNewWriteBoth),
@@ -150,6 +169,9 @@ definition document {
 }
 
 func TestSchemaDeleteRelation(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -219,6 +241,9 @@ func TestSchemaDeleteRelation(t *testing.T) {
 }
 
 func TestSchemaDeletePermission(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -258,6 +283,9 @@ func TestSchemaDeletePermission(t *testing.T) {
 }
 
 func TestSchemaChangeRelationToPermission(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -318,6 +346,9 @@ func TestSchemaChangeRelationToPermission(t *testing.T) {
 }
 
 func TestSchemaDeleteDefinition(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -370,6 +401,9 @@ func TestSchemaDeleteDefinition(t *testing.T) {
 }
 
 func TestSchemaRemoveWildcard(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -432,6 +466,9 @@ definition example/user {}`
 }
 
 func TestSchemaEmpty(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -485,6 +522,9 @@ func TestSchemaEmpty(t *testing.T) {
 }
 
 func TestSchemaTypeRedefined(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -507,6 +547,9 @@ func TestSchemaTypeRedefined(t *testing.T) {
 }
 
 func TestSchemaTypeInvalid(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, false,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -525,6 +568,9 @@ func TestSchemaTypeInvalid(t *testing.T) {
 }
 
 func TestSchemaRemoveCaveat(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -596,6 +642,9 @@ definition user {}`
 }
 
 func TestSchemaUnchangedNamespaces(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, ds, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -639,6 +688,9 @@ func TestSchemaUnchangedNamespaces(t *testing.T) {
 }
 
 func TestSchemaInvalid(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, false,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -662,6 +714,9 @@ func TestSchemaInvalid(t *testing.T) {
 }
 
 func TestSchemaChangeExpiration(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -737,6 +792,9 @@ func TestSchemaChangeExpiration(t *testing.T) {
 }
 
 func TestSchemaChangeExpirationAllowed(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -781,6 +839,9 @@ func TestSchemaChangeExpirationAllowed(t *testing.T) {
 }
 
 func TestSchemaDiff(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -874,6 +935,9 @@ func TestSchemaDiff(t *testing.T) {
 }
 
 func TestReflectSchema(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
 		testserver.DefaultTestServerConfig,
 		tf.EmptyDatastore)
@@ -1287,6 +1351,9 @@ definition user {}`,
 }
 
 func TestDependentRelations(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	tcs := []struct {
 		name             string
 		schema           string
@@ -1521,6 +1588,9 @@ func TestDependentRelations(t *testing.T) {
 }
 
 func TestComputablePermissions(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	tcs := []struct {
 		name             string
 		schema           string

--- a/internal/services/v1/watch_test.go
+++ b/internal/services/v1/watch_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/authzed/spicedb/internal/testserver"
 	"github.com/authzed/spicedb/pkg/datalayer"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/testutil"
 	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
@@ -53,6 +55,9 @@ func update(
 }
 
 func TestWatch(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	testCases := []struct {
 		name                   string
 		watchKinds             []v1.WatchKind
@@ -437,6 +442,9 @@ definition document {
 }
 
 func TestWatchCarriesSchemaHash(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
 	require := require.New(t)
 
 	// SchemaModeReadNewWriteBoth is required for the datastore to produce real

--- a/internal/telemetry/reporter.go
+++ b/internal/telemetry/reporter.go
@@ -209,6 +209,7 @@ func RemoteReporter(
 				ticker = time.After(nextPush)
 
 			case <-ctx.Done():
+				client.CloseIdleConnections()
 				return nil
 			}
 		}

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -33,10 +33,6 @@ type ServerConfig struct {
 }
 
 var DefaultTestServerConfig = ServerConfig{
-	MaxUpdatesPerWrite:                 1000,
-	MaxPreconditionsCount:              1000,
-	StreamingAPITimeout:                30 * time.Second,
-	MaxRelationshipContextSize:         25000,
 	EnableExperimentalLookupResources3: true,
 }
 
@@ -72,6 +68,8 @@ func NewTestServerWithConfigAndDatastore(t testing.TB, schemaPrefixRequired bool
 	cfg := server.NewConfigWithOptionsAndDefaults(
 		server.WithDatastore(ds),
 		server.WithDispatcher(dispatcher),
+		server.WithTelemetryEndpoint(""),
+		server.WithSilentlyDisableTelemetry(true),
 		server.WithQueryPlanMetadata(queryPlanMetadata),
 		server.WithDispatchMaxDepth(50),
 		server.WithMaximumPreconditionCount(config.MaxPreconditionsCount),


### PR DESCRIPTION
Followup to https://github.com/authzed/spicedb/pull/3171 since there are more goroutine leaks.

I am pretty sure that the leak is that we made telemetry ON by default 

https://github.com/authzed/spicedb/blame/87482ed4fbeabd57ae4e896e1b4674958e6b16ba/pkg/cmd/server/server.go#L162

and now we are leaking its connection. The fix is in `internal/telemetry/reporter.go`.