### PR TITLE
fix: prevent namespace cache exhaustion and fix hitrate metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Fixed
+- Namespace cache: Fixed an issue where the cache was configured without a TTL, which meant that entries accumulated until the cache filled and new sets were rejected, reducing cache hit rate and increasing datastore load. (https://github.com/authzed/spicedb/pull/3112)
+- Cache metrics: Fixed cache hit rate reporting by removing unnecessary reads from the `Set` path (https://github.com/authzed/spicedb/pull/3112)
 - MemDB: a read at a given revision, such as a `Check` at an `at_exact_snapshot` ZedToken, could include relationships written *after* that revision, so the same revision returned different results as later writes arrived instead of a stable point-in-time view. Reads at a revision now return only the data committed as of it. (https://github.com/authzed/spicedb/pull/3257)
 - Spanner: the configured `--datastore-gc-window` was ignored, and revisions were always treated as valid for 24 hours (the change stream retention). Spanner now honors the configured window, capped at that retention since older revisions cannot be read regardless. (https://github.com/authzed/spicedb/pull/3257)
 

--- a/internal/datastore/proxy/schemacaching/caching.go
+++ b/internal/datastore/proxy/schemacaching/caching.go
@@ -39,7 +39,7 @@ type CacheEntry = *cacheEntry
 // are loaded at specific datastore revisions.
 // The caller MUST call Close on the returned proxy when it is no longer needed.
 func NewCachingDatastoreProxy(delegate datastore.Datastore, c cache.Cache[cache.StringKey, CacheEntry], gcWindow time.Duration, cachingMode CachingMode, watchHeartbeat time.Duration) datastore.Datastore {
-	standardCachingProxy := NewDefinitionCachingProxy(delegate, c)
+	standardCachingProxy := MustNewDefinitionCachingProxy(delegate, c)
 
 	if cachingMode == JustInTimeCaching {
 		log.Info().Msg("schema watch explicitly disabled")

--- a/internal/datastore/proxy/schemacaching/hitrate_test.go
+++ b/internal/datastore/proxy/schemacaching/hitrate_test.go
@@ -1,0 +1,207 @@
+package schemacaching
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/ccoveille/go-safecast/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore/proxy/proxy_test"
+	"github.com/authzed/spicedb/internal/datastore/revisions"
+	"github.com/authzed/spicedb/pkg/cache"
+	"github.com/authzed/spicedb/pkg/datastore"
+	ns "github.com/authzed/spicedb/pkg/namespace"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+)
+
+// countingReader is a datastore.Reader that serves a fixed schema and counts
+// how many times a definition was actually loaded from "the datastore" without
+// hitting the cache.
+type countingReader struct {
+	proxy_test.MockReader
+
+	defs  map[string]*core.NamespaceDefinition
+	reads atomic.Int64
+}
+
+func (cr *countingReader) LegacyReadNamespaceByName(_ context.Context, name string) (*core.NamespaceDefinition, datastore.Revision, error) {
+	cr.reads.Add(1)
+	def, ok := cr.defs[name]
+	if !ok {
+		return nil, datastore.NoRevision, datastore.NewNamespaceNotFoundErr(name)
+	}
+	return def, revisions.NewForTransactionID(1), nil
+}
+
+// countingDatastore hands out the same countingReader for every revision. Only
+// SnapshotReader and Close are exercised, so the embedded interface is left nil.
+type countingDatastore struct {
+	datastore.Datastore
+
+	reader *countingReader
+}
+
+func (cd *countingDatastore) SnapshotReader(datastore.Revision) datastore.Reader {
+	return cd.reader
+}
+
+func (cd *countingDatastore) Close() error { return nil }
+
+// schemaForHitRateTest builds a schema of the given size, with definitions
+// shaped roughly like real ones so the size estimator produces realistic costs.
+func schemaForHitRateTest(numDefs int) map[string]*core.NamespaceDefinition {
+	defs := make(map[string]*core.NamespaceDefinition, numDefs)
+	for i := range numDefs {
+		name := fmt.Sprintf("resource_definition_number_%d", i)
+		defs[name] = ns.Namespace(
+			name,
+			ns.MustRelation("owner", nil, ns.AllowedRelation("user", "...")),
+			ns.MustRelation("editor", nil, ns.AllowedRelation("user", "..."), ns.AllowedRelation("group", "member")),
+			ns.MustRelation("viewer", nil, ns.AllowedRelation("user", "..."), ns.AllowedRelation("group", "member")),
+			ns.MustRelation("view", ns.Union(
+				ns.ComputedUserset("viewer"),
+				ns.ComputedUserset("editor"),
+				ns.ComputedUserset("owner"),
+			)),
+		)
+	}
+	return defs
+}
+
+// TestNamespaceCacheHitsUnderStandardUsage exercises the namespace cache the
+// way a running SpiceDB exercises it: a stable schema is read over and over,
+// while the revision at which it is read rotates as the quantization window
+// advances.
+//
+// Because cache keys are (definition name, revision) pairs, every rotation
+// produces a whole new set of keys and strands the previous set: no request
+// will ever ask for the old revision again. The working set, though, is only
+// ever one revision's worth of definitions, which fits with room to spare.
+//
+// Under those conditions the cache must keep serving the current revision's
+// definitions from memory, so each (definition, revision) pair should reach the
+// datastore exactly once no matter how many revisions have rolled by. This test
+// runs long enough for the cache to fill several times over, because that is
+// when the failure appears: a cache that lets stranded entries accumulate ends
+// up permanently at capacity, and an eviction policy that prefers incumbents
+// then starts turning away the definitions that are actually in use. Hit rate
+// falls and the extra reads land on the datastore.
+func TestNamespaceCacheHitsUnderStandardUsage(t *testing.T) {
+	const (
+		numDefinitions = 20
+
+		// Simulated quantization window: how long each revision stays current,
+		// and how many of them roll by over the course of the test.
+		quantizationWindow = 5 * time.Second
+		numRevisions       = 400
+
+		// How many times each definition is read while its revision is current;
+		// stands in for the requests served during one quantization window.
+		readsPerRevision = 25
+
+		// Cache budget, expressed in revisions' worth of schema. The live
+		// working set is a single revision, so this is ample headroom; the test
+		// is about entries that are stranded, not entries that don't fit.
+		revisionsOfCapacity = 20
+	)
+
+	defs := schemaForHitRateTest(numDefinitions)
+	names := make([]string, 0, numDefinitions)
+	for name := range defs {
+		names = append(names, name)
+	}
+
+	// Derive the cache budget from the cost the caching proxy actually charges
+	// for these definitions, so the test isn't sensitive to the size estimator.
+	var costPerRevision int64
+	for _, def := range defs {
+		costPerRevision += estimatedNamespaceDefinitionSize(def.SizeVT()) + 128 // ~key overhead
+	}
+
+	// Mirrors how the server builds this cache: see the namespace cache in
+	// (*Config).complete, whose TTL comes from CacheConfig.WithRevisionParameters.
+	ttl := 2 * quantizationWindow
+
+	synctest.Test(t, func(t *testing.T) {
+		c, err := cache.NewStandardCacheWithMetrics[cache.StringKey, CacheEntry](
+			prometheus.NewRegistry(),
+			"namespace",
+			&cache.Config{
+				MaxCost:    costPerRevision * revisionsOfCapacity,
+				DefaultTTL: ttl,
+			},
+		)
+		require.NoError(t, err)
+		t.Cleanup(c.Close)
+
+		reader := &countingReader{defs: defs}
+		ds := MustNewDefinitionCachingProxy(&countingDatastore{reader: reader}, c)
+
+		ctx := t.Context()
+
+		// Reads are counted per quarter of the run so that a hit rate which
+		// decays as the cache fills is distinguishable from one that is simply
+		// bad from the start.
+		var readsPerQuarter [4]int64
+		previousReads := int64(0)
+
+		for revNum := 1; revNum <= numRevisions; revNum++ {
+			snapshot := ds.SnapshotReader(revisions.NewForTransactionID(uint64(revNum)))
+			for range readsPerRevision {
+				for _, name := range names {
+					def, _, err := snapshot.LegacyReadNamespaceByName(ctx, name)
+					require.NoError(t, err)
+					require.Equal(t, name, def.Name)
+				}
+			}
+
+			totalReads := reader.reads.Load()
+			readsPerQuarter[(revNum-1)*4/numRevisions] += totalReads - previousReads
+			previousReads = totalReads
+
+			// Advance into the next quantization window.
+			time.Sleep(quantizationWindow)
+		}
+
+		// Every (definition, revision) pair is a distinct key, so the ideal
+		// number of datastore reads is one per pair.
+		idealPerQuarter := int64(numDefinitions * numRevisions / 4)
+		idealTotal := idealPerQuarter * 4
+		actualTotal := reader.reads.Load()
+
+		metrics := c.GetMetrics()
+		t.Logf("datastore reads: %d (ideal %d, %.2fx); reads per quarter of run: %.2fx %.2fx %.2fx %.2fx",
+			actualTotal, idealTotal, float64(actualTotal)/float64(idealTotal),
+			float64(readsPerQuarter[0])/float64(idealPerQuarter),
+			float64(readsPerQuarter[1])/float64(idealPerQuarter),
+			float64(readsPerQuarter[2])/float64(idealPerQuarter),
+			float64(readsPerQuarter[3])/float64(idealPerQuarter))
+		t.Logf("cache hits: %d, misses: %d, hit rate: %.2f%%; cost added: %d, cost evicted: %d",
+			metrics.Hits(), metrics.Misses(),
+			100*float64(metrics.Hits())/float64(metrics.Hits()+metrics.Misses()),
+			metrics.CostAdded(), metrics.CostEvicted())
+
+		// The strict assertion: no definition is ever fetched twice for the same
+		// revision. Anything above this is a definition that was cached, dropped
+		// while still in use, and re-fetched.
+		require.Equal(t, idealTotal, actualTotal,
+			"the cache should serve every repeat read of a definition at a given revision")
+
+		// And the shape of the failure the users reported: the last quarter of
+		// the run, long after the cache has filled, must be no worse than the
+		// first.
+		require.LessOrEqual(t, readsPerQuarter[3], readsPerQuarter[0],
+			"cache effectiveness degraded over the course of the run: reads per quarter were %v", readsPerQuarter)
+
+		// The reported hit rate should match the reads actually issued; a Get
+		// that misses is the only thing that should count as a miss.
+		require.Equal(t, safecast.RequireConvert[uint64](t, actualTotal), metrics.Misses(),
+			"reported cache misses should equal the number of datastore reads")
+	})
+}

--- a/internal/datastore/proxy/schemacaching/standardcache.go
+++ b/internal/datastore/proxy/schemacaching/standardcache.go
@@ -7,6 +7,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/dustin/go-humanize"
 	"resenje.org/singleflight"
 
 	"github.com/authzed/spicedb/pkg/cache"
@@ -24,14 +25,22 @@ type definitionCachingProxy struct {
 	readGroup singleflight.Group[string, *cacheEntry]
 }
 
+const (
+	// fallbackMaxCost is the budget for the cache built when the caller supplies
+	// none. ~1mb reflects the usage of a normal schema.
+	fallbackMaxCost = 1 * humanize.MiByte
+
+	// fallbackTTL bounds how long a stranded entry is kept. Cache keys
+	// contain the revision, so entries are only valid for as long as a quantization
+	// window; this provides a low upper bound compared to the default quantization
+	// window of 5s.
+	fallbackTTL = 1 * time.Minute
+)
+
 // The caller MUST call Close on the returned proxy when it is no longer needed.
-// If a nil cache is passed, one is created, so Close is needed to stop its cleanup goroutine.
-func NewDefinitionCachingProxy(delegate datastore.Datastore, c cache.Cache[cache.StringKey, *cacheEntry]) *definitionCachingProxy {
+func MustNewDefinitionCachingProxy(delegate datastore.Datastore, c cache.Cache[cache.StringKey, *cacheEntry]) *definitionCachingProxy {
 	if c == nil {
-		c, _ = cache.NewStandardCache[cache.StringKey, *cacheEntry](&cache.Config{
-			MaxCost:    10000,
-			DefaultTTL: 10000 * time.Second,
-		})
+		panic("cache reference must be non-nil")
 	}
 
 	return &definitionCachingProxy{Datastore: delegate, c: c}

--- a/internal/datastore/proxy/schemacaching/standardcache_test.go
+++ b/internal/datastore/proxy/schemacaching/standardcache_test.go
@@ -354,7 +354,7 @@ func TestOldRWTCaching(t *testing.T) {
 
 			ctx := t.Context()
 
-			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			ds := NewCachingDatastoreProxy(dsMock, cacheForTest(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 			dsMock.On("Close").Return(nil).Maybe()
 			t.Cleanup(func() { _ = ds.Close() })
 
@@ -391,7 +391,7 @@ func TestRWTCaching(t *testing.T) {
 
 	ctx := t.Context()
 
-	ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+	ds := NewCachingDatastoreProxy(dsMock, cacheForTest(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 	dsMock.On("Close").Return(nil).Maybe()
 	t.Cleanup(func() { _ = ds.Close() })
 
@@ -439,7 +439,7 @@ func TestOldRWTCacheWithWrites(t *testing.T) {
 
 			ctx := t.Context()
 
-			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			ds := NewCachingDatastoreProxy(dsMock, cacheForTest(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 			dsMock.On("Close").Return(nil).Maybe()
 			t.Cleanup(func() { _ = ds.Close() })
 
@@ -491,7 +491,7 @@ func TestOldSingleFlight(t *testing.T) {
 
 			require := require.New(t)
 
-			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			ds := NewCachingDatastoreProxy(dsMock, cacheForTest(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 			dsMock.On("Close").Return(nil).Maybe()
 			t.Cleanup(func() { _ = ds.Close() })
 
@@ -534,7 +534,7 @@ func TestSingleFlight(t *testing.T) {
 
 		assert := assert.New(t)
 
-		ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+		ds := NewCachingDatastoreProxy(dsMock, cacheForTest(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 		snapshotReader := ds.SnapshotReader(one)
 
 		readNamespace := func() {
@@ -616,7 +616,7 @@ func TestOldSnapshotCachingRealDatastore(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := t.Context()
-			ds := NewCachingDatastoreProxy(rawDS, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			ds := NewCachingDatastoreProxy(rawDS, cacheForTest(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 			t.Cleanup(func() { _ = ds.Close() })
 
 			if tc.nsDef != nil {
@@ -695,7 +695,7 @@ func TestSnapshotCachingRealDatastore(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := t.Context()
-			ds := NewCachingDatastoreProxy(rawDS, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			ds := NewCachingDatastoreProxy(rawDS, cacheForTest(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 			t.Cleanup(func() { _ = ds.Close() })
 
 			if tc.nsDef != nil {
@@ -764,7 +764,7 @@ func TestOldSingleFlightCancelled(t *testing.T) {
 
 			dsMock.On("SnapshotReader", one).Return(&singleflightReader{MockReader: proxy_test.MockReader{}})
 
-			ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+			ds := NewCachingDatastoreProxy(dsMock, cacheForTest(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 			dsMock.On("Close").Return(nil).Maybe()
 			t.Cleanup(func() { _ = ds.Close() })
 
@@ -802,7 +802,7 @@ func TestSingleFlightCancelled(t *testing.T) {
 		dsMock.On("Close").Return(nil).Once()
 		dsMock.On("SnapshotReader", one).Return(&singleflightReader{MockReader: proxy_test.MockReader{}})
 
-		ds := NewCachingDatastoreProxy(dsMock, nil, 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
+		ds := NewCachingDatastoreProxy(dsMock, cacheForTest(t), 1*time.Hour, JustInTimeCaching, 100*time.Millisecond)
 		snapshotReader := ds.SnapshotReader(one)
 
 		var nsDef *core.NamespaceDefinition

--- a/internal/datastore/proxy/schemacaching/watchingcache_test.go
+++ b/internal/datastore/proxy/schemacaching/watchingcache_test.go
@@ -28,6 +28,15 @@ func assertEventuallyFallback(t *testing.T, wcache *watchingCachingProxy, want b
 	}, 5*time.Second, 5*time.Millisecond, "cache did not reach inFallbackMode=%v", want)
 }
 
+func cacheForTest(t *testing.T) cache.Cache[cache.StringKey, *cacheEntry] {
+	built, err := cache.NewStandardCache[cache.StringKey, *cacheEntry](&cache.Config{
+		MaxCost:    fallbackMaxCost,
+		DefaultTTL: fallbackTTL,
+	})
+	require.NoError(t, err)
+	return built
+}
+
 func TestWatchingCachingProxyUnwrap(t *testing.T) {
 	fakeDS := &fakeDatastore{
 		headRevision: rev("0"),
@@ -37,7 +46,7 @@ func TestWatchingCachingProxyUnwrap(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	unwrapped := wcache.Unwrap()
 	require.Equal(t, fakeDS, unwrapped)
 	t.Cleanup(func() {
@@ -58,7 +67,7 @@ func TestOldWatchingCacheBasicOperation(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
@@ -163,7 +172,7 @@ func TestWatchingCacheBasicOperation(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
@@ -268,7 +277,7 @@ func TestOldWatchingCacheParallelOperations(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
@@ -362,7 +371,7 @@ func TestWatchingCacheParallelOperations(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
@@ -456,7 +465,7 @@ func TestWatchingCacheParallelReaderWriter(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
@@ -526,7 +535,7 @@ func TestOldWatchingCacheParallelReaderWriter(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
@@ -596,7 +605,7 @@ func TestWatchingCacheFallbackToStandardCache(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	c := NewDefinitionCachingProxy(fakeDS, nil)
+	c := MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t))
 
 	wcache := NewWatchingCacheProxy(fakeDS, c, 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
@@ -647,7 +656,7 @@ func TestWatchingCacheStaysInFallbackDuringPrepopulate(t *testing.T) {
 		},
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 
 	// Ensure cleanup completes even if the assertion fails — close the gate
@@ -687,7 +696,7 @@ func TestWatchingCacheRecoversFromTransientError(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	t.Cleanup(func() { wcache.Close() })
 
@@ -717,7 +726,7 @@ func TestOldWatchingCacheFallbackToStandardCache(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	def := NewDefinitionCachingProxy(fakeDS, nil)
+	def := MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t))
 
 	wcache := NewWatchingCacheProxy(fakeDS, def, 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
@@ -772,7 +781,7 @@ func TestOldWatchingCachePrepopulated(t *testing.T) {
 		},
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
@@ -812,7 +821,7 @@ func TestWatchingCachePrepopulated(t *testing.T) {
 		},
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	assertEventuallyFallback(t, wcache, false)
 	t.Cleanup(func() {
@@ -1144,7 +1153,7 @@ func TestWatchingCacheTerminatesOnWatchDisabled(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	t.Cleanup(func() { wcache.Close() })
 
@@ -1173,7 +1182,7 @@ func TestWatchingCacheTerminatesOnContextCancellation(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(t.Context())
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(ctx))
 
 	assertEventuallyFallback(t, wcache, false)
@@ -1194,7 +1203,7 @@ func TestWatchingCacheRecoversAcrossMultipleErrors(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	t.Cleanup(func() { wcache.Close() })
 
@@ -1233,7 +1242,7 @@ func TestWatchingCacheUpdatesLastEventTimestamp(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	t.Cleanup(func() { wcache.Close() })
 
@@ -1256,7 +1265,7 @@ func TestWatchingCacheIncrementsCycleRestartsOnRecovery(t *testing.T) {
 		errChan:      make(chan error, 1),
 	}
 
-	wcache := NewWatchingCacheProxy(fakeDS, NewDefinitionCachingProxy(fakeDS, nil), 1*time.Hour, 100*time.Millisecond)
+	wcache := NewWatchingCacheProxy(fakeDS, MustNewDefinitionCachingProxy(fakeDS, cacheForTest(t)), 1*time.Hour, 100*time.Millisecond)
 	require.NoError(t, wcache.startSync(t.Context()))
 	t.Cleanup(func() { wcache.Close() })
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -59,11 +59,6 @@ type Cache[K KeyString, V any] interface {
 	// otherwise it returns the zero value of V and false.
 	Get(key K) (V, bool)
 
-	// GetTTL returns the TTL configured for entries in this cache.
-	// If zero, entries never expire. The current Otter-backed
-	// implementation refreshes the TTL on access.
-	GetTTL() time.Duration
-
 	// Set attempts to store an entry for key, overwriting any existing entry,
 	// and returns true if the write was accepted for processing. cost is
 	// passed to the eviction policy and weighed against Config.MaxCost;
@@ -109,7 +104,6 @@ type noopCache[K KeyString, V any] struct{}
 var _ Cache[StringKey, any] = (*noopCache[StringKey, any])(nil)
 
 func (no *noopCache[K, V]) Get(_ K) (V, bool)          { return *new(V), false }
-func (no *noopCache[K, V]) GetTTL() time.Duration      { return time.Duration(0) }
 func (no *noopCache[K, V]) Set(_ K, _ V, _ int64) bool { return false }
 func (no *noopCache[K, V]) Close()                     {}
 func (no *noopCache[K, V]) GetMetrics() Metrics        { return &noopMetrics{} }

--- a/pkg/cache/cache_otter.go
+++ b/pkg/cache/cache_otter.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"sync/atomic"
-	"time"
 
 	"github.com/ccoveille/go-safecast/v2"
 	"github.com/maypok86/otter/v2"
@@ -92,7 +91,6 @@ func newOtterCache[K KeyString, V any](name string, config *Config) (*otterCache
 		name:    name,
 		cache:   cache,
 		metrics: otterMetrics{atomic.Uint64{}, counter},
-		ttl:     config.DefaultTTL,
 	}, err
 }
 
@@ -100,7 +98,6 @@ type otterCache[K KeyString, V any] struct {
 	name    string
 	cache   *otter.Cache[string, valueAndCost[V]]
 	metrics otterMetrics
-	ttl     time.Duration
 
 	// registerer and collectors are set when metrics are registered (via
 	// NewOtterCacheWithMetrics) and used to unregister them on Close.
@@ -149,10 +146,6 @@ func (wtc *otterCache[K, V]) registerMetrics(registerer prometheus.Registerer) e
 	return nil
 }
 
-func (wtc *otterCache[K, V]) GetTTL() time.Duration {
-	return wtc.ttl
-}
-
 func (wtc *otterCache[K, V]) Get(key K) (V, bool) {
 	vac, ok := wtc.cache.GetIfPresent(key.KeyString())
 	if !ok {
@@ -179,13 +172,7 @@ func (wtc *otterCache[K, V]) Set(key K, value V, cost int64) bool {
 	weight := entryWeight(keyStr, uintCost)
 
 	wtc.metrics.costAdded.Add(uint64(weight))
-	if _, ok := wtc.cache.GetIfPresent(keyStr); ok {
-		wtc.cache.Invalidate(keyStr)
-	}
 	wtc.cache.Set(keyStr, valueAndCost[V]{value, weight})
-	if wtc.ttl > 0 {
-		wtc.cache.SetExpiresAfter(keyStr, wtc.ttl)
-	}
 	return true
 }
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -37,10 +37,43 @@ func TestCostAddedIncludesKey(t *testing.T) {
 
 	// costAdded must reflect the full entry weight (payload + key bytes), not
 	// just the caller-supplied payload cost.
-	require.Equal(t,
+	require.Equal(
+		t,
 		uint64(payloadCost+len(key)),
 		cache.GetMetrics().CostAdded(),
 	)
+}
+
+// TestSetDoesNotRecordAccesses asserts that Set leaves the hit/miss counters
+// alone. Set must not probe the cache first: the underlying cache records every
+// lookup it is asked to perform, so a probe inside Set would be counted as a
+// hit or a miss that no caller ever made, understating the reported hit rate.
+func TestSetDoesNotRecordAccesses(t *testing.T) {
+	cache, err := NewOtterCacheWithMetrics[StringKey, string](
+		prometheus.NewRegistry(), "test-otter",
+		&Config{MaxCost: 100000, DefaultTTL: 10 * time.Hour},
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	// A write to a new key, then a write overwriting it.
+	require.True(t, cache.Set(StringKey("key"), "first", 10))
+	require.True(t, cache.Set(StringKey("key"), "second", 10))
+
+	metrics := cache.GetMetrics()
+	require.Zero(t, metrics.Hits(), "Set must not record a hit")
+	require.Zero(t, metrics.Misses(), "Set must not record a miss")
+
+	// One real hit and one real miss, and nothing else.
+	value, found := cache.Get(StringKey("key"))
+	require.True(t, found)
+	require.Equal(t, "second", value, "the overwriting Set should have taken effect")
+
+	_, found = cache.Get(StringKey("absent"))
+	require.False(t, found)
+
+	require.Equal(t, uint64(1), metrics.Hits())
+	require.Equal(t, uint64(1), metrics.Misses())
 }
 
 func TestCacheWithMetrics(t *testing.T) {
@@ -103,14 +136,6 @@ func TestCacheWithMetrics(t *testing.T) {
 		for range 10 {
 			cache.Close()
 		}
-	})
-
-	t.Run("GetTTL", func(t *testing.T) {
-		cache, err := NewOtterCacheWithMetrics[StringKey, string](prometheus.NewRegistry(), "test-otter", config)
-		require.NoError(t, err)
-		defer cache.Close()
-
-		require.Equal(t, 10*time.Hour, cache.GetTTL())
 	})
 
 	t.Run("GetMetrics", func(t *testing.T) {

--- a/pkg/cmd/server/cacheconfig.go
+++ b/pkg/cmd/server/cacheconfig.go
@@ -20,6 +20,10 @@ import (
 // Factor by which we will extend the maximum amount of expected needed TTL
 const ttlExtensionFactor = 2.0
 
+// fallbackRevisionTTL exists to make sure that the cache's TTL is never set to 0,
+// which would result in the cache filling up and then rejecting new entries.
+const fallbackRevisionTTL = 1 * time.Minute
+
 var errOverHundredPercent = errors.New("percentage greater than 100")
 
 // CacheConfig defines the configuration various SpiceDB caches.
@@ -44,6 +48,10 @@ func (cc *CacheConfig) WithRevisionParameters(
 ) *CacheConfig {
 	maxExpectedLifetime := float64(quantizationInterval.Nanoseconds())*(1+maxStalenessPercent) + float64(followerReadDelay.Nanoseconds())
 	cc.defaultTTL = time.Duration(maxExpectedLifetime*ttlExtensionFactor) * time.Nanosecond
+	// Ensure that a TTL of 0 is never passed to a cache.
+	if cc.defaultTTL <= 0 {
+		cc.defaultTTL = fallbackRevisionTTL
+	}
 	return cc
 }
 

--- a/pkg/cmd/server/cacheconfig_test.go
+++ b/pkg/cmd/server/cacheconfig_test.go
@@ -5,6 +5,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/internal/datastore/dsfortesting"
+	"github.com/authzed/spicedb/pkg/cmd/util"
 )
 
 func TestParsePercent(t *testing.T) {
@@ -60,11 +63,14 @@ func TestWithRevisionParameters(t *testing.T) {
 		expectedTTL          time.Duration
 	}{
 		{
+			// A zero TTL means "never expire", which is not a safe value
+			// revision-keyed cache where cache keys don't repeat as revisions
+			// roll forward, so the fallback is used instead.
 			name:                 "zero values",
 			quantizationInterval: 0,
 			followerReadDelay:    0,
 			maxStalenessPercent:  0,
-			expectedTTL:          0,
+			expectedTTL:          fallbackRevisionTTL,
 		},
 		{
 			name:                 "basic configuration",
@@ -130,5 +136,44 @@ func TestWithRevisionParameters(t *testing.T) {
 
 			require.Equal(t, tt.expectedTTL, result.defaultTTL)
 		})
+	}
+}
+
+// TestRevisionKeyedCachesExpire asserts that every cache whose keys embed a
+// datastore revision is completed with a TTL. Such a cache strands every entry
+// it holds each time the quantization window advances, so without expiry it
+// climbs to capacity and stays there, packed with keys no request can ask for
+// again — at which point the eviction policy begins rejecting the entries that
+// are still being read, and the hit rate falls away.
+func TestRevisionKeyedCachesExpire(t *testing.T) {
+	ds, err := dsfortesting.NewMemDBDatastoreForTesting(t, 0, 1*time.Second, 10*time.Second)
+	require.NoError(t, err)
+
+	c := ConfigWithOptions(
+		&Config{},
+		WithPresharedSecureKey("psk"),
+		WithDatastore(ds),
+		WithGRPCServer(util.GRPCServerConfig{Network: util.BufferedNetwork, Enabled: true}),
+		// The cluster dispatch cache is only built when the dispatch server is on.
+		WithDispatchServer(util.GRPCServerConfig{Network: util.BufferedNetwork, Enabled: true}),
+		WithNamespaceCacheConfig(CacheConfig{Name: "namespace", Enabled: true, MaxCost: "32MiB"}),
+		WithDispatchCacheConfig(CacheConfig{Name: "dispatch", Enabled: true, MaxCost: "1MiB"}),
+		WithClusterDispatchCacheConfig(CacheConfig{Name: "cluster_dispatch", Enabled: true, MaxCost: "1MiB"}),
+		WithEnableMemoryProtectionMiddleware(false),
+	)
+
+	completed, err := c.complete(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = completed.closeFunc() })
+
+	// Note that this Config was assembled in code, so DatastoreConfig carries
+	// zero revision parameters; the TTL comes from fallbackRevisionTTL.
+	for name, cacheConfig := range map[string]CacheConfig{
+		"namespace":        c.NamespaceCacheConfig,
+		"dispatch":         c.DispatchCacheConfig,
+		"cluster_dispatch": c.ClusterDispatchCacheConfig,
+	} {
+		require.Positive(t, cacheConfig.defaultTTL,
+			"the %s cache is keyed by revision and must be given a TTL", name)
 	}
 }

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -227,7 +227,15 @@ func (c *Config) complete(ctx context.Context) (*completedServerConfig, error) {
 		return nil, err
 	}
 
-	nscc, err := CompleteCache[cache.StringKey, schemacaching.CacheEntry](c.OTel.PrometheusRegistry, &c.NamespaceCacheConfig)
+	nscc, err := CompleteCache[cache.StringKey, schemacaching.CacheEntry](c.OTel.PrometheusRegistry,
+		// the namespace cache has revisions in its keys, so it needs
+		// this configuration to ensure that those entries expire along
+		// with the revisions.
+		c.NamespaceCacheConfig.WithRevisionParameters(
+			c.DatastoreConfig.RevisionQuantization,
+			c.DatastoreConfig.FollowerReadDelay,
+			c.DatastoreConfig.MaxRevisionStalenessPercent,
+		))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create namespace cache: %w", err)
 	}


### PR DESCRIPTION
Fixes #3290 
Written with LLM assistance

## Description

In #3112 we changed to using otter as the cache implementation. It has a different set of behaviors around admission, retention, and eviction of values. A combination of that difference in behavior and us failing to align the namespace cache TTL with revision window meant that cache entries slowly accumulated until Sets began to fail, reducing cache hit rate.

We were also miscounting cache hit rates because of how we were reading entries before setting, which effectively double-counted certain events.

This adds tests to ensure that namespace cache entries get properly evicted over time, aligns the TTL of the cache with the revision window (namespace entry cache keys include the revision), and puts some safeguards around a long TTL getting set and the behavior recurring.

## Changes
See annotations.

## Testing
Review. See that tests pass.