### PR TITLE
test: fix flaky TestOldWatchingCacheBasicOperation

### DIFF
--- a/internal/datastore/proxy/schemacaching/caching.go
+++ b/internal/datastore/proxy/schemacaching/caching.go
@@ -37,6 +37,7 @@ type CacheEntry = *cacheEntry
 
 // NewCachingDatastoreProxy creates a new datastore proxy which caches definitions that
 // are loaded at specific datastore revisions.
+// The caller MUST call Close on the returned proxy when it is no longer needed.
 func NewCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache[cache.StringKey, CacheEntry], gcWindow time.Duration, cachingMode CachingMode, watchHeartbeat time.Duration) datastore.Datastore {
 	standardCachingProxy := NewDefinitionCachingProxy(delegate, c)
 

--- a/internal/datastore/proxy/schemacaching/standardcache.go
+++ b/internal/datastore/proxy/schemacaching/standardcache.go
@@ -24,6 +24,8 @@ type definitionCachingProxy struct {
 	readGroup singleflight.Group[string, *cacheEntry]
 }
 
+// The caller MUST call Close on the returned proxy when it is no longer needed.
+// If a nil cache is passed, one is created, so Close is needed to stop its cleanup goroutine.
 func NewDefinitionCachingProxy(delegate datastore.Datastore, c cache.Cache[cache.StringKey, *cacheEntry]) *definitionCachingProxy {
 	if c == nil {
 		c, _ = cache.NewStandardCache[cache.StringKey, *cacheEntry](&cache.Config{

--- a/internal/datastore/proxy/schemacaching/standardcache_test.go
+++ b/internal/datastore/proxy/schemacaching/standardcache_test.go
@@ -355,6 +355,8 @@ func TestOldRWTCaching(t *testing.T) {
 			ctx := t.Context()
 
 			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			dsMock.On("Close").Return(nil).Maybe()
+			t.Cleanup(func() { _ = ds.Close() })
 
 			rev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 				_, updatedA, err := tester.readSingleFunc(ctx, rwt, nsA)
@@ -390,6 +392,8 @@ func TestRWTCaching(t *testing.T) {
 	ctx := t.Context()
 
 	ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+	dsMock.On("Close").Return(nil).Maybe()
+	t.Cleanup(func() { _ = ds.Close() })
 
 	rev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 		// read the namespace
@@ -436,6 +440,8 @@ func TestOldRWTCacheWithWrites(t *testing.T) {
 			ctx := t.Context()
 
 			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			dsMock.On("Close").Return(nil).Maybe()
+			t.Cleanup(func() { _ = ds.Close() })
 
 			rev, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
 				// Cache the 404
@@ -486,6 +492,8 @@ func TestOldSingleFlight(t *testing.T) {
 			require := require.New(t)
 
 			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			dsMock.On("Close").Return(nil).Maybe()
+			t.Cleanup(func() { _ = ds.Close() })
 
 			readNamespace := func() error {
 				_, updatedAt, err := tester.readSingleFunc(t.Context(), ds.SnapshotReader(one), nsA)
@@ -609,6 +617,7 @@ func TestOldSnapshotCachingRealDatastore(t *testing.T) {
 
 			ctx := t.Context()
 			ds := NewCachingDatastoreProxy(rawDS, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			t.Cleanup(func() { _ = ds.Close() })
 
 			if tc.nsDef != nil {
 				_, err = ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
@@ -687,6 +696,7 @@ func TestSnapshotCachingRealDatastore(t *testing.T) {
 
 			ctx := t.Context()
 			ds := NewCachingDatastoreProxy(rawDS, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			t.Cleanup(func() { _ = ds.Close() })
 
 			if tc.nsDef != nil {
 				_, err = ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
@@ -755,6 +765,8 @@ func TestOldSingleFlightCancelled(t *testing.T) {
 			dsMock.On("SnapshotReader", one).Return(&singleflightReader{MockReader: proxy_test.MockReader{}})
 
 			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			dsMock.On("Close").Return(nil).Maybe()
+			t.Cleanup(func() { _ = ds.Close() })
 
 			g := sync.WaitGroup{}
 			var d2 datastore.SchemaDefinition


### PR DESCRIPTION
Fixes

```
-- FAIL: TestOldWatchingCacheBasicOperation (0.46s)
    watchingcache_test.go:50: found unexpected goroutines:
        [Goroutine 531 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 530
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 497 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 496
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 537 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 536
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 519 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 518
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 493 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 492
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 495 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 494
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 500 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 499
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 502 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 501
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 505 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 504
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 523 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 522
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 548 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 547
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 509 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 508
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
         Goroutine 529 in state select, with github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp on top of the stack:
        github.com/maypok86/otter/v2.(*cache[...]).periodicCleanUp(0x1aac900)
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:1274 +0x10c
        created by github.com/maypok86/otter/v2.newCache[...] in goroutine 528
        	/home/runner/go/pkg/mod/github.com/maypok86/otter/v2@v2.3.0/cache_impl.go:195 +0xeb4
        ]
FAIL
coverage: 7.3% of statements in ./...
```