### PR TITLE
fix: match IPv4-mapped IPv6 addresses in the in_cidr caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - When SpiceDB loses a connection to a CockroachDB node, every read happening in the server blocks for a short period of time (https://github.com/authzed/spicedb/pull/3181)
 - LSP: hover and go-to-definition now resolve identifiers on the right-hand side of arrow expressions (`->`, `.any(...)`, `.all(...)`) (https://github.com/authzed/spicedb/pull/3157)
+- The `in_cidr` caveat now matches IPv4-mapped IPv6 addresses (e.g. `::ffff:10.1.2.3`) against IPv4 CIDRs, the same as the dotted form (https://github.com/authzed/spicedb/pull/3184)
 
 ## [1.54.0] - 2026-06-18
 ### Added

--- a/pkg/caveats/types/ipaddress.go
+++ b/pkg/caveats/types/ipaddress.go
@@ -13,7 +13,7 @@ import (
 // ParseIPAddress parses the string form of an IP Address into an IPAddress object type.
 func ParseIPAddress(ip string) (IPAddress, error) {
 	parsed, err := netip.ParseAddr(ip)
-	return IPAddress{parsed}, err
+	return IPAddress{parsed.Unmap()}, err
 }
 
 // MustParseIPAddress parses the string form of an IP Address into an IPAddress object type.

--- a/pkg/caveats/types_test.go
+++ b/pkg/caveats/types_test.go
@@ -29,6 +29,28 @@ func TestIPAddress(t *testing.T) {
 	require.False(t, result.Value())
 }
 
+func TestIPAddressIPv4Mapped(t *testing.T) {
+	compiled, err := compileCaveat(MustEnvForVariablesWithDefaultTypeSet(map[string]types.VariableType{
+		"user_ip": types.Default.IPAddressType,
+	}), "user_ip.in_cidr('10.0.0.0/8')")
+	require.NoError(t, err)
+
+	parsed, _ := types.ParseIPAddress("10.1.2.3")
+	result, err := EvaluateCaveat(compiled, map[string]any{
+		"user_ip": parsed,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Value())
+
+	// ::ffff:10.1.2.3 is the same host as 10.1.2.3 (RFC 4291 section 2.5.5.2).
+	parsed, _ = types.ParseIPAddress("::ffff:10.1.2.3")
+	result, err = EvaluateCaveat(compiled, map[string]any{
+		"user_ip": parsed,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Value())
+}
+
 func TestIPAddressInvalidCIDR(t *testing.T) {
 	compiled, err := compileCaveat(MustEnvForVariablesWithDefaultTypeSet(map[string]types.VariableType{
 		"user_ip": types.Default.IPAddressType,


### PR DESCRIPTION
## Description

`in_cidr` does not match an IPv4-mapped IPv6 address (`::ffff:10.1.2.3`) against an IPv4 CIDR, while the dotted form (`10.1.2.3`) matches. They are the same host (RFC 4291 section 2.5.5.2). The parsed address is not unmapped, so `netip.Prefix.Contains` compares across families.

Unmap at parse time so both forms compare equal.

## Testing

`TestIPAddressIPv4Mapped` fails before the change and passes after; the rest of `pkg/caveats` stays green.
