### PR TITLE
feat: add metric counting % of HAS_PERMISSION results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- New metric `check_permissionship_total` for CheckPermission and CheckBulkPermissions that counts the number of requests that returned HAS_PERMISSION. Also, `write_relationships_updates` also includes BulkImport calls (https://github.com/authzed/spicedb/pull/3240)
+
 ### Changed
 - Schema: reads inside write transactions now use a cheap hash-only lookup (`schema_revision`) to check the cache before loading the full schema blob, reducing DB round-trips on cache hits (https://github.com/authzed/spicedb/pull/3160)
 - Updated the Prometheus buckets for `grpc_server_handling_seconds` and `spicedb_datastore_query_latency` to be able to correlate them (https://github.com/authzed/spicedb/pull/3188)

--- a/development/grafana/dashboards/dashboard.json
+++ b/development/grafana/dashboards/dashboard.json
@@ -513,7 +513,7 @@
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum(rate(spicedb_perf_insights_api_shape_latency_seconds{job=\"spicedb\",instance=~\"$instance\",resource_type!=\"\"}[$__rate_interval])) by (api_kind, resource_type, resource_relation, subject_type, subject_relation))",
-          "legendFormat": "{{api_kind}} {{resource_type}}:{{resource_relation}} → {{subject_type}}#{{subject_relation}}",
+          "legendFormat": "{{api_kind}} {{resource_type}}:{{resource_relation}} \u2192 {{subject_type}}#{{subject_relation}}",
           "range": true,
           "refId": "A"
         }
@@ -526,7 +526,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Average logical checks per second across all APIs. Counts each item within a CheckBulk and each result returned from LookupResources/LookupSubjects separately. This measures workload intensity independently of gRPC RPS — a single LookupResources call can account for hundreds of logical checks.",
+      "description": "Average logical checks per second across all APIs. Counts each item within a CheckBulk and each result returned from LookupResources/LookupSubjects separately. This measures workload intensity independently of gRPC RPS \u2014 a single LookupResources call can account for hundreds of logical checks.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -705,6 +705,101 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Percentage of check results (CheckPermission and CheckBulkPermissions, each bulk item counted individually) that return HAS_PERMISSION, aggregated across all instances. CONDITIONAL_PERMISSION and NO_PERMISSION results count toward the denominator. Only successful checks are counted; errored checks are excluded.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 81,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 *\nsum by(method) (rate(spicedb_v1_check_permissionship_total{job=\"spicedb\",permissionship=\"HAS_PERMISSION\"}[$__rate_interval]))\n/\n(sum by(method) (rate(spicedb_v1_check_permissionship_total{job=\"spicedb\"}[$__rate_interval])) > 0)",
+          "legendFormat": "HAS_PERMISSION % ({{method}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Check HAS_PERMISSION Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Distribution of request rate across instances. If one instance receives significantly more traffic than others, there may be a load balancing issue in front of the instances.",
       "fieldConfig": {
         "defaults": {
@@ -762,7 +857,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 47
       },
       "id": 45,
       "options": {
@@ -855,7 +950,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 55
       },
       "id": 46,
       "options": {
@@ -892,7 +987,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 63
       },
       "id": 70,
       "panels": [
@@ -901,7 +996,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Cache hit ratio for each dispatch operation type, split by dispatcher layer. High ratios (>80%) for check operations are expected under steady workloads. Low ratios indicate cache churn, highly diverse queries, or an undersized cache. Per-instance variance is expected and normal: the dispatch cache is local in-process (not shared across instances), and every cache key is scoped to a specific revision — so any write that advances the revision causes all instances to miss on subsequent requests until they re-warm at the new revision. Instances that recently restarted or received the first requests after a revision bump will show lower ratios than instances with a warm cache at a stable revision.",
+          "description": "Cache hit ratio for each dispatch operation type, split by dispatcher layer. High ratios (>80%) for check operations are expected under steady workloads. Low ratios indicate cache churn, highly diverse queries, or an undersized cache. Per-instance variance is expected and normal: the dispatch cache is local in-process (not shared across instances), and every cache key is scoped to a specific revision \u2014 so any write that advances the revision causes all instances to miss on subsequent requests until they re-warm at the new revision. Instances that recently restarted or received the first requests after a revision bump will show lower ratios than instances with a warm cache at a stable revision.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1050,7 +1145,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "p99 of the number of chunks dispatched per Check request. Each chunk holds up to dispatch-chunk-size subjects (default: 100) and is processed in parallel. A value of N means the check fanned out to N×chunk-size subjects of the same type. Consistently high values indicate broad permission checks with large subject fan-out.",
+          "description": "p99 of the number of chunks dispatched per Check request. Each chunk holds up to dispatch-chunk-size subjects (default: 100) and is processed in parallel. A value of N means the check fanned out to N\u00d7chunk-size subjects of the same type. Consistently high values indicate broad permission checks with large subject fan-out.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1155,7 +1250,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 64
       },
       "id": 42,
       "panels": [
@@ -1164,7 +1259,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Hit ratio per cache, from spicedb_cache_hits_total and spicedb_cache_misses_total. Three caches emit metrics:\n\n• namespace (32MiB): caches parsed namespace and caveat definitions. Should be near 100% — schemas change infrequently. A sustained drop means schema writes are frequent or the cache is undersized.\n\n• dispatch (default: 30% of free memory): caches sub-problem results for dispatches this node sends out (outbound). Revision-scoped — every write that advances the revision invalidates prior entries.\n\n• cluster_dispatch (default: 70% of free memory): caches sub-problem results for dispatches this node receives from other nodes (inbound). Also revision-scoped. Larger by default because in a multi-node cluster this node handles a proportionally larger share of inbound sub-problems.",
+          "description": "Hit ratio per cache, from spicedb_cache_hits_total and spicedb_cache_misses_total. Three caches emit metrics:\n\n\u2022 namespace (32MiB): caches parsed namespace and caveat definitions. Should be near 100% \u2014 schemas change infrequently. A sustained drop means schema writes are frequent or the cache is undersized.\n\n\u2022 dispatch (default: 30% of free memory): caches sub-problem results for dispatches this node sends out (outbound). Revision-scoped \u2014 every write that advances the revision invalidates prior entries.\n\n\u2022 cluster_dispatch (default: 70% of free memory): caches sub-problem results for dispatches this node receives from other nodes (inbound). Also revision-scoped. Larger by default because in a multi-node cluster this node handles a proportionally larger share of inbound sub-problems.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1295,7 +1390,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 65
       },
       "id": 30,
       "panels": [
@@ -1583,7 +1678,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "p99 of the number of relationship updates per WriteRelationships call, split by update kind (CREATE, TOUCH, DELETE). Large batches (>1000) can cause write amplification and lock contention in the datastore.",
+          "description": "p99 of the number of relationship updates per write call, split by update kind (CREATE, TOUCH, DELETE). Includes WriteRelationships calls and bulk imports (ImportBulkRelationships and the deprecated BulkImportRelationships), whose imported relationships are counted as CREATE. Large batches (>1000) can cause write amplification and lock contention in the datastore. Uses the metric's native histogram representation, which has no bucket cap, so large bulk imports report accurate percentiles.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1658,13 +1753,13 @@
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, rate(spicedb_v1_write_relationships_updates_bucket{job=\"spicedb\",instance=~\"$instance\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.99, rate(spicedb_v1_write_relationships_updates{job=\"spicedb\",instance=~\"$instance\"}[$__rate_interval]))",
               "legendFormat": "{{kind}} ({{instance}})",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "p99 WriteRelationships Batch Size - $instance",
+          "title": "p99 Write Batch Size (WriteRelationships + bulk imports) - $instance",
           "type": "timeseries"
         }
       ],
@@ -1677,7 +1772,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 66
       },
       "id": 65,
       "panels": [
@@ -1828,7 +1923,7 @@
               },
               "editorMode": "code",
               "expr": "crdb_connections_per_node{job=\"spicedb\",instance=~\"$instance\"}",
-              "legendFormat": "{{pool}} → node {{node_id}} ({{instance}})",
+              "legendFormat": "{{pool}} \u2192 node {{node_id}} ({{instance}})",
               "range": true,
               "refId": "A"
             }
@@ -2067,7 +2162,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 67
       },
       "id": 48,
       "panels": [
@@ -2983,7 +3078,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 68
       },
       "id": 51,
       "panels": [
@@ -3256,7 +3351,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 69
       },
       "id": 54,
       "panels": [
@@ -3265,7 +3360,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Ratios (0–1) reflecting Spanner session pool health. max_allowed_sessions_ratio approaching 1 means the pool is near its configured limit. max_in_use_sessions_ratio shows peak concurrent session usage. num_sessions_in_pool_ratio and open_session_count_ratio show current utilization.",
+          "description": "Ratios (0\u20131) reflecting Spanner session pool health. max_allowed_sessions_ratio approaching 1 means the pool is near its configured limit. max_in_use_sessions_ratio shows peak concurrent session usage. num_sessions_in_pool_ratio and open_session_count_ratio show current utilization.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3389,7 +3484,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Rate of Spanner sessions acquired and released from the pool, plus the rate of GFE (Google Front End) responses missing the server-timing header — a non-zero gfe_header_missing_count may indicate requests bypassing the GFE or connectivity issues.",
+          "description": "Rate of Spanner sessions acquired and released from the pool, plus the rate of GFE (Google Front End) responses missing the server-timing header \u2014 a non-zero gfe_header_missing_count may indicate requests bypassing the GFE or connectivity issues.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3507,7 +3602,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 70
       },
       "id": 74,
       "panels": [
@@ -3836,7 +3931,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 71
       },
       "id": 4,
       "panels": [

--- a/internal/services/v1/bulkcheck.go
+++ b/internal/services/v1/bulkcheck.go
@@ -45,7 +45,7 @@ type bulkChecker struct {
 
 const maxBulkCheckCount = 10000
 
-func (bc *bulkChecker) checkBulkPermissions(ctx context.Context, req *v1.CheckBulkPermissionsRequest) (*v1.CheckBulkPermissionsResponse, error) {
+func (bc *bulkChecker) checkBulkPermissions(ctx context.Context, req *v1.CheckBulkPermissionsRequest, metrics *Metrics) (*v1.CheckBulkPermissionsResponse, error) {
 	telemetry.LogicalChecks.Add(float64(len(req.Items)))
 
 	atRevision, schemaHash, checkedAt, err := consistency.RevisionFromContext(ctx)
@@ -239,7 +239,7 @@ func (bc *bulkChecker) checkBulkPermissions(ctx context.Context, req *v1.CheckBu
 
 			if err := addPair(&v1.CheckBulkPermissionsPair{
 				Request:  reqItem,
-				Response: pairItemFromCheckResult(results[resourceID], debugTrace),
+				Response: pairItemFromCheckResult(results[resourceID], debugTrace, metrics),
 			}); err != nil {
 				return err
 			}

--- a/internal/services/v1/bulkcheck_test.go
+++ b/internal/services/v1/bulkcheck_test.go
@@ -122,7 +122,7 @@ func runBulkCheck(t *testing.T, d dispatch.Dispatcher, withTracing bool) *v1.Che
 		dispatchChunkSize:    100,
 	}
 
-	resp, err := bc.checkBulkPermissions(ctx, req)
+	resp, err := bc.checkBulkPermissions(ctx, req, NewMetrics(nil))
 	require.NoError(err)
 	return resp
 }

--- a/internal/services/v1/experimental.go
+++ b/internal/services/v1/experimental.go
@@ -95,6 +95,11 @@ func NewExperimentalServer(dispatch dispatch.Dispatcher, permServerConfig Permis
 		chunkSize = 100
 	}
 
+	metrics := permServerConfig.Metrics
+	if metrics == nil {
+		metrics = NewMetrics(nil)
+	}
+
 	return &experimentalServer{
 		WithServiceSpecificInterceptors: shared.WithServiceSpecificInterceptors{
 			Unary: middleware.ChainUnaryServer(
@@ -113,6 +118,7 @@ func NewExperimentalServer(dispatch dispatch.Dispatcher, permServerConfig Permis
 		},
 		maxBatchSize:  uint64(config.MaxExportBatchSize),
 		caveatTypeSet: caveattypes.TypeSetOrDefault(permServerConfig.CaveatTypeSet),
+		metrics:       metrics,
 		bulkChecker: &bulkChecker{
 			maxAPIDepth:          permServerConfig.MaximumAPIDepth,
 			maxCaveatContextSize: permServerConfig.MaxCaveatContextSize,
@@ -132,6 +138,7 @@ type experimentalServer struct {
 
 	bulkChecker   *bulkChecker
 	caveatTypeSet *caveattypes.TypeSet
+	metrics       *Metrics
 }
 
 type bulkLoadAdapter struct {
@@ -308,6 +315,8 @@ func (es *experimentalServer) BulkImportRelationships(stream v1.ExperimentalServ
 		// One request for the whole load
 		DispatchCount: 1,
 	})
+
+	es.metrics.RecordBulkImportedRelationships(numWritten)
 
 	return stream.SendAndClose(&v1.BulkImportRelationshipsResponse{
 		NumLoaded: numWritten,
@@ -507,7 +516,7 @@ func (es *experimentalServer) BulkCheckPermission(ctx context.Context, req *v1.B
 	perfinsights.SetInContext(ctx, perfinsights.NoLabels)
 
 	convertedReq := toCheckBulkPermissionsRequest(req)
-	res, err := es.bulkChecker.checkBulkPermissions(ctx, convertedReq)
+	res, err := es.bulkChecker.checkBulkPermissions(ctx, convertedReq, es.metrics)
 	if err != nil {
 		return nil, shared.RewriteErrorWithoutConfig(ctx, err)
 	}

--- a/internal/services/v1/metrics.go
+++ b/internal/services/v1/metrics.go
@@ -1,0 +1,82 @@
+package v1
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+)
+
+// Metrics holds the Prometheus metrics exported by the v1 services. It is
+// intended to be constructed once when the server is assembled and shared by
+// every service registered against the same registry.
+// It holds metrics that are emmitted from various APIs.
+type Metrics struct {
+	// checkResultCounter counts the results of CheckPermission and
+	// CheckBulkPermissions calls by their returned permissionship, e.g. to
+	// compute the percentage of checks that return HAS_PERMISSION.
+	checkResultCounter *prometheus.CounterVec
+
+	// writeUpdateHistogram tracks the relationship update counts per write call
+	// (WriteRelationships, ImportBulkRelationships and the deprecated
+	// BulkImportRelationships), by update kind.
+	writeUpdateHistogram *prometheus.HistogramVec
+}
+
+// NewMetrics creates the v1 services metrics and registers them with the given
+// registry. If the registry is nil, the metrics are usable but not registered
+// anywhere and thus never exported; this is the safe default for tests and
+// tooling that construct servers repeatedly within one process.
+func NewMetrics(registry prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		checkResultCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "spicedb",
+			Subsystem: "v1",
+			Name:      "check_permissionship_total",
+			Help:      "Count of CheckPermission/CheckBulkPermissions results, by API method and returned permissionship.",
+		}, []string{"method", "permissionship"}),
+		writeUpdateHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "spicedb",
+			Subsystem: "v1",
+			Name:      "write_relationships_updates",
+			Help:      "The relationship update counts for the WriteRelationships and bulk import calls, by update kind.",
+			// Classic buckets are kept for scrapers without native histogram support.
+			// The native histogram representation has no cap.
+			Buckets:                        []float64{0, 1, 2, 5, 10, 15, 25, 50, 100, 250, 500, 1000},
+			NativeHistogramBucketFactor:    1.1,
+			NativeHistogramMaxBucketNumber: 100,
+		}, []string{"kind"}),
+	}
+
+	// Pre-initialize all label combinations so every series is exported at zero from startup
+	for _, method := range []string{"CheckPermission", "CheckBulkPermissions"} {
+		for name, value := range v1.CheckPermissionResponse_Permissionship_value {
+			if value == int32(v1.CheckPermissionResponse_PERMISSIONSHIP_UNSPECIFIED) {
+				continue
+			}
+			m.checkResultCounter.WithLabelValues(method, strings.TrimPrefix(name, "PERMISSIONSHIP_"))
+		}
+	}
+
+	if registry != nil {
+		registry.MustRegister(m.checkResultCounter, m.writeUpdateHistogram)
+	}
+
+	return m
+}
+
+// RecordCheckResult records the permissionship returned by a successful check.
+func (m *Metrics) RecordCheckResult(method string, permissionship v1.CheckPermissionResponse_Permissionship) {
+	m.checkResultCounter.WithLabelValues(method, strings.TrimPrefix(permissionship.String(), "PERMISSIONSHIP_")).Inc()
+}
+
+// RecordWriteRelationshipsUpdates records the number of updates of the given kind in a WriteRelationships call.
+func (m *Metrics) RecordWriteRelationshipsUpdates(kind v1.RelationshipUpdate_Operation, count int) {
+	m.writeUpdateHistogram.WithLabelValues(v1.RelationshipUpdate_Operation_name[int32(kind)]).Observe(float64(count))
+}
+
+// RecordBulkImportedRelationships records the number of relationships written by a bulk import call, as CREATE updates on the write-updates histogram.
+func (m *Metrics) RecordBulkImportedRelationships(count uint64) {
+	m.writeUpdateHistogram.WithLabelValues(v1.RelationshipUpdate_OPERATION_CREATE.String()).Observe(float64(count))
+}

--- a/internal/services/v1/metrics_test.go
+++ b/internal/services/v1/metrics_test.go
@@ -1,0 +1,218 @@
+package v1_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+
+	"github.com/authzed/spicedb/internal/datastore/memdb"
+	tf "github.com/authzed/spicedb/internal/testfixtures"
+	"github.com/authzed/spicedb/internal/testserver"
+	"github.com/authzed/spicedb/pkg/datalayer"
+	"github.com/authzed/spicedb/pkg/testutil"
+	"github.com/authzed/spicedb/pkg/zedtoken"
+)
+
+func TestCheckPermissionshipMetric(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
+
+	registry := prometheus.NewRegistry()
+	config := testserver.DefaultTestServerConfig
+	config.MetricsRegistry = registry
+
+	conn, _, revision := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true, config, tf.StandardDatastoreWithData)
+	client := v1.NewPermissionsServiceClient(conn)
+
+	consistency := &v1.Consistency{
+		Requirement: &v1.Consistency_AtLeastAsFresh{
+			AtLeastAsFresh: zedtoken.MustNewFromRevisionForTesting(revision, datalayer.NoSchemaHashInLegacyZedToken),
+		},
+	}
+
+	// Two single checks: one allowed, one denied.
+	for _, tc := range []struct {
+		subjectID string
+		expected  v1.CheckPermissionResponse_Permissionship
+	}{
+		{"eng_lead", v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION},
+		{"villain", v1.CheckPermissionResponse_PERMISSIONSHIP_NO_PERMISSION},
+	} {
+		resp, err := client.CheckPermission(t.Context(), &v1.CheckPermissionRequest{
+			Consistency: consistency,
+			Resource:    obj("document", "masterplan"),
+			Permission:  "view",
+			Subject:     sub("user", tc.subjectID, ""),
+		})
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, resp.Permissionship)
+	}
+
+	// One bulk check with three items: two allowed, one denied.
+	bulkResp, err := client.CheckBulkPermissions(t.Context(), &v1.CheckBulkPermissionsRequest{
+		Consistency: consistency,
+		Items: []*v1.CheckBulkPermissionsRequestItem{
+			{Resource: obj("document", "masterplan"), Permission: "view", Subject: sub("user", "eng_lead", "")},
+			{Resource: obj("document", "masterplan"), Permission: "view", Subject: sub("user", "owner", "")},
+			{Resource: obj("document", "masterplan"), Permission: "view", Subject: sub("user", "villain", "")},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, bulkResp.Pairs, 3)
+
+	expectedCounts := map[[2]string]float64{
+		{"CheckPermission", "HAS_PERMISSION"}:              1,
+		{"CheckPermission", "NO_PERMISSION"}:               1,
+		{"CheckPermission", "CONDITIONAL_PERMISSION"}:      0,
+		{"CheckBulkPermissions", "HAS_PERMISSION"}:         2,
+		{"CheckBulkPermissions", "NO_PERMISSION"}:          1,
+		{"CheckBulkPermissions", "CONDITIONAL_PERMISSION"}: 0,
+	}
+	for key, expected := range expectedCounts {
+		value := checkPermissionshipCounterValue(t, registry, key[0], key[1])
+		require.InDelta(t, expected, value, 0, "unexpected count for method=%q permissionship=%q", key[0], key[1])
+	}
+}
+
+// TestBulkImportRecordsWriteUpdatesMetric ensures that relationships written via
+// ImportBulkRelationships are observed on the write-updates histogram as CREATEs.
+func TestBulkImportRecordsWriteUpdatesMetric(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
+
+	registry := prometheus.NewRegistry()
+	config := testserver.DefaultTestServerConfig
+	config.MetricsRegistry = registry
+
+	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true, config, tf.StandardDatastoreWithData)
+	client := v1.NewPermissionsServiceClient(conn)
+
+	stream, err := client.ImportBulkRelationships(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&v1.ImportBulkRelationshipsRequest{
+		Relationships: []*v1.Relationship{
+			{Resource: obj("document", "importeddoc"), Relation: "viewer", Subject: sub("user", "tom", "")},
+			{Resource: obj("document", "importeddoc"), Relation: "viewer", Subject: sub("user", "fred", "")},
+		},
+	}))
+	importResp, err := stream.CloseAndRecv()
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), importResp.NumLoaded)
+
+	count, sum := writeUpdatesHistogramValue(t, registry, v1.RelationshipUpdate_OPERATION_CREATE.String())
+	require.Equal(t, uint64(1), count, "expected one bulk import observation")
+	require.InDelta(t, float64(2), sum, 0, "expected two imported relationships observed")
+}
+
+// TestWriteRelationshipsRecordsWriteUpdatesMetric ensures that a WriteRelationships
+// call is observed on the write-updates histogram, with one observation per update
+// kind carrying that kind's update count.
+func TestWriteRelationshipsRecordsWriteUpdatesMetric(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
+
+	registry := prometheus.NewRegistry()
+	config := testserver.DefaultTestServerConfig
+	config.MetricsRegistry = registry
+
+	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true, config, tf.StandardDatastoreWithData)
+	client := v1.NewPermissionsServiceClient(conn)
+
+	// One write with two CREATEs, one TOUCH of an existing relationship and one
+	// DELETE of an existing relationship.
+	_, err := client.WriteRelationships(t.Context(), &v1.WriteRelationshipsRequest{
+		Updates: []*v1.RelationshipUpdate{
+			{
+				Operation:    v1.RelationshipUpdate_OPERATION_CREATE,
+				Relationship: &v1.Relationship{Resource: obj("document", "newdoc"), Relation: "viewer", Subject: sub("user", "tom", "")},
+			},
+			{
+				Operation:    v1.RelationshipUpdate_OPERATION_CREATE,
+				Relationship: &v1.Relationship{Resource: obj("document", "newdoc"), Relation: "viewer", Subject: sub("user", "fred", "")},
+			},
+			{
+				Operation:    v1.RelationshipUpdate_OPERATION_TOUCH,
+				Relationship: &v1.Relationship{Resource: obj("document", "masterplan"), Relation: "viewer", Subject: sub("user", "eng_lead", "")},
+			},
+			{
+				Operation:    v1.RelationshipUpdate_OPERATION_DELETE,
+				Relationship: &v1.Relationship{Resource: obj("document", "companyplan"), Relation: "parent", Subject: sub("folder", "company", "")},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	for kind, expectedSum := range map[v1.RelationshipUpdate_Operation]float64{
+		v1.RelationshipUpdate_OPERATION_CREATE: 2,
+		v1.RelationshipUpdate_OPERATION_TOUCH:  1,
+		v1.RelationshipUpdate_OPERATION_DELETE: 1,
+	} {
+		count, sum := writeUpdatesHistogramValue(t, registry, kind.String())
+		require.Equal(t, uint64(1), count, "expected one observation for kind %s", kind)
+		require.InDelta(t, expectedSum, sum, 0, "unexpected update count for kind %s", kind)
+	}
+}
+
+// writeUpdatesHistogramValue reads the sample count and sum of the
+// spicedb_v1_write_relationships_updates histogram for the given kind from the
+// given registry.
+func writeUpdatesHistogramValue(t *testing.T, registry *prometheus.Registry, kind string) (uint64, float64) {
+	t.Helper()
+
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range mfs {
+		if mf.GetName() != "spicedb_v1_write_relationships_updates" {
+			continue
+		}
+
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "kind" && lp.GetValue() == kind {
+					return m.GetHistogram().GetSampleCount(), m.GetHistogram().GetSampleSum()
+				}
+			}
+		}
+	}
+
+	t.Fatalf("metric spicedb_v1_write_relationships_updates{kind=%q} not found", kind)
+	return 0, 0
+}
+
+// checkPermissionshipCounterValue reads the current value of the
+// spicedb_v1_check_permissionship_total counter for the given labels from the
+// given registry.
+func checkPermissionshipCounterValue(t *testing.T, registry *prometheus.Registry, method string, permissionship string) float64 {
+	t.Helper()
+
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range mfs {
+		if mf.GetName() != "spicedb_v1_check_permissionship_total" {
+			continue
+		}
+
+		for _, m := range mf.GetMetric() {
+			labels := make(map[string]string, len(m.GetLabel()))
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+
+			if labels["method"] == method && labels["permissionship"] == permissionship {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+
+	t.Fatalf("metric spicedb_v1_check_permissionship_total{method=%q,permissionship=%q} not found", method, permissionship)
+	return 0
+}

--- a/internal/services/v1/permissions.go
+++ b/internal/services/v1/permissions.go
@@ -166,6 +166,7 @@ func (ps *permissionServer) CheckPermission(ctx context.Context, req *v1.CheckPe
 	}
 
 	permissionship, partialCaveat := checkResultToAPITypes(cr)
+	ps.metrics.RecordCheckResult("CheckPermission", permissionship)
 
 	return &v1.CheckPermissionResponse{
 		CheckedAt:         checkedAt,
@@ -194,7 +195,7 @@ func (ps *permissionServer) CheckBulkPermissions(ctx context.Context, req *v1.Ch
 	// NOTE: perfinsights are added for the individual check results as well, so there is no shape here.
 	perfinsights.SetInContext(ctx, perfinsights.NoLabels)
 
-	res, err := ps.bulkChecker.checkBulkPermissions(ctx, req)
+	res, err := ps.bulkChecker.checkBulkPermissions(ctx, req, ps.metrics)
 	if err != nil {
 		return nil, ps.rewriteError(ctx, err)
 	}
@@ -202,8 +203,9 @@ func (ps *permissionServer) CheckBulkPermissions(ctx context.Context, req *v1.Ch
 	return res, nil
 }
 
-func pairItemFromCheckResult(checkResult *dispatch.ResourceCheckResult, debugTrace *v1.DebugInformation) *v1.CheckBulkPermissionsPair_Item {
+func pairItemFromCheckResult(checkResult *dispatch.ResourceCheckResult, debugTrace *v1.DebugInformation, metrics *Metrics) *v1.CheckBulkPermissionsPair_Item {
 	permissionship, partialCaveat := checkResultToAPITypes(checkResult)
+	metrics.RecordCheckResult("CheckBulkPermissions", permissionship)
 	return &v1.CheckBulkPermissionsPair_Item{
 		Item: &v1.CheckBulkPermissionsResponseItem{
 			Permissionship:    permissionship,
@@ -1176,6 +1178,8 @@ func (ps *permissionServer) ImportBulkRelationships(stream grpc.ClientStreamingS
 		// One request for the whole load
 		DispatchCount: 1,
 	})
+
+	ps.metrics.RecordBulkImportedRelationships(numWritten)
 
 	return stream.SendAndClose(&v1.ImportBulkRelationshipsResponse{
 		NumLoaded: numWritten,

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -9,8 +9,6 @@ import (
 
 	"buf.build/go/protovalidate"
 	grpcvalidate "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/protovalidate"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -44,14 +42,6 @@ import (
 	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/authzed/spicedb/pkg/zedtoken"
 )
-
-var writeUpdateCounter = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "spicedb",
-	Subsystem: "v1",
-	Name:      "write_relationships_updates",
-	Help:      "The update counts for the WriteRelationships calls",
-	Buckets:   []float64{0, 1, 2, 5, 10, 15, 25, 50, 100, 250, 500, 1000},
-}, []string{"kind"})
 
 const MaximumTransactionMetadataSize = 65000 // bytes. Limited by the BLOB size used in MySQL driver
 
@@ -122,6 +112,12 @@ type PermissionsServerConfig struct {
 	// ExperimentalQueryPlan configures which API operations use the experimental query plan.
 	ExperimentalQueryPlan ExperimentalQueryPlanConfig
 
+	// Metrics holds the metrics shared by the v1 services. It is meant to be
+	// built once (via NewMetrics) when the server is assembled and passed to
+	// every service constructor sharing this config. When nil, a fresh,
+	// unregistered (and therefore unexported) instance is used.
+	Metrics *Metrics
+
 	// QueryPlanMetadata is the shared per-server stats store that drives the
 	// count-based plan advisor. When nil, NewPermissionsServer allocates a fresh
 	// instance. To share stats with a co-located dispatcher (so receiver-side
@@ -166,10 +162,14 @@ func NewPermissionsServer(
 		PerformanceInsightMetricsEnabled:   config.PerformanceInsightMetricsEnabled,
 		EnableExperimentalLookupResources3: config.EnableExperimentalLookupResources3,
 		ExperimentalQueryPlan:              config.ExperimentalQueryPlan,
+		Metrics:                            config.Metrics,
 		QueryPlanMetadata:                  config.QueryPlanMetadata,
 	}
 	if configWithDefaults.QueryPlanMetadata == nil {
 		configWithDefaults.QueryPlanMetadata = query.NewQueryPlanMetadata()
+	}
+	if configWithDefaults.Metrics == nil {
+		configWithDefaults.Metrics = NewMetrics(nil)
 	}
 	return &permissionServer{
 		dispatch: dispatch,
@@ -198,6 +198,7 @@ func NewPermissionsServer(
 			caveatTypeSet:        configWithDefaults.CaveatTypeSet,
 		},
 		queryPlanMetadata: configWithDefaults.QueryPlanMetadata,
+		metrics:           configWithDefaults.Metrics,
 	}
 }
 
@@ -210,6 +211,7 @@ type permissionServer struct {
 
 	bulkChecker       *bulkChecker
 	queryPlanMetadata *query.QueryPlanMetadata
+	metrics           *Metrics
 }
 
 func (ps *permissionServer) ReadRelationships(req *v1.ReadRelationshipsRequest, resp v1.PermissionsService_ReadRelationshipsServer) error {
@@ -457,7 +459,7 @@ func (ps *permissionServer) WriteRelationships(ctx context.Context, req *v1.Writ
 	}
 
 	for kind, count := range updateCountByOperation {
-		writeUpdateCounter.WithLabelValues(v1.RelationshipUpdate_Operation_name[int32(kind)]).Observe(float64(count))
+		ps.metrics.RecordWriteRelationshipsUpdates(kind, count)
 	}
 
 	zedToken, err := zedtoken.NewFromRevision(ctx, revision, datalayer.NoSchemaHashInTransaction, dl)

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -30,6 +31,10 @@ type ServerConfig struct {
 	CaveatTypeSet                      *caveattypes.TypeSet
 	EnableExperimentalLookupResources3 bool
 	DataLayerOpts                      []datalayer.DataLayerOption
+
+	// MetricsRegistry, when non-nil, is the Prometheus registry the server's
+	// metrics are registered with, allowing tests to make assertions on them.
+	MetricsRegistry prometheus.Registerer
 }
 
 var DefaultTestServerConfig = ServerConfig{
@@ -65,9 +70,17 @@ func NewTestServerWithConfigAndDatastore(t testing.TB, schemaPrefixRequired bool
 	dispatcher, err := graph.NewLocalOnlyDispatcher(params)
 	require.NoError(t, err)
 
+	metricsRegistry := config.MetricsRegistry
+	if metricsRegistry == nil {
+		metricsRegistry = prometheus.NewRegistry()
+	}
+
 	cfg := server.NewConfigWithOptionsAndDefaults(
 		server.WithDatastore(ds),
 		server.WithDispatcher(dispatcher),
+		server.WithOTel(*server.NewOTelConfigWithOptionsAndDefaults(
+			server.WithPrometheusRegistry(metricsRegistry),
+		)),
 		server.WithTelemetryEndpoint(""),
 		server.WithSilentlyDisableTelemetry(true),
 		server.WithQueryPlanMetadata(queryPlanMetadata),

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -522,6 +522,7 @@ func (c *Config) complete(ctx context.Context) (*completedServerConfig, error) {
 			LookupResources: slices.Contains(c.ExperimentalQueryPlan, "lr"),
 			LookupSubjects:  slices.Contains(c.ExperimentalQueryPlan, "ls"),
 		},
+		Metrics:           v1svc.NewMetrics(c.OTel.PrometheusRegistry),
 		QueryPlanMetadata: queryPlanMetadata,
 	}
 

--- a/pkg/cmd/testserver/testserver.go
+++ b/pkg/cmd/testserver/testserver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/filters"
@@ -91,6 +92,8 @@ func (c *Config) complete(ctx context.Context) (*completedTestServer, error) {
 	datastoreMiddleware := pertoken.NewMiddleware(c.LoadConfigs, cts)
 	healthManager := health.NewHealthManager(dispatcher, &datastoreReady{})
 
+	metrics := v1svc.NewMetrics(prometheus.DefaultRegisterer)
+
 	registerServices := func(srv *grpc.Server) {
 		services.RegisterGrpcServices(
 			srv,
@@ -99,6 +102,7 @@ func (c *Config) complete(ctx context.Context) (*completedTestServer, error) {
 			services.V1SchemaServiceEnabled,
 			services.WatchServiceEnabled,
 			v1svc.PermissionsServerConfig{
+				Metrics:                         metrics,
 				MaxPreconditionsCount:           c.MaximumPreconditionCount,
 				MaxUpdatesPerWrite:              c.MaximumUpdatesPerWrite,
 				MaximumAPIDepth:                 maxDepth,


### PR DESCRIPTION
## Changes

- New metric to count number of HAS_PERMISISSION results
- Updated metric `write_relationships_updates` to also be emitted during `bulkImports`

## Testing

1. `zed backup restore` + see updated metric

<img width="1212" height="458" alt="image" src="https://github.com/user-attachments/assets/985ced35-c40f-4614-8cde-943507f6c7f2" />

2. `zed permission bulk document:1#view@user:1 document:2#view@user:1 && zed permission check document:2 view user:2 --consistency-min-latency --explain` + see new metric

<img width="1208" height="426" alt="image" src="https://github.com/user-attachments/assets/9ab2963d-eb1d-4827-bbf3-0fa2fd0816e8" />

