### PR TITLE
chore: update docker-composes's prometheus version

### DIFF
--- a/development/grafana/dashboards/dashboard.json
+++ b/development/grafana/dashboards/dashboard.json
@@ -512,7 +512,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(spicedb_perf_insights_api_shape_latency_seconds_bucket{job=\"spicedb\",instance=~\"$instance\",resource_type!=\"\"}[$__rate_interval])) by (le, api_kind, resource_type, resource_relation, subject_type, subject_relation))",
+          "expr": "histogram_quantile(0.99, sum(rate(spicedb_perf_insights_api_shape_latency_seconds{job=\"spicedb\",instance=~\"$instance\",resource_type!=\"\"}[$__rate_interval])) by (api_kind, resource_type, resource_relation, subject_type, subject_relation))",
           "legendFormat": "{{api_kind}} {{resource_type}}:{{resource_relation}} → {{subject_type}}#{{subject_relation}}",
           "range": true,
           "refId": "A"

--- a/development/prometheus.yaml
+++ b/development/prometheus.yaml
@@ -2,10 +2,11 @@
 global:
   scrape_interval: "1s"
   evaluation_interval: "1s"
+  scrape_native_histograms: true
 
 scrape_configs:
   - job_name: "spicedb"
-    scrape_classic_histograms: true
+    always_scrape_classic_histograms: true
     static_configs:
       - targets: ["spicedb-1:9090"]
         labels:

--- a/docker-compose.memdb.yaml
+++ b/docker-compose.memdb.yaml
@@ -35,11 +35,10 @@ services:
       timeout: "30s"
       retries: 3
   prometheus:
-    image: "prom/prometheus:v2.47.0"
+    image: "prom/prometheus:v3.13.1"
     command:
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--storage.tsdb.path=/prometheus"
-      - "--enable-feature=native-histograms"
     volumes:
       - "./development/prometheus.yaml:/etc/prometheus/prometheus.yaml"
     ports:

--- a/docker-compose.mysql.yaml
+++ b/docker-compose.mysql.yaml
@@ -131,11 +131,10 @@ services:
       timeout: "30s"
       retries: 3
   prometheus:
-    image: "prom/prometheus:v2.47.0"
+    image: "prom/prometheus:v3.13.1"
     command:
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--storage.tsdb.path=/prometheus"
-      - "--enable-feature=native-histograms"
     volumes:
       - "./development/prometheus.yaml:/etc/prometheus/prometheus.yaml"
     ports:

--- a/docker-compose.pgbouncer.yaml
+++ b/docker-compose.pgbouncer.yaml
@@ -224,11 +224,10 @@ services:
       retries: 3
 
   prometheus:
-    image: "prom/prometheus:v2.47.0"
+    image: "prom/prometheus:v3.13.1"
     command:
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--storage.tsdb.path=/prometheus"
-      - "--enable-feature=native-histograms"
     volumes:
       - "./development/prometheus.yaml:/etc/prometheus/prometheus.yaml"
     ports:

--- a/docker-compose.postgres.yaml
+++ b/docker-compose.postgres.yaml
@@ -169,11 +169,10 @@ services:
       retries: 3
 
   prometheus:
-    image: "prom/prometheus:v2.47.0"
+    image: "prom/prometheus:v3.13.1"
     command:
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--storage.tsdb.path=/prometheus"
-      - "--enable-feature=native-histograms"
     volumes:
       - "./development/prometheus.yaml:/etc/prometheus/prometheus.yaml"
     ports:

--- a/docker-compose.spanner.yaml
+++ b/docker-compose.spanner.yaml
@@ -132,11 +132,10 @@ services:
       timeout: "30s"
       retries: 3
   prometheus:
-    image: "prom/prometheus:v2.47.0"
+    image: "prom/prometheus:v3.13.1"
     command:
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--storage.tsdb.path=/prometheus"
-      - "--enable-feature=native-histograms"
     volumes:
       - "./development/prometheus.yaml:/etc/prometheus/prometheus.yaml"
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -127,11 +127,10 @@ services:
       timeout: "30s"
       retries: 3
   prometheus:
-    image: "prom/prometheus:v2.47.0"
+    image: "prom/prometheus:v3.13.1"
     command:
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--storage.tsdb.path=/prometheus"
-      - "--enable-feature=native-histograms"
     volumes:
       - "./development/prometheus.yaml:/etc/prometheus/prometheus.yaml"
     ports:


### PR DESCRIPTION
`docker-compose up --build` now shows the perf insights metric correctly:

<img width="1271" height="487" alt="image" src="https://github.com/user-attachments/assets/239f208d-be1b-4796-b89a-9cd50f3b120a" />
