### PR TITLE
perf(postgres): key limited relationship deletes on (tableoid, ctid)

### DIFF
--- a/internal/datastore/benchmark/postgres_delete_bench_test.go
+++ b/internal/datastore/benchmark/postgres_delete_bench_test.go
@@ -1,0 +1,207 @@
+package benchmark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+
+	"github.com/authzed/spicedb/internal/datastore/postgres"
+	"github.com/authzed/spicedb/internal/testfixtures"
+	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
+	"github.com/authzed/spicedb/internal/testserver/datastore/config"
+	dsconfig "github.com/authzed/spicedb/pkg/cmd/datastore"
+	"github.com/authzed/spicedb/pkg/datastore"
+	"github.com/authzed/spicedb/pkg/datastore/options"
+	"github.com/authzed/spicedb/pkg/tuple"
+)
+
+// The seeded data mimics the statistical shape of a large production
+// relation_tuple table rather than its absolute size, since the shape is what
+// determines the query plans Postgres chooses:
+//
+//   - A large background population with a modest number of distinct subjects
+//     (production tables commonly have on the order of 10k) spread evenly over
+//     many (namespace, relation) pairs. This gives the columns of relation_tuple
+//     production-like selectivity estimates, and gives the subject-leading
+//     indexes the same size ratio to the primary key as on a large table.
+//   - Small per-scenario namespaces that differ only in subject fan-in: the
+//     number of relationships sharing one subject on one relation. Each scenario
+//     is kept to a small fraction of the table so that its own subjects do not
+//     dominate the column statistics, and the plan stays the same across
+//     scenarios while the fan-in varies.
+const (
+	// Background population: evenly spread subjects, as on a production table.
+	pgDeleteBenchBackgroundRows       = 2_000_000
+	pgDeleteBenchBackgroundNamespaces = 20
+	pgDeleteBenchBackgroundRelations  = 50
+	pgDeleteBenchBackgroundSubjects   = 13_000
+
+	// Per scenario: one namespace with this many relations and rows per relation.
+	// The rows per relation is also the fan-in of the shared and wildcard scenarios,
+	// and must exceed the largest delete limit below.
+	pgDeleteBenchScenarioRelations       = 2
+	pgDeleteBenchScenarioRowsPerRelation = 21_000
+)
+
+var pgDeleteBenchLimits = []uint64{100, 1000}
+
+// errRollbackBenchmarkTx is returned from the ReadWriteTx callback to roll back
+// the deletion, so every iteration operates on the same set of live rows.
+var errRollbackBenchmarkTx = errors.New("rollback benchmark transaction")
+
+// pgDeleteBenchScenario describes a set of relationships living in their own
+// namespace that share a subject fan-in pattern.
+type pgDeleteBenchScenario struct {
+	name      string
+	namespace string
+	// subjectIDSQL is a SQL expression yielding the subject object ID for the
+	// row numbered g in generate_series; r is the row's relation index.
+	subjectIDSQL string
+}
+
+var pgDeleteBenchScenarios = []pgDeleteBenchScenario{
+	{
+		// Every relationship has a subject unique to its resource (fan-in of 1).
+		name:         "UniqueSubject",
+		namespace:    "unique",
+		subjectIDSQL: "'unique-' || g",
+	},
+	{
+		// Every relationship on a relation shares one subject, so each subject has
+		// a fan-in of pgDeleteBenchScenarioRowsPerRelation on that relation.
+		name:         "SharedSubject",
+		namespace:    "shared",
+		subjectIDSQL: "'shared-' || r",
+	},
+	{
+		// Every relationship is granted to the wildcard subject.
+		name:         "WildcardSubject",
+		namespace:    "wild",
+		subjectIDSQL: "'" + tuple.PublicWildcard + "'",
+	},
+}
+
+// BenchmarkPostgresDeleteWithLimit benchmarks DeleteRelationships with a delete
+// limit against Postgres, on a table shaped like a large production deployment,
+// for subjects with differing fan-in. Requires Docker.
+//
+// Run with:
+//
+//	go test ./internal/datastore/benchmark/ -bench BenchmarkPostgresDeleteWithLimit \
+//	    -benchmem -run '^$' -timeout 60m
+func BenchmarkPostgresDeleteWithLimit(b *testing.B) {
+	if testing.Short() {
+		b.Skip("skipping postgres delete benchmarks in -short mode")
+	}
+
+	b.StopTimer()
+	ctx := b.Context()
+
+	engine := testdatastore.RunDatastoreEngine(b, postgres.Engine)
+
+	var dsURI string
+	initFunc := config.DatastoreConfigInitFunc(
+		b,
+		dsconfig.WithRevisionQuantization(5*time.Second),
+		dsconfig.WithGCWindow(2*time.Hour),
+		dsconfig.WithGCInterval(1*time.Hour),
+		dsconfig.WithWatchBufferLength(1000),
+		dsconfig.WithWriteAcquisitionTimeout(5*time.Second),
+	)
+	ds := engine.NewDatastore(b, func(engine, uri string) datastore.Datastore {
+		dsURI = uri
+		return initFunc(engine, uri)
+	})
+	b.Cleanup(func() { _ = ds.Close() })
+
+	ds, _ = testfixtures.StandardDatastoreWithSchema(b, ds)
+
+	// Write one relationship through the datastore so a transaction exists whose
+	// xid the bulk-seeded rows can be created under.
+	_, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
+		return rwt.WriteRelationships(ctx, []tuple.RelationshipUpdate{
+			tuple.Create(tuple.MustParse("document:seed#viewer@user:seed")),
+		})
+	})
+	require.NoError(b, err)
+
+	// Maintenance connection, used for bulk seeding and, off the timer, to keep
+	// the table's statistics and dead-tuple count representative between iterations.
+	maintConn, err := pgx.Connect(ctx, dsURI)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = maintConn.Close(context.Background()) })
+
+	// Seed in bulk with SQL: writing millions of rows through WriteRelationships
+	// takes minutes per million, while generate_series takes seconds.
+	const insertRows = `INSERT INTO relation_tuple (namespace, object_id, relation, userset_namespace, userset_object_id, userset_relation, created_xid)
+		SELECT %s, 'obj-' || g, 'rel' || r, 'user', %s, '...', (SELECT max(xid) FROM relation_tuple_transaction)
+		FROM generate_series(0, %d) g, LATERAL (SELECT %s AS r) rel`
+
+	_, err = maintConn.Exec(ctx, fmt.Sprintf(insertRows,
+		fmt.Sprintf("'bg-' || (g %% %d)", pgDeleteBenchBackgroundNamespaces),
+		fmt.Sprintf("'user-' || (g %% %d)", pgDeleteBenchBackgroundSubjects),
+		pgDeleteBenchBackgroundRows-1,
+		fmt.Sprintf("(g / %d) %% %d", pgDeleteBenchBackgroundNamespaces, pgDeleteBenchBackgroundRelations),
+	))
+	require.NoError(b, err, "seeding background rows")
+
+	for _, scenario := range pgDeleteBenchScenarios {
+		_, err := maintConn.Exec(ctx, fmt.Sprintf(insertRows,
+			"'"+scenario.namespace+"'",
+			scenario.subjectIDSQL,
+			pgDeleteBenchScenarioRelations*pgDeleteBenchScenarioRowsPerRelation-1,
+			fmt.Sprintf("g %% %d", pgDeleteBenchScenarioRelations),
+		))
+		require.NoError(b, err, "seeding scenario %s", scenario.name)
+	}
+
+	vacuumAnalyze := func(b *testing.B) {
+		_, err := maintConn.Exec(ctx, "VACUUM ANALYZE relation_tuple")
+		require.NoError(b, err)
+	}
+	vacuumAnalyze(b)
+
+	for _, scenario := range pgDeleteBenchScenarios {
+		b.Run(scenario.name, func(b *testing.B) {
+			for _, limit := range pgDeleteBenchLimits {
+				b.Run(fmt.Sprintf("limit=%d", limit), func(b *testing.B) {
+					filter := &v1.RelationshipFilter{
+						ResourceType:     scenario.namespace,
+						OptionalRelation: "rel0",
+						OptionalSubjectFilter: &v1.SubjectFilter{
+							SubjectType: "user",
+						},
+					}
+
+					b.ResetTimer()
+					for range b.N {
+						b.StopTimer()
+						// Each rolled-back iteration leaves behind a dead tuple version per
+						// updated row; vacuum them away so later iterations are not penalized.
+						vacuumAnalyze(b)
+						b.StartTimer()
+
+						_, err := ds.ReadWriteTx(ctx, func(ctx context.Context, rwt datastore.ReadWriteTransaction) error {
+							numDeleted, limitReached, err := rwt.DeleteRelationships(ctx, filter, options.WithDeleteLimit(&limit))
+							if err != nil {
+								return err
+							}
+							if numDeleted != limit || !limitReached {
+								return fmt.Errorf("expected to delete %d rows and hit the limit, deleted %d (limit reached: %v)", limit, numDeleted, limitReached)
+							}
+							return errRollbackBenchmarkTx
+						}, options.WithDisableRetries(true))
+						require.ErrorIs(b, err, errRollbackBenchmarkTx)
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/datastore/postgres/readwrite.go
+++ b/internal/datastore/postgres/readwrite.go
@@ -33,6 +33,13 @@ const (
 	errUnableToDeleteRelationshipsCounter = "unable to delete relationships counter: %w"
 )
 
+// Postgres system columns identifying a row's physical location.
+// See https://www.postgresql.org/docs/current/ddl-system-columns.html
+const (
+	colTableOID = "tableoid"
+	colCTID     = "ctid"
+)
+
 var (
 	writeNamespace = psql.Insert(schema.TableNamespace).Columns(
 		schema.ColNamespace,
@@ -55,15 +62,15 @@ var (
 		schema.ColExpiration,
 	)
 
-	deleteTuple     = psql.Update(schema.TableTuple).Where(sq.Eq{schema.ColDeletedXid: liveDeletedTxnID})
+	deleteTuple = psql.Update(schema.TableTuple).Where(sq.Eq{schema.ColDeletedXid: liveDeletedTxnID})
+
+	// selectForDelete selects the physical addresses of the rows to soft-delete, so
+	// the UPDATE can fetch each one directly with a Tid Scan instead of looking it up
+	// through an index. "tableoid" is included because "ctid" is only unique within
+	// a single physical table.
 	selectForDelete = psql.Select(
-		schema.ColNamespace,
-		schema.ColObjectID,
-		schema.ColRelation,
-		schema.ColUsersetNamespace,
-		schema.ColUsersetObjectID,
-		schema.ColUsersetRelation,
-		schema.ColCreatedXid,
+		colTableOID,
+		colCTID,
 	).From(schema.TableTuple).Where(sq.Eq{schema.ColDeletedXid: liveDeletedTxnID})
 
 	writeRelationshipCounter = psql.Insert(schema.TableRelationshipCounter).Columns(
@@ -488,18 +495,15 @@ func (rwt *pgReadWriteTXN) deleteRelationshipsWithLimit(ctx context.Context, fil
 
 	// Construct a CTE to update the relationships as removed.
 	cteSQL := fmt.Sprintf(
-		"WITH found_tuples AS (%s)\nUPDATE %s SET %s = $%d WHERE (%s, %s, %s, %s, %s, %s, %s) IN (select * from found_tuples)",
+		"WITH found_tuples AS (%s)\nUPDATE %s SET %s = $%d WHERE (%s, %s) IN (SELECT %s, %s FROM found_tuples)",
 		selectSQL,
 		schema.TableTuple,
 		schema.ColDeletedXid,
 		len(args),
-		schema.ColNamespace,
-		schema.ColObjectID,
-		schema.ColRelation,
-		schema.ColUsersetNamespace,
-		schema.ColUsersetObjectID,
-		schema.ColUsersetRelation,
-		schema.ColCreatedXid,
+		colTableOID,
+		colCTID,
+		colTableOID,
+		colCTID,
 	)
 
 	result, err := rwt.tx.Exec(ctx, cteSQL, args...)


### PR DESCRIPTION
## Description

Fixes #3306

Improves performance of `DeleteRelationships` when using a limit, by using the `ctid` to avoid an expensive crawl of a second index in order to `UPDATE` the identified tuples in some query plans.

Query planners are fun so it took a bit to come up with a benchmark that successfully triggered the bad plan, but it got there in the end. The good news is that tables which never hit the bad plan see no regression from this change - the `Tid Scan` re-find is at worst equivalent to an index lookup on the primary key, and measured slightly faster.

## Benchmarks

Adds `BenchmarkPostgresDeleteWithLimit`, which seeds rows shaped like a large production table and deletes 100 or 1000 rows for three subject fan-in scenarios. On this table `EXPLAIN` shows the previous query re-finding rows through `ix_relation_tuple_by_subject` (`Rows Removed by Filter: 20999` per row in the shared and wildcard scenarios); the new query uses a `Tid Scan`.

Results on my MacBook Pro M5 24gb against Postgres 18 using `-count 6 -benchtime 5x`: 

| Scenario | Limit | Before | After | Change |
| --- | --- | --- | --- | --- |
| Unique subject | 100 | 4.16 ms ± 15% | 3.62 ms ± 20% | −13% (p=0.041) |
| Unique subject | 1000 | 20.8 ms ± 13% | 17.8 ms ± 6% | −15% (p=0.009) |
| Shared subject (fan-in 21k) | 100 | 120.6 ms ± 2% | 3.65 ms ± 26% | −97% (p=0.002) |
| Shared subject (fan-in 21k) | 1000 | 1208.6 ms ± 2% | 18.2 ms ± 6% | −98% (p=0.002) |
| Wildcard subject (fan-in 21k) | 100 | 120.0 ms ± 4% | 3.47 ms ± 17% | −97% (p=0.002) |
| Wildcard subject (fan-in 21k) | 1000 | 1187.0 ms ± 4% | 18.1 ms ± 4% | −98% (p=0.002) |
| geomean | | 110.3 ms | 8.03 ms | −93% |

## Testing

Existing Postgres datastore tests cover the limited delete path and no regressions were found running the tests locally.