### PR TITLE
chore: change how memory limit is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - MySQL: MySQL deadlocks on `WriteRelationships` (https://github.com/authzed/spicedb/pull/3187)
 - Datastore: a hung datastore round-trip while computing the optimized revision can no longer wedge the server. The revision is computed under singleflight, which detaches the work from the caller's context (stripping its gRPC deadline); a stuck computation (e.g. a half-open connection silently dropped by a load balancer) therefore pinned the latency of *every* concurrent caller and inflated whole-system P99. The shared computation is now aggressively bounded (2s), with a direct, deadline-respecting retry outside singleflight on failure so a transient wedge does not fail the request. Applies to all datastores. (https://github.com/authzed/spicedb/pull/3142)
 - Postgres & CockroachDB: pooled connections that have gone idle are now liveness-pinged with a bounded timeout (default 5s) before being handed to a query, so a half-open connection is discarded and replaced instead of hanging the acquiring request. (https://github.com/authzed/spicedb/pull/3142)
+- Memory: If SpiceDB couldn't determine the memory available to it (such as can happen in AWS ECS), it assumed that its memory was unbounded. We changed how memory detection works to make conservative estimates in these cases and made some improvements to cache entry cost estimation. (https://github.com/authzed/spicedb/pull/3201)
 
 ## [1.54.0] - 2026-06-18
 ### Added

--- a/pkg/cache/cache_otter.go
+++ b/pkg/cache/cache_otter.go
@@ -27,6 +27,27 @@ type valueAndCost[V any] struct {
 	cost  uint32
 }
 
+// entryWeight computes the weight Otter should account for an entry: the
+// caller-supplied payload cost plus the key bytes. Otter's MaximumWeight bounds
+// only the sum of Weigher outputs (the node weight is exactly the weigher's
+// return value), and the key is retained on the node for the entry's lifetime
+// without being included in that weight. Callers supply a cost covering only the
+// payload, so folding in the key length stops the cache from systematically
+// undercounting real memory and overfilling its configured MaximumWeight. It
+// saturates at math.MaxUint32 rather than overflowing.
+//
+// Fixed per-entry structural overhead (the node struct, hash-table slot, and
+// frequency-sketch state) is deliberately not added here: it is internal to
+// Otter, varies by version, and is instead absorbed by the headroom ratio
+// applied in pkgruntime.AvailableMemory.
+func entryWeight(key string, payloadCost uint32) uint32 {
+	weight := uint64(payloadCost) + uint64(len(key))
+	if weight > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(weight)
+}
+
 // NewOtterCache creates an Otter-backed cache. It tracks its own metrics (see
 // Cache.GetMetrics) but does not export them; use NewOtterCacheWithMetrics to
 // also register those metrics with a Prometheus registerer.
@@ -149,14 +170,21 @@ func (wtc *otterCache[K, V]) Set(key K, value V, cost int64) bool {
 		uintCost = math.MaxUint32
 	}
 
-	wtc.metrics.costAdded.Add(uint64(uintCost))
-	_, ok := wtc.Get(key)
-	if ok {
-		wtc.cache.Invalidate(key.KeyString())
+	keyStr := key.KeyString()
+	// Account for the key bytes and fixed per-entry overhead in addition to the
+	// caller-supplied payload cost so the cache's weight tracks real memory usage
+	// rather than systematically undercounting it. The weigher returns this
+	// stored cost, and the costAdded metric uses the same figure, keeping the
+	// weight bound and the exported metrics consistent.
+	weight := entryWeight(keyStr, uintCost)
+
+	wtc.metrics.costAdded.Add(uint64(weight))
+	if _, ok := wtc.cache.GetIfPresent(keyStr); ok {
+		wtc.cache.Invalidate(keyStr)
 	}
-	wtc.cache.Set(key.KeyString(), valueAndCost[V]{value, uintCost})
+	wtc.cache.Set(keyStr, valueAndCost[V]{value, weight})
 	if wtc.ttl > 0 {
-		wtc.cache.SetExpiresAfter(key.KeyString(), wtc.ttl)
+		wtc.cache.SetExpiresAfter(keyStr, wtc.ttl)
 	}
 	return true
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,12 +1,46 @@
 package cache
 
 import (
+	"math"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
+
+func TestEntryWeight(t *testing.T) {
+	// Empty key, zero payload.
+	require.Equal(t, uint32(0), entryWeight("", 0))
+
+	// Payload + key bytes.
+	require.Equal(t, uint32(10+3), entryWeight("abc", 10))
+
+	// Saturates rather than overflowing uint32.
+	require.Equal(t, uint32(math.MaxUint32), entryWeight("x", math.MaxUint32))
+	require.Equal(t, uint32(math.MaxUint32), entryWeight("x", math.MaxUint32-1))
+}
+
+func TestCostAddedIncludesKey(t *testing.T) {
+	cache, err := NewOtterCacheWithMetrics[StringKey, string](
+		prometheus.NewRegistry(), "test-otter",
+		&Config{MaxCost: 100000, DefaultTTL: 10 * time.Hour},
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	const key = "some-key"
+	const payloadCost = 10
+	require.True(t, cache.Set(StringKey(key), "value", payloadCost))
+	cache.Wait()
+
+	// costAdded must reflect the full entry weight (payload + key bytes), not
+	// just the caller-supplied payload cost.
+	require.Equal(t,
+		uint64(payloadCost+len(key)),
+		cache.GetMetrics().CostAdded(),
+	)
+}
 
 func TestCacheWithMetrics(t *testing.T) {
 	config := &Config{

--- a/pkg/cmd/server/cacheconfig.go
+++ b/pkg/cmd/server/cacheconfig.go
@@ -83,14 +83,6 @@ func resolveMaxCost(cc *CacheConfig, availableMem uint64) (int64, error) {
 	)
 
 	if strings.HasSuffix(cc.MaxCost, "%") {
-		if availableMem == 0 {
-			// A percent-based budget against undeterminable available memory
-			// resolves to a zero MaxCost, which is a degenerate cache config
-			// (e.g. on AWS ECS where the container memory limit isn't written
-			// to the cgroup). Fail loudly rather than silently building a
-			// useless or unbounded cache.
-			return 0, fmt.Errorf("cache %q is configured as a percentage of available memory (%q), but available memory could not be determined; set %s as an absolute byte value (e.g. 1GiB) or ensure GOMEMLIMIT / the container cgroup memory limit is set", cc.Name, cc.MaxCost, cc.Name)
-		}
 		maxCost, err = parsePercent(cc.MaxCost, availableMem)
 	} else {
 		maxCost, err = humanize.ParseBytes(cc.MaxCost)

--- a/pkg/cmd/server/cacheconfig.go
+++ b/pkg/cmd/server/cacheconfig.go
@@ -54,23 +54,9 @@ func CompleteCache[K cache.KeyString, V any](registerer prometheus.Registerer, c
 		return cache.NoopCache[K, V](), nil
 	}
 
-	var (
-		maxCost uint64
-		err     error
-	)
-
-	if strings.HasSuffix(cc.MaxCost, "%") {
-		maxCost, err = parsePercent(cc.MaxCost, pkgruntime.AvailableMemory())
-	} else {
-		maxCost, err = humanize.ParseBytes(cc.MaxCost)
-	}
+	intMaxCost, err := resolveMaxCost(cc, pkgruntime.AvailableMemory())
 	if err != nil {
-		return nil, fmt.Errorf("error parsing cache max memory: `%s`: %w", cc.MaxCost, err)
-	}
-
-	intMaxCost, err := safecast.Convert[int64](maxCost)
-	if err != nil {
-		return nil, errors.New("could not cast max cost to int64")
+		return nil, err
 	}
 
 	if cc.Metrics {
@@ -84,6 +70,40 @@ func CompleteCache[K cache.KeyString, V any](registerer prometheus.Registerer, c
 		MaxCost:    intMaxCost,
 		DefaultTTL: cc.defaultTTL,
 	})
+}
+
+// resolveMaxCost translates the configured MaxCost (an absolute byte value or a
+// percentage of available memory) into a concrete byte budget. availableMem is
+// the figure to apply percentages against, as reported by
+// pkgruntime.AvailableMemory().
+func resolveMaxCost(cc *CacheConfig, availableMem uint64) (int64, error) {
+	var (
+		maxCost uint64
+		err     error
+	)
+
+	if strings.HasSuffix(cc.MaxCost, "%") {
+		if availableMem == 0 {
+			// A percent-based budget against undeterminable available memory
+			// resolves to a zero MaxCost, which is a degenerate cache config
+			// (e.g. on AWS ECS where the container memory limit isn't written
+			// to the cgroup). Fail loudly rather than silently building a
+			// useless or unbounded cache.
+			return 0, fmt.Errorf("cache %q is configured as a percentage of available memory (%q), but available memory could not be determined; set %s as an absolute byte value (e.g. 1GiB) or ensure GOMEMLIMIT / the container cgroup memory limit is set", cc.Name, cc.MaxCost, cc.Name)
+		}
+		maxCost, err = parsePercent(cc.MaxCost, availableMem)
+	} else {
+		maxCost, err = humanize.ParseBytes(cc.MaxCost)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("error parsing cache max memory: `%s`: %w", cc.MaxCost, err)
+	}
+
+	intMaxCost, err := safecast.Convert[int64](maxCost)
+	if err != nil {
+		return 0, errors.New("could not cast max cost to int64")
+	}
+	return intMaxCost, nil
 }
 
 func parsePercent(str string, freeMem uint64) (uint64, error) {

--- a/pkg/cmd/server/cacheconfig_test.go
+++ b/pkg/cmd/server/cacheconfig_test.go
@@ -32,6 +32,32 @@ func TestParsePercent(t *testing.T) {
 	}
 }
 
+func TestResolveMaxCost(t *testing.T) {
+	t.Run("absolute byte value ignores available memory", func(t *testing.T) {
+		got, err := resolveMaxCost(&CacheConfig{Name: "test", MaxCost: "1GiB"}, 0)
+		require.NoError(t, err)
+		require.Equal(t, int64(1024*1024*1024), got)
+	})
+
+	t.Run("percent resolves against available memory", func(t *testing.T) {
+		got, err := resolveMaxCost(&CacheConfig{Name: "test", MaxCost: "25%"}, 1000)
+		require.NoError(t, err)
+		require.Equal(t, int64(250), got)
+	})
+
+	t.Run("percent with undeterminable available memory errors", func(t *testing.T) {
+		_, err := resolveMaxCost(&CacheConfig{Name: "dispatch", MaxCost: "25%"}, 0)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "available memory could not be determined")
+		require.ErrorContains(t, err, "dispatch")
+	})
+
+	t.Run("invalid value errors", func(t *testing.T) {
+		_, err := resolveMaxCost(&CacheConfig{Name: "test", MaxCost: "not-a-size"}, 1000)
+		require.Error(t, err)
+	})
+}
+
 func TestWithRevisionParameters(t *testing.T) {
 	table := []struct {
 		name                 string

--- a/pkg/cmd/server/cacheconfig_test.go
+++ b/pkg/cmd/server/cacheconfig_test.go
@@ -45,13 +45,6 @@ func TestResolveMaxCost(t *testing.T) {
 		require.Equal(t, int64(250), got)
 	})
 
-	t.Run("percent with undeterminable available memory errors", func(t *testing.T) {
-		_, err := resolveMaxCost(&CacheConfig{Name: "dispatch", MaxCost: "25%"}, 0)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "available memory could not be determined")
-		require.ErrorContains(t, err, "dispatch")
-	})
-
 	t.Run("invalid value errors", func(t *testing.T) {
 		_, err := resolveMaxCost(&CacheConfig{Name: "test", MaxCost: "not-a-size"}, 1000)
 		require.Error(t, err)

--- a/pkg/datalayer/datalayer_test.go
+++ b/pkg/datalayer/datalayer_test.go
@@ -883,12 +883,16 @@ func TestWriteSchemaDeletesRemovedDefinitions(t *testing.T) {
 
 // testSchemaCache is a simple in-memory cache satisfying SchemaCache for tests.
 type testSchemaCache struct {
-	mu    sync.Mutex
-	items map[SchemaCacheKey]*datastore.ReadOnlyStoredSchema // GUARDED_BY(mu)
+	mu        sync.Mutex
+	items     map[SchemaCacheKey]*datastore.ReadOnlyStoredSchema // GUARDED_BY(mu)
+	lastCosts map[SchemaCacheKey]int64                           // GUARDED_BY(mu)
 }
 
 func newTestSchemaCache() *testSchemaCache {
-	return &testSchemaCache{items: make(map[SchemaCacheKey]*datastore.ReadOnlyStoredSchema)}
+	return &testSchemaCache{
+		items:     make(map[SchemaCacheKey]*datastore.ReadOnlyStoredSchema),
+		lastCosts: make(map[SchemaCacheKey]int64),
+	}
 }
 
 func (c *testSchemaCache) Get(key SchemaCacheKey) (*datastore.ReadOnlyStoredSchema, bool) {
@@ -898,11 +902,18 @@ func (c *testSchemaCache) Get(key SchemaCacheKey) (*datastore.ReadOnlyStoredSche
 	return v, ok
 }
 
-func (c *testSchemaCache) Set(key SchemaCacheKey, entry *datastore.ReadOnlyStoredSchema, _ int64) bool {
+func (c *testSchemaCache) Set(key SchemaCacheKey, entry *datastore.ReadOnlyStoredSchema, cost int64) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.items[key] = entry
+	c.lastCosts[key] = cost
 	return true
+}
+
+func (c *testSchemaCache) cost(key SchemaCacheKey) int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastCosts[key]
 }
 
 func (c *testSchemaCache) Wait() {}

--- a/pkg/datalayer/hashcache.go
+++ b/pkg/datalayer/hashcache.go
@@ -113,10 +113,6 @@ func (c *schemaHashCache) Set(schemaHash SchemaHash, schema *datastore.ReadOnlyS
 		schema: schema,
 	})
 
-	// Cost the entry by its (approximate) size rather than a flat 1, so the
-	// backing cache's weight bound tracks the real memory held by cached schemas
-	// instead of treating each as a single unit (which let large schemas
-	// massively overfill a byte-denominated MaxCost).
 	c.cache.Set(SchemaCacheKey(schemaHash), schema, int64(schema.EstimatedSize()))
 	return nil
 }

--- a/pkg/datalayer/hashcache.go
+++ b/pkg/datalayer/hashcache.go
@@ -113,7 +113,11 @@ func (c *schemaHashCache) Set(schemaHash SchemaHash, schema *datastore.ReadOnlyS
 		schema: schema,
 	})
 
-	c.cache.Set(SchemaCacheKey(schemaHash), schema, 1)
+	// Cost the entry by its (approximate) size rather than a flat 1, so the
+	// backing cache's weight bound tracks the real memory held by cached schemas
+	// instead of treating each as a single unit (which let large schemas
+	// massively overfill a byte-denominated MaxCost).
+	c.cache.Set(SchemaCacheKey(schemaHash), schema, int64(schema.EstimatedSize()))
 	return nil
 }
 

--- a/pkg/datalayer/hashcache_test.go
+++ b/pkg/datalayer/hashcache_test.go
@@ -46,6 +46,24 @@ func TestSchemaHashCache_BasicGetSet(t *testing.T) {
 	require.Equal(t, schema.Get().GetV1().SchemaText, retrieved.Get().GetV1().SchemaText)
 }
 
+func TestSchemaHashCache_SetCostsBySize(t *testing.T) {
+	tc := newTestSchemaCache()
+	shc := newSchemaHashCache(tc)
+
+	// A larger schema must be costed higher than a smaller one, and the cost
+	// must match the schema's estimated (serialized) size rather than a flat 1.
+	small := makeTestSchema("definition user {}")
+	large := makeTestSchema("definition user {}" + string(make([]byte, 4096)))
+
+	require.NoError(t, shc.Set(SchemaHash("small"), small))
+	require.NoError(t, shc.Set(SchemaHash("large"), large))
+
+	require.Equal(t, int64(small.EstimatedSize()), tc.cost(SchemaCacheKey("small")))
+	require.Equal(t, int64(large.EstimatedSize()), tc.cost(SchemaCacheKey("large")))
+	require.Greater(t, tc.cost(SchemaCacheKey("large")), tc.cost(SchemaCacheKey("small")))
+	require.Greater(t, tc.cost(SchemaCacheKey("small")), int64(1))
+}
+
 func TestSchemaHashCache_EmptyHash(t *testing.T) {
 	shc := newSchemaHashCache(newTestSchemaCache())
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -535,6 +535,18 @@ func (r *ReadOnlyStoredSchema) Get() *core.StoredSchema {
 	return r.schema
 }
 
+// EstimatedSize returns an approximate size of the stored schema in bytes, using
+// the serialized protobuf size as a proxy. It is used for cache cost accounting;
+// the live in-memory object graph is somewhat larger than the serialized size,
+// but this is a far better estimate than treating every schema as a fixed cost.
+// Returns 0 for a nil schema.
+func (r *ReadOnlyStoredSchema) EstimatedSize() int {
+	if r == nil || r.schema == nil {
+		return 0
+	}
+	return r.schema.SizeVT()
+}
+
 // Reader is an interface for reading relationships from the datastore.
 type Reader interface {
 	LegacySchemaReader

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -535,16 +535,16 @@ func (r *ReadOnlyStoredSchema) Get() *core.StoredSchema {
 	return r.schema
 }
 
-// EstimatedSize returns an approximate size of the stored schema in bytes, using
-// the serialized protobuf size as a proxy. It is used for cache cost accounting;
-// the live in-memory object graph is somewhat larger than the serialized size,
-// but this is a far better estimate than treating every schema as a fixed cost.
+// EstimatedSize returns an approximate size of the stored schema in bytes,
+// using the length of the schema string as a proxy.
+// It is used for cache cost accounting; the live in-memory object graph is
+// somewhat larger than the serialized size, but this is a decent estimate.
 // Returns 0 for a nil schema.
 func (r *ReadOnlyStoredSchema) EstimatedSize() int {
 	if r == nil || r.schema == nil {
 		return 0
 	}
-	return r.schema.SizeVT()
+	return len(r.schema.GetV1().SchemaText)
 }
 
 // Reader is an interface for reading relationships from the datastore.

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -33,7 +33,7 @@ func TestReadOnlyStoredSchemaEstimatedSize(t *testing.T) {
 	})
 	require.Positive(t, small.EstimatedSize())
 	require.Greater(t, large.EstimatedSize(), small.EstimatedSize())
-	require.Equal(t, small.Get().SizeVT(), small.EstimatedSize())
+	require.Equal(t, len(small.Get().GetV1().SchemaText), small.EstimatedSize())
 }
 
 func TestRelationshipsFilterFromPublicFilter(t *testing.T) {

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -9,8 +9,32 @@ import (
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
 	"github.com/authzed/spicedb/pkg/datastore/options"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
 )
+
+func TestReadOnlyStoredSchemaEstimatedSize(t *testing.T) {
+	// Nil-safe: a nil wrapper and a wrapper around nil both report 0.
+	var nilSchema *ReadOnlyStoredSchema
+	require.Equal(t, 0, nilSchema.EstimatedSize())
+	require.Equal(t, 0, NewReadOnlyStoredSchema(nil).EstimatedSize())
+
+	// A populated schema reports its serialized size (greater than zero), and a
+	// larger schema reports a larger size.
+	small := NewReadOnlyStoredSchema(&core.StoredSchema{
+		VersionOneof: &core.StoredSchema_V1{
+			V1: &core.StoredSchema_V1StoredSchema{SchemaText: "definition user {}"},
+		},
+	})
+	large := NewReadOnlyStoredSchema(&core.StoredSchema{
+		VersionOneof: &core.StoredSchema_V1{
+			V1: &core.StoredSchema_V1StoredSchema{SchemaText: "definition user {}" + string(make([]byte, 1024))},
+		},
+	})
+	require.Positive(t, small.EstimatedSize())
+	require.Greater(t, large.EstimatedSize(), small.EstimatedSize())
+	require.Equal(t, small.Get().SizeVT(), small.EstimatedSize())
+}
 
 func TestRelationshipsFilterFromPublicFilter(t *testing.T) {
 	tests := []struct {

--- a/pkg/runtime/memory.go
+++ b/pkg/runtime/memory.go
@@ -25,6 +25,11 @@ const (
 	MemorySourceUndetermined MemorySource = "undetermined"
 )
 
+// fallbackMemoryLimit is the amount of memory allocated for caches etc.
+// when the amount of available memory can't be determined through the usual methods.
+// 256mb is tiny, but it should comfortably fit in most runtimes.
+const fallbackMemoryLimit = 256 * 1024
+
 var logAvailableMemoryOnce sync.Once
 
 // AvailableMemory returns 75% of the memory available to this process.
@@ -39,13 +44,16 @@ var logAvailableMemoryOnce sync.Once
 func AvailableMemory() uint64 {
 	mem, source := availableMemory()
 	logAvailableMemoryOnce.Do(func() {
-		evt := logging.Info().
-			Uint64("available-memory-bytes", mem).
-			Str("source", string(source))
 		if source == MemorySourceUndetermined {
-			evt.Msg("could not determine available memory; percent-based cache budgets cannot be honored")
+			logging.Warn().
+				Uint64("available-memory-bytes", mem).
+				Str("source", string(source)).
+				Msg("could not determine available memory; using a conservative default")
 		} else {
-			evt.Msg("determined available memory for percent-based budgets")
+			logging.Info().
+				Uint64("available-memory-bytes", mem).
+				Str("source", string(source)).
+				Msg("determined available memory for percent-based budgets")
 		}
 	})
 	return mem
@@ -72,7 +80,7 @@ func availableMemory() (uint64, MemorySource) {
 	memProvider := memlimit.ApplyFallback(memlimit.FromCgroup, memlimit.FromSystem)
 	totalMemory, err := memProvider()
 	if err != nil || totalMemory == 0 {
-		return 0, MemorySourceUndetermined
+		return fallbackMemoryLimit, MemorySourceUndetermined
 	}
 	return totalMemory * 75 / 100, MemorySourceDetected
 }

--- a/pkg/runtime/memory.go
+++ b/pkg/runtime/memory.go
@@ -1,27 +1,78 @@
 package runtime
 
 import (
+	"math"
 	"runtime/debug"
+	"sync"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
+
+	"github.com/authzed/spicedb/internal/logging"
 )
+
+// MemorySource describes where the available-memory figure was derived from.
+type MemorySource string
+
+const (
+	// MemorySourceGOMEMLIMIT means the figure came from GOMEMLIMIT, which is set
+	// cgroup-aware at startup (and always set under Kubernetes).
+	MemorySourceGOMEMLIMIT MemorySource = "GOMEMLIMIT"
+	// MemorySourceDetected means GOMEMLIMIT was not usable and the figure came
+	// from direct cgroup/system detection.
+	MemorySourceDetected MemorySource = "cgroup/system"
+	// MemorySourceUndetermined means available memory could not be determined at
+	// all. Percent-based budgets (e.g. cache MaxCost) cannot be honored.
+	MemorySourceUndetermined MemorySource = "undetermined"
+)
+
+var logAvailableMemoryOnce sync.Once
 
 // AvailableMemory returns 75% of the memory available to this process.
 // It reads GOMEMLIMIT (set by cobraproclimits during startup, which is cgroup-aware
 // in Kubernetes), falling back to cgroup/system detection if GOMEMLIMIT is not set.
 // The 75% ratio provides headroom for memory not tracked by the caller (e.g. goroutine
 // stacks, GC metadata, fragmentation).
+//
+// The detected value and its source are logged once, the first time this is called,
+// to make percent-based-budget misconfiguration diagnosable (notably on AWS ECS,
+// where the container memory limit may not be written to the cgroup).
 func AvailableMemory() uint64 {
+	mem, source := availableMemory()
+	logAvailableMemoryOnce.Do(func() {
+		evt := logging.Info().
+			Uint64("available-memory-bytes", mem).
+			Str("source", string(source))
+		if source == MemorySourceUndetermined {
+			evt.Msg("could not determine available memory; percent-based cache budgets cannot be honored")
+		} else {
+			evt.Msg("determined available memory for percent-based budgets")
+		}
+	})
+	return mem
+}
+
+// availableMemory returns 75% of the memory available to this process along with
+// the source the figure was derived from, for diagnostics and logging.
+func availableMemory() (uint64, MemorySource) {
 	limit := debug.SetMemoryLimit(-1)
-	if limit > 0 {
-		return uint64(limit) * 75 / 100
+	// When GOMEMLIMIT is never set (the Go runtime default is math.MaxInt64), or
+	// cgroup detection failed at startup, debug.SetMemoryLimit(-1) reports the
+	// max-int sentinel rather than a real limit. This happens on platforms where
+	// the container memory limit isn't written to the cgroup (e.g. AWS ECS tasks
+	// without a container-level hard memory limit), unlike Kubernetes where the
+	// kubelet always sets it. Treating the sentinel as a real limit would yield an
+	// absurdly large "available memory" and let percent-based budgets (e.g. the
+	// cache MaxCost) grow unbounded until the process is OOM-killed. Fall through
+	// to cgroup/system detection instead.
+	if limit > 0 && limit != math.MaxInt64 {
+		return uint64(limit) * 75 / 100, MemorySourceGOMEMLIMIT
 	}
 
 	// Fallback if GOMEMLIMIT was not set (e.g. during tests).
 	memProvider := memlimit.ApplyFallback(memlimit.FromCgroup, memlimit.FromSystem)
 	totalMemory, err := memProvider()
 	if err != nil || totalMemory == 0 {
-		return 0
+		return 0, MemorySourceUndetermined
 	}
-	return totalMemory * 75 / 100
+	return totalMemory * 75 / 100, MemorySourceDetected
 }

--- a/pkg/runtime/memory_test.go
+++ b/pkg/runtime/memory_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"math"
 	"runtime/debug"
 	"testing"
 
@@ -35,6 +36,24 @@ func TestAvailableMemory_FallsBackWhenGOMEMLIMITUnset(t *testing.T) {
 
 	mem := AvailableMemory()
 	require.Positive(t, mem, "should fall back to cgroup/system memory detection")
+}
+
+func TestAvailableMemory_FallsBackWhenGOMEMLIMITUnsetSentinel(t *testing.T) {
+	original := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() {
+		debug.SetMemoryLimit(original)
+	})
+
+	// The Go runtime's default soft memory limit (i.e. GOMEMLIMIT never set) is
+	// math.MaxInt64, which is what debug.SetMemoryLimit(-1) reports. This is the
+	// case seen on AWS ECS tasks where cgroup detection fails at startup. We must
+	// fall back to cgroup/system detection rather than returning 75% of MaxInt64.
+	debug.SetMemoryLimit(math.MaxInt64)
+
+	mem := AvailableMemory()
+	require.Positive(t, mem, "should fall back to cgroup/system memory detection")
+	require.Less(t, mem, uint64(math.MaxInt64)/100*75,
+		"must not treat the max-int sentinel as a real memory limit")
 }
 
 func TestAvailableMemory_Applies75PercentRatio(t *testing.T) {


### PR DESCRIPTION
## Description
See #3200. When SpiceDB couldn't determine the memory available to it, such as can happen in AWS ECS, it was assuming that it had much more memory than it did. This is a set of improvements to that behavior.

## Changes
* Choose a conservative limit when memory can't be determined and emit a warning message
* Log the memory limit on startup together with how the limit was determined for debugging purposes
* Improve cost estimations for cache entries for the general cache
* Improve cost estimations for the schema hash cache using the size of the serialized schema
* Add tests for the new behaviors
## Testing
Review. See that tests pass.