### PR TITLE
test: consolidate TestConsistency

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -300,7 +300,7 @@ jobs:
 
   crdbdatastoreconstest:
     name: "Datastore Consistency Tests"
-    runs-on: "depot-ubuntu-24.04-arm-4"
+    runs-on: "depot-ubuntu-24.04-arm-8"
     needs: "paths-filter"
     strategy:
       fail-fast: false

--- a/internal/datastore/common/schema.go
+++ b/internal/datastore/common/schema.go
@@ -71,6 +71,10 @@ type SchemaInformation struct {
 func (si SchemaInformation) expectedIndexesForShape(shape queryshape.Shape) options.SQLIndexInformation {
 	expectedIndexes := options.SQLIndexInformation{}
 	for _, index := range si.Indexes {
+		// Track every index that serves at least one query shape.
+		if len(index.Shapes) > 0 {
+			expectedIndexes.ShapeServingIndexNames = append(expectedIndexes.ShapeServingIndexNames, index.Name)
+		}
 		if index.matchesShape(shape) {
 			expectedIndexes.ExpectedIndexNames = append(expectedIndexes.ExpectedIndexNames, index.Name)
 		}

--- a/internal/datastore/common/schema_test.go
+++ b/internal/datastore/common/schema_test.go
@@ -3,8 +3,9 @@ package common
 import (
 	"testing"
 
-	"github.com/authzed/spicedb/pkg/datastore/queryshape"
 	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/datastore/queryshape"
 )
 
 func TestExpectedIndexesForShape(t *testing.T) {
@@ -23,17 +24,28 @@ func TestExpectedIndexesForShape(t *testing.T) {
 					queryshape.CheckPermissionSelectIndirectSubjects,
 				},
 			},
+			{
+				// A maintenance index serving no query shape (e.g. GC).
+				Name: "idx_maintenance",
+			},
 		},
 	}
 
+	// All indexes serving a shape are reported as shape-serving, regardless of the requested
+	// shape; the maintenance index is never reported.
+	allShapeServing := []string{"idx1", "idx2"}
+
 	expectedIndexes := schema.expectedIndexesForShape(queryshape.Unspecified)
-	require.Empty(t, expectedIndexes)
+	require.Empty(t, expectedIndexes.ExpectedIndexNames)
+	require.Equal(t, expectedIndexes.ShapeServingIndexNames, allShapeServing)
 
 	expectedIndexes = schema.expectedIndexesForShape(queryshape.CheckPermissionSelectDirectSubjects)
 	require.Equal(t, []string{"idx1", "idx2"}, expectedIndexes.ExpectedIndexNames)
+	require.Equal(t, expectedIndexes.ShapeServingIndexNames, allShapeServing)
 
 	expectedIndexes = schema.expectedIndexesForShape(queryshape.CheckPermissionSelectIndirectSubjects)
 	require.Equal(t, []string{"idx2"}, expectedIndexes.ExpectedIndexNames)
+	require.Equal(t, expectedIndexes.ShapeServingIndexNames, allShapeServing)
 }
 
 func TestSortByResourceColumnOrderColumns(t *testing.T) {

--- a/internal/datastore/common/schema_test.go
+++ b/internal/datastore/common/schema_test.go
@@ -3,9 +3,8 @@ package common
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/authzed/spicedb/pkg/datastore/queryshape"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExpectedIndexesForShape(t *testing.T) {

--- a/internal/datastore/proxy/indexcheck/fakedatastore_test.go
+++ b/internal/datastore/proxy/indexcheck/fakedatastore_test.go
@@ -14,8 +14,13 @@ import (
 )
 
 type fakeDatastore struct {
-	revision    datastore.Revision
+	revision datastore.Revision
+	// indexesUsed is reported as the expected indexes for the query shape.
 	indexesUsed []string
+	// parsedIndexes is what ParseExplain reports as actually used by the query. If empty, it defaults to []string{"testindex"}.
+	parsedIndexes []string
+	// shapeServingIndexes is reported as the set of indexes that serve some query shape.
+	shapeServingIndexes []string
 }
 
 func (f fakeDatastore) MetricsID() (string, error) {
@@ -28,8 +33,10 @@ func (f fakeDatastore) UniqueID(_ context.Context) (string, error) {
 
 func (f fakeDatastore) SnapshotReader(revision datastore.Revision) datastore.Reader {
 	return fakeSnapshotReader{
-		revision:    revision,
-		indexesUsed: f.indexesUsed,
+		revision:            revision,
+		indexesUsed:         f.indexesUsed,
+		parsedIndexes:       f.parsedIndexes,
+		shapeServingIndexes: f.shapeServingIndexes,
 	}
 }
 
@@ -93,8 +100,12 @@ func (f fakeDatastore) BuildExplainQuery(sql string, args []any) (string, []any,
 
 // ParseExplain parses the output of an EXPLAIN statement.
 func (f fakeDatastore) ParseExplain(explain string) (datastore.ParsedExplain, error) {
+	parsed := f.parsedIndexes
+	if len(parsed) == 0 {
+		parsed = []string{"testindex"}
+	}
 	return datastore.ParsedExplain{
-		IndexesUsed: []string{"testindex"},
+		IndexesUsed: parsed,
 	}, nil
 }
 
@@ -103,8 +114,10 @@ func (f fakeDatastore) PreExplainStatements() []string {
 }
 
 type fakeSnapshotReader struct {
-	revision    datastore.Revision
-	indexesUsed []string
+	revision            datastore.Revision
+	indexesUsed         []string
+	parsedIndexes       []string
+	shapeServingIndexes []string
 }
 
 func (fsr fakeSnapshotReader) LegacyLookupNamespacesWithNames(_ context.Context, nsNames []string) ([]datastore.RevisionedDefinition[*corev1.NamespaceDefinition], error) {
@@ -163,7 +176,8 @@ func fakeIterator(fsr fakeSnapshotReader, explainCallback options.SQLExplainCall
 	return func(yield func(tuple.Relationship, error) bool) {
 		if explainCallback != nil {
 			if err := explainCallback(context.Background(), "SOME QUERY", nil, queryshape.CheckPermissionSelectDirectSubjects, "EXPLAIN IS FAKE", options.SQLIndexInformation{
-				ExpectedIndexNames: fsr.indexesUsed,
+				ExpectedIndexNames:     fsr.indexesUsed,
+				ShapeServingIndexNames: fsr.shapeServingIndexes,
 			}); err != nil {
 				yield(tuple.Relationship{}, err)
 				return

--- a/internal/datastore/proxy/indexcheck/indexcheck.go
+++ b/internal/datastore/proxy/indexcheck/indexcheck.go
@@ -150,13 +150,21 @@ func (r *indexcheckingReader) mustEnsureIndexes(ctx context.Context, sql string,
 		return fmt.Errorf("failed to parse explain output: %w", err)
 	}
 
+	indexesUsed := mapz.NewSet(parsed.IndexesUsed...)
+
+	// Ignore any indexes that do not serve a query shape (e.g. maintenance indexes used for GC,
+	// watch or expiration, or the implicit primary key). On small datasets the optimizer may
+	// fall back to one of these instead of the intended index, so it is treated the same as no index being used.
+	if len(expectedIndexes.ShapeServingIndexNames) > 0 {
+		indexesUsed = indexesUsed.Intersect(mapz.NewSet(expectedIndexes.ShapeServingIndexNames...))
+	}
+
 	// If an index is not used (perhaps because the data is too small), the query is still valid.
-	if len(parsed.IndexesUsed) == 0 {
+	if indexesUsed.IsEmpty() {
 		return nil
 	}
 
 	// Otherwise, ensure the index used is one of the expected indexes.
-	indexesUsed := mapz.NewSet(parsed.IndexesUsed...)
 	indexesExpected := mapz.NewSet(expectedIndexes.ExpectedIndexNames...)
 	if indexesExpected.Intersect(indexesUsed).IsEmpty() {
 		return fmt.Errorf("expected index(es) %v for query shape %v not used: %s", expectedIndexes.ExpectedIndexNames, shape, explain)

--- a/internal/datastore/proxy/indexcheck/indexcheck_test.go
+++ b/internal/datastore/proxy/indexcheck/indexcheck_test.go
@@ -72,6 +72,73 @@ func TestIndexCheckingFoundIndex(t *testing.T) {
 	}
 }
 
+// TestIndexCheckingIgnoresNonShapeServingIndex ensures that when the optimizer falls back to an
+// index that serves no query shape (e.g. the GC index on small datasets), the check passes rather
+// than erroring, mirroring the "no index used" small-data carve-out.
+func TestIndexCheckingIgnoresNonShapeServingIndex(t *testing.T) {
+	ds := fakeDatastore{
+		indexesUsed:         []string{"uq_relation_tuple_living"},
+		parsedIndexes:       []string{"ix_relation_tuple_by_deleted_transaction"},
+		shapeServingIndexes: []string{"uq_relation_tuple_living", "ix_relation_tuple_by_subject"},
+	}
+	wrapped := WrapWithIndexCheckingDatastoreProxyIfApplicable(ds)
+
+	headRevResult, err := ds.HeadRevision(t.Context())
+	require.NoError(t, err)
+
+	reader := wrapped.SnapshotReader(headRevResult.Revision)
+	it, err := reader.QueryRelationships(t.Context(), datastore.RelationshipsFilter{
+		OptionalResourceType:     "document",
+		OptionalResourceIds:      []string{"somedoc"},
+		OptionalResourceRelation: "viewer",
+		OptionalSubjectsSelectors: []datastore.SubjectsSelector{
+			{
+				OptionalSubjectType: "user",
+				OptionalSubjectIds:  []string{"tom"},
+				RelationFilter:      datastore.SubjectRelationFilter{}.WithEllipsisRelation(),
+			},
+		},
+	}, options.WithQueryShape(queryshape.CheckPermissionSelectDirectSubjects))
+	require.NoError(t, err)
+
+	for _, err := range it {
+		require.NoError(t, err)
+	}
+}
+
+// TestIndexCheckingWrongShapeServingIndex ensures that using a shape-serving index that is not one
+// of the expected indexes for the query shape still fails, even when shape-serving info is present.
+func TestIndexCheckingWrongShapeServingIndex(t *testing.T) {
+	ds := fakeDatastore{
+		indexesUsed:         []string{"uq_relation_tuple_living"},
+		parsedIndexes:       []string{"ix_relation_tuple_by_subject"},
+		shapeServingIndexes: []string{"uq_relation_tuple_living", "ix_relation_tuple_by_subject"},
+	}
+	wrapped := WrapWithIndexCheckingDatastoreProxyIfApplicable(ds)
+
+	headRevResult, err := ds.HeadRevision(t.Context())
+	require.NoError(t, err)
+
+	reader := wrapped.SnapshotReader(headRevResult.Revision)
+	it, err := reader.QueryRelationships(t.Context(), datastore.RelationshipsFilter{
+		OptionalResourceType:     "document",
+		OptionalResourceIds:      []string{"somedoc"},
+		OptionalResourceRelation: "viewer",
+		OptionalSubjectsSelectors: []datastore.SubjectsSelector{
+			{
+				OptionalSubjectType: "user",
+				OptionalSubjectIds:  []string{"tom"},
+				RelationFilter:      datastore.SubjectRelationFilter{}.WithEllipsisRelation(),
+			},
+		},
+	}, options.WithQueryShape(queryshape.CheckPermissionSelectDirectSubjects))
+	require.NoError(t, err)
+
+	for _, err := range it {
+		require.ErrorContains(t, err, "expected index(es) [uq_relation_tuple_living] for query shape check-permission-select-direct-subjects not used")
+	}
+}
+
 func TestWrapWithIndexCheckingDatastoreProxyIfApplicable(t *testing.T) {
 	t.Run("wraps SQL datastore", func(t *testing.T) {
 		ds := fakeDatastore{}

--- a/internal/dispatch/singleflight/singleflight.go
+++ b/internal/dispatch/singleflight/singleflight.go
@@ -124,15 +124,16 @@ func (d *Dispatcher) DispatchExpand(ctx context.Context, req *v1.DispatchExpandR
 		return d.delegate.DispatchExpand(ctx, req)
 	}
 
-	v, isShared, err := d.expandGroup.Do(ctx, keyString, func(innerCtx context.Context) (*v1.DispatchExpandResponse, error) {
+	sharedResp, isShared, err := d.expandGroup.Do(ctx, keyString, func(innerCtx context.Context) (*v1.DispatchExpandResponse, error) {
 		return d.delegate.DispatchExpand(innerCtx, req)
 	})
 
-	singleFlightCount.WithLabelValues("DispatchExpand", strconv.FormatBool(isShared)).Inc()
-	if err != nil {
-		return &v1.DispatchExpandResponse{Metadata: &v1.ResponseMeta{DispatchCount: 1}}, err
+	if sharedResp == nil {
+		sharedResp = &v1.DispatchExpandResponse{Metadata: &v1.ResponseMeta{DispatchCount: 1}}
 	}
-	return v, err
+
+	singleFlightCount.WithLabelValues("DispatchExpand", strconv.FormatBool(isShared)).Inc()
+	return sharedResp.CloneVT(), err
 }
 
 func (d *Dispatcher) DispatchLookupResources2(req *v1.DispatchLookupResources2Request, stream dispatch.LookupResources2Stream) error {

--- a/internal/services/integrationtesting/consistency_datastore_test.go
+++ b/internal/services/integrationtesting/consistency_datastore_test.go
@@ -3,74 +3,28 @@
 package integrationtesting_test
 
 import (
-	"path"
-	"runtime"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/authzed/spicedb/internal/datastore/proxy/indexcheck"
-	"github.com/authzed/spicedb/internal/dispatch/graph"
-	"github.com/authzed/spicedb/internal/services/integrationtesting/consistencytestutil"
-	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
-	"github.com/authzed/spicedb/internal/testserver/datastore/config"
-	dsconfig "github.com/authzed/spicedb/pkg/cmd/datastore"
+	consistencytest "github.com/authzed/spicedb/pkg/consistency/test"
 	"github.com/authzed/spicedb/pkg/datastore"
 )
 
+// TestConsistencyPerDatastore is a system-wide consistency test suite that reads in
+// the various validation files in the testconfigs directory and executes the full set
+// of APIs against the data within, ensuring that all results of the various APIs are
+// consistent with one another. It runs the suite against every supported datastore
+// engine, the local and caching dispatchers, and multiple dispatch chunk sizes.
+//
+// This test suite acts as essentially a full integration test for the API,
+// dispatching, caching, computation and datastore layers. It should reflect
+// both real-world schemas, as well as the full set of hand-constructed corner
+// cases so that the system can be fully exercised.
 func TestConsistencyPerDatastore(t *testing.T) {
-	//nolint:tparallel
-	// TODO(jschorr): Re-enable for *all* files once we make this faster.
-	_, filename, _, _ := runtime.Caller(0)
-	consistencyTestFiles := []string{
-		path.Join(path.Join(path.Dir(filename), "testconfigs"), "document.yaml"),
-		path.Join(path.Join(path.Dir(filename), "testconfigs"), "basicrbac.yaml"),
-		path.Join(path.Join(path.Dir(filename), "testconfigs"), "public.yaml"),
-		path.Join(path.Join(path.Dir(filename), "testconfigs"), "nil.yaml"),
-		path.Join(path.Join(path.Dir(filename), "testconfigs"), "basiccaveat.yaml"),
-		path.Join(path.Join(path.Dir(filename), "testconfigs"), "relexpiration.yaml"),
-		path.Join(path.Join(path.Dir(filename), "testconfigs"), "expirationwithcaveat.yaml"),
-		path.Join(path.Join(path.Dir(filename), "testconfigs"), "simplewildcard.yaml"),
-		path.Join(path.Join(path.Dir(filename), "testconfigs"), "caveatarrow.yaml"),
-		path.Join(path.Join(path.Dir(filename), "testconfigs"), "intersectionarrow.yaml"),
-	}
+	// TODO inmemory?
 
 	for _, engineID := range datastore.Engines {
 		t.Run(engineID, func(t *testing.T) {
-			for _, filePath := range consistencyTestFiles {
-				rde := testdatastore.RunDatastoreEngine(t, engineID)
-				baseds := rde.NewDatastore(t, config.DatastoreConfigInitFunc(t,
-					dsconfig.WithWatchBufferLength(0),
-					dsconfig.WithGCWindow(time.Duration(90_000_000_000_000)),
-					dsconfig.WithRevisionQuantization(10),
-					dsconfig.WithMaxRetries(50),
-					dsconfig.WithWriteAcquisitionTimeout(5*time.Second)))
-				ds := indexcheck.WrapWithIndexCheckingDatastoreProxyIfApplicable(baseds)
-
-				cad := consistencytestutil.BuildDataAndCreateClusterForTesting(t, filePath, ds)
-				dispatcher, err := graph.NewLocalOnlyDispatcher(graph.MustNewDefaultDispatcherParametersForTesting())
-				require.NoError(t, err)
-				t.Cleanup(func() { dispatcher.Close() })
-				accessibilitySet := consistencytestutil.BuildAccessibilitySet(t, cad.Ctx, cad.Populated, cad.DataStore)
-
-				headRevisionResult, err := cad.DataStore.HeadRevision(cad.Ctx)
-				require.NoError(t, err)
-
-				// Run the assertions within each file.
-				tester := consistencytestutil.NewServiceTester(cad.Conn)
-				vctx := validationContext{
-					clusterAndData:   cad,
-					accessibilitySet: accessibilitySet,
-					serviceTester:    tester,
-					revision:         headRevisionResult.Revision,
-					dispatcher:       dispatcher,
-				}
-
-				t.Run(path.Base(filePath)+"/"+tester.Name(), func(t *testing.T) {
-					runAssertions(t, vctx)
-				})
-			}
+			consistencytest.ConsistencyForEngine(t, engineID, nil)
 		})
 	}
 }

--- a/internal/services/integrationtesting/consistency_test.go
+++ b/internal/services/integrationtesting/consistency_test.go
@@ -3,258 +3,64 @@
 package integrationtesting_test
 
 import (
-	"fmt"
-	"maps"
-	"path"
-	"slices"
 	"testing"
 	"time"
 
-	"github.com/jzelinskie/stringz"
 	"github.com/stretchr/testify/require"
-	yamlv3 "go.yaml.in/yaml/v3"
-	"google.golang.org/protobuf/types/known/structpb"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-
-	"github.com/authzed/spicedb/internal/developmentmembership"
-	"github.com/authzed/spicedb/internal/dispatch"
+	"github.com/authzed/spicedb/internal/datastore/dsfortesting"
+	"github.com/authzed/spicedb/internal/datastore/memdb"
 	"github.com/authzed/spicedb/internal/services/integrationtesting/consistencytestutil"
+	"github.com/authzed/spicedb/internal/testserver"
+	"github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/datalayer"
-	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/development"
-	"github.com/authzed/spicedb/pkg/genutil/mapz"
-	core "github.com/authzed/spicedb/pkg/proto/core/v1"
-	devinterface "github.com/authzed/spicedb/pkg/proto/developer/v1"
-	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
 	"github.com/authzed/spicedb/pkg/schema"
 	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/authzed/spicedb/pkg/validationfile"
-	"github.com/authzed/spicedb/pkg/validationfile/blocks"
 )
 
 const testTimedelta = 1 * time.Second
 
-// TestConsistency is a system-wide consistency test suite that reads in various
-// validation files in the testconfigs directory, and executes a full set of APIs
-// against the data within, ensuring that all results of the various APIs are
-// consistent with one another.
-//
-// This test suite acts as essentially a full integration test for the API,
-// dispatching, caching, computation and datastore layers. It should reflect
-// both real-world schemas, as well as the full set of hand-constructed corner
-// cases so that the system can be fully exercised.
-func TestConsistency(t *testing.T) {
-	// List all the defined consistency test files.
-	consistencyTestFiles, err := consistencytestutil.ListTestConfigs()
-	require.NoError(t, err)
-
-	for _, filePath := range consistencyTestFiles {
-		t.Run(path.Base(filePath), func(t *testing.T) {
-			for _, dispatcherKind := range []string{"local", "caching"} {
-				t.Run(dispatcherKind, func(t *testing.T) {
-					// This t.Parallel, and the one inside runConsistencyTestSuiteForFile, actually help our parallelism.
-					// This is because there is an unbounded, and combinatoric, number of actual subtests we are going to run for each file
-					// depending on the data (since we validate all subjects and all resources and all reachability)
-					//
-					// Thus, running each of those in parallel, once we've built the datastore for each, is useful.
-					// But the files are done in serial.
-					t.Parallel()
-
-					for _, chunkSize := range []uint16{5, 10} {
-						t.Run(fmt.Sprintf("chunk-size-%d", chunkSize), func(t *testing.T) {
-							runConsistencyTestSuiteForFile(t, filePath, dispatcherKind == "caching", chunkSize)
-						})
-					}
-				})
-			}
-		})
-	}
-	// NOTE: this test is mostly a copy of runConsistencyTestSuiteForFile
-	// but it is defined separately because the integration test harness
-	// can't deal with logic that doesn't have a concrete relation associated with it
-	// as of time of writing.
-	// TODO: remove this test and rename self.yaml.skip to self.yaml
-	t.Run("self keyword consistency test", func(t *testing.T) {
-		options := []server.ConfigOption{
-			server.WithDispatchChunkSize(5),
-			server.WithEnableExperimentalLookupResources(true),
-			server.WithExperimentalLookupResourcesVersion("lr3"),
-		}
-
-		cad := consistencytestutil.LoadDataAndCreateClusterForTesting(t, "testconfigs/self.yaml.skip", testTimedelta, options...)
-
-		// Validate the type system for each namespace.
-		headRevisionResult, err := cad.DataStore.HeadRevision(cad.Ctx)
-		require.NoError(t, err)
-		headRevision := headRevisionResult.Revision
-
-		ts := schema.NewTypeSystem(schema.ResolverForDatastoreReader(cad.DataStore.SnapshotReader(headRevision)))
-
-		for _, nsDef := range cad.Populated.NamespaceDefinitions {
-			_, err := ts.GetValidatedDefinition(cad.Ctx, nsDef.Name)
-			require.NoError(t, err)
-
-			_, err = development.AddDefinitionWarnings(cad.Ctx, nsDef, ts)
-			// We would normally check to see if there were any warnings; however, some of the integration tests are
-			// here to intentionally test things that are warnings-but-not-errors in a schema (like arrow-references-relation).
-			// So instead, just validate that warning validation succeeds.
-			require.NoError(t, err)
-		}
-
-		tester := consistencytestutil.NewServiceTester(cad.Conn)
-		accessibilitySet := consistencytestutil.BuildAccessibilitySet(t, cad.Ctx, cad.Populated, cad.DataStore)
-
-		dispatcher := consistencytestutil.CreateDispatcherForTesting(t, false)
-
-		vctx := validationContext{
-			clusterAndData:   cad,
-			accessibilitySet: accessibilitySet,
-			serviceTester:    tester,
-			revision:         headRevision,
-			dispatcher:       dispatcher,
-		}
-
-		// Call a write on each relationship to make sure it type checks.
-		ensureRelationshipWrites(t, vctx)
-
-		// Call a read on each relationship resource type and ensure it finds all expected relationships.
-		validateRelationshipReads(t, vctx)
-
-		// Run the assertions defined in the file.
-		runAssertions(t, vctx)
-
-		// Run basic expansion on each relation and ensure no errors are raised.
-		ensureNoExpansionErrors(t, vctx)
-
-		// We skip validating expansion subjects for this case
-
-		// Validate lookup resources manually for this schema
-
-		// Look for resources for alice
-		foundResources, _, err := vctx.serviceTester.LookupResources(
-			t.Context(),
-			tuple.RelationReference{
-				ObjectType: "user",
-				Relation:   "me_or_related",
-			},
-			tuple.ObjectAndRelation{
-				ObjectType: "user",
-				ObjectID:   "alice",
-				Relation:   tuple.Ellipsis,
-			},
-			vctx.revision,
-			nil,
-			10,
-			nil,
-		)
-		require.NoError(t, err)
-		resourceIds := make([]string, 0, len(foundResources))
-		for _, resource := range foundResources {
-			resourceIds = append(resourceIds, resource.ResourceObjectId)
-		}
-
-		// We expect that alice is related to himself and bob
-		require.ElementsMatch(t, []string{"alice", "bob"}, resourceIds, "expected both bob and alice as resources")
-
-		// Look for resources for alice
-		foundResources, _, err = vctx.serviceTester.LookupResources(
-			t.Context(),
-			tuple.RelationReference{
-				ObjectType: "user",
-				Relation:   "me_or_related",
-			},
-			tuple.ObjectAndRelation{
-				ObjectType: "user",
-				ObjectID:   "bob",
-				Relation:   tuple.Ellipsis,
-			},
-			vctx.revision,
-			nil,
-			10,
-			nil,
-		)
-		require.NoError(t, err)
-		resourceIds = make([]string, 0, len(foundResources))
-		for _, resource := range foundResources {
-			resourceIds = append(resourceIds, resource.ResourceObjectId)
-		}
-
-		// We expect that bob is related only to himself
-		require.ElementsMatch(t, []string{"bob"}, resourceIds, "expected just bob as resource")
-
-		// Validate lookup subjects manually for this schema
-		// Look for subjects for alice
-		foundSubjects, err := vctx.serviceTester.LookupSubjects(
-			t.Context(),
-			tuple.ObjectAndRelation{
-				ObjectType: "user",
-				ObjectID:   "alice",
-				Relation:   "me_or_related",
-			},
-			tuple.RelationReference{
-				ObjectType: "user",
-			},
-			vctx.revision,
-			nil,
-		)
-		require.NoError(t, err)
-		subjectIds := make([]string, 0, len(foundSubjects))
-		for _, subject := range foundSubjects {
-			subjectIds = append(subjectIds, subject.Subject.SubjectObjectId)
-		}
-
-		// We expect that alice is related to himself
-		require.ElementsMatch(t, []string{"alice"}, subjectIds, "expected just alice as subject")
-
-		// Look for subjects for bob
-		foundSubjects, err = vctx.serviceTester.LookupSubjects(
-			t.Context(),
-			tuple.ObjectAndRelation{
-				ObjectType: "user",
-				ObjectID:   "bob",
-				Relation:   "me_or_related",
-			},
-			tuple.RelationReference{
-				ObjectType: "user",
-			},
-			vctx.revision,
-			nil,
-		)
-		require.NoError(t, err)
-		subjectIds = make([]string, 0, len(foundSubjects))
-		for _, subject := range foundSubjects {
-			subjectIds = append(subjectIds, subject.Subject.SubjectObjectId)
-		}
-
-		// We expect that bob is related to himself and to alice
-		require.ElementsMatch(t, []string{"bob", "alice"}, subjectIds, "expected bob and alice as subjects")
-
-		// We skip validating the development expected relations for this schema
-
-		// Ensure that the set of reachable subject types matches the actual reachable subjects.
-		validateReachableSubjectTypes(t, vctx)
-	})
-}
-
-func runConsistencyTestSuiteForFile(t *testing.T, filePath string, useCachingDispatcher bool, chunkSize uint16) {
-	t.Parallel()
-
+// TestConsistencyWithSelfKeyword exercises the `self` keyword schema, which
+// cannot flow through the generic consistency suite (TestConsistencyPerDatastore)
+// because the integration test harness can't deal with logic that doesn't have a
+// concrete relation associated with it as of time of writing. It runs against the
+// in-memory datastore only, as the behavior under test is engine-independent.
+// TODO: remove this test and rename self.yaml.skip to self.yaml
+func TestConsistencyWithSelfKeyword(t *testing.T) {
 	options := []server.ConfigOption{
-		server.WithDispatchChunkSize(chunkSize),
+		server.WithDispatchChunkSize(5),
 		server.WithEnableExperimentalLookupResources(true),
 		server.WithExperimentalLookupResourcesVersion("lr3"),
 	}
 
-	cad := consistencytestutil.LoadDataAndCreateClusterForTesting(t, filePath, testTimedelta, options...)
+	ds, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, testTimedelta, memdb.DisableGC)
+	require.NoError(t, err)
+
+	dl := datalayer.NewDataLayer(ds)
+	dsCtx := datalayer.ContextWithHandle(t.Context())
+	require.NoError(t, datalayer.SetInContext(dsCtx, dl))
+
+	populated, _, err := validationfile.PopulateFromFiles(t.Context(), dl, types.Default.TypeSet, []string{"testconfigs/self.yaml.skip"})
+	require.NoError(t, err)
+
+	connections := testserver.TestClusterWithDispatch(t, 1, ds, options...)
+
+	cad := consistencytestutil.ConsistencyClusterAndData{
+		Conn:      connections[0],
+		DataStore: ds,
+		Ctx:       dsCtx,
+		Populated: populated,
+	}
 
 	// Validate the type system for each namespace.
-	headRevisionResult, err := cad.DataStore.HeadRevision(cad.Ctx)
+	headRevisionResult, err := ds.HeadRevision(cad.Ctx)
 	require.NoError(t, err)
 	headRevision := headRevisionResult.Revision
 
-	ts := schema.NewTypeSystem(schema.ResolverForDatastoreReader(cad.DataStore.SnapshotReader(headRevision)))
+	ts := schema.NewTypeSystem(schema.ResolverForDatastoreReader(ds.SnapshotReader(headRevision)))
 
 	for _, nsDef := range cad.Populated.NamespaceDefinitions {
 		_, err := ts.GetValidatedDefinition(cad.Ctx, nsDef.Name)
@@ -267,850 +73,136 @@ func runConsistencyTestSuiteForFile(t *testing.T, filePath string, useCachingDis
 		require.NoError(t, err)
 	}
 
-	// Run consistency tests.
 	tester := consistencytestutil.NewServiceTester(cad.Conn)
-	t.Run(tester.Name(), func(t *testing.T) {
-		runConsistencyTestsWithServiceTester(t, cad, tester, headRevision, useCachingDispatcher)
-	})
-}
-
-type validationContext struct {
-	clusterAndData   consistencytestutil.ConsistencyClusterAndData
-	accessibilitySet *consistencytestutil.AccessibilitySet
-	serviceTester    consistencytestutil.ServiceTester
-	revision         datastore.Revision
-	dispatcher       dispatch.Dispatcher
-}
-
-func runConsistencyTestsWithServiceTester(
-	t *testing.T,
-	cad consistencytestutil.ConsistencyClusterAndData,
-	tester consistencytestutil.ServiceTester,
-	revision datastore.Revision,
-	useCachingDispatcher bool,
-) {
-	// Build an accessibility set.
 	accessibilitySet := consistencytestutil.BuildAccessibilitySet(t, cad.Ctx, cad.Populated, cad.DataStore)
 
-	dispatcher := consistencytestutil.CreateDispatcherForTesting(t, useCachingDispatcher)
+	dispatcher := consistencytestutil.CreateDispatcherForTesting(t, false)
 
-	vctx := validationContext{
-		clusterAndData:   cad,
-		accessibilitySet: accessibilitySet,
-		serviceTester:    tester,
-		revision:         revision,
-		dispatcher:       dispatcher,
+	vctx := consistencytestutil.ValidationContext{
+		ClusterAndData:   cad,
+		AccessibilitySet: accessibilitySet,
+		ServiceTester:    tester,
+		Revision:         headRevision,
+		Dispatcher:       dispatcher,
 	}
 
 	// Call a write on each relationship to make sure it type checks.
-	ensureRelationshipWrites(t, vctx)
+	consistencytestutil.EnsureRelationshipWrites(t, vctx)
 
 	// Call a read on each relationship resource type and ensure it finds all expected relationships.
-	validateRelationshipReads(t, vctx)
+	consistencytestutil.ValidateRelationshipReads(t, vctx)
 
 	// Run the assertions defined in the file.
-	runAssertions(t, vctx)
+	consistencytestutil.RunAssertions(t, vctx)
 
 	// Run basic expansion on each relation and ensure no errors are raised.
-	ensureNoExpansionErrors(t, vctx)
+	consistencytestutil.EnsureNoExpansionErrors(t, vctx)
 
-	// Run a fully recursive expand on each relation and ensure all terminal subjects are reached.
-	validateExpansionSubjects(t, vctx)
+	// We skip validating expansion subjects for this case
 
-	// For each relation in each namespace, for each subject, collect the resources accessible
-	// to that subject and then verify the lookup resources returns the same set of subjects.
-	validateLookupResources(t, vctx)
+	// Validate lookup resources manually for this schema
 
-	// For each object accessible, validate that the subjects that can access it are found.
-	validateLookupSubjects(t, vctx)
+	// Look for resources for alice
+	foundResources, _, err := vctx.ServiceTester.LookupResources(
+		t.Context(),
+		tuple.RelationReference{
+			ObjectType: "user",
+			Relation:   "me_or_related",
+		},
+		tuple.ObjectAndRelation{
+			ObjectType: "user",
+			ObjectID:   "alice",
+			Relation:   tuple.Ellipsis,
+		},
+		vctx.Revision,
+		nil,
+		10,
+		nil,
+	)
+	require.NoError(t, err)
+	resourceIds := make([]string, 0, len(foundResources))
+	for _, resource := range foundResources {
+		resourceIds = append(resourceIds, resource.ResourceObjectId)
+	}
 
-	// Run the development system over the full set of context and ensure they also return the expected information.
-	validateDevelopment(t, vctx)
+	// We expect that alice is related to himself and bob
+	require.ElementsMatch(t, []string{"alice", "bob"}, resourceIds, "expected both bob and alice as resources")
+
+	// Look for resources for alice
+	foundResources, _, err = vctx.ServiceTester.LookupResources(
+		t.Context(),
+		tuple.RelationReference{
+			ObjectType: "user",
+			Relation:   "me_or_related",
+		},
+		tuple.ObjectAndRelation{
+			ObjectType: "user",
+			ObjectID:   "bob",
+			Relation:   tuple.Ellipsis,
+		},
+		vctx.Revision,
+		nil,
+		10,
+		nil,
+	)
+	require.NoError(t, err)
+	resourceIds = make([]string, 0, len(foundResources))
+	for _, resource := range foundResources {
+		resourceIds = append(resourceIds, resource.ResourceObjectId)
+	}
+
+	// We expect that bob is related only to himself
+	require.ElementsMatch(t, []string{"bob"}, resourceIds, "expected just bob as resource")
+
+	// Validate lookup subjects manually for this schema
+	// Look for subjects for alice
+	foundSubjects, err := vctx.ServiceTester.LookupSubjects(
+		t.Context(),
+		tuple.ObjectAndRelation{
+			ObjectType: "user",
+			ObjectID:   "alice",
+			Relation:   "me_or_related",
+		},
+		tuple.RelationReference{
+			ObjectType: "user",
+		},
+		vctx.Revision,
+		nil,
+	)
+	require.NoError(t, err)
+	subjectIds := make([]string, 0, len(foundSubjects))
+	for _, subject := range foundSubjects {
+		subjectIds = append(subjectIds, subject.Subject.SubjectObjectId)
+	}
+
+	// We expect that alice is related to himself
+	require.ElementsMatch(t, []string{"alice"}, subjectIds, "expected just alice as subject")
+
+	// Look for subjects for bob
+	foundSubjects, err = vctx.ServiceTester.LookupSubjects(
+		t.Context(),
+		tuple.ObjectAndRelation{
+			ObjectType: "user",
+			ObjectID:   "bob",
+			Relation:   "me_or_related",
+		},
+		tuple.RelationReference{
+			ObjectType: "user",
+		},
+		vctx.Revision,
+		nil,
+	)
+	require.NoError(t, err)
+	subjectIds = make([]string, 0, len(foundSubjects))
+	for _, subject := range foundSubjects {
+		subjectIds = append(subjectIds, subject.Subject.SubjectObjectId)
+	}
+
+	// We expect that bob is related to himself and to alice
+	require.ElementsMatch(t, []string{"bob", "alice"}, subjectIds, "expected bob and alice as subjects")
+
+	// We skip validating the development expected relations for this schema
 
 	// Ensure that the set of reachable subject types matches the actual reachable subjects.
-	validateReachableSubjectTypes(t, vctx)
-}
-
-// testForEachRelationship runs a subtest for each relationship defined.
-func testForEachRelationship(
-	t *testing.T,
-	vctx validationContext,
-	prefix string,
-	handler func(t *testing.T, relationship tuple.Relationship),
-) {
-	t.Helper()
-
-	for _, relationship := range vctx.clusterAndData.Populated.Relationships {
-		t.Run(fmt.Sprintf("%s_%s", prefix, tuple.MustString(relationship)),
-			func(t *testing.T) {
-				handler(t, relationship)
-			})
-	}
-}
-
-// testForEachResource runs a subtest for each possible resource+relation in the schema.
-func testForEachResource(
-	t *testing.T,
-	vctx validationContext,
-	prefix string,
-	handler func(t *testing.T, resource tuple.ObjectAndRelation),
-) {
-	t.Helper()
-
-	for _, resourceType := range vctx.clusterAndData.Populated.NamespaceDefinitions {
-		resources, ok := vctx.accessibilitySet.ResourcesByNamespace.Get(resourceType.Name)
-		if !ok {
-			continue
-		}
-
-		resourceType := resourceType
-		for _, relation := range resourceType.Relation {
-			for _, resource := range resources {
-				t.Run(fmt.Sprintf("%s_%s_%s_%s", prefix, resourceType.Name, resource.ObjectID, relation.Name),
-					func(t *testing.T) {
-						handler(t, tuple.ObjectAndRelation{
-							ObjectType: resourceType.Name,
-							ObjectID:   resource.ObjectID,
-							Relation:   relation.Name,
-						})
-					})
-			}
-		}
-	}
-}
-
-// testForEachResourceType runs a subtest for each possible resource type+relation in the schema.
-func testForEachResourceType(
-	t *testing.T,
-	vctx validationContext,
-	prefix string,
-	handler func(t *testing.T, resourceType tuple.RelationReference),
-) {
-	for _, resourceType := range vctx.clusterAndData.Populated.NamespaceDefinitions {
-		for _, relation := range resourceType.Relation {
-			t.Run(fmt.Sprintf("%s_%s_%s_", prefix, resourceType.Name, relation.Name),
-				func(t *testing.T) {
-					handler(t, tuple.RelationReference{
-						ObjectType: resourceType.Name,
-						Relation:   relation.Name,
-					})
-				})
-		}
-	}
-}
-
-// ensureRelationshipWrites ensures that all relationships can be written via the API.
-func ensureRelationshipWrites(t *testing.T, vctx validationContext) {
-	for _, nsDef := range vctx.clusterAndData.Populated.NamespaceDefinitions {
-		relationships, ok := vctx.accessibilitySet.RelationshipsByResourceNamespace.Get(nsDef.Name)
-		if !ok {
-			continue
-		}
-
-		for _, relationship := range relationships {
-			err := vctx.serviceTester.Write(t.Context(), relationship)
-			require.NoError(t, err, "failed to write %s", tuple.MustString(relationship))
-		}
-	}
-}
-
-// validateRelationshipReads ensures that all defined relationships are returned by the Read API.
-func validateRelationshipReads(t *testing.T, vctx validationContext) {
-	testForEachRelationship(t, vctx, "read", func(t *testing.T, relationship tuple.Relationship) {
-		foundRelationships, err := vctx.serviceTester.Read(t.Context(),
-			relationship.Resource.ObjectType,
-			vctx.revision,
-		)
-		require.NoError(t, err)
-
-		foundRelationshipsSet := mapz.NewSet[string]()
-		for _, rel := range foundRelationships {
-			foundRelationshipsSet.Insert(tuple.MustString(rel))
-		}
-
-		if relationship.OptionalExpiration != nil && relationship.OptionalExpiration.Before(time.Now()) {
-			require.False(t, foundRelationshipsSet.Has(tuple.MustString(relationship)), "found unexpected expired relationship %s in read results: %s", tuple.MustString(relationship), foundRelationshipsSet.AsSlice())
-		} else {
-			require.True(t, foundRelationshipsSet.Has(tuple.MustString(relationship)), "missing expected relationship %s in read results: %s", tuple.MustString(relationship), foundRelationshipsSet.AsSlice())
-		}
-	})
-}
-
-// ensureNoExpansionErrors runs basic expansion on each relation and ensures no errors are raised.
-func ensureNoExpansionErrors(t *testing.T, vctx validationContext) {
-	testForEachResource(t, vctx, "run_expand",
-		func(t *testing.T, resource tuple.ObjectAndRelation) {
-			_, err := vctx.serviceTester.Expand(t.Context(),
-				resource,
-				vctx.revision,
-			)
-			require.NoError(t, err)
-		})
-}
-
-// validateExpansionSubjects runs a fully recursive expand on each relation and ensures that all expected terminal subjects are reached.
-func validateExpansionSubjects(t *testing.T, vctx validationContext) {
-	testForEachResource(t, vctx, "validate_expand",
-		func(t *testing.T, resource tuple.ObjectAndRelation) {
-			// Run a *recursive* expansion to collect all the reachable subjects.
-			resp, err := vctx.dispatcher.DispatchExpand(
-				vctx.clusterAndData.Ctx,
-				&dispatchv1.DispatchExpandRequest{
-					ResourceAndRelation: resource.ToCoreONR(),
-					Metadata: &dispatchv1.ResolverMeta{
-						AtRevision:     vctx.revision.String(),
-						DepthRemaining: 100,
-						TraversalBloom: dispatchv1.MustNewTraversalBloomFilter(100),
-						SchemaHash:     []byte(datalayer.NoSchemaHashForTesting),
-					},
-					ExpansionMode: dispatchv1.DispatchExpandRequest_RECURSIVE,
-				})
-			require.NoError(t, err)
-
-			// Build an accessible subject set from the expansion tree.
-			subjectsFoundSet, err := developmentmembership.AccessibleExpansionSubjects(resp.TreeNode)
-			require.NoError(t, err)
-
-			// Ensure all non-wildcard terminal subjects that were found in the expansion are accessible.
-			for _, foundSubject := range subjectsFoundSet.ToSlice() {
-				if foundSubject.GetSubjectId() != tuple.PublicWildcard {
-					accessiblity, permissionship, ok := vctx.accessibilitySet.AccessibilityAndPermissionshipFor(resource, foundSubject.Subject())
-					require.True(t, ok, "missing accessibility for resource %s and subject %s", tuple.StringONR(resource), tuple.StringONR(foundSubject.Subject()))
-
-					// NOTE: an expanded subject must either be accessible directly (e.g. not via a wildcard)
-					// OR must be removed due to a static caveat context removing it from the set.
-					require.True(t,
-						accessiblity == consistencytestutil.AccessibleDirectly ||
-							accessiblity == consistencytestutil.NotAccessibleDueToPrespecifiedCaveat,
-						"mismatch between expand and accessibility for resource %s and subject %s. accessibility: %v, permissionship: %v",
-						tuple.StringONR(resource),
-						tuple.StringONR(foundSubject.Subject()),
-						accessiblity,
-						permissionship,
-					)
-				}
-			}
-
-			// Ensure all terminal subjects are found in the expansion.
-			for _, expectedSubject := range vctx.accessibilitySet.DirectlyAccessibleDefinedSubjects(resource) {
-				found := subjectsFoundSet.Contains(expectedSubject)
-				require.True(t, found, "missing expected subject %s in expand for resource %s", tuple.StringONR(expectedSubject), tuple.StringONR(resource))
-			}
-		})
-}
-
-func requireSubsetOf(t *testing.T, found []string, expected []string) {
-	if len(expected) == 0 {
-		return
-	}
-
-	foundSet := mapz.NewSet(found...)
-	for _, expectedObjectID := range expected {
-		require.True(t, foundSet.Has(expectedObjectID), "missing expected object ID %s", expectedObjectID)
-	}
-}
-
-// validateLookupResources ensures that a lookup resources call returns the expected objects and
-// only those expected.
-func validateLookupResources(t *testing.T, vctx validationContext) {
-	// Run a lookup resources for each resource type and ensure that the returned objects are those
-	// that are accessible to the subject.
-	testForEachResourceType(t, vctx, "validate_lookup_resources",
-		func(t *testing.T, resourceRelation tuple.RelationReference) {
-			for _, subject := range vctx.accessibilitySet.AllSubjectsNoWildcards() {
-				t.Run(tuple.StringONR(subject), func(t *testing.T) {
-					for _, pageSize := range []uint32{0, 2} {
-						t.Run(fmt.Sprintf("pagesize-%d", pageSize), func(t *testing.T) {
-							accessibleResources := vctx.accessibilitySet.LookupAccessibleResources(resourceRelation, subject)
-
-							// Perform a lookup call and ensure it returns the at least the same set of object IDs.
-							// Loop until all resources have been found or we've hit max iterations.
-							var currentCursor *v1.Cursor
-							resolvedResources := map[string]*v1.LookupResourcesResponse{}
-							for range 100 {
-								foundResources, lastCursor, err := vctx.serviceTester.LookupResources(t.Context(), resourceRelation, subject, vctx.revision, currentCursor, pageSize, nil)
-								require.NoError(t, err)
-
-								if pageSize > 0 {
-									require.LessOrEqual(t, len(foundResources), int(pageSize))
-								}
-
-								currentCursor = lastCursor
-
-								for _, resource := range foundResources {
-									resolvedResources[resource.ResourceObjectId] = resource
-								}
-
-								if pageSize == 0 || len(foundResources) < int(pageSize) {
-									break
-								}
-							}
-
-							require.ElementsMatch(t,
-								slices.Collect(maps.Keys(accessibleResources)),
-								slices.Collect(maps.Keys(resolvedResources)),
-								"expected accessibleResources in list A don't match actual resolvedResources in list B",
-							)
-
-							// Ensure that every returned concrete object Checks directly.
-							checkBulkItems := make([]*v1.CheckBulkPermissionsRequestItem, 0, len(resolvedResources))
-							expectedBulkPermissions := map[string]v1.CheckPermissionResponse_Permissionship{}
-
-							for _, resolvedResource := range resolvedResources {
-								permissionship, err := vctx.serviceTester.Check(t.Context(),
-									tuple.ObjectAndRelation{
-										ObjectType: resourceRelation.ObjectType,
-										ObjectID:   resolvedResource.ResourceObjectId,
-										Relation:   resourceRelation.Relation,
-									},
-									subject,
-									vctx.revision,
-									nil,
-								)
-
-								expectedPermissionship := v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION
-								if resolvedResource.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
-									expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
-								}
-
-								expectedBulkPermissions[resolvedResource.ResourceObjectId] = expectedPermissionship
-
-								require.NoError(t, err)
-								require.Equal(t,
-									expectedPermissionship,
-									permissionship,
-									"Found Check failure for relation %s:%s#%s and subject %s in lookup resources; LR permission %v, Check Permission %v",
-									resourceRelation.ObjectType,
-									resolvedResource.ResourceObjectId,
-									resourceRelation.Relation,
-									tuple.StringONR(subject),
-									expectedPermissionship,
-									permissionship,
-								)
-
-								checkBulkItems = append(checkBulkItems, &v1.CheckBulkPermissionsRequestItem{
-									Resource: &v1.ObjectReference{
-										ObjectType: resourceRelation.ObjectType,
-										ObjectId:   resolvedResource.ResourceObjectId,
-									},
-									Permission: resourceRelation.Relation,
-									Subject: &v1.SubjectReference{
-										Object: &v1.ObjectReference{
-											ObjectType: subject.ObjectType,
-											ObjectId:   subject.ObjectID,
-										},
-										OptionalRelation: stringz.Default(subject.Relation, "", tuple.Ellipsis),
-									},
-								})
-							}
-
-							// Ensure they are all found via bulk check as well.
-							results, err := vctx.serviceTester.CheckBulk(t.Context(),
-								checkBulkItems,
-								vctx.revision,
-							)
-							require.NoError(t, err)
-							for _, result := range results {
-								require.Equal(t, expectedBulkPermissions[result.Request.Resource.ObjectId], result.GetItem().Permissionship)
-							}
-						})
-					}
-				})
-			}
-		})
-}
-
-// validateLookupSubjects validates that the subjects that can access it are those expected.
-func validateLookupSubjects(t *testing.T, vctx validationContext) {
-	testForEachResource(t, vctx, "validate_lookup_subjects",
-		func(t *testing.T, resource tuple.ObjectAndRelation) {
-			for _, subjectType := range vctx.accessibilitySet.SubjectTypes() {
-				t.Run(fmt.Sprintf("%s#%s", subjectType.ObjectType, subjectType.Relation),
-					func(t *testing.T) {
-						resolvedSubjects, err := vctx.serviceTester.LookupSubjects(t.Context(), resource, subjectType, vctx.revision, nil)
-						require.NoError(t, err)
-
-						// Ensure the subjects found include those defined as expected. Since the
-						// accessibility set does not include "inferred" subjects (e.g. those with
-						// permissions as their subject relation, or wildcards), this should be a
-						// subset.
-						expectedDefinedSubjects := vctx.accessibilitySet.DirectlyAccessibleDefinedSubjectsOfType(resource, subjectType)
-						requireSubsetOf(t,
-							slices.Collect(maps.Keys(resolvedSubjects)),
-							slices.Collect(maps.Keys(expectedDefinedSubjects)),
-						)
-
-						// Ensure all subjects in true and caveated assertions for the subject type are found
-						// in the LookupSubject result, except those added via wildcard.
-						for _, parsedFile := range vctx.clusterAndData.Populated.ParsedFiles {
-							for _, entry := range []struct {
-								assertions         []blocks.Assertion
-								requiresPermission bool
-							}{
-								{
-									assertions:         parsedFile.Assertions.AssertTrue,
-									requiresPermission: true,
-								},
-								{
-									assertions:         parsedFile.Assertions.AssertCaveated,
-									requiresPermission: false,
-								},
-							} {
-								for _, assertion := range entry.assertions {
-									assertionRel := assertion.Relationship
-									if !tuple.ONREqual(assertionRel.Resource, resource) {
-										continue
-									}
-
-									if assertionRel.Subject.ObjectType != subjectType.ObjectType ||
-										assertionRel.Subject.Relation != subjectType.Relation {
-										continue
-									}
-
-									// For subjects found solely via wildcard, check that a wildcard instead exists in
-									// the result and that the subject is not excluded.
-									accessibility, _, ok := vctx.accessibilitySet.AccessibilityAndPermissionshipFor(resource, assertionRel.Subject)
-									if !ok || accessibility == consistencytestutil.AccessibleViaWildcardOnly {
-										resolvedSubjectsToCheck := resolvedSubjects
-
-										// If the assertion has caveat context, rerun LookupSubjects with the context to ensure the returned subject
-										// matches the context given.
-										if len(assertion.CaveatContext) > 0 {
-											resolvedSubjectsWithContext, err := vctx.serviceTester.LookupSubjects(t.Context(), resource, subjectType, vctx.revision, assertion.CaveatContext)
-											require.NoError(t, err)
-
-											resolvedSubjectsToCheck = resolvedSubjectsWithContext
-										}
-
-										resolvedSubject, ok := resolvedSubjectsToCheck[tuple.PublicWildcard]
-										require.True(t, ok, "expected wildcard in lookupsubjects response for assertion `%s`", assertion.RelationshipWithContextString)
-
-										if entry.requiresPermission {
-											require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, resolvedSubject.Subject.Permissionship)
-										}
-
-										// Ensure that the subject is not excluded. If a caveated assertion, then the exclusion
-										// can be caveated.
-										for _, excludedSubject := range resolvedSubject.ExcludedSubjects {
-											if entry.requiresPermission {
-												require.NotEqual(t, excludedSubject.SubjectObjectId, assertionRel.Subject.ObjectID, "wildcard excludes the asserted subject ID: %s", assertionRel.Subject.ObjectID)
-											} else if excludedSubject.SubjectObjectId == assertionRel.Subject.ObjectID {
-												require.NotEqual(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, excludedSubject.Permissionship, "wildcard concretely excludes the asserted subject ID: %s", assertionRel.Subject.ObjectID)
-											}
-										}
-										continue
-									}
-
-									_, ok = resolvedSubjects[assertionRel.Subject.ObjectID]
-									require.True(t, ok, "missing expected subject %s from assertion %s", assertionRel.Subject.ObjectID, assertion.RelationshipWithContextString)
-								}
-							}
-						}
-
-						// Ensure that all excluded subjects from wildcards do not have access.
-						for _, resolvedSubject := range resolvedSubjects {
-							if resolvedSubject.Subject.SubjectObjectId != tuple.PublicWildcard {
-								continue
-							}
-
-							for _, excludedSubject := range resolvedSubject.ExcludedSubjects {
-								permissionship, err := vctx.serviceTester.Check(t.Context(),
-									resource,
-									tuple.ObjectAndRelation{
-										ObjectType: subjectType.ObjectType,
-										ObjectID:   excludedSubject.SubjectObjectId,
-										Relation:   subjectType.Relation,
-									},
-									vctx.revision,
-									nil,
-								)
-								require.NoError(t, err)
-
-								expectedPermissionship := v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION
-								if resolvedSubject.Subject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
-									expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
-								}
-								if excludedSubject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
-									expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
-								}
-
-								require.Equal(t,
-									expectedPermissionship,
-									permissionship,
-									"Found Check failure for resource %s and excluded subject %s in lookup subjects",
-									tuple.StringONR(resource),
-									excludedSubject.SubjectObjectId,
-								)
-							}
-						}
-
-						// Ensure that every returned defined, non-wildcard subject found checks as expected.
-						for _, resolvedSubject := range resolvedSubjects {
-							if resolvedSubject.Subject.SubjectObjectId == tuple.PublicWildcard {
-								continue
-							}
-
-							subject := tuple.ObjectAndRelation{
-								ObjectType: subjectType.ObjectType,
-								ObjectID:   resolvedSubject.Subject.SubjectObjectId,
-								Relation:   subjectType.Relation,
-							}
-
-							permissionship, err := vctx.serviceTester.Check(t.Context(),
-								resource,
-								subject,
-								vctx.revision,
-								nil,
-							)
-							require.NoError(t, err)
-
-							expectedPermissionship := v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION
-							if resolvedSubject.Subject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
-								expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
-							}
-
-							require.Equal(t,
-								expectedPermissionship,
-								permissionship,
-								"Found Check failure for resource %s and subject %s in lookup subjects",
-								tuple.StringONR(resource),
-								tuple.StringONR(subject),
-							)
-						}
-					})
-			}
-		})
-}
-
-// runAssertions runs all assertions defined in the validation files and ensures they
-// return the expected results.
-func runAssertions(t *testing.T, vctx validationContext) {
-	t.Run("assertions", func(t *testing.T) {
-		for _, parsedFile := range vctx.clusterAndData.Populated.ParsedFiles {
-			for _, entry := range []struct {
-				name                   string
-				assertions             []blocks.Assertion
-				expectedPermissionship v1.CheckPermissionResponse_Permissionship
-			}{
-				{
-					"true",
-					parsedFile.Assertions.AssertTrue,
-					v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION,
-				},
-				{
-					"caveated",
-					parsedFile.Assertions.AssertCaveated,
-					v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION,
-				},
-				{
-					"false",
-					parsedFile.Assertions.AssertFalse,
-					v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION,
-				},
-			} {
-				t.Run(entry.name, func(t *testing.T) {
-					bulkCheckItems := make([]*v1.BulkCheckPermissionRequestItem, 0, len(entry.assertions))
-
-					for _, assertion := range entry.assertions {
-						var caveatContext *structpb.Struct
-						if assertion.CaveatContext != nil {
-							built, err := structpb.NewStruct(assertion.CaveatContext)
-							require.NoError(t, err)
-							caveatContext = built
-						}
-
-						rel := tuple.ToV1Relationship(assertion.Relationship)
-
-						bulkCheckItems = append(bulkCheckItems, &v1.BulkCheckPermissionRequestItem{
-							Resource:   rel.Resource,
-							Permission: rel.Relation,
-							Subject:    rel.Subject,
-							Context:    caveatContext,
-						})
-
-						// Run each individual assertion.
-						assertion := assertion
-						t.Run(assertion.RelationshipWithContextString, func(t *testing.T) {
-							rel := assertion.Relationship
-							permissionship, err := vctx.serviceTester.Check(t.Context(), rel.Resource, rel.Subject, vctx.revision, assertion.CaveatContext)
-							require.NoError(t, err)
-							require.Equal(t, entry.expectedPermissionship, permissionship, "Assertion `%s` returned %s; expected %s", tuple.MustString(rel), permissionship, entry.expectedPermissionship)
-
-							// Ensure the assertion passes LookupResources with context, directly.
-							resolvedDirectResources, _, err := vctx.serviceTester.LookupResources(t.Context(), rel.Resource.RelationReference(), rel.Subject, vctx.revision, nil, 0, assertion.CaveatContext)
-							require.NoError(t, err)
-
-							resolvedDirectResourcesMap := map[string]*v1.LookupResourcesResponse{}
-							for _, resource := range resolvedDirectResources {
-								resolvedDirectResourcesMap[resource.ResourceObjectId] = resource
-							}
-
-							// Ensure the assertion passes LookupResources without context, indirectly.
-							resolvedIndirectResources, _, err := vctx.serviceTester.LookupResources(t.Context(), rel.Resource.RelationReference(), rel.Subject, vctx.revision, nil, 0, nil)
-							require.NoError(t, err)
-
-							resolvedIndirectResourcesMap := map[string]*v1.LookupResourcesResponse{}
-							for _, resource := range resolvedIndirectResources {
-								resolvedIndirectResourcesMap[resource.ResourceObjectId] = resource
-							}
-
-							// Check the assertion was returned for a direct (with context) lookup.
-							resolvedDirectResourceIds := slices.Collect(maps.Keys(resolvedDirectResourcesMap))
-							switch permissionship {
-							case v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION:
-								require.NotContains(t, resolvedDirectResourceIds, rel.Resource.ObjectID, "Found unexpected object %s in direct lookup for assertion %s", rel.Resource, rel)
-
-							case v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION:
-								require.Contains(t, resolvedDirectResourceIds, rel.Resource.ObjectID, "Missing object %s in lookup for assertion %s", rel.Resource, rel)
-								require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, resolvedDirectResourcesMap[rel.Resource.ObjectID].Permissionship)
-
-							case v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION:
-								require.Contains(t, resolvedDirectResourceIds, rel.Resource.ObjectID, "Missing object %s in lookup for assertion %s", rel.Resource, rel)
-								require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION, resolvedDirectResourcesMap[rel.Resource.ObjectID].Permissionship,
-									"Expected caveated permission in direct lookup for assertion %s", rel,
-								)
-							}
-
-							// Check the assertion was returned for an indirect (without context) lookup.
-							resolvedIndirectResourceIds := slices.Collect(maps.Keys(resolvedIndirectResourcesMap))
-							accessibility, _, _ := vctx.accessibilitySet.AccessibilityAndPermissionshipFor(rel.Resource, rel.Subject)
-
-							switch permissionship {
-							case v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION:
-								// If the caveat context given is empty, then the lookup result must not exist at all.
-								// Otherwise, it *could* be caveated or not exist, depending on the context given.
-								switch {
-								case len(assertion.CaveatContext) == 0:
-									require.NotContains(t, resolvedIndirectResourceIds, rel.Resource.ObjectID, "Found unexpected object %s in indirect lookup for assertion %s", rel.Resource, rel)
-								case accessibility == consistencytestutil.NotAccessible:
-									found, ok := resolvedIndirectResourcesMap[rel.Resource.ObjectID]
-									require.True(t, !ok || found.Permissionship != v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION) // LookupResources can be caveated, since we didn't rerun LookupResources with the context
-								case accessibility != consistencytestutil.NotAccessibleDueToPrespecifiedCaveat:
-									found, ok := resolvedIndirectResourcesMap[rel.Resource.ObjectID]
-									require.True(t, ok, "Missing expected object %s in indirect lookup for assertion %s", rel.Resource, rel)
-									require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION, found.Permissionship,
-										"Expected caveated permission in indirect lookup for assertion %s", rel,
-									)
-								}
-
-							case v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION:
-								require.Contains(t, resolvedIndirectResourceIds, rel.Resource.ObjectID, "Missing object %s in lookup for assertion %s", rel.Resource, rel)
-								// If the caveat context given is empty, then the lookup result must be fully permissioned.
-								// Otherwise, it *could* be caveated or fully permissioned, depending on the context given.
-								if len(assertion.CaveatContext) == 0 {
-									require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, resolvedIndirectResourcesMap[rel.Resource.ObjectID].Permissionship)
-								}
-
-							case v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION:
-								require.Contains(t, resolvedIndirectResourceIds, rel.Resource.ObjectID, "Missing object %s in lookup for assertion %s", rel.Resource, rel)
-								require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION, resolvedIndirectResourcesMap[rel.Resource.ObjectID].Permissionship)
-
-							default:
-								panic("unknown permissionship")
-							}
-						})
-
-						// Run all assertions under bulk check and ensure they match as well.
-						results, err := vctx.serviceTester.BulkCheck(t.Context(), bulkCheckItems, vctx.revision)
-						require.NoError(t, err)
-
-						for _, result := range results {
-							require.Equal(t, entry.expectedPermissionship, result.GetItem().GetPermissionship(), "Bulk check for assertion request `%s` returned %s; expected %s", result.GetRequest(), result.GetItem().GetPermissionship(), entry.expectedPermissionship)
-						}
-					}
-				})
-			}
-		}
-	})
-}
-
-// validateDevelopment runs the development package against the validation context and
-// ensures its output matches that expected.
-func validateDevelopment(t *testing.T, vctx validationContext) {
-	rels := make([]*core.RelationTuple, 0, len(vctx.clusterAndData.Populated.Relationships))
-	for _, rel := range vctx.clusterAndData.Populated.Relationships {
-		rels = append(rels, rel.ToCoreTuple())
-	}
-
-	reqContext := &devinterface.RequestContext{
-		Schema:        vctx.clusterAndData.Populated.Schema,
-		Relationships: rels,
-	}
-
-	devContext, devErr, err := development.NewDevContext(t.Context(), reqContext)
-	require.NoError(t, err)
-	require.Nil(t, devErr, "dev error: %v", devErr)
-	require.NotNil(t, devContext)
-
-	// Validate checks.
-	validateDevelopmentChecks(t, devContext, vctx)
-
-	// Validate assertions.
-	validateDevelopmentAssertions(t, devContext, vctx)
-
-	// Validate expected relationships.
-	validateDevelopmentExpectedRels(t, devContext, vctx)
-}
-
-// validateDevelopmentChecks validates that the Check operation in the development package
-// returns the expected permissionship.
-func validateDevelopmentChecks(t *testing.T, devContext *development.DevContext, vctx validationContext) {
-	testForEachResource(t, vctx, "validate_check_watch",
-		func(t *testing.T, resource tuple.ObjectAndRelation) {
-			for _, subject := range vctx.accessibilitySet.AllSubjectsNoWildcards() {
-				t.Run(tuple.StringONR(subject), func(t *testing.T) {
-					require.NotNil(t, devContext)
-					cr, err := development.RunCheck(devContext, resource, subject, nil)
-					require.NoError(t, err, "Got unexpected error from development check")
-
-					_, permissionship, ok := vctx.accessibilitySet.AccessibilityAndPermissionshipFor(resource, subject)
-					require.True(t, ok)
-					require.Equal(t, permissionship, cr.Permissionship,
-						"Found unexpected membership difference for %s@%s. Expected %v, Found: %v",
-						tuple.StringONR(resource),
-						tuple.StringONR(subject),
-						permissionship,
-						cr.Permissionship)
-				})
-			}
-		})
-}
-
-// validateDevelopmentAssertions validates that Assertions in the development package return
-// the expected results.
-func validateDevelopmentAssertions(t *testing.T, devContext *development.DevContext, vctx validationContext) {
-	// Build the assertions YAML.
-	var trueAssertions []string
-	var caveatedAssertions []string
-	var falseAssertions []string
-
-	for relString, permissionship := range vctx.accessibilitySet.PermissionshipByRelationship {
-		switch permissionship {
-		case dispatchv1.ResourceCheckResult_MEMBER:
-			trueAssertions = append(trueAssertions, relString)
-		case dispatchv1.ResourceCheckResult_CAVEATED_MEMBER:
-			caveatedAssertions = append(caveatedAssertions, relString)
-		case dispatchv1.ResourceCheckResult_NOT_MEMBER:
-			falseAssertions = append(falseAssertions, relString)
-		default:
-			require.Fail(t, "unknown permissionship")
-		}
-	}
-
-	assertionsMap := map[string]any{
-		"assertTrue":     trueAssertions,
-		"assertCaveated": caveatedAssertions,
-		"assertFalse":    falseAssertions,
-	}
-	assertions, err := yamlv3.Marshal(assertionsMap)
-	require.NoError(t, err, "Could not marshal assertions map")
-
-	// Run validation with the assertions and the updated YAML.
-	parsedAssertions, devErr := development.ParseAssertionsYAML(string(assertions))
-	require.NoError(t, err, "Got unexpected error from assertions")
-	require.Nil(t, devErr, "Got unexpected request error from assertions: %v", devErr)
-
-	devErrs, err := development.RunAllAssertions(devContext, parsedAssertions)
-	require.NoError(t, err, "Got unexpected error from assertions")
-	require.Empty(t, devErrs, "Got unexpected errors from validation: %v", devErrs)
-}
-
-// validateDevelopmentExpectedRels validates that the generated expected relationships matches
-// that expected.
-func validateDevelopmentExpectedRels(t *testing.T, devContext *development.DevContext, vctx validationContext) {
-	// Build the Expected Relations (inputs only).
-	expectedMap := map[string]any{}
-	for relString, permissionship := range vctx.accessibilitySet.PermissionshipByRelationship {
-		if permissionship == dispatchv1.ResourceCheckResult_NOT_MEMBER {
-			continue
-		}
-
-		relationship := tuple.MustParse(relString)
-		expectedMap[tuple.StringONR(relationship.Resource)] = []string{}
-	}
-
-	expectedRelations, err := yamlv3.Marshal(expectedMap)
-	require.NoError(t, err, "Could not marshal expected relations map")
-
-	expectedRelationsMap, devErr := development.ParseExpectedRelationsYAML(string(expectedRelations))
-	require.Nil(t, devErr)
-
-	// NOTE: We are using this to generate, so we ignore any errors.
-	membershipSet, _, err := development.RunValidation(devContext, expectedRelationsMap)
-	require.NoError(t, err, "Got unexpected error from validation")
-
-	// Parse the full validation YAML, and ensure every referenced subject is, in fact, allowed.
-	updatedValidationYaml, gerr := development.GenerateValidation(membershipSet)
-	require.NoError(t, gerr)
-
-	validationMap, err := validationfile.ParseExpectedRelationsBlock([]byte(updatedValidationYaml))
-	require.NoError(t, err)
-
-	for resourceKey, expectedSubjects := range validationMap.ValidationMap {
-		for _, expectedSubject := range expectedSubjects {
-			resourceAndRelation := resourceKey.ObjectAndRelation
-			subjectWithExceptions := expectedSubject.SubjectWithExceptions
-			require.NotNil(t, subjectWithExceptions, "Found expected relation without subject: %s", expectedSubject.ValidationString)
-
-			// For non-wildcard subjects, ensure they are accessible.
-			if subjectWithExceptions.Subject.Subject.ObjectID != tuple.PublicWildcard {
-				accessibility, permissionship, ok := vctx.accessibilitySet.AccessibilityAndPermissionshipFor(resourceAndRelation, subjectWithExceptions.Subject.Subject)
-				require.True(t, ok, "missing expected subject %s in accessibility set", tuple.StringONR(subjectWithExceptions.Subject.Subject))
-
-				switch permissionship {
-				case dispatchv1.ResourceCheckResult_MEMBER:
-					// May be caveated or uncaveated, so check the uncomputed permissionship.
-					uncomputed, ok := vctx.accessibilitySet.UncomputedPermissionshipFor(resourceAndRelation, subjectWithExceptions.Subject.Subject)
-					require.True(t, ok, "missing expected subject in accessibility set")
-					require.Equal(t, subjectWithExceptions.Subject.IsCaveated, (uncomputed == dispatchv1.ResourceCheckResult_CAVEATED_MEMBER), "found mismatch in uncomputed permissionship")
-
-				case dispatchv1.ResourceCheckResult_CAVEATED_MEMBER:
-					require.True(t, subjectWithExceptions.Subject.IsCaveated, "found uncaveated expected subject for caveated subject")
-
-				case dispatchv1.ResourceCheckResult_NOT_MEMBER:
-					// May be caveated or uncaveated, so check the accessibility.
-					if accessibility == consistencytestutil.NotAccessibleDueToPrespecifiedCaveat {
-						require.True(t, subjectWithExceptions.Subject.IsCaveated, "found uncaveated expected subject for caveated subject")
-					} else {
-						require.Failf(t, "found unexpected subject", "%s", tuple.StringONR(subjectWithExceptions.Subject.Subject))
-					}
-
-				default:
-					require.Fail(t, "expected valid permissionship")
-				}
-			}
-		}
-	}
-}
-
-// validateReachableSubjectTypes validates that the reachable subject types are those expected.
-func validateReachableSubjectTypes(t *testing.T, vctx validationContext) {
-	testForEachResource(t, vctx, "validate_reachable_subject_types", func(t *testing.T, resource tuple.ObjectAndRelation) {
-		headRevResult, err := vctx.clusterAndData.DataStore.HeadRevision(t.Context())
-		require.NoError(t, err)
-		headRev := headRevResult.Revision
-
-		reader := vctx.clusterAndData.DataStore.SnapshotReader(headRev)
-		ts := schema.NewTypeSystem(schema.ResolverForDatastoreReader(reader))
-
-		reachableSubjectTypes, err := ts.GetFullRecursiveSubjectTypesForRelation(t.Context(), resource.ObjectType, resource.Relation)
-		require.NoError(t, err)
-
-		reachableSubjectTypesSet := mapz.NewSet(reachableSubjectTypes...)
-
-		for _, member := range vctx.accessibilitySet.DirectlyAccessibleDefinedSubjects(resource) {
-			subjectTypeRef := member.ObjectType
-			if member.Relation != tuple.Ellipsis {
-				subjectTypeRef = subjectTypeRef + "#" + member.Relation
-			}
-
-			require.True(t, reachableSubjectTypesSet.Has(subjectTypeRef),
-				"Found unexpected subject type %s#%s in lookup subjects for resource %s; expected one of %s",
-				member.ObjectType,
-				member.Relation,
-				tuple.StringONR(resource),
-				reachableSubjectTypesSet.AsSlice(),
-			)
-		}
-	})
+	consistencytestutil.ValidateReachableSubjectTypes(t, vctx)
 }

--- a/internal/services/integrationtesting/consistencytestutil/clusteranddata.go
+++ b/internal/services/integrationtesting/consistencytestutil/clusteranddata.go
@@ -3,21 +3,14 @@ package consistencytestutil
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	"github.com/authzed/spicedb/internal/datastore/dsfortesting"
-	"github.com/authzed/spicedb/internal/datastore/memdb"
 	"github.com/authzed/spicedb/internal/dispatch"
 	"github.com/authzed/spicedb/internal/dispatch/caching"
 	"github.com/authzed/spicedb/internal/dispatch/graph"
 	"github.com/authzed/spicedb/internal/dispatch/keys"
-	"github.com/authzed/spicedb/internal/testserver"
-	caveattypes "github.com/authzed/spicedb/pkg/caveats/types"
-	"github.com/authzed/spicedb/pkg/cmd/server"
-	"github.com/authzed/spicedb/pkg/datalayer"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/validationfile"
 )
@@ -29,40 +22,6 @@ type ConsistencyClusterAndData struct {
 	DataStore datastore.Datastore
 	Ctx       context.Context
 	Populated *validationfile.PopulatedValidationFile
-}
-
-// LoadDataAndCreateClusterForTesting loads the data found in a consistency test file,
-// builds a cluster for it, and returns both the data and cluster.
-func LoadDataAndCreateClusterForTesting(t *testing.T, consistencyTestFilePath string, revisionDelta time.Duration, additionalServerOptions ...server.ConfigOption) ConsistencyClusterAndData {
-	require := require.New(t)
-
-	ds, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, revisionDelta, memdb.DisableGC)
-	require.NoError(err)
-
-	return BuildDataAndCreateClusterForTesting(t, consistencyTestFilePath, ds, additionalServerOptions...)
-}
-
-// BuildDataAndCreateClusterForTesting loads the data found in a consistency test file,
-// builds a cluster for it, and returns both the data and cluster.
-func BuildDataAndCreateClusterForTesting(t *testing.T, consistencyTestFilePath string, ds datastore.Datastore, additionalServerOptions ...server.ConfigOption) ConsistencyClusterAndData {
-	require := require.New(t)
-
-	populated, _, err := validationfile.PopulateFromFiles(t.Context(), datalayer.NewDataLayer(ds), caveattypes.Default.TypeSet, []string{consistencyTestFilePath})
-	require.NoError(err)
-
-	connections := testserver.TestClusterWithDispatch(t, 1, ds, additionalServerOptions...)
-
-	dl := datalayer.NewDataLayer(ds)
-
-	dsCtx := datalayer.ContextWithHandle(t.Context())
-	require.NoError(datalayer.SetInContext(dsCtx, dl))
-
-	return ConsistencyClusterAndData{
-		Conn:      connections[0],
-		DataStore: ds,
-		Ctx:       dsCtx,
-		Populated: populated,
-	}
 }
 
 // CreateDispatcherForTesting creates a dispatcher for consistency testing, with or without

--- a/internal/services/integrationtesting/consistencytestutil/suite.go
+++ b/internal/services/integrationtesting/consistencytestutil/suite.go
@@ -1,0 +1,690 @@
+package consistencytestutil
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/jzelinskie/stringz"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+
+	"github.com/authzed/spicedb/internal/developmentmembership"
+	"github.com/authzed/spicedb/internal/dispatch"
+	"github.com/authzed/spicedb/pkg/datalayer"
+	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/genutil/mapz"
+	dispatchv1 "github.com/authzed/spicedb/pkg/proto/dispatch/v1"
+	"github.com/authzed/spicedb/pkg/schema"
+	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/validationfile/blocks"
+)
+
+// ValidationContext holds everything needed to run the consistency suite against a
+// single populated cluster.
+type ValidationContext struct {
+	ClusterAndData   ConsistencyClusterAndData
+	AccessibilitySet *AccessibilitySet
+	ServiceTester    ServiceTester
+	Revision         datastore.Revision
+	Dispatcher       dispatch.Dispatcher
+}
+
+// RunConsistencyTestSuiteForCluster runs the full consistency suite against the cluster
+// and data described by vctx.
+func RunConsistencyTestSuiteForCluster(t *testing.T, vctx ValidationContext) {
+	// Call a write on each relationship to make sure it type checks.
+	EnsureRelationshipWrites(t, vctx)
+
+	// Call a read on each relationship resource type and ensure it finds all expected relationships.
+	ValidateRelationshipReads(t, vctx)
+
+	// Run the assertions defined in the file.
+	RunAssertions(t, vctx)
+
+	// Run basic expansion on each relation and ensure no errors are raised.
+	EnsureNoExpansionErrors(t, vctx)
+
+	// Run a fully recursive expand on each relation and ensure all terminal subjects are reached.
+	ValidateExpansionSubjects(t, vctx)
+
+	// For each relation in each namespace, for each subject, collect the resources accessible
+	// to that subject and then verify the lookup resources returns the same set of subjects.
+	ValidateLookupResources(t, vctx)
+
+	// For each object accessible, validate that the subjects that can access it are found.
+	ValidateLookupSubjects(t, vctx)
+
+	// Ensure that the set of reachable subject types matches the actual reachable subjects.
+	ValidateReachableSubjectTypes(t, vctx)
+}
+
+// testForEachRelationship runs a subtest for each relationship defined.
+func testForEachRelationship(
+	t *testing.T,
+	vctx ValidationContext,
+	prefix string,
+	handler func(t *testing.T, relationship tuple.Relationship),
+) {
+	t.Helper()
+
+	for _, relationship := range vctx.ClusterAndData.Populated.Relationships {
+		t.Run(fmt.Sprintf("%s_%s", prefix, tuple.MustString(relationship)),
+			func(t *testing.T) {
+				handler(t, relationship)
+			})
+	}
+}
+
+// testForEachResource runs a subtest for each possible resource+relation in the schema.
+func testForEachResource(
+	t *testing.T,
+	vctx ValidationContext,
+	prefix string,
+	handler func(t *testing.T, resource tuple.ObjectAndRelation),
+) {
+	t.Helper()
+
+	for _, resourceType := range vctx.ClusterAndData.Populated.NamespaceDefinitions {
+		resources, ok := vctx.AccessibilitySet.ResourcesByNamespace.Get(resourceType.Name)
+		if !ok {
+			continue
+		}
+
+		resourceType := resourceType
+		for _, relation := range resourceType.Relation {
+			for _, resource := range resources {
+				t.Run(fmt.Sprintf("%s_%s_%s_%s", prefix, resourceType.Name, resource.ObjectID, relation.Name),
+					func(t *testing.T) {
+						handler(t, tuple.ObjectAndRelation{
+							ObjectType: resourceType.Name,
+							ObjectID:   resource.ObjectID,
+							Relation:   relation.Name,
+						})
+					})
+			}
+		}
+	}
+}
+
+// testForEachResourceType runs a subtest for each possible resource type+relation in the schema.
+func testForEachResourceType(
+	t *testing.T,
+	vctx ValidationContext,
+	prefix string,
+	handler func(t *testing.T, resourceType tuple.RelationReference),
+) {
+	for _, resourceType := range vctx.ClusterAndData.Populated.NamespaceDefinitions {
+		for _, relation := range resourceType.Relation {
+			t.Run(fmt.Sprintf("%s_%s_%s_", prefix, resourceType.Name, relation.Name),
+				func(t *testing.T) {
+					handler(t, tuple.RelationReference{
+						ObjectType: resourceType.Name,
+						Relation:   relation.Name,
+					})
+				})
+		}
+	}
+}
+
+// EnsureRelationshipWrites ensures that all relationships can be written via the API.
+func EnsureRelationshipWrites(t *testing.T, vctx ValidationContext) {
+	for _, nsDef := range vctx.ClusterAndData.Populated.NamespaceDefinitions {
+		relationships, ok := vctx.AccessibilitySet.RelationshipsByResourceNamespace.Get(nsDef.Name)
+		if !ok {
+			continue
+		}
+
+		for _, relationship := range relationships {
+			err := vctx.ServiceTester.Write(t.Context(), relationship)
+			require.NoError(t, err, "failed to write %s", tuple.MustString(relationship))
+		}
+	}
+}
+
+// ValidateRelationshipReads ensures that all defined relationships are returned by the Read API.
+func ValidateRelationshipReads(t *testing.T, vctx ValidationContext) {
+	testForEachRelationship(t, vctx, "read", func(t *testing.T, relationship tuple.Relationship) {
+		foundRelationships, err := vctx.ServiceTester.Read(t.Context(),
+			relationship.Resource.ObjectType,
+			vctx.Revision,
+		)
+		require.NoError(t, err)
+
+		foundRelationshipsSet := mapz.NewSet[string]()
+		for _, rel := range foundRelationships {
+			foundRelationshipsSet.Insert(tuple.MustString(rel))
+		}
+
+		if relationship.OptionalExpiration != nil && relationship.OptionalExpiration.Before(time.Now()) {
+			require.False(t, foundRelationshipsSet.Has(tuple.MustString(relationship)), "found unexpected expired relationship %s in read results: %s", tuple.MustString(relationship), foundRelationshipsSet.AsSlice())
+		} else {
+			require.True(t, foundRelationshipsSet.Has(tuple.MustString(relationship)), "missing expected relationship %s in read results: %s", tuple.MustString(relationship), foundRelationshipsSet.AsSlice())
+		}
+	})
+}
+
+// EnsureNoExpansionErrors runs basic expansion on each relation and ensures no errors are raised.
+func EnsureNoExpansionErrors(t *testing.T, vctx ValidationContext) {
+	testForEachResource(t, vctx, "run_expand",
+		func(t *testing.T, resource tuple.ObjectAndRelation) {
+			_, err := vctx.ServiceTester.Expand(t.Context(),
+				resource,
+				vctx.Revision,
+			)
+			require.NoError(t, err)
+		})
+}
+
+// ValidateExpansionSubjects runs a fully recursive expand on each relation and ensures that all expected terminal subjects are reached.
+func ValidateExpansionSubjects(t *testing.T, vctx ValidationContext) {
+	testForEachResource(t, vctx, "validate_expand",
+		func(t *testing.T, resource tuple.ObjectAndRelation) {
+			// Run a *recursive* expansion to collect all the reachable subjects.
+			// Note: we don't use vctx.ServiceTester.Expand here because we are asking for RECURSIVE mode
+			resp, err := vctx.Dispatcher.DispatchExpand(
+				vctx.ClusterAndData.Ctx,
+				&dispatchv1.DispatchExpandRequest{
+					ResourceAndRelation: resource.ToCoreONR(),
+					Metadata: &dispatchv1.ResolverMeta{
+						AtRevision:     vctx.Revision.String(),
+						DepthRemaining: 100,
+						TraversalBloom: dispatchv1.MustNewTraversalBloomFilter(100),
+						SchemaHash:     []byte(datalayer.NoSchemaHashForTesting),
+					},
+					ExpansionMode: dispatchv1.DispatchExpandRequest_RECURSIVE,
+				})
+			require.NoError(t, err)
+
+			// Build an accessible subject set from the expansion tree.
+			subjectsFoundSet, err := developmentmembership.AccessibleExpansionSubjects(resp.TreeNode)
+			require.NoError(t, err)
+
+			// Ensure all non-wildcard terminal subjects that were found in the expansion are accessible.
+			for _, foundSubject := range subjectsFoundSet.ToSlice() {
+				if foundSubject.GetSubjectId() != tuple.PublicWildcard {
+					accessiblity, permissionship, ok := vctx.AccessibilitySet.AccessibilityAndPermissionshipFor(resource, foundSubject.Subject())
+					require.True(t, ok, "missing accessibility for resource %s and subject %s", tuple.StringONR(resource), tuple.StringONR(foundSubject.Subject()))
+
+					// NOTE: an expanded subject must either be accessible directly (e.g. not via a wildcard)
+					// OR must be removed due to a static caveat context removing it from the set.
+					require.True(t,
+						accessiblity == AccessibleDirectly ||
+							accessiblity == NotAccessibleDueToPrespecifiedCaveat,
+						"mismatch between expand and accessibility for resource %s and subject %s. accessibility: %v, permissionship: %v",
+						tuple.StringONR(resource),
+						tuple.StringONR(foundSubject.Subject()),
+						accessiblity,
+						permissionship,
+					)
+				}
+			}
+
+			// Ensure all terminal subjects are found in the expansion.
+			for _, expectedSubject := range vctx.AccessibilitySet.DirectlyAccessibleDefinedSubjects(resource) {
+				found := subjectsFoundSet.Contains(expectedSubject)
+				require.True(t, found, "missing expected subject %s in expand for resource %s", tuple.StringONR(expectedSubject), tuple.StringONR(resource))
+			}
+		})
+}
+
+func requireSubsetOf(t *testing.T, found []string, expected []string) {
+	if len(expected) == 0 {
+		return
+	}
+
+	foundSet := mapz.NewSet(found...)
+	for _, expectedObjectID := range expected {
+		require.True(t, foundSet.Has(expectedObjectID), "missing expected object ID %s", expectedObjectID)
+	}
+}
+
+// ValidateLookupResources ensures that a lookup resources call returns the expected objects and
+// only those expected.
+func ValidateLookupResources(t *testing.T, vctx ValidationContext) {
+	// Run a lookup resources for each resource type and ensure that the returned objects are those
+	// that are accessible to the subject.
+	testForEachResourceType(t, vctx, "validate_lookup_resources",
+		func(t *testing.T, resourceRelation tuple.RelationReference) {
+			for _, subject := range vctx.AccessibilitySet.AllSubjectsNoWildcards() {
+				t.Run(tuple.StringONR(subject), func(t *testing.T) {
+					for _, pageSize := range []uint32{0, 2} {
+						t.Run(fmt.Sprintf("pagesize-%d", pageSize), func(t *testing.T) {
+							accessibleResources := vctx.AccessibilitySet.LookupAccessibleResources(resourceRelation, subject)
+
+							// Perform a lookup call and ensure it returns the at least the same set of object IDs.
+							// Loop until all resources have been found or we've hit max iterations.
+							var currentCursor *v1.Cursor
+							resolvedResources := map[string]*v1.LookupResourcesResponse{}
+							for range 100 {
+								foundResources, lastCursor, err := vctx.ServiceTester.LookupResources(t.Context(), resourceRelation, subject, vctx.Revision, currentCursor, pageSize, nil)
+								require.NoError(t, err)
+
+								if pageSize > 0 {
+									require.LessOrEqual(t, len(foundResources), int(pageSize))
+								}
+
+								currentCursor = lastCursor
+
+								for _, resource := range foundResources {
+									resolvedResources[resource.ResourceObjectId] = resource
+								}
+
+								if pageSize == 0 || len(foundResources) < int(pageSize) {
+									break
+								}
+							}
+
+							require.ElementsMatch(t,
+								slices.Collect(maps.Keys(accessibleResources)),
+								slices.Collect(maps.Keys(resolvedResources)),
+								"expected accessibleResources in list A don't match actual resolvedResources in list B",
+							)
+
+							// Ensure that every returned concrete object Checks directly.
+							checkBulkItems := make([]*v1.CheckBulkPermissionsRequestItem, 0, len(resolvedResources))
+							expectedBulkPermissions := map[string]v1.CheckPermissionResponse_Permissionship{}
+
+							for _, resolvedResource := range resolvedResources {
+								permissionship, err := vctx.ServiceTester.Check(t.Context(),
+									tuple.ObjectAndRelation{
+										ObjectType: resourceRelation.ObjectType,
+										ObjectID:   resolvedResource.ResourceObjectId,
+										Relation:   resourceRelation.Relation,
+									},
+									subject,
+									vctx.Revision,
+									nil,
+								)
+
+								expectedPermissionship := v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION
+								if resolvedResource.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
+									expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+								}
+
+								expectedBulkPermissions[resolvedResource.ResourceObjectId] = expectedPermissionship
+
+								require.NoError(t, err)
+								require.Equal(t,
+									expectedPermissionship,
+									permissionship,
+									"Found Check failure for relation %s:%s#%s and subject %s in lookup resources; LR permission %v, Check Permission %v",
+									resourceRelation.ObjectType,
+									resolvedResource.ResourceObjectId,
+									resourceRelation.Relation,
+									tuple.StringONR(subject),
+									expectedPermissionship,
+									permissionship,
+								)
+
+								checkBulkItems = append(checkBulkItems, &v1.CheckBulkPermissionsRequestItem{
+									Resource: &v1.ObjectReference{
+										ObjectType: resourceRelation.ObjectType,
+										ObjectId:   resolvedResource.ResourceObjectId,
+									},
+									Permission: resourceRelation.Relation,
+									Subject: &v1.SubjectReference{
+										Object: &v1.ObjectReference{
+											ObjectType: subject.ObjectType,
+											ObjectId:   subject.ObjectID,
+										},
+										OptionalRelation: stringz.Default(subject.Relation, "", tuple.Ellipsis),
+									},
+								})
+							}
+
+							// Ensure they are all found via bulk check as well.
+							results, err := vctx.ServiceTester.CheckBulk(t.Context(),
+								checkBulkItems,
+								vctx.Revision,
+							)
+							require.NoError(t, err)
+							for _, result := range results {
+								require.Equal(t, expectedBulkPermissions[result.Request.Resource.ObjectId], result.GetItem().Permissionship)
+							}
+						})
+					}
+				})
+			}
+		})
+}
+
+// ValidateLookupSubjects validates that the subjects that can access it are those expected.
+func ValidateLookupSubjects(t *testing.T, vctx ValidationContext) {
+	testForEachResource(t, vctx, "validate_lookup_subjects",
+		func(t *testing.T, resource tuple.ObjectAndRelation) {
+			for _, subjectType := range vctx.AccessibilitySet.SubjectTypes() {
+				t.Run(fmt.Sprintf("%s#%s", subjectType.ObjectType, subjectType.Relation),
+					func(t *testing.T) {
+						resolvedSubjects, err := vctx.ServiceTester.LookupSubjects(t.Context(), resource, subjectType, vctx.Revision, nil)
+						require.NoError(t, err)
+
+						// Ensure the subjects found include those defined as expected. Since the
+						// accessibility set does not include "inferred" subjects (e.g. those with
+						// permissions as their subject relation, or wildcards), this should be a
+						// subset.
+						expectedDefinedSubjects := vctx.AccessibilitySet.DirectlyAccessibleDefinedSubjectsOfType(resource, subjectType)
+						requireSubsetOf(t,
+							slices.Collect(maps.Keys(resolvedSubjects)),
+							slices.Collect(maps.Keys(expectedDefinedSubjects)),
+						)
+
+						// Ensure all subjects in true and caveated assertions for the subject type are found
+						// in the LookupSubject result, except those added via wildcard.
+						for _, parsedFile := range vctx.ClusterAndData.Populated.ParsedFiles {
+							for _, entry := range []struct {
+								assertions         []blocks.Assertion
+								requiresPermission bool
+							}{
+								{
+									assertions:         parsedFile.Assertions.AssertTrue,
+									requiresPermission: true,
+								},
+								{
+									assertions:         parsedFile.Assertions.AssertCaveated,
+									requiresPermission: false,
+								},
+							} {
+								for _, assertion := range entry.assertions {
+									assertionRel := assertion.Relationship
+									if !tuple.ONREqual(assertionRel.Resource, resource) {
+										continue
+									}
+
+									if assertionRel.Subject.ObjectType != subjectType.ObjectType ||
+										assertionRel.Subject.Relation != subjectType.Relation {
+										continue
+									}
+
+									// For subjects found solely via wildcard, check that a wildcard instead exists in
+									// the result and that the subject is not excluded.
+									accessibility, _, ok := vctx.AccessibilitySet.AccessibilityAndPermissionshipFor(resource, assertionRel.Subject)
+									if !ok || accessibility == AccessibleViaWildcardOnly {
+										resolvedSubjectsToCheck := resolvedSubjects
+
+										// If the assertion has caveat context, rerun LookupSubjects with the context to ensure the returned subject
+										// matches the context given.
+										if len(assertion.CaveatContext) > 0 {
+											resolvedSubjectsWithContext, err := vctx.ServiceTester.LookupSubjects(t.Context(), resource, subjectType, vctx.Revision, assertion.CaveatContext)
+											require.NoError(t, err)
+
+											resolvedSubjectsToCheck = resolvedSubjectsWithContext
+										}
+
+										resolvedSubject, ok := resolvedSubjectsToCheck[tuple.PublicWildcard]
+										require.True(t, ok, "expected wildcard in lookupsubjects response for assertion `%s`", assertion.RelationshipWithContextString)
+
+										if entry.requiresPermission {
+											require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, resolvedSubject.Subject.Permissionship)
+										}
+
+										// Ensure that the subject is not excluded. If a caveated assertion, then the exclusion
+										// can be caveated.
+										for _, excludedSubject := range resolvedSubject.ExcludedSubjects {
+											if entry.requiresPermission {
+												require.NotEqual(t, excludedSubject.SubjectObjectId, assertionRel.Subject.ObjectID, "wildcard excludes the asserted subject ID: %s", assertionRel.Subject.ObjectID)
+											} else if excludedSubject.SubjectObjectId == assertionRel.Subject.ObjectID {
+												require.NotEqual(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, excludedSubject.Permissionship, "wildcard concretely excludes the asserted subject ID: %s", assertionRel.Subject.ObjectID)
+											}
+										}
+										continue
+									}
+
+									_, ok = resolvedSubjects[assertionRel.Subject.ObjectID]
+									require.True(t, ok, "missing expected subject %s from assertion %s", assertionRel.Subject.ObjectID, assertion.RelationshipWithContextString)
+								}
+							}
+						}
+
+						// Ensure that all excluded subjects from wildcards do not have access.
+						for _, resolvedSubject := range resolvedSubjects {
+							if resolvedSubject.Subject.SubjectObjectId != tuple.PublicWildcard {
+								continue
+							}
+
+							for _, excludedSubject := range resolvedSubject.ExcludedSubjects {
+								permissionship, err := vctx.ServiceTester.Check(t.Context(),
+									resource,
+									tuple.ObjectAndRelation{
+										ObjectType: subjectType.ObjectType,
+										ObjectID:   excludedSubject.SubjectObjectId,
+										Relation:   subjectType.Relation,
+									},
+									vctx.Revision,
+									nil,
+								)
+								require.NoError(t, err)
+
+								expectedPermissionship := v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION
+								if resolvedSubject.Subject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
+									expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+								}
+								if excludedSubject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
+									expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+								}
+
+								require.Equal(t,
+									expectedPermissionship,
+									permissionship,
+									"Found Check failure for resource %s and excluded subject %s in lookup subjects",
+									tuple.StringONR(resource),
+									excludedSubject.SubjectObjectId,
+								)
+							}
+						}
+
+						// Ensure that every returned defined, non-wildcard subject found checks as expected.
+						for _, resolvedSubject := range resolvedSubjects {
+							if resolvedSubject.Subject.SubjectObjectId == tuple.PublicWildcard {
+								continue
+							}
+
+							subject := tuple.ObjectAndRelation{
+								ObjectType: subjectType.ObjectType,
+								ObjectID:   resolvedSubject.Subject.SubjectObjectId,
+								Relation:   subjectType.Relation,
+							}
+
+							permissionship, err := vctx.ServiceTester.Check(t.Context(),
+								resource,
+								subject,
+								vctx.Revision,
+								nil,
+							)
+							require.NoError(t, err)
+
+							expectedPermissionship := v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION
+							if resolvedSubject.Subject.Permissionship == v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION {
+								expectedPermissionship = v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION
+							}
+
+							require.Equal(t,
+								expectedPermissionship,
+								permissionship,
+								"Found Check failure for resource %s and subject %s in lookup subjects",
+								tuple.StringONR(resource),
+								tuple.StringONR(subject),
+							)
+						}
+					})
+			}
+		})
+}
+
+// RunAssertions runs all assertions defined in the validation files and ensures they
+// return the expected results.
+func RunAssertions(t *testing.T, vctx ValidationContext) {
+	t.Run("assertions", func(t *testing.T) {
+		for _, parsedFile := range vctx.ClusterAndData.Populated.ParsedFiles {
+			for _, entry := range []struct {
+				name                   string
+				assertions             []blocks.Assertion
+				expectedPermissionship v1.CheckPermissionResponse_Permissionship
+			}{
+				{
+					"true",
+					parsedFile.Assertions.AssertTrue,
+					v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION,
+				},
+				{
+					"caveated",
+					parsedFile.Assertions.AssertCaveated,
+					v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION,
+				},
+				{
+					"false",
+					parsedFile.Assertions.AssertFalse,
+					v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION,
+				},
+			} {
+				t.Run(entry.name, func(t *testing.T) {
+					bulkCheckItems := make([]*v1.BulkCheckPermissionRequestItem, 0, len(entry.assertions))
+
+					for _, assertion := range entry.assertions {
+						var caveatContext *structpb.Struct
+						if assertion.CaveatContext != nil {
+							built, err := structpb.NewStruct(assertion.CaveatContext)
+							require.NoError(t, err)
+							caveatContext = built
+						}
+
+						rel := tuple.ToV1Relationship(assertion.Relationship)
+
+						bulkCheckItems = append(bulkCheckItems, &v1.BulkCheckPermissionRequestItem{
+							Resource:   rel.Resource,
+							Permission: rel.Relation,
+							Subject:    rel.Subject,
+							Context:    caveatContext,
+						})
+
+						// Run each individual assertion.
+						assertion := assertion
+						t.Run(assertion.RelationshipWithContextString, func(t *testing.T) {
+							rel := assertion.Relationship
+							permissionship, err := vctx.ServiceTester.Check(t.Context(), rel.Resource, rel.Subject, vctx.Revision, assertion.CaveatContext)
+							require.NoError(t, err)
+							require.Equal(t, entry.expectedPermissionship, permissionship, "Assertion `%s` returned %s; expected %s", tuple.MustString(rel), permissionship, entry.expectedPermissionship)
+
+							// Ensure the assertion passes LookupResources with context, directly.
+							resolvedDirectResources, _, err := vctx.ServiceTester.LookupResources(t.Context(), rel.Resource.RelationReference(), rel.Subject, vctx.Revision, nil, 0, assertion.CaveatContext)
+							require.NoError(t, err)
+
+							resolvedDirectResourcesMap := map[string]*v1.LookupResourcesResponse{}
+							for _, resource := range resolvedDirectResources {
+								resolvedDirectResourcesMap[resource.ResourceObjectId] = resource
+							}
+
+							// Ensure the assertion passes LookupResources without context, indirectly.
+							resolvedIndirectResources, _, err := vctx.ServiceTester.LookupResources(t.Context(), rel.Resource.RelationReference(), rel.Subject, vctx.Revision, nil, 0, nil)
+							require.NoError(t, err)
+
+							resolvedIndirectResourcesMap := map[string]*v1.LookupResourcesResponse{}
+							for _, resource := range resolvedIndirectResources {
+								resolvedIndirectResourcesMap[resource.ResourceObjectId] = resource
+							}
+
+							// Check the assertion was returned for a direct (with context) lookup.
+							resolvedDirectResourceIds := slices.Collect(maps.Keys(resolvedDirectResourcesMap))
+							switch permissionship {
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION:
+								require.NotContains(t, resolvedDirectResourceIds, rel.Resource.ObjectID, "Found unexpected object %s in direct lookup for assertion %s", rel.Resource, rel)
+
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION:
+								require.Contains(t, resolvedDirectResourceIds, rel.Resource.ObjectID, "Missing object %s in lookup for assertion %s", rel.Resource, rel)
+								require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, resolvedDirectResourcesMap[rel.Resource.ObjectID].Permissionship)
+
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION:
+								require.Contains(t, resolvedDirectResourceIds, rel.Resource.ObjectID, "Missing object %s in lookup for assertion %s", rel.Resource, rel)
+								require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION, resolvedDirectResourcesMap[rel.Resource.ObjectID].Permissionship,
+									"Expected caveated permission in direct lookup for assertion %s", rel,
+								)
+							}
+
+							// Check the assertion was returned for an indirect (without context) lookup.
+							resolvedIndirectResourceIds := slices.Collect(maps.Keys(resolvedIndirectResourcesMap))
+							accessibility, _, _ := vctx.AccessibilitySet.AccessibilityAndPermissionshipFor(rel.Resource, rel.Subject)
+
+							switch permissionship {
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION:
+								// If the caveat context given is empty, then the lookup result must not exist at all.
+								// Otherwise, it *could* be caveated or not exist, depending on the context given.
+								switch {
+								case len(assertion.CaveatContext) == 0:
+									require.NotContains(t, resolvedIndirectResourceIds, rel.Resource.ObjectID, "Found unexpected object %s in indirect lookup for assertion %s", rel.Resource, rel)
+								case accessibility == NotAccessible:
+									found, ok := resolvedIndirectResourcesMap[rel.Resource.ObjectID]
+									require.True(t, !ok || found.Permissionship != v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION) // LookupResources can be caveated, since we didn't rerun LookupResources with the context
+								case accessibility != NotAccessibleDueToPrespecifiedCaveat:
+									found, ok := resolvedIndirectResourcesMap[rel.Resource.ObjectID]
+									require.True(t, ok, "Missing expected object %s in indirect lookup for assertion %s", rel.Resource, rel)
+									require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION, found.Permissionship,
+										"Expected caveated permission in indirect lookup for assertion %s", rel,
+									)
+								}
+
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION:
+								require.Contains(t, resolvedIndirectResourceIds, rel.Resource.ObjectID, "Missing object %s in lookup for assertion %s", rel.Resource, rel)
+								// If the caveat context given is empty, then the lookup result must be fully permissioned.
+								// Otherwise, it *could* be caveated or fully permissioned, depending on the context given.
+								if len(assertion.CaveatContext) == 0 {
+									require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, resolvedIndirectResourcesMap[rel.Resource.ObjectID].Permissionship)
+								}
+
+							case v1.CheckPermissionResponse_PERMISSIONSHIP_CONDITIONAL_PERMISSION:
+								require.Contains(t, resolvedIndirectResourceIds, rel.Resource.ObjectID, "Missing object %s in lookup for assertion %s", rel.Resource, rel)
+								require.Equal(t, v1.LookupPermissionship_LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION, resolvedIndirectResourcesMap[rel.Resource.ObjectID].Permissionship)
+
+							default:
+								panic("unknown permissionship")
+							}
+						})
+
+						// Run all assertions under bulk check and ensure they match as well.
+						results, err := vctx.ServiceTester.BulkCheck(t.Context(), bulkCheckItems, vctx.Revision)
+						require.NoError(t, err)
+
+						for _, result := range results {
+							require.Equal(t, entry.expectedPermissionship, result.GetItem().GetPermissionship(), "Bulk check for assertion request `%s` returned %s; expected %s", result.GetRequest(), result.GetItem().GetPermissionship(), entry.expectedPermissionship)
+						}
+					}
+				})
+			}
+		}
+	})
+}
+
+// ValidateReachableSubjectTypes validates that the reachable subject types are those expected.
+func ValidateReachableSubjectTypes(t *testing.T, vctx ValidationContext) {
+	testForEachResource(t, vctx, "validate_reachable_subject_types", func(t *testing.T, resource tuple.ObjectAndRelation) {
+		headRevResult, err := vctx.ClusterAndData.DataStore.HeadRevision(t.Context())
+		require.NoError(t, err)
+		headRev := headRevResult.Revision
+
+		reader := vctx.ClusterAndData.DataStore.SnapshotReader(headRev)
+		ts := schema.NewTypeSystem(schema.ResolverForDatastoreReader(reader))
+
+		reachableSubjectTypes, err := ts.GetFullRecursiveSubjectTypesForRelation(t.Context(), resource.ObjectType, resource.Relation)
+		require.NoError(t, err)
+
+		reachableSubjectTypesSet := mapz.NewSet(reachableSubjectTypes...)
+
+		for _, member := range vctx.AccessibilitySet.DirectlyAccessibleDefinedSubjects(resource) {
+			subjectTypeRef := member.ObjectType
+			if member.Relation != tuple.Ellipsis {
+				subjectTypeRef = subjectTypeRef + "#" + member.Relation
+			}
+
+			require.True(t, reachableSubjectTypesSet.Has(subjectTypeRef),
+				"Found unexpected subject type %s#%s in lookup subjects for resource %s; expected one of %s",
+				member.ObjectType,
+				member.Relation,
+				tuple.StringONR(resource),
+				reachableSubjectTypesSet.AsSlice(),
+			)
+		}
+	})
+}

