### PR TITLE
perf(postgres): add index for resource ID prefix filter

### DIFF
--- a/internal/datastore/postgres/migrations/zz_migration.0026_add_resource_id_prefix_index.go
+++ b/internal/datastore/postgres/migrations/zz_migration.0026_add_resource_id_prefix_index.go
@@ -1,0 +1,13 @@
+package migrations
+
+import (
+	"github.com/authzed/spicedb/internal/datastore/postgres/schema"
+)
+
+func init() {
+	registerIndexMigration(
+		schema.IndexRelationshipByResourceIDPrefix,
+		"add-resource-id-prefix-index",
+		"populate-schema-tables",
+	)
+}

--- a/internal/datastore/postgres/schema/indexes.go
+++ b/internal/datastore/postgres/schema/indexes.go
@@ -104,6 +104,14 @@ var IndexGCDeadRelationships = common.IndexDefinition{
 	PreferredSortOrder: options.Unsorted,
 }
 
+// IndexRelationshipByResourceIDPrefix is an index that supports ReadRelationships queries
+// which filter on optional_resource_id_prefix.
+var IndexRelationshipByResourceIDPrefix = common.IndexDefinition{
+	Name:               `ix_relation_tuple_by_resource_id_prefix`,
+	ColumnsSQL:         `relation_tuple (namespace, object_id varchar_pattern_ops)`,
+	PreferredSortOrder: options.Unsorted,
+}
+
 var pgIndexes = []common.IndexDefinition{
 	UniqueLivingRelationshipIndex,
 	IndexRelationshipBySubject,
@@ -113,6 +121,7 @@ var pgIndexes = []common.IndexDefinition{
 	IndexExpiringRelationships,
 	IndexSortedRelationTupleTransaction,
 	IndexGCDeadRelationships,
+	IndexRelationshipByResourceIDPrefix,
 }
 
 var NoIndexingHint common.IndexingHint = nil


### PR DESCRIPTION
## Description

A prefix filter in `ReadRelationships` cannot currently use any of the existing indexes due to using a `LIKE` in the query, unless the database is configured to use `C` collation.

This PR adds an index with `object_id varchar_pattern_ops` which allows it to be used for `LIKE` queries regardless of collation.

Obviously there is some tradeoff in terms of writes with adding an additional index which needs some consideration. But without the index or appropriate collation the filter is basically unusable on any deployment using postgres with a significant number of tuples.

## Testing

I couldn't find any existing tests specifically around index usage so testing was all manual, and was done by capturing the output from the query builder, replacing the specific revision with `pg_current_snapshot()`, and manually running the following query before and after adding the index manually, on a deployment with ~4.1 million tuples:

```sql
SELECT object_id, relation, userset_namespace, userset_object_id, userset_relation, caveat_name, caveat_context, expiration
FROM relation_tuple
WHERE pg_visible_in_snapshot(created_xid, pg_current_snapshot()) = true
  AND pg_visible_in_snapshot(deleted_xid, pg_current_snapshot()) = false
  AND namespace = '<namespace>'
  AND object_id LIKE '<prefix>\_%'
  AND (expiration IS NULL OR expiration > NOW());
```

### Before

```
Gather  (cost=1000.00..410914.91 rows=21 width=154) (actual time=82.851..1220.622 rows=11 loops=1)
  Workers Planned: 2
  Workers Launched: 2
  Buffers: shared hit=327354 read=32287
  I/O Timings: shared read=2045.173
  ->  Parallel Seq Scan on relation_tuple  (cost=0.00..409912.81 rows=9 width=154) (actual time=446.095..1202.032 rows=4 loops=3)
"        Filter: (((object_id)::text ~~ '<prefix>\_%'::text) AND ((namespace)::text = '<namespace>'::text) AND pg_visible_in_snapshot(created_xid, pg_current_snapshot()) AND (NOT pg_visible_in_snapshot(deleted_xid, pg_current_snapshot())) AND ((expiration IS NULL) OR (expiration > now())))"
        Rows Removed by Filter: 1367386
        Buffers: shared hit=327354 read=32287
        I/O Timings: shared read=2045.173
Planning:
  Buffers: shared hit=1
Planning Time: 0.161 ms
Execution Time: 1220.659 ms
```

### After

```
Index Scan using ix_relation_tuple_by_resource_id_prefix on relation_tuple  (cost=0.56..2.79 rows=22 width=154) (actual time=0.035..0.052 rows=11 loops=1)
  Index Cond: (((namespace)::text = '<namespace>'::text) AND ((object_id)::text ~>=~ '<prefix>_'::text) AND ((object_id)::text ~<~ '<prefix>`'::text))
"  Filter: (((object_id)::text ~~ '<prefix>\_%'::text) AND pg_visible_in_snapshot(created_xid, pg_current_snapshot()) AND (NOT pg_visible_in_snapshot(deleted_xid, pg_current_snapshot())) AND ((expiration IS NULL) OR (expiration > now())))"
  Buffers: shared hit=15
Planning:
  Buffers: shared hit=49 read=1
  I/O Timings: shared read=0.613
Planning Time: 0.988 ms
Execution Time: 0.635 ms
```

## References

Fixes #3274