### PR TITLE
fix: ReadRels doing useless work after hitting the page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Prevent ReadRelationships from doing work that's immediately discarded when the `optional_limit` parameter is used (https://github.com/authzed/spicedb/pull/3253)
+
+## [1.56.0] - 2026-07-24
 ### Added
 - New metric `check_permissionship_total` for CheckPermission and CheckBulkPermissions that counts the number of requests that returned HAS_PERMISSION. Also, `write_relationships_updates` also includes BulkImport calls (https://github.com/authzed/spicedb/pull/3240)
 
@@ -3667,7 +3671,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - First release.
 
-[Unreleased]: https://github.com/authzed/spicedb/compare/v1.54.0...HEAD
+[Unreleased]: https://github.com/authzed/spicedb/compare/v1.56.0...HEAD
+[1.56.0]: https://github.com/authzed/spicedb/compare/v1.54.0...v1.56.0
 [1.54.0]: https://github.com/authzed/spicedb/compare/v1.53.0...v1.54.0
 [1.53.0]: https://github.com/authzed/spicedb/compare/v1.52.0...v1.53.0
 [1.52.0]: https://github.com/authzed/spicedb/compare/v1.51.1...v1.52.0

--- a/internal/services/v1/relationships.go
+++ b/internal/services/v1/relationships.go
@@ -326,10 +326,6 @@ func (ps *permissionServer) ReadRelationships(req *v1.ReadRelationshipsRequest, 
 			return ps.rewriteError(ctx, fmt.Errorf("error when reading tuples: %w", err))
 		}
 
-		if limit > 0 && returnedCount >= limit {
-			break
-		}
-
 		dispatchCursor.Sections[0] = tuple.StringWithoutCaveatOrExpiration(rel)
 		encodedCursor, err := cursor.EncodeFromDispatchCursor(dispatchCursor, rrRequestHash, atRevision, schemaHash, nil)
 		if err != nil {
@@ -344,6 +340,12 @@ func (ps *permissionServer) ReadRelationships(req *v1.ReadRelationshipsRequest, 
 			return ps.rewriteError(ctx, fmt.Errorf("error when streaming tuple: %w", err))
 		}
 		returnedCount++
+
+		// Check and break on returnedCount before restarting the loop
+		// so that we don't overfetch from the iterator
+		if limit > 0 && returnedCount >= limit {
+			break
+		}
 	}
 	return nil
 }

--- a/internal/services/v1/relationships_test.go
+++ b/internal/services/v1/relationships_test.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/authzed/spicedb/internal/testserver"
 	"github.com/authzed/spicedb/pkg/datalayer"
 	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/datastore/options"
 	core "github.com/authzed/spicedb/pkg/proto/core/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/testutil"
@@ -1368,6 +1370,73 @@ func TestReadRelationshipsBeyondAllowedLimit(t *testing.T) {
 	_, err = resp.Recv()
 	require.Error(err)
 	require.Contains(err.Error(), "provided limit 1005 is greater than maximum allowed of 1000")
+}
+
+// queryCountingDatastore wraps a datastore, counting the number of calls made to
+// QueryRelationships on its snapshot readers.
+type queryCountingDatastore struct {
+	datastore.Datastore
+	queryCount *atomic.Uint64
+}
+
+func (q queryCountingDatastore) SnapshotReader(rev datastore.Revision) datastore.Reader {
+	return queryCountingReader{q.Datastore.SnapshotReader(rev), q.queryCount}
+}
+
+type queryCountingReader struct {
+	datastore.Reader
+	queryCount *atomic.Uint64
+}
+
+func (q queryCountingReader) QueryRelationships(ctx context.Context, filter datastore.RelationshipsFilter, opts ...options.QueryOptionsOption) (datastore.RelationshipIterator, error) {
+	q.queryCount.Add(1)
+	return q.Reader.QueryRelationships(ctx, filter, opts...)
+}
+
+// TestReadRelationshipsWithLimitIssuesNoTrailingQuery ensures that a ReadRelationships call with a
+// limit does not issue an additional datastore query once the limit has been reached. Because the
+// page size is capped at the limit, the final page is always exactly full, so asking the paginated
+// iterator for one more relationship would kick off a wholly unnecessary query, whose latency the
+// caller pays for as a stream that hangs after the last relationship has already been delivered.
+func TestReadRelationshipsWithLimitIssuesNoTrailingQuery(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, testutil.GoLeakIgnores()...)
+	})
+
+	// The number of relationships requested must be less than the total number of relationships
+	// matching the filter, so that a trailing page would in fact have results to return.
+	limit := uint32(3)
+
+	queryCount := &atomic.Uint64{}
+	conn, _, _ := testserver.NewTestServerWithConfig(t, 0, memdb.DisableGC, true,
+		testserver.DefaultTestServerConfig,
+		func(t testing.TB, ds datastore.Datastore) (datastore.Datastore, datastore.Revision) {
+			ds, rev := tf.StandardDatastoreWithData(t, ds)
+			return queryCountingDatastore{ds, queryCount}, rev
+		})
+	client := v1.NewPermissionsServiceClient(conn)
+
+	resp, err := client.ReadRelationships(t.Context(), &v1.ReadRelationshipsRequest{
+		RelationshipFilter: &v1.RelationshipFilter{
+			ResourceType: tf.DocumentNS.Name,
+		},
+		OptionalLimit: limit,
+	})
+	require.NoError(t, err)
+
+	var received int
+	for {
+		_, err := resp.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		received++
+	}
+
+	require.Equal(t, int(limit), received)
+	require.Equal(t, 1, safecast.RequireConvert[int](t, queryCount.Load()),
+		"expected a single datastore query for a limit that fits within a single page")
 }
 
 func TestDeleteRelationshipsBeyondLimitPartial(t *testing.T) {


### PR DESCRIPTION
## Description
A user reported an issue where they received `optional_limit` values from `ReadRelationships` but then the query hung open until it timed out. I found a place in the readrels logic where when we were iterating over the paginated datastore values, we were always fetching at least one additional rel, which in the worst case could produce the hang the user saw. This fixes that particular failure mode.

## Changes
* Move iteration break check to the bottom of the fetch loop to prevent overfetching from the datastore iterator
## Testing
Review.