--- a/internal/services/integrationtesting/queryconsistency/query_plan_grpc_test.go
+++ b/internal/services/integrationtesting/queryconsistency/query_plan_grpc_test.go
@@ -13,8 +13,13 @@ import (
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
+	"github.com/authzed/spicedb/internal/datastore/dsfortesting"
+	"github.com/authzed/spicedb/internal/datastore/memdb"
 	"github.com/authzed/spicedb/internal/services/integrationtesting/consistencytestutil"
+	"github.com/authzed/spicedb/internal/testserver"
+	"github.com/authzed/spicedb/pkg/caveats/types"
 	"github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/datalayer"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/genutil/mapz"
 	"github.com/authzed/spicedb/pkg/tuple"
@@ -59,7 +64,24 @@ func runQueryPlanConsistencyGRPCForFile(t *testing.T, filePath string) {
 		server.WithExperimentalQueryPlan("ls"),
 	}
 
-	cad := consistencytestutil.LoadDataAndCreateClusterForTesting(t, filePath, testTimedelta, options...)
+	ds, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, testTimedelta, memdb.DisableGC)
+	require.NoError(t, err)
+
+	populated, _, err := validationfile.PopulateFromFiles(t.Context(), datalayer.NewDataLayer(ds), types.Default.TypeSet, []string{filePath})
+	require.NoError(t, err)
+
+	connections := testserver.TestClusterWithDispatch(t, 1, ds, options...)
+
+	dl := datalayer.NewDataLayer(ds)
+
+	dsCtx := datalayer.ContextWithHandle(t.Context())
+	require.NoError(t, datalayer.SetInContext(dsCtx, dl))
+	cad := consistencytestutil.ConsistencyClusterAndData{
+		Conn:      connections[0],
+		DataStore: ds,
+		Ctx:       dsCtx,
+		Populated: populated,
+	}
 
 	headRevision, err := cad.DataStore.HeadRevision(cad.Ctx)
 	require.NoError(t, err)

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -249,6 +249,9 @@ func (c *Config) complete(ctx context.Context) (*completedServerConfig, error) {
 				ExitCode(sysexits.Config).
 				Error()
 		}
+	} else {
+		// the server didn't create this datastore, so it should not close it
+		ds = NoCloseProxy(ds)
 	}
 
 	cachingMode := schemacaching.JustInTimeCaching
@@ -891,3 +894,19 @@ func (c *completedServerConfig) NewClient(opts ...grpc.DialOption) (*grpc.Client
 	}
 	return grpc.NewClient(c.gRPCServer.Address(), opts...)
 }
+
+// noCloseDatastore wraps a datastore so that Close is a no-op.
+// It is used when the server is handed a datastore it did not create: the creator is responsible for closing them.
+type noCloseDatastore struct {
+	datastore.Datastore
+}
+
+// NoCloseProxy wraps the given datastore so that calls to Close are ignored. The
+// underlying datastore remains the responsibility of whoever created it.
+func NoCloseProxy(ds datastore.Datastore) datastore.Datastore {
+	return &noCloseDatastore{Datastore: ds}
+}
+
+func (p *noCloseDatastore) Close() error { return nil }
+
+func (p *noCloseDatastore) Unwrap() datastore.Datastore { return p.Datastore }

--- a/pkg/consistency/test/consistency.go
+++ b/pkg/consistency/test/consistency.go
@@ -1,0 +1,167 @@
+// Package test provides the system-wide consistency test suite: it reads the
+// validation files in the testconfigs directory and executes the full set of APIs
+// against the data within, ensuring that all results of the various APIs are
+// consistent with one another.
+//
+// This package lives outside of pkg/datastore/test on purpose. The consistency
+// harness needs to stand up a full SpiceDB cluster (via internal/testserver and
+// pkg/cmd/server), both of which transitively import every datastore engine. The
+// per-engine datastore tests live in internal test packages (package crdb, etc.)
+// that import pkg/datastore/test, so placing this harness there would create an
+// import cycle (engine [test] -> pkg/datastore/test -> server -> engine). No engine
+// package imports pkg/consistency/test, so it is free to depend on the full stack.
+package test
+
+import (
+	"fmt"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore/proxy/indexcheck"
+	"github.com/authzed/spicedb/internal/services/integrationtesting/consistencytestutil"
+	"github.com/authzed/spicedb/internal/testserver"
+	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
+	"github.com/authzed/spicedb/internal/testserver/datastore/config"
+	"github.com/authzed/spicedb/pkg/caveats/types"
+	dsconfig "github.com/authzed/spicedb/pkg/cmd/datastore"
+	"github.com/authzed/spicedb/pkg/cmd/server"
+	"github.com/authzed/spicedb/pkg/datalayer"
+	"github.com/authzed/spicedb/pkg/datastore"
+	dstest "github.com/authzed/spicedb/pkg/datastore/test"
+	"github.com/authzed/spicedb/pkg/development"
+	"github.com/authzed/spicedb/pkg/schema"
+	"github.com/authzed/spicedb/pkg/validationfile"
+)
+
+// veryLargeGCWindow is a very large time duration which, when passed to a datastore
+// constructor, effectively disables garbage collection.
+const (
+	veryLargeGCWindow   = 90000 * time.Second
+	veryLargeGCInterval = 90000 * time.Second
+)
+
+// AllConsistency runs the full system-wide consistency suite against the datastore
+// produced by the given tester. It is the consistency analog of test.All and lets any
+// DatastoreTester be exercised by the consistency suite.
+func AllConsistency(t *testing.T, tester dstest.DatastoreTester) {
+	ConsistencyForEngine(t, "", tester)
+}
+
+// ConsistencyForEngine runs the system-wide consistency suite, reading in the various
+// validation files in the testconfigs directory and executing the full set of APIs
+// against the data within, ensuring that all results of the various APIs are consistent
+// with one another. It runs the suite against the local and caching dispatchers and
+// multiple dispatch chunk sizes.
+//
+// The datastore under test is obtained in one of two ways:
+//   - If tester is non-nil, it is used to create a fresh datastore for each test file.
+//     This supports running the consistency suite against any DatastoreTester.
+//   - Otherwise, a single Docker instance is spun up for engineID (one of the supported
+//     engines: postgres, mysql, crdb, spanner) and reused across all test files.
+//
+// This acts as essentially a full integration test for the API, dispatching, caching,
+// computation and datastore layers.
+func ConsistencyForEngine(t *testing.T, engineID string, tester dstest.DatastoreTester) {
+	consistencyTestFiles, err := consistencytestutil.ListTestConfigs()
+	require.NoError(t, err)
+
+	// newDatastore creates a fresh datastore for a single consistency test file.
+	var newDatastore func(t *testing.T) datastore.Datastore
+	if tester != nil {
+		newDatastore = func(t *testing.T) datastore.Datastore {
+			ds, err := tester.New(t, 10, veryLargeGCInterval, veryLargeGCWindow, 0)
+			require.NoError(t, err)
+			return ds
+		}
+	} else {
+		// One Docker instance per engine, reused across all test files.
+		rde := testdatastore.RunDatastoreEngine(t, engineID)
+		newDatastore = func(t *testing.T) datastore.Datastore {
+			return rde.NewDatastore(t, config.DatastoreConfigInitFunc(t,
+				dsconfig.WithWatchBufferLength(0),
+				dsconfig.WithGCWindow(time.Duration(90_000_000_000_000)),
+				dsconfig.WithRevisionQuantization(10),
+				dsconfig.WithMaxRetries(50),
+				dsconfig.WithWriteAcquisitionTimeout(5*time.Second)))
+		}
+	}
+
+	for _, filePath := range consistencyTestFiles {
+		t.Run(path.Base(filePath), func(t *testing.T) {
+			baseds := newDatastore(t)
+			ds := indexcheck.WrapWithIndexCheckingDatastoreProxyIfApplicable(baseds)
+
+			// Write the schema and relationships.
+			dl := datalayer.NewDataLayer(ds)
+			populated, _, err := validationfile.PopulateFromFiles(t.Context(), dl, types.Default.TypeSet, []string{filePath})
+			require.NoError(t, err)
+
+			dsCtx := datalayer.ContextWithHandle(t.Context())
+			require.NoError(t, datalayer.SetInContext(dsCtx, dl))
+
+			headRevisionResult, _, err := dl.HeadRevision(t.Context())
+			require.NoError(t, err)
+			headRevision := headRevisionResult
+
+			// Validate the type system for each namespace.
+			ts := schema.NewTypeSystem(schema.ResolverForDatastoreReader(ds.SnapshotReader(headRevision)))
+
+			for _, nsDef := range populated.NamespaceDefinitions {
+				_, err := ts.GetValidatedDefinition(t.Context(), nsDef.Name)
+				require.NoError(t, err)
+
+				_, err = development.AddDefinitionWarnings(t.Context(), nsDef, ts)
+				// We would normally check to see if there were any warnings; however, some of the integration tests are
+				// here to intentionally test things that are warnings-but-not-errors in a schema (like arrow-references-relation).
+				// So instead, just validate that warning validation succeeds.
+				require.NoError(t, err)
+			}
+
+			accessibilitySet := consistencytestutil.BuildAccessibilitySet(t, dsCtx, populated, ds)
+
+			for _, chunkSize := range []uint16{5, 10} {
+				t.Run(fmt.Sprintf("chunk-size-%d", chunkSize), func(t *testing.T) {
+					t.Parallel()
+
+					options := []server.ConfigOption{
+						server.WithDispatchChunkSize(chunkSize),
+						server.WithEnableExperimentalLookupResources(true),
+						server.WithExperimentalLookupResourcesVersion("lr3"),
+					}
+
+					connections := testserver.TestClusterWithDispatch(t, 1, ds, options...)
+
+					cad := consistencytestutil.ConsistencyClusterAndData{
+						Conn:      connections[0],
+						DataStore: ds,
+						Ctx:       dsCtx,
+						Populated: populated,
+					}
+
+					serviceTester := consistencytestutil.NewServiceTester(cad.Conn)
+
+					for _, dispatcherKind := range []string{"local", "caching"} {
+						t.Run(dispatcherKind, func(t *testing.T) {
+							t.Parallel()
+
+							dispatcher := consistencytestutil.CreateDispatcherForTesting(t, dispatcherKind == "caching")
+
+							vctx := consistencytestutil.ValidationContext{
+								ClusterAndData:   cad,
+								AccessibilitySet: accessibilitySet,
+								ServiceTester:    serviceTester,
+								Revision:         headRevision,
+								Dispatcher:       dispatcher,
+							}
+
+							consistencytestutil.RunConsistencyTestSuiteForCluster(t, vctx)
+						})
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/datastore/options/options.go
+++ b/pkg/datastore/options/options.go
@@ -56,6 +56,13 @@ type SQLIndexInformation struct {
 	// ExpectedIndexNames are the name(s) of the index(es) that are expected to be used by this
 	// SQL query.
 	ExpectedIndexNames []string
+
+	// ShapeServingIndexNames are the names of all indexes that serve at least one query shape.
+	// Any index used by a query that is *not* in this set (e.g. maintenance indexes such as
+	// those used for garbage collection or watch, or the implicit primary key) is considered a
+	// small-data optimizer artifact rather than a meaningful index choice, and is ignored when
+	// validating that an expected index was used.
+	ShapeServingIndexNames []string
 }
 
 // SQLExplainCallbackForTest is a callback invoked with the explain plan of the SQL query string.


### PR DESCRIPTION
## Changes
- Makes it so that `TestConsistency` and `TestConsistencyPerDatastore` are now _one_ suite that runs against _all_ test files for _all_ datastores
- `TestConsistencyPerDatastore` no longer runs the DevContext assertions (i believe this brings no value and just wastes time)
- Fixes an issue found for MySQL for `TestConsistencyPerDatastore/mysql/publiccaveat.yaml/chunk-size-5/local/assertions/true/document:firstdoc#view@user:fred`.
   - This is a TEST issue, not a production issue.