### PR TITLE
docs(fdw): fix has_permission filter examples

### DIFF
--- a/internal/fdw/Architecture.md
+++ b/internal/fdw/Architecture.md
@@ -254,8 +254,7 @@ The permissions table supports three distinct query patterns, each mapping to a 
    ```sql
    SELECT resource_id FROM permissions
    WHERE resource_type = 'doc' AND permission = 'view'
-     AND subject_type = 'user' AND subject_id = 'alice'
-     AND has_permission = true;
+     AND subject_type = 'user' AND subject_id = 'alice';
    ```
    → Calls `LookupResources(user:alice, view, doc)`
 
@@ -264,8 +263,7 @@ The permissions table supports three distinct query patterns, each mapping to a 
    SELECT subject_id FROM permissions
    WHERE resource_type = 'doc' AND resource_id = '1'
      AND permission = 'view'
-     AND subject_type = 'user'
-     AND has_permission = true;
+     AND subject_type = 'user';
    ```
    → Calls `LookupSubjects(doc:1, view, user)`
 
@@ -655,8 +653,7 @@ WHERE ... AND consistency = 'fully_consistent';
    DECLARE c CURSOR FOR
      SELECT resource_id FROM permissions
      WHERE resource_type = 'doc' AND permission = 'view'
-       AND subject_type = 'user' AND subject_id = 'alice'
-       AND has_permission = true;
+       AND subject_type = 'user' AND subject_id = 'alice';
 
 2. FDW Proxy:
    ┌──────────────────────────────────┐

--- a/internal/fdw/README.md
+++ b/internal/fdw/README.md
@@ -113,7 +113,7 @@ WHERE resource_type = 'document'
   AND permission = 'view'
   AND subject_type = 'user'
   AND subject_id = 'alice'
-  AND has_permission = true;
+  AND has_permission IS true;
 ```
 
 #### Lookup Subjects
@@ -126,7 +126,7 @@ WHERE resource_type = 'document'
   AND resource_id = 'readme'
   AND permission = 'view'
   AND subject_type = 'user'
-  AND has_permission = true;
+  AND has_permission IS true;
 ```
 
 #### Query Relationships


### PR DESCRIPTION
Fixes #3236

The documented `AND has_permission = true` examples fail when run: Postgres
folds `= true` into a bare column reference before pushdown, and the proxy
rejects `has_permission` in WHERE clauses.

## Changes

* `README.md`: use `has_permission IS true` in the Lookup Resources / Lookup
  Subjects examples — `IS TRUE` is not pushed down by postgres_fdw and gets
  evaluated locally, so the query works as intended.
* `Architecture.md`: drop the `has_permission` condition from the
  handler-dispatch and cursor examples entirely — these show SQL as received
  by the proxy, where no local filtering exists and neither form is supported.

## Testing

Verified against a live setup (SpiceDB + FDW proxy + Postgres 17 with
postgres_fdw): the original examples fail with `operation not supported:
column_ref`, the updated README examples return the expected rows
(`EXPLAIN VERBOSE` confirms `IS TRUE` becomes a local `Filter` node), and the
updated Architecture.md queries dispatch to LookupResources/LookupSubjects.