### PR TITLE
chore: update buckets for latency and datastore latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 - Schema: reads inside write transactions now use a cheap hash-only lookup (`schema_revision`) to check the cache before loading the full schema blob, reducing DB round-trips on cache hits (https://github.com/authzed/spicedb/pull/3160)
+- Updated the Prometheus buckets for `grpc_server_handling_seconds` and `spicedb_datastore_query_latency` to be able to correlate them (https://github.com/authzed/spicedb/pull/3188)
 
 ### Fixed
 - When SpiceDB loses a connection to a CockroachDB node, every read happening in the server blocks for a short period of time (https://github.com/authzed/spicedb/pull/3181)

--- a/development/grafana/dashboards/dashboard.json
+++ b/development/grafana/dashboards/dashboard.json
@@ -188,7 +188,7 @@
               },
               {
                 "color": "red",
-                "value": 2
+                "value": 1
               }
             ]
           },

--- a/internal/datastore/proxy/observable.go
+++ b/internal/datastore/proxy/observable.go
@@ -34,8 +34,13 @@ var (
 		Namespace: "spicedb",
 		Subsystem: "datastore",
 		Name:      "query_latency",
-		Buckets:   []float64{.0005, .001, .002, .005, .01, .02, .05, .1, .2, .5},
-		Help:      "response latency for a database query",
+		Buckets: []float64{
+			// same as grpc_server_handling_seconds
+			.0005, .001, .002, .005, .01, .02, .05, .1, .2, .5, 1, 5, 30,
+		},
+		Help:                           "response latency for a database query, in seconds",
+		NativeHistogramBucketFactor:    1.1, // At most 10% increase from bucket to bucket.
+		NativeHistogramMaxBucketNumber: 100,
 	}, []string{
 		"operation", "query_shape",
 	})

--- a/pkg/cmd/server/defaults.go
+++ b/pkg/cmd/server/defaults.go
@@ -496,7 +496,8 @@ func createServerMetrics(disableHistogram bool) (grpc.UnaryServerInterceptor, gr
 				NativeHistogramBucketFactor:    1.1, // At most 10% increase from bucket to bucket.
 				NativeHistogramMaxBucketNumber: 100,
 				Buckets: []float64{
-					.001, .003, .006, .010, .018, .024, .032, .042, .056, .075, .100, .178, .316, .562, 1, 5,
+					// grpc_server_handling_seconds, same as spicedb_datastore_query_latency
+					.0005, .001, .002, .005, .01, .02, .05, .1, .2, .5, 1, 5, 30,
 				},
 			}),
 		))


### PR DESCRIPTION
## Description

Previously:

```
grpc_server_handling_seconds_bucketgrpcprom.WithServerHandlingTimeHistogram(
    grpcprom.WithHistogramOpts(&prometheus.HistogramOpts{
       NativeHistogramBucketFactor:    1.1, // At most 10% increase from bucket to bucket.
       NativeHistogramMaxBucketNumber: 100,
       Buckets: []float64{
          .001, .003, .006, .010, .018, .024, .032, .042, .056, .075, .100, .178, .316, .562, 1, 5,
       },
    }),
)
```
vs

```
spicedb_datastore_query_latency_bucketqueryLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
    Namespace: "spicedb",
    Subsystem: "datastore",
    Name:      "query_latency",
    Buckets:   []float64{.0005, .001, .002, .005, .01, .02, .05, .1, .2, .5},
}
```

Look at the buckets. The highest value we record for spicedb latency is 5 seconds, but the highest value we record for datastore latency is 500ms. So it'll be near impossible to correlate "high spicedb latency <> high datastore latency"
