### PR TITLE
chore: fix broken test

### DIFF
--- a/pkg/datalayer/hashcache_test.go
+++ b/pkg/datalayer/hashcache_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/authzed/spicedb/pkg/datastore"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
@@ -112,48 +113,37 @@ func TestSchemaHashCache_GetOrLoadEmptyHash(t *testing.T) {
 func TestSchemaHashCache_Singleflight(t *testing.T) {
 	shc := newSchemaHashCache(newTestSchemaCache())
 
-	loadCalls := 0
+	var loadCalls atomic.Int32
 	loadStarted := make(chan struct{})
 	loadContinue := make(chan struct{})
 
 	loader := func(_ context.Context) (*datastore.ReadOnlyStoredSchema, error) {
-		loadCalls++
-		close(loadStarted)
+		if loadCalls.Add(1) == 1 {
+			close(loadStarted)
+		}
 		<-loadContinue
 		return makeTestSchema("loaded definition"), nil
 	}
 
 	const numGoroutines = 10
-	var wg sync.WaitGroup
-	wg.Add(numGoroutines)
-
-	results := make(chan error, numGoroutines)
-	for i := 0; i < numGoroutines; i++ {
-		go func() {
-			defer wg.Done()
+	var g errgroup.Group
+	for range numGoroutines {
+		g.Go(func() error {
 			schema, err := shc.GetOrLoad(t.Context(), datastore.NoRevision, SchemaHash("hash1"), loader)
 			if err != nil {
-				results <- err
-				return
+				return err
 			}
 			if schema == nil {
-				results <- fmt.Errorf("schema is nil")
-				return
+				return fmt.Errorf("schema is nil")
 			}
-			results <- nil
-		}()
+			return nil
+		})
 	}
 
 	<-loadStarted
 	close(loadContinue)
-	wg.Wait()
-	close(results)
-
-	for err := range results {
-		require.NoError(t, err)
-	}
-
-	require.Equal(t, 1, loadCalls)
+	require.NoError(t, g.Wait())
+	require.Equal(t, int32(1), loadCalls.Load())
 }
 
 func TestSchemaHashCache_LoadError(t *testing.T) {


### PR DESCRIPTION
## Description
This test was [failing reliably](https://github.com/authzed/spicedb/actions/runs/29281782343/job/86924624271?pr=3218) prior to this.

## Changes
* Use an atomic for `loadCalls`
* Use an errgroup for the spawned goroutines
* Use `Go()` instead of `Add()`
## Testing
Review. See that tests pass.