### PR TITLE
perf(crdb): use pgx exec mode for reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [1.56.1] - 2026-08-26
 ### Changed
 - Schema compilation: reduce memory usage when caveats are involved (https://github.com/authzed/spicedb/pull/3266)
+- CockroachDB: read queries no longer accumulate prepared statements in CockroachDB. Reads inline the revision into the SQL text (`AS OF SYSTEM TIME <rev>`), so every new revision produced statement text that was never reused, and pgx's text-keyed statement cache grew without bound. The read pool now uses pgx's `exec` mode, matching Postgres. The write pool continues to use prepared statements, since write queries inline no revision and are genuinely reused. Measured on a three-node cluster under a blended read/write load, prepared-statement memory went from 61.75 MB and still growing to 1.18 MB and flat. Deployments can revert with `default_query_exec_mode=cache_statement` in the datastore URI. (https://github.com/authzed/spicedb/pull/3286)
 
 ### Fixed
 - Postgres: read replicas no longer intermittently return `object definition not found` under load. The strict read-replica guard now verifies that the replica's snapshot has caught up to the revision being read (snapshot domination) instead of checking a single transaction id, and raises from within the read itself rather than from a trailing assertion, so a replica that catches up mid-query can no longer let an incomplete read through. In both cases the read correctly falls back to the primary. (https://github.com/authzed/spicedb/pull/3243)

--- a/internal/datastore/crdb/crdb.go
+++ b/internal/datastore/crdb/crdb.go
@@ -80,6 +80,12 @@ func newCRDBDatastore(ctx context.Context, url string, options ...Option) (datas
 	if err != nil {
 		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, url)
 	}
+	// Reads only. See the note on the write pool below for why the two differ.
+	pgxcommon.ConfigureDefaultQueryExecMode(readPoolConfig.ConnConfig)
+	readPoolConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		RegisterTypes(conn.TypeMap())
+		return nil
+	}
 
 	writePoolConfig, err := pgxpool.ParseConfig(url)
 	if err != nil {
@@ -88,6 +94,28 @@ func newCRDBDatastore(ctx context.Context, url string, options ...Option) (datas
 	err = config.writePoolOpts.ConfigurePgx(writePoolConfig, includeQueryParametersInTraces)
 	if err != nil {
 		return nil, common.RedactAndLogSensitiveConnString(ctx, errUnableToInstantiate, err, url)
+	}
+	// The write pool deliberately KEEPS pgx's default cache_statement mode, while the read pool is
+	// switched to exec. The two paths generate SQL text with very different lifetimes:
+	//
+	//   Reads inline the revision -- crdbReader.addFromToQuery concatenates
+	//   "AS OF SYSTEM TIME <rev>" into the FROM clause -- so every new revision produces a fresh
+	//   generation of statement text that will never be looked up again. pgx keys its cache on exact
+	//   text, so a read pool accumulates prepared statements without bound: measured at 62-68MB
+	//   across a 3-node cluster and still climbing linearly when the test ended.
+	//
+	//   Writes run with atSpecificRevision == "" and inline nothing. Their text varies only with the
+	//   number of relationships in the batch (squirrel appends one VALUES tuple per row), which is
+	//   bounded by the distinct batch sizes a workload uses, not by elapsed time. Those statements
+	//   are genuinely reused, so caching them is a real win rather than dead weight.
+	//
+	// Measured: writes were consistently ~1.4-2.5% slower at p50 under exec, in both a 0.2ms and an
+	// 11.5ms RTT condition -- the only latency signal in this work whose sign was stable across
+	// conditions. Keeping cache_statement here recovers that without reintroducing the unbounded
+	// growth, because the bound is structural rather than a matter of degree.
+	writePoolConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		RegisterTypes(conn.TypeMap())
+		return nil
 	}
 
 	healthChecker, err := pool.NewNodeHealthChecker(url)

--- a/internal/datastore/crdb/migrations/driver.go
+++ b/internal/datastore/crdb/migrations/driver.go
@@ -36,6 +36,7 @@ func NewCRDBDriver(ctx context.Context, url string) (*CRDBDriver, error) {
 	}
 	pgxcommon.ConfigurePGXLogger(connConfig)
 	pgxcommon.ConfigureOTELTracer(connConfig, false)
+	pgxcommon.ConfigureDefaultQueryExecMode(connConfig)
 
 	db, err := pgx.ConnectConfig(ctx, connConfig)
 	if err != nil {

--- a/internal/datastore/crdb/pool/health.go
+++ b/internal/datastore/crdb/pool/health.go
@@ -46,6 +46,7 @@ func NewNodeHealthChecker(url string) (*NodeHealthTracker, error) {
 	if err != nil {
 		return nil, err
 	}
+	pgxcommon.ConfigureDefaultQueryExecMode(connConfig)
 
 	return &NodeHealthTracker{
 		connConfig:    connConfig,

--- a/internal/datastore/crdb/schema_chunker.go
+++ b/internal/datastore/crdb/schema_chunker.go
@@ -17,6 +17,39 @@ const (
 	crdbMaxChunkSize = 1024 * 1024 // 1MB
 )
 
+// binaryChunkTransfer forces pgx to fetch the statement description before
+// executing, so that bytea parameters and results use the binary format.
+//
+// It exists to override the READ pool's connection default. newCRDBDatastore puts
+// the read pool on pgx.QueryExecModeExec and leaves the write pool on
+// cache_statement, so this is load-bearing for chunk READS and belt-and-braces for
+// chunk WRITES, which already get the binary format from the write pool's mode.
+// It is applied on both paths so behaviour does not silently depend on which pool
+// a caller happens to be using.
+//
+// Under exec, parameters and results are text, and bytea in text is hex-encoded,
+// so every chunk doubles in size on the wire. That is merely wasteful on most
+// queries, but it breaks
+// schema writes outright: WriteChunkedBytes puts every chunk of a schema into a
+// single multi-row INSERT, so the pgwire message is the size of the whole
+// serialized schema. Doubling it pushes a large schema past CockroachDB's 16MiB
+// message limit -- observed as
+//
+//	failed to insert chunks: message size 17 MiB bigger than maximum allowed
+//	message size 16 MiB (SQLSTATE 08P01)
+//
+// which in effect halves the largest schema SpiceDB can store on CRDB. Note that
+// shrinking crdbMaxChunkSize does not help, because the limit is hit by the
+// combined message rather than by any individual chunk.
+//
+// DescribeExec is used rather than CacheStatement deliberately. Both restore the
+// binary format, but CacheStatement would leave named prepared statements on the
+// server, which is the very cost the exec-mode default was introduced to avoid;
+// and because the INSERT's SQL text varies with the number of chunks, caching it
+// would churn rather than be reused. DescribeExec costs one extra round trip, on
+// queries that run only when a schema is written or when the schema cache misses.
+const binaryChunkTransfer = pgx.QueryExecModeDescribeExec
+
 // BaseSchemaChunkerConfig provides the base configuration for CRDB schema chunking.
 // CRDB uses delete-and-insert write mode since it handles MVCC automatically.
 var BaseSchemaChunkerConfig = common.SQLByteChunkerConfig[any]{
@@ -64,7 +97,9 @@ func (e *revisionAwareExecutor) ExecuteRead(ctx context.Context, builder sq.Sele
 			result[chunkIndex] = chunkData
 		}
 		return rows.Err()
-	}, sql, args...)
+		// binaryChunkTransfer: chunk_data is bytea, which the pool's default text
+		// mode would return hex-encoded at twice the wire size.
+	}, sql, append([]any{binaryChunkTransfer}, args...)...)
 
 	return result, err
 }
@@ -98,7 +133,11 @@ func (t *transactionAwareTransaction) ExecuteWrite(ctx context.Context, builder 
 		return err
 	}
 
-	_, err = t.tx.Exec(ctx, sql, args...)
+	// binaryChunkTransfer: this INSERT carries every chunk of the schema as bytea
+	// parameters in one message. Under the pool's default text mode they would be
+	// hex-encoded, doubling the message and breaching CRDB's 16MiB pgwire limit for
+	// large schemas.
+	_, err = t.tx.Exec(ctx, sql, append([]any{binaryChunkTransfer}, args...)...)
 	return err
 }
 

--- a/internal/datastore/crdb/types.go
+++ b/internal/datastore/crdb/types.go
@@ -1,0 +1,17 @@
+package crdb
+
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// RegisterTypes registers the Go types whose PostgreSQL mapping pgx cannot infer
+// on its own under the text-based query exec modes.
+//
+// Under QueryExecModeExec pgx does not ask the server for parameter OIDs; it
+// derives them from the Go type of each argument and rejects anything it cannot
+// type unambiguously. A caveat context is passed as a bare map[string]any (see
+// crdbReadWriteTXN.WriteRelationships), which pgx would otherwise consider
+// ambiguous between json, jsonb and hstore.
+func RegisterTypes(m *pgtype.Map) {
+	m.RegisterDefaultPgType(map[string]any{}, "jsonb")
+}

--- a/internal/datastore/crdb/types_test.go
+++ b/internal/datastore/crdb/types_test.go
@@ -1,0 +1,44 @@
+package crdb
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+)
+
+// Under QueryExecModeExec pgx infers parameter types from Go types rather than
+// asking the server, and rejects arguments it cannot type unambiguously. A caveat
+// context is written as a bare map[string]any, so without an explicit default
+// type every caveated write would fail to encode.
+func TestRegisterTypesMapsCaveatContextToJSONB(t *testing.T) {
+	m := pgtype.NewMap()
+
+	_, ok := m.TypeForValue(map[string]any{})
+	require.False(t, ok, "precondition: pgx should not type map[string]any on its own")
+
+	RegisterTypes(m)
+
+	typ, ok := m.TypeForValue(map[string]any{})
+	require.True(t, ok, "caveat context must have a registered default type")
+	require.Equal(t, "jsonb", typ.Name)
+}
+
+// The encode path is what actually runs during a write, so exercise it in the
+// text format that exec mode uses rather than trusting the type lookup alone.
+func TestCaveatContextEncodesUnderExecMode(t *testing.T) {
+	m := pgtype.NewMap()
+	RegisterTypes(m)
+
+	typ, ok := m.TypeForValue(map[string]any{})
+	require.True(t, ok)
+
+	ctx := map[string]any{"expired": true, "n": float64(42)}
+	plan := m.PlanEncode(typ.OID, pgx.TextFormatCode, ctx)
+	require.NotNil(t, plan, "no encode plan for caveat context in text format")
+
+	buf, err := plan.Encode(ctx, nil)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"expired":true,"n":42}`, string(buf))
+}

--- a/internal/datastore/postgres/common/pgx.go
+++ b/internal/datastore/postgres/common/pgx.go
@@ -325,6 +325,7 @@ func ConfigureDefaultQueryExecMode(config *pgx.ConnConfig) {
 	if !strings.Contains(config.ConnString(), "default_query_exec_mode") {
 		// the execution mode was not overridden by the user
 		config.DefaultQueryExecMode = pgx.QueryExecModeExec
+		return
 	}
 
 	log.Info().


### PR DESCRIPTION
CockroachDB reads inline the revision into the SQL text — `crdbReader.addFromToQuery` concatenates `AS OF SYSTEM TIME <rev>` into the FROM clause — so every new revision produces statement text that will never be looked up again. pgx keys its statement cache on exact text, so the read pool accumulates prepared statements in CockroachDB without bound.

Writes are different: they run with no `AS OF SYSTEM TIME` inlined, and their text varies only with the number of relationships in a batch. Those statements are genuinely reused, so the write pool keeps pgx's default `cache_statement` mode.

Postgres has defaulted to `exec` since #1994; CRDB was never switched over.

### Numbers

3-node CockroachDB cluster, blended check / bulk-check / write load, 15 minutes per arm. CockroachDB's `sql_mem_sql_session_prepared_current`, summed across nodes:

| | prepared statement memory |
| --- | --- |
| before | 61.75 MB, growing linearly, no plateau |
| after | 1.18 MB, plateaus early |

Check latency is unchanged.

### Also included

- Registers `map[string]any` as `jsonb`. Exec mode infers parameter types from Go types rather than asking the server, and would otherwise reject caveat context as ambiguous.
- Forces binary transfer for the schema chunk queries. `bytea` in text format is hex-encoded, and since every chunk of a schema goes into a single multi-row INSERT, a large schema would exceed CockroachDB's 16MiB pgwire message limit.

Deployments can revert with `?default_query_exec_mode=cache_statement` in the datastore URI.
