### PR TITLE
docs(fdw): correct relationships table caveat columns

### DIFF
--- a/internal/fdw/README.md
+++ b/internal/fdw/README.md
@@ -226,8 +226,8 @@ SPICEDB_SHUTDOWN_GRACE_PERIOD
 | `subject_type` | text | Subject type |
 | `subject_id` | text | Subject ID |
 | `optional_subject_relation` | text | Optional subject relation |
-| `optional_caveat_name` | text | Optional caveat name |
-| `optional_caveat_context` | jsonb | Optional caveat context |
+| `caveat_name` | text | Optional caveat name |
+| `caveat_context` | text | Optional caveat context |
 | `consistency` | text | Consistency token (ZedToken) |
 
 **Supported Operations:**


### PR DESCRIPTION
## Description

Fixes incorrect caveat column names and types in `internal/fdw/README.md`.

The documentation currently describes:

- `optional_caveat_name (text)`
- `optional_caveat_context (jsonb)`

However, the implementation and the example configuration use:

- `caveat_name (text)`
- `caveat_context (text)`

This PR updates the documentation to match the current implementation.

## Testing

Verified that the documentation matches:

- `internal/fdw/tables/relationships.go`
- `internal/fdw/configuration.sql`

Documentation change only. No functional changes.

## References

Closes #3227