### PR TITLE
fix(postgres): stop logging a harmless(*this is not correct*) GC lock release as an error

### DIFF
--- a/internal/datastore/postgres/gc.go
+++ b/internal/datastore/postgres/gc.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/authzed/spicedb/internal/datastore/common"
 	"github.com/authzed/spicedb/internal/datastore/postgres/schema"
+	log "github.com/authzed/spicedb/internal/logging"
 	"github.com/authzed/spicedb/pkg/datastore"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 )
@@ -63,7 +65,17 @@ func (pgg *pgGarbageCollector) LockForGCRun(ctx context.Context) (bool, error) {
 }
 
 func (pgg *pgGarbageCollector) UnlockAfterGCRun() error {
-	return pgg.pgd.releaseLock(context.Background(), pgg.conn, gcRunLock)
+	err := pgg.pgd.releaseLock(context.Background(), pgg.conn, gcRunLock)
+	if errors.Is(err, ErrLockNotHeld) {
+		// The session lost the lock before we released it (e.g. a connection
+		// reset mid-GC), so there is nothing left to release. This is benign:
+		// the GC lock only prevents redundant concurrent runs, and GC deletes
+		// are txID-watermark-bounded and idempotent, so a concurrent run is
+		// safe. Don't surface it as an error.
+		log.Debug().Err(err).Msg("gc advisory lock was already released")
+		return nil
+	}
+	return err
 }
 
 func (pgg *pgGarbageCollector) Now(ctx context.Context) (time.Time, error) {

--- a/internal/datastore/postgres/locks.go
+++ b/internal/datastore/postgres/locks.go
@@ -2,12 +2,20 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type lockID uint32
+
+// ErrLockNotHeld is returned by releaseLock when pg_advisory_unlock reports the
+// session did not hold the lock. Advisory locks are session-level, so this
+// happens when the session was reset/reconnected after acquiring the lock (e.g.
+// a connection blip mid-GC). It is benign during teardown — the lock is already
+// gone — so callers may choose to tolerate it.
+var ErrLockNotHeld = errors.New("advisory lock was not held at release time")
 
 const (
 	// gcRunLock is the lock ID for the garbage collection run.
@@ -49,7 +57,7 @@ func (pgd *pgDatastore) releaseLock(ctx context.Context, conn *pgxpool.Conn, loc
 	}
 
 	if !lockReleased {
-		return fmt.Errorf("failed to release lock %d", lockID)
+		return fmt.Errorf("lock %d: %w", lockID, ErrLockNotHeld)
 	}
 
 	return nil

--- a/internal/datastore/postgres/locks_test.go
+++ b/internal/datastore/postgres/locks_test.go
@@ -1,0 +1,21 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestErrLockNotHeldWrapping locks in the contract both the GC and revision
+// heartbeat release paths rely on: releaseLock wraps ErrLockNotHeld with %w, so
+// callers can distinguish the benign "lock not held" case (e.g. a session reset
+// after acquiring the lock) from a genuine error via errors.Is.
+func TestErrLockNotHeldWrapping(t *testing.T) {
+	wrapped := fmt.Errorf("lock %d: %w", gcRunLock, ErrLockNotHeld)
+	require.ErrorIs(t, wrapped, ErrLockNotHeld)
+
+	// A different error must not match the sentinel.
+	require.NotErrorIs(t, errors.New("some other failure"), ErrLockNotHeld)
+}

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -764,7 +764,8 @@ func (pgd *pgDatastore) startRevisionHeartbeat(ctx context.Context) error {
 	}
 
 	defer func() {
-		if err := pgd.releaseLock(ctx, conn, revisionHeartbeatLock); err != nil && !errors.Is(err, context.Canceled) {
+		if err := pgd.releaseLock(ctx, conn, revisionHeartbeatLock); err != nil &&
+			!errors.Is(err, context.Canceled) && !errors.Is(err, ErrLockNotHeld) {
 			log.Warn().Err(err).Msg("failed to release revision heartbeat lock")
 		}
 	}()


### PR DESCRIPTION
We log an ERROR ("failed to release lock 1 / error unlocking after gc run") whenever pg_advisory_unlock says we don't hold the lock. That happens when the GC connection gets reset mid-run — the new session never took the lock, so there's nothing to release. It's harmless (the lock just avoids redundant GC runs, and GC deletes are idempotent), but it shows up as a scary error.

Now we recognize that specific case and skip the error. Real release failures still get logged.

Fixes #2847